### PR TITLE
Remove MeshMonitor instantiation from NetworkManager

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
@@ -18,7 +18,6 @@ import org.slf4j.LoggerFactory;
 
 import com.zsmartsystems.zigbee.internal.NotificationService;
 import com.zsmartsystems.zigbee.internal.ZigBeeNetworkDiscoverer;
-import com.zsmartsystems.zigbee.internal.ZigBeeNetworkMeshMonitor;
 import com.zsmartsystems.zigbee.serialization.ZigBeeDeserializer;
 import com.zsmartsystems.zigbee.serialization.ZigBeeSerializer;
 import com.zsmartsystems.zigbee.transport.ZigBeeTransportReceive;
@@ -149,13 +148,6 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
     private final ZigBeeNetworkDiscoverer networkDiscoverer;
 
     /**
-     * The ZigBee network {@link ZigBeeNetworkMeshMonitor} update class. The updater is
-     * responsible for periodic update of information relating to the mesh health
-     * including neighbors, routes and link quality information
-     */
-    private final ZigBeeNetworkMeshMonitor meshUpdater;
-
-    /**
      * The command listener creation times. Used to timeout queued commands.
      */
     private final Set<CommandExecution> commandExecutions = new HashSet<CommandExecution>();
@@ -207,7 +199,6 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
     public ZigBeeNetworkManager(final ZigBeeTransportTransmit transport) {
         this.transport = transport;
         this.networkDiscoverer = new ZigBeeNetworkDiscoverer(this);
-        this.meshUpdater = new ZigBeeNetworkMeshMonitor(this);
 
         transport.setZigBeeTransportReceive(this);
     }
@@ -372,10 +363,6 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
 
         if (networkDiscoverer != null) {
             networkDiscoverer.startup();
-        }
-
-        if (meshUpdater != null) {
-            meshUpdater.startup(60);
         }
 
         return true;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkMeshMonitor.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkMeshMonitor.java
@@ -1,4 +1,4 @@
-package com.zsmartsystems.zigbee.internal;
+package com.zsmartsystems.zigbee;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -16,13 +16,6 @@ import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.zsmartsystems.zigbee.Command;
-import com.zsmartsystems.zigbee.CommandListener;
-import com.zsmartsystems.zigbee.CommandResult;
-import com.zsmartsystems.zigbee.ZigBeeDeviceAddress;
-import com.zsmartsystems.zigbee.ZigBeeDeviceStatus;
-import com.zsmartsystems.zigbee.ZigBeeNetworkManager;
-import com.zsmartsystems.zigbee.ZigBeeNode;
 import com.zsmartsystems.zigbee.zdo.ZdoStatus;
 import com.zsmartsystems.zigbee.zdo.command.DeviceAnnounce;
 import com.zsmartsystems.zigbee.zdo.command.IeeeAddressRequest;


### PR DESCRIPTION
This makes it the responsibility of the application to instantiate this if desired, and to set the rate etc.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>