### PR TITLE
Modify initialisation methods to allow higher layer to know if a network is already joined.

### DIFF
--- a/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsole.java
+++ b/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsole.java
@@ -203,13 +203,6 @@ public final class ZigBeeConsole {
         mainThread = Thread.currentThread();
         System.out.print("ZigBee API starting up...");
 
-        if (!networkManager.startup()) {
-            print("ZigBee API starting up ... [FAIL]", System.out);
-            return;
-        } else {
-            print("ZigBee API starting up ... [OK]", System.out);
-        }
-
         print("ZigBee console ready.", System.out);
 
         print("PAN ID          = " + networkManager.getZigBeePanId(), System.out);

--- a/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleMain.java
+++ b/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleMain.java
@@ -131,6 +131,13 @@ public class ZigBeeConsoleMain {
             }
         }
 
+        if (!networkManager.startup(resetNetwork)) {
+            System.out.println("ZigBee API starting up ... [FAIL]");
+            return;
+        } else {
+            System.out.println("ZigBee API starting up ... [OK]");
+        }
+
         console.start();
     }
 

--- a/com.zsmartsystems.zigbee.dongle.cc2531/src/main/java/com/zsmartsystems/zigbee/dongle/cc2531/ZigBeeDongleTiCc2531.java
+++ b/com.zsmartsystems.zigbee.dongle.cc2531/src/main/java/com/zsmartsystems/zigbee/dongle/cc2531/ZigBeeDongleTiCc2531.java
@@ -7,6 +7,7 @@ import org.slf4j.LoggerFactory;
 
 import com.zsmartsystems.zigbee.ZigBeeApsFrame;
 import com.zsmartsystems.zigbee.ZigBeeException;
+import com.zsmartsystems.zigbee.ZigBeeNetworkManager.ZigBeeInitializeResponse;
 import com.zsmartsystems.zigbee.ZigBeePort;
 import com.zsmartsystems.zigbee.ZigBeeTransportReceive;
 import com.zsmartsystems.zigbee.ZigBeeTransportState;
@@ -66,18 +67,18 @@ public class ZigBeeDongleTiCc2531
     }
 
     @Override
-    public boolean initialize() {
+    public ZigBeeInitializeResponse initialize() {
         logger.debug("CC2531 transport initialize");
 
         zigbeeNetworkReceive.setNetworkState(ZigBeeTransportState.UNINITIALISED);
 
         if (!networkManager.startup()) {
-            return false;
+            return ZigBeeInitializeResponse.FAILED;
         }
 
         zigbeeNetworkReceive.setNetworkState(ZigBeeTransportState.INITIALISING);
 
-        return true;
+        return ZigBeeInitializeResponse.JOINED;
     }
 
     @Override
@@ -117,7 +118,7 @@ public class ZigBeeDongleTiCc2531
     }
 
     @Override
-    public boolean startup() {
+    public boolean startup(boolean reinitialize) {
         logger.debug("CC2531 transport startup");
 
         // Add listeners for ZCL and ZDO received messages
@@ -527,5 +528,4 @@ public class ZigBeeDongleTiCc2531
             }
         }
     }
