### PR TITLE
Initialise channel mask

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/structure/EzspChannelMask.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/structure/EzspChannelMask.java
@@ -4,8 +4,10 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Provides a list of channel mask values used for channel scans. <br>
- * The 868MHz frequency band has only one channel and is used in Europe with a data rate of 20kbps. <br>
+ * Provides a list of channel mask values used for channel scans.
+ * <p>
+ * The 868MHz frequency band has only one channel and is used in Europe with a data rate of 20kbps.
+ * <p>
  * The 915MHz frequency band band has 10 channels ranging from channel-1 to channel-10. It delivers data rate of 40 Kbps
  * and used in Americas.
  * The 2.4GHz frequency band is used worldwide and has total of 16 channels from channel-11 to channel-26 delivering a
@@ -39,7 +41,7 @@ import java.util.Map;
  * <li>channel-25 2475 MHz
  * <li>channel-26 2480 MHz
  * </ol>
- * 
+ *
  * @author Chris Jackson
  *
  */

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/EmberNetworkInitialisation.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/EmberNetworkInitialisation.java
@@ -113,6 +113,11 @@ public class EmberNetworkInitialisation {
             networkParameters.setRadioChannel(quietestChannel);
         }
 
+        // If the channel set is empty, use the single channel defined above
+        if (networkParameters.getChannels() == 0) {
+            networkParameters.setChannels(1 << networkParameters.getRadioChannel());
+        }
+
         // Initialise security
         setSecurityState(networkKey);
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzspTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzspTest.java
@@ -1,4 +1,4 @@
-package com.zsmartsystems.zigbee.dongle;
+package com.zsmartsystems.zigbee.dongle.ember;
 
 import static org.junit.Assert.assertEquals;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/structure/EzspChannelMaskTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/structure/EzspChannelMaskTest.java
@@ -1,0 +1,17 @@
+package com.zsmartsystems.zigbee.dongle.ember.ezsp.structure;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+/**
+ *
+ * @author Chris Jackson
+ *
+ */
+public class EzspChannelMaskTest {
+    @Test
+    public void testMask() {
+        assertEquals(EzspChannelMask.EZSP_CHANNEL_MASK_CHAN18, EzspChannelMask.getEzspChannelMask(1 << 18));
+    }
+}


### PR DESCRIPTION
If channel mask is not set when forming a network, then set it using the radio channel.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>