### PR TITLE
Update EmberOutgoingMessageType

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/structure/EmberOutgoingMessageType.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/structure/EmberOutgoingMessageType.java
@@ -45,10 +45,22 @@ public enum EmberOutgoingMessageType {
     EMBER_OUTGOING_MULTICAST(0x0003),
 
     /**
+     * Aliased multicast message.  This value is passed to emberMessageSentHandler() only. It may
+     * not be passed to emberSendUnicast().
+     */
+    EMBER_OUTGOING_MULTICAST_WITH_ALIAS(0x0004),
+
+    /**
+     * Aliased broadcast message.  This value is passed to emberMessageSentHandler() only. It may
+     * not be passed to emberSendUnicast().
+     */
+    EMBER_OUTGOING_BROADCAST_WITH_ALIAS(0x0005),
+
+    /**
      * Broadcast message. This value is passed to emberMessageSentHandler() only. It may not be
      * passed to emberSendUnicast().
      */
-    EMBER_OUTGOING_BROADCAST(0x0004);
+    EMBER_OUTGOING_BROADCAST(0x0006);
 
     /**
      * A mapping between the integer code and its corresponding type to


### PR DESCRIPTION
Updated EmberOutgoingMessageType - note that this is now inconsistent with the ember documentation but is as described [here](http://community.silabs.com/t5/Mesh/Undocumented-value-in-messageSentHandler/m-p/211707/highlight/false#M2552).
Signed-off-by: Chris Jackson <chris@cd-jackson.com>