### PR TITLE
Improved handling of ZNP channel setting method to ensure incorrect data uses default channel

### DIFF
--- a/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleMain.java
+++ b/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleMain.java
@@ -122,7 +122,7 @@ public class ZigBeeConsoleMain {
             System.out.println("*** Resetting network");
             System.out.println("  * Channel          = " + channel);
             System.out.println("  * PAN ID           = " + pan);
-            System.out.println("  * Extended PAN ID  = " + String.format("%016X", extendedPan));
+            System.out.println("  * Extended PAN ID  = " + extendedPan);
 
             networkManager.setZigBeeChannel(channel);
             networkManager.setZigBeePanId(pan);

--- a/com.zsmartsystems.zigbee.dongle.cc2531/src/main/java/com/zsmartsystems/zigbee/dongle/cc2531/ZigBeeDongleTiCc2531.java
+++ b/com.zsmartsystems.zigbee.dongle.cc2531/src/main/java/com/zsmartsystems/zigbee/dongle/cc2531/ZigBeeDongleTiCc2531.java
@@ -24,6 +24,7 @@ import com.zsmartsystems.zigbee.dongle.cc2531.network.ApplicationFrameworkMessag
 import com.zsmartsystems.zigbee.dongle.cc2531.network.AsynchronousCommandListener;
 import com.zsmartsystems.zigbee.dongle.cc2531.network.DriverStatus;
 import com.zsmartsystems.zigbee.dongle.cc2531.network.NetworkMode;
+import com.zsmartsystems.zigbee.dongle.cc2531.network.impl.CommandInterfaceImpl;
 import com.zsmartsystems.zigbee.dongle.cc2531.network.impl.ZigBeeNetworkManagerImpl;
 import com.zsmartsystems.zigbee.dongle.cc2531.network.packet.ZToolCMD;
 import com.zsmartsystems.zigbee.dongle.cc2531.network.packet.ZToolPacket;
@@ -82,7 +83,8 @@ public class ZigBeeDongleTiCc2531
      *            the serial port
      */
     public ZigBeeDongleTiCc2531(final ZigBeePort serialPort) {
-        networkManager = new ZigBeeNetworkManagerImpl(serialPort, NetworkMode.Coordinator, 2500L);
+        networkManager = new ZigBeeNetworkManagerImpl(new CommandInterfaceImpl(serialPort), NetworkMode.Coordinator,
+                2500L);
     }
 
     /**

--- a/com.zsmartsystems.zigbee.dongle.cc2531/src/main/java/com/zsmartsystems/zigbee/dongle/cc2531/network/ZigBeeNetworkManager.java
+++ b/com.zsmartsystems.zigbee.dongle.cc2531/src/main/java/com/zsmartsystems/zigbee/dongle/cc2531/network/ZigBeeNetworkManager.java
@@ -27,7 +27,6 @@ import com.zsmartsystems.zigbee.dongle.cc2531.network.packet.af.AF_DATA_CONFIRM;
 import com.zsmartsystems.zigbee.dongle.cc2531.network.packet.af.AF_DATA_REQUEST;
 import com.zsmartsystems.zigbee.dongle.cc2531.network.packet.af.AF_REGISTER;
 import com.zsmartsystems.zigbee.dongle.cc2531.network.packet.af.AF_REGISTER_SRSP;
-import com.zsmartsystems.zigbee.transport.ZigBeePort;
 
 /**
  * @author <a href="mailto:stefano.lenzi@isti.cnr.it">Stefano "Kismet" Lenzi - ISTI-CNR</a>
@@ -42,13 +41,6 @@ public interface ZigBeeNetworkManager {
      * @param networkMode the network mode
      */
     void setZigBeeNodeMode(NetworkMode networkMode);
-
-    /**
-     * Sets serial port.
-     *
-     * @param port the serial port.
-     */
-    void setSerialPort(ZigBeePort port);
 
     /**
      * Starts up network manager.

--- a/com.zsmartsystems.zigbee.dongle.cc2531/src/test/java/com/zsmartsystems/zigbee/dongle/cc2531/Cc2351TestPacket.java
+++ b/com.zsmartsystems.zigbee.dongle.cc2531/src/test/java/com/zsmartsystems/zigbee/dongle/cc2531/Cc2351TestPacket.java
@@ -1,4 +1,4 @@
-package com.zsmartsystems.zigbee.dongle.cc2531.test;
+package com.zsmartsystems.zigbee.dongle.cc2531;
 
 import static org.junit.Assert.assertFalse;
 

--- a/com.zsmartsystems.zigbee.dongle.cc2531/src/test/java/com/zsmartsystems/zigbee/dongle/cc2531/ZDO_ACTIVE_EP_RSP_Test.java
+++ b/com.zsmartsystems.zigbee.dongle.cc2531/src/test/java/com/zsmartsystems/zigbee/dongle/cc2531/ZDO_ACTIVE_EP_RSP_Test.java
@@ -1,4 +1,4 @@
-package com.zsmartsystems.zigbee.dongle.cc2531.test;
+package com.zsmartsystems.zigbee.dongle.cc2531;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -8,7 +8,7 @@ import java.util.Arrays;
 import org.junit.Test;
 
 import com.zsmartsystems.zigbee.ZigBeeApsFrame;
-import com.zsmartsystems.zigbee.dongle.cc2531.frame.ZdoManagementRouting;
+import com.zsmartsystems.zigbee.dongle.cc2531.frame.ZdoActiveEndpoint;
 import com.zsmartsystems.zigbee.dongle.cc2531.network.packet.ZToolPacket;
 
 /**
@@ -16,18 +16,18 @@ import com.zsmartsystems.zigbee.dongle.cc2531.network.packet.ZToolPacket;
  * @author Chris Jackson
  *
  */
-public class ZDO_MGMT_RTG_RSP_Test extends Cc2351TestPacket {
+public class ZDO_ACTIVE_EP_RSP_Test extends Cc2351TestPacket {
 
     @Test
     public void testReceive() {
-        ZToolPacket data = getPacket("FE 0B 45 B2 00 00 00 01 00 01 2A 2F 00 35 38 F4");
+        ZToolPacket data = getPacket("FE 08 45 85 00 00 00 00 00 02 02 01 C9");
 
-        ZigBeeApsFrame apsFrame = ZdoManagementRouting.create(data);
+        ZigBeeApsFrame apsFrame = ZdoActiveEndpoint.create(data);
 
         assertEquals(0x0000, apsFrame.getSourceAddress());
         assertEquals(0, apsFrame.getProfile());
         assertEquals(0, apsFrame.getDestinationEndpoint());
-        assertTrue(Arrays.equals(getPacketData("00 00 01 00 01 2A 2F 00 35 38"), apsFrame.getPayload()));
+        assertTrue(Arrays.equals(getPacketData("00 00 00 00 02 02 01"), apsFrame.getPayload()));
     }
 
 }

--- a/com.zsmartsystems.zigbee.dongle.cc2531/src/test/java/com/zsmartsystems/zigbee/dongle/cc2531/ZDO_END_DEVICE_ANNCE_IND_Test.java
+++ b/com.zsmartsystems.zigbee.dongle.cc2531/src/test/java/com/zsmartsystems/zigbee/dongle/cc2531/ZDO_END_DEVICE_ANNCE_IND_Test.java
@@ -1,4 +1,4 @@
-package com.zsmartsystems.zigbee.dongle.cc2531.test;
+package com.zsmartsystems.zigbee.dongle.cc2531;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;

--- a/com.zsmartsystems.zigbee.dongle.cc2531/src/test/java/com/zsmartsystems/zigbee/dongle/cc2531/ZDO_IEEE_ADDR_RSP_Test.java
+++ b/com.zsmartsystems.zigbee.dongle.cc2531/src/test/java/com/zsmartsystems/zigbee/dongle/cc2531/ZDO_IEEE_ADDR_RSP_Test.java
@@ -1,4 +1,4 @@
-package com.zsmartsystems.zigbee.dongle.cc2531.test;
+package com.zsmartsystems.zigbee.dongle.cc2531;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;

--- a/com.zsmartsystems.zigbee.dongle.cc2531/src/test/java/com/zsmartsystems/zigbee/dongle/cc2531/ZDO_MGMT_LEAVE_RSP_Test.java
+++ b/com.zsmartsystems.zigbee.dongle.cc2531/src/test/java/com/zsmartsystems/zigbee/dongle/cc2531/ZDO_MGMT_LEAVE_RSP_Test.java
@@ -1,4 +1,4 @@
-package com.zsmartsystems.zigbee.dongle.cc2531.test;
+package com.zsmartsystems.zigbee.dongle.cc2531;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;

--- a/com.zsmartsystems.zigbee.dongle.cc2531/src/test/java/com/zsmartsystems/zigbee/dongle/cc2531/ZDO_MGMT_LQI_RSP_Test.java
+++ b/com.zsmartsystems.zigbee.dongle.cc2531/src/test/java/com/zsmartsystems/zigbee/dongle/cc2531/ZDO_MGMT_LQI_RSP_Test.java
@@ -1,4 +1,4 @@
-package com.zsmartsystems.zigbee.dongle.cc2531.test;
+package com.zsmartsystems.zigbee.dongle.cc2531;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;

--- a/com.zsmartsystems.zigbee.dongle.cc2531/src/test/java/com/zsmartsystems/zigbee/dongle/cc2531/ZDO_MGMT_RTG_RSP_Test.java
+++ b/com.zsmartsystems.zigbee.dongle.cc2531/src/test/java/com/zsmartsystems/zigbee/dongle/cc2531/ZDO_MGMT_RTG_RSP_Test.java
@@ -1,4 +1,4 @@
-package com.zsmartsystems.zigbee.dongle.cc2531.test;
+package com.zsmartsystems.zigbee.dongle.cc2531;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -8,7 +8,7 @@ import java.util.Arrays;
 import org.junit.Test;
 
 import com.zsmartsystems.zigbee.ZigBeeApsFrame;
-import com.zsmartsystems.zigbee.dongle.cc2531.frame.ZdoPowerDescriptor;
+import com.zsmartsystems.zigbee.dongle.cc2531.frame.ZdoManagementRouting;
 import com.zsmartsystems.zigbee.dongle.cc2531.network.packet.ZToolPacket;
 
 /**
@@ -16,18 +16,18 @@ import com.zsmartsystems.zigbee.dongle.cc2531.network.packet.ZToolPacket;
  * @author Chris Jackson
  *
  */
-public class ZDO_POWER_DESC_RSP_Test extends Cc2351TestPacket {
+public class ZDO_MGMT_RTG_RSP_Test extends Cc2351TestPacket {
 
     @Test
     public void testReceive() {
-        ZToolPacket data = getPacket("FE 07 45 83 00 00 00 00 00 10 C1 10");
+        ZToolPacket data = getPacket("FE 0B 45 B2 00 00 00 01 00 01 2A 2F 00 35 38 F4");
 
-        ZigBeeApsFrame apsFrame = ZdoPowerDescriptor.create(data);
+        ZigBeeApsFrame apsFrame = ZdoManagementRouting.create(data);
 
         assertEquals(0x0000, apsFrame.getSourceAddress());
         assertEquals(0, apsFrame.getProfile());
         assertEquals(0, apsFrame.getDestinationEndpoint());
-        assertTrue(Arrays.equals(getPacketData("00 00 00 00 10 C1"), apsFrame.getPayload()));
+        assertTrue(Arrays.equals(getPacketData("00 00 01 00 01 2A 2F 00 35 38"), apsFrame.getPayload()));
     }
 
 }

--- a/com.zsmartsystems.zigbee.dongle.cc2531/src/test/java/com/zsmartsystems/zigbee/dongle/cc2531/ZDO_MSG_CB_INCOMING_Test.java
+++ b/com.zsmartsystems.zigbee.dongle.cc2531/src/test/java/com/zsmartsystems/zigbee/dongle/cc2531/ZDO_MSG_CB_INCOMING_Test.java
@@ -1,4 +1,4 @@
-package com.zsmartsystems.zigbee.dongle.cc2531.test;
+package com.zsmartsystems.zigbee.dongle.cc2531;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;

--- a/com.zsmartsystems.zigbee.dongle.cc2531/src/test/java/com/zsmartsystems/zigbee/dongle/cc2531/ZDO_NODE_DESC_RSP_Test.java
+++ b/com.zsmartsystems.zigbee.dongle.cc2531/src/test/java/com/zsmartsystems/zigbee/dongle/cc2531/ZDO_NODE_DESC_RSP_Test.java
@@ -1,4 +1,4 @@
-package com.zsmartsystems.zigbee.dongle.cc2531.test;
+package com.zsmartsystems.zigbee.dongle.cc2531;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -8,7 +8,7 @@ import java.util.Arrays;
 import org.junit.Test;
 
 import com.zsmartsystems.zigbee.ZigBeeApsFrame;
-import com.zsmartsystems.zigbee.dongle.cc2531.frame.ZdoActiveEndpoint;
+import com.zsmartsystems.zigbee.dongle.cc2531.frame.ZdoNodeDescriptor;
 import com.zsmartsystems.zigbee.dongle.cc2531.network.packet.ZToolPacket;
 
 /**
@@ -16,18 +16,19 @@ import com.zsmartsystems.zigbee.dongle.cc2531.network.packet.ZToolPacket;
  * @author Chris Jackson
  *
  */
-public class ZDO_ACTIVE_EP_RSP_Test extends Cc2351TestPacket {
+public class ZDO_NODE_DESC_RSP_Test extends Cc2351TestPacket {
 
     @Test
     public void testReceive() {
-        ZToolPacket data = getPacket("FE 08 45 85 00 00 00 00 00 02 02 01 C9");
+        ZToolPacket data = getPacket("FE 12 45 82 00 00 00 00 00 00 40 0F 00 00 50 A0 00 01 00 A0 00 00 CB");
 
-        ZigBeeApsFrame apsFrame = ZdoActiveEndpoint.create(data);
+        ZigBeeApsFrame apsFrame = ZdoNodeDescriptor.create(data);
 
         assertEquals(0x0000, apsFrame.getSourceAddress());
         assertEquals(0, apsFrame.getProfile());
         assertEquals(0, apsFrame.getDestinationEndpoint());
-        assertTrue(Arrays.equals(getPacketData("00 00 00 00 02 02 01"), apsFrame.getPayload()));
+        assertTrue(Arrays.equals(getPacketData("00 00 00 00 00 40 0F 00 00 50 A0 00 01 00 A0 00 00"),
+                apsFrame.getPayload()));
     }
 
 }

--- a/com.zsmartsystems.zigbee.dongle.cc2531/src/test/java/com/zsmartsystems/zigbee/dongle/cc2531/ZDO_POWER_DESC_RSP_Test.java
+++ b/com.zsmartsystems.zigbee.dongle.cc2531/src/test/java/com/zsmartsystems/zigbee/dongle/cc2531/ZDO_POWER_DESC_RSP_Test.java
@@ -1,4 +1,4 @@
-package com.zsmartsystems.zigbee.dongle.cc2531.test;
+package com.zsmartsystems.zigbee.dongle.cc2531;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -8,7 +8,7 @@ import java.util.Arrays;
 import org.junit.Test;
 
 import com.zsmartsystems.zigbee.ZigBeeApsFrame;
-import com.zsmartsystems.zigbee.dongle.cc2531.frame.ZdoNodeDescriptor;
+import com.zsmartsystems.zigbee.dongle.cc2531.frame.ZdoPowerDescriptor;
 import com.zsmartsystems.zigbee.dongle.cc2531.network.packet.ZToolPacket;
 
 /**
@@ -16,19 +16,18 @@ import com.zsmartsystems.zigbee.dongle.cc2531.network.packet.ZToolPacket;
  * @author Chris Jackson
  *
  */
-public class ZDO_NODE_DESC_RSP_Test extends Cc2351TestPacket {
+public class ZDO_POWER_DESC_RSP_Test extends Cc2351TestPacket {
 
     @Test
     public void testReceive() {
-        ZToolPacket data = getPacket("FE 12 45 82 00 00 00 00 00 00 40 0F 00 00 50 A0 00 01 00 A0 00 00 CB");
+        ZToolPacket data = getPacket("FE 07 45 83 00 00 00 00 00 10 C1 10");
 
-        ZigBeeApsFrame apsFrame = ZdoNodeDescriptor.create(data);
+        ZigBeeApsFrame apsFrame = ZdoPowerDescriptor.create(data);
 
         assertEquals(0x0000, apsFrame.getSourceAddress());
         assertEquals(0, apsFrame.getProfile());
         assertEquals(0, apsFrame.getDestinationEndpoint());
-        assertTrue(Arrays.equals(getPacketData("00 00 00 00 00 40 0F 00 00 50 A0 00 01 00 A0 00 00"),
-                apsFrame.getPayload()));
+        assertTrue(Arrays.equals(getPacketData("00 00 00 00 10 C1"), apsFrame.getPayload()));
     }
 
 }

--- a/com.zsmartsystems.zigbee.dongle.cc2531/src/test/java/com/zsmartsystems/zigbee/dongle/cc2531/ZDO_SIMPLE_DESC_RSP_Test.java
+++ b/com.zsmartsystems.zigbee.dongle.cc2531/src/test/java/com/zsmartsystems/zigbee/dongle/cc2531/ZDO_SIMPLE_DESC_RSP_Test.java
@@ -1,4 +1,4 @@
-package com.zsmartsystems.zigbee.dongle.cc2531.test;
+package com.zsmartsystems.zigbee.dongle.cc2531;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;

--- a/com.zsmartsystems.zigbee.dongle.cc2531/src/test/java/com/zsmartsystems/zigbee/dongle/cc2531/network/impl/ZigBeeNetworkManagerImplTest.java
+++ b/com.zsmartsystems.zigbee.dongle.cc2531/src/test/java/com/zsmartsystems/zigbee/dongle/cc2531/network/impl/ZigBeeNetworkManagerImplTest.java
@@ -1,0 +1,117 @@
+package com.zsmartsystems.zigbee.dongle.cc2531.network.impl;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import com.zsmartsystems.zigbee.dongle.cc2531.network.CommandInterface;
+import com.zsmartsystems.zigbee.dongle.cc2531.network.SynchronousCommandListener;
+import com.zsmartsystems.zigbee.dongle.cc2531.network.packet.ZToolPacket;
+
+/**
+ *
+ * @author Chris Jackson
+ *
+ */
+public class ZigBeeNetworkManagerImplTest {
+    protected ArgumentCaptor<ZToolPacket> argumentPacket;
+    protected ArgumentCaptor<SynchronousCommandListener> argumentListener;
+    protected ArgumentCaptor<Long> argumentTimeout;
+
+    private CommandInterface getCommandInterface() {
+        CommandInterface commandInterface = Mockito.mock(CommandInterface.class);
+        argumentPacket = ArgumentCaptor.forClass(ZToolPacket.class);
+        argumentListener = ArgumentCaptor.forClass(SynchronousCommandListener.class);
+        argumentTimeout = ArgumentCaptor.forClass(Long.class);
+        try {
+            Mockito.doNothing().when(commandInterface).sendSynchronousCommand(argumentPacket.capture(),
+                    argumentListener.capture(), argumentTimeout.capture());
+        } catch (IOException e) {
+            // TODO Auto-generated catch block
+            e.printStackTrace();
+        }
+
+        return commandInterface;
+    }
+
+    @Test
+    public void dongleSetChannel() {
+        CommandInterface commandInterface = getCommandInterface();
+        ZigBeeNetworkManagerImpl networkManager = new ZigBeeNetworkManagerImpl(commandInterface, null, 0);
+        networkManager.setRetryConfiguration(1, 0);
+
+        Method privateMethod;
+        try {
+            privateMethod = ZigBeeNetworkManagerImpl.class.getDeclaredMethod("dongleSetChannel",
+                    new Class[] { int[].class });
+            privateMethod.setAccessible(true);
+
+            // Channel 11
+            privateMethod.invoke(networkManager, new int[] { 0x00, 0x08, 0x00, 0x00 });
+            ZToolPacket packet = argumentPacket.getAllValues().get(0);
+            assertTrue(Arrays.equals(new int[] { 254, 6, 38, 5, 132, 0x04, 0x00, 0x08, 0x00, 0x00, 173 },
+                    packet.getPacket()));
+
+            // Check channel 11 is set even when incorrect data
+            privateMethod.invoke(networkManager, new int[] { 0x01, 0x08, 0x00, 0x00 });
+            packet = argumentPacket.getAllValues().get(1);
+            assertTrue(Arrays.equals(new int[] { 254, 6, 38, 5, 132, 0x04, 0x00, 0x08, 0x00, 0x00, 173 },
+                    packet.getPacket()));
+
+            // Check channel 11 is set when no channels are set
+            privateMethod.invoke(networkManager, new int[] { 0x00, 0x00, 0x00, 0x00 });
+            packet = argumentPacket.getAllValues().get(2);
+            assertTrue(Arrays.equals(new int[] { 254, 6, 38, 5, 132, 0x04, 0x00, 0x08, 0x00, 0x00, 173 },
+                    packet.getPacket()));
+
+            // Check a number of channels are set
+            privateMethod.invoke(networkManager, new int[] { 0x00, 0xff, 0x00, 0x00 });
+            packet = argumentPacket.getAllValues().get(3);
+            assertTrue(Arrays.equals(new int[] { 254, 6, 38, 5, 132, 0x04, 0x00, 0xf8, 0x00, 0x00, 0x5D },
+                    packet.getPacket()));
+
+            networkManager.setZigBeeChannel(12);
+            packet = argumentPacket.getAllValues().get(4);
+            assertTrue(Arrays.equals(new int[] { 254, 6, 38, 5, 132, 0x04, 0x00, 0x10, 0x00, 0x00, 0xB5 },
+                    packet.getPacket()));
+        } catch (NoSuchMethodException | SecurityException | IllegalAccessException | IllegalArgumentException
+                | InvocationTargetException e) {
+            // TODO Auto-generated catch block
+            e.printStackTrace();
+        }
+    }
+
+    @Test
+    public void buildChannelMask() {
+        ZigBeeNetworkManagerImpl networkManager = new ZigBeeNetworkManagerImpl(null, null, 0);
+
+        int[] mask;
+        Method privateMethod;
+        try {
+            privateMethod = ZigBeeNetworkManagerImpl.class.getDeclaredMethod("buildChannelMask",
+                    new Class[] { int.class });
+            privateMethod.setAccessible(true);
+
+            mask = (int[]) privateMethod.invoke(networkManager, -1);
+            assertTrue(Arrays.equals(new int[] { 0x00, 0x00, 0x00, 0x00 }, mask));
+            mask = (int[]) privateMethod.invoke(networkManager, 32);
+            assertTrue(Arrays.equals(new int[] { 0x00, 0x00, 0x00, 0x00 }, mask));
+            mask = (int[]) privateMethod.invoke(networkManager, 11);
+            assertTrue(Arrays.equals(new int[] { 0x00, 0x08, 0x00, 0x00 }, mask));
+            mask = (int[]) privateMethod.invoke(networkManager, 27);
+            assertTrue(Arrays.equals(new int[] { 0x00, 0x00, 0x00, 0x08 }, mask));
+
+        } catch (NoSuchMethodException | SecurityException | IllegalAccessException | IllegalArgumentException
+                | InvocationTargetException e) {
+            // TODO Auto-generated catch block
+            e.printStackTrace();
+        }
+    }
+}

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
@@ -286,6 +286,7 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
      */
     public boolean setZigBeeChannel(int channel) {
         if (channel < 11 || channel > 26) {
+            logger.debug("Can't set channel to {}", channel);
             return false;
         }
         return transport.setZigBeeChannel(channel);


### PR DESCRIPTION
This prevents an invalid channel being set which can cause the dongle to hang. Refactored the ZigBeeNetworkManagerImpl class to inject the CommandInterface to make it more testable, and added tests.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>