-
 }

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/serializer/EzspSerializer.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/serializer/EzspSerializer.java
@@ -83,6 +83,13 @@ public class EzspSerializer {
     }
 
     public void serializeEmberKeyData(EmberKeyData keyData) {
+        // If we pass in null, then send a null key.
+        // Note that ember will not accept this key, so this check is here to prevent the system
+        // throwing an NPE - the application needs to resolve this so it sends a valid key.
+        if (keyData == null || keyData.getContents() == null) {
+            serializeUInt8Array(new int[] { 0, 0, 0, 0, 0, 0, 0, 0 });
+            return;
+        }
         serializeUInt8Array(keyData.getContents());
     }
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/EmberNetworkInitialisation.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/EmberNetworkInitialisation.java
@@ -86,23 +86,23 @@ public class EmberNetworkInitialisation {
         getNetworkParameters();
 
         // Create a random PAN ID and Extended PAN ID
-        if (networkParameters.getPanId() == 0
-                || Arrays.equals(networkParameters.getExtendedPanId(), new int[] { 0, 0, 0, 0, 0, 0, 0, 0 })) {
-            Random random = new Random();
-            int panId = random.nextInt(65535);
-            networkParameters.setPanId(panId);
-            logger.debug("Created random PAN ID: {}", panId);
+        // if (networkParameters.getPanId() == 0
+        // || Arrays.equals(networkParameters.getExtendedPanId(), new int[] { 0, 0, 0, 0, 0, 0, 0, 0 })) {
+        Random random = new Random();
+        int panId = random.nextInt(65535);
+        networkParameters.setPanId(panId);
+        logger.debug("Created random PAN ID: {}", panId);
 
-            int extendedPanId[] = new int[8];
-            StringBuilder extendedPanIdBuilder = new StringBuilder();
-            for (int cnt = 0; cnt < 8; cnt++) {
-                extendedPanId[cnt] = random.nextInt(256);
-                extendedPanIdBuilder.append(String.format("%2X", extendedPanId[cnt]));
-            }
-
-            networkParameters.setExtendedPanId(extendedPanId);
-            logger.debug("Created random Extended PAN ID: {}", extendedPanIdBuilder.toString());
+        int extendedPanId[] = new int[8];
+        StringBuilder extendedPanIdBuilder = new StringBuilder();
+        for (int cnt = 0; cnt < 8; cnt++) {
+            extendedPanId[cnt] = random.nextInt(256);
+            extendedPanIdBuilder.append(String.format("%2X", extendedPanId[cnt]));
         }
+
+        networkParameters.setExtendedPanId(extendedPanId);
+        logger.debug("Created random Extended PAN ID: {}", extendedPanIdBuilder.toString());
+        // }
 
         if (networkParameters.getRadioChannel() == 0) {
             networkParameters.setRadioChannel(quietestChannel);
@@ -194,7 +194,7 @@ public class EmberNetworkInitialisation {
         logger.debug(activeScanCompleteResponse.toString());
 
         if (activeScanCompleteResponse.getStatus() != EmberStatus.EMBER_SUCCESS) {
-            logger.debug("Error during energy scan: {}", activeScanCompleteResponse);
+            logger.debug("Error during active scan: {}", activeScanCompleteResponse);
             return false;
         }
         return true;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeTransportTransmit.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeTransportTransmit.java
@@ -1,5 +1,6 @@
 package com.zsmartsystems.zigbee;
 
+import com.zsmartsystems.zigbee.ZigBeeNetworkManager.ZigBeeInitializeResponse;
 import com.zsmartsystems.zigbee.serialization.ZigBeeDeserializer;
 import com.zsmartsystems.zigbee.serialization.ZigBeeSerializer;
 
@@ -25,17 +26,24 @@ public interface ZigBeeTransportTransmit {
     /**
      * Initialize the transport interface. Following the call to initialize the configuration methods may be used to
      * configure the transport layer.
+     * <p>
+     * During the initialize() method, the provider must initialize the ports and perform any configuration required to
+     * get the stack ready for use. If the dongle has already joined a network, then this method will return true.
      *
-     * @return true if initialization was success.
+     * @return {@link ZigBeeInitializeResponse}
      */
-    boolean initialize();
+    ZigBeeInitializeResponse initialize();
 
     /**
      * Starts the transport interface.
+     * <p>
+     * This call will optionally reconfigure the interface if the reinitialize parameter is true.
      *
+     * @param reinitialize true if the provider is to reinitialise the network with the parameters configured since the
+     *            {@link #initialize} method was called.
      * @return true if startup was success.
      */
-    boolean startup();
+    boolean startup(boolean reinitialize);
 
     /**
      * Shuts down a transport interface.
@@ -59,16 +67,6 @@ public interface ZigBeeTransportTransmit {
      * @throws {@link ZigBeeException} if exception occurs in sending
      */
     void sendCommand(final ZigBeeApsFrame apsFrame) throws ZigBeeException;
-
-    /**
-     * The ZDO interface exchanges only command classes. This is different to the ZCL interface since different sticks
-     * tend to implement ZDO functionality as individual commands rather than allowing a binary ZDO packet to be sent
-     * and received.
-     *
-     * @param command the {@link ZdoCommand} to send
-     * @throws {@link ZigBeeException} if exception occurs in sending
-     */
-    // void sendZdoCommand(final ZdoCommand command) throws ZigBeeException;
 
     /**
      * Sets the {@link ZigBeeTransportReceive}. Set by the network so that the {@link ZigBeeTransportTransmit} can send


### PR DESCRIPTION
The initialise() method returns a state JOINED, NOT_JOINED, FAILED, and the startup() takes a parameter to define if the dongle needs to be reinitialised.
This allows the app to tell if the dongle was previously joined to a network, and if so not to reconfigure it.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>