### PR TITLE
Fix bug handling transaction ID where it can end up as a negative number

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
@@ -833,7 +833,7 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
             try {
                 int transactionId = sendCommand(command);
                 if (command instanceof ZclCommand) {
-                    ((ZclCommand) command).setTransactionId((byte) transactionId);
+                    ((ZclCommand) command).setTransactionId(transactionId);
                 }
             } catch (final ZigBeeException e) {
                 future.set(new CommandResult(e.toString()));


### PR DESCRIPTION
Casting to (byte) means the transaction ID can end up negative which means the response matcher doesn't match some commands.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>