### PR TITLE
Rewrite Ember Frame Handler and add tests

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
@@ -162,9 +162,10 @@ public class ZigBeeDongleEzsp implements ZigBeeTransportTransmit, EzspFrameHandl
             logger.error("Unable to open Ember serial port");
             return ZigBeeInitializeResponse.FAILED;
         }
-        ashHandler = new AshFrameHandler(serialPort.getInputStream(), serialPort.getOutputStream(), this);
+        ashHandler = new AshFrameHandler(this);
 
         // Connect to the ASH handler and NCP
+        ashHandler.start(serialPort.getInputStream(), serialPort.getOutputStream());
         ashHandler.connect();
 
         // We MUST send the version command first.

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ash/AshFrame.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ash/AshFrame.java
@@ -152,9 +152,9 @@ public class AshFrame {
         }
     }
 
-    public static AshFrame createFromInput(int[] buffer, int length) {
+    public static AshFrame createFromInput(int[] buffer) {
         // A frame must be at least 3 bytes long
-        if (length < 3) {
+        if (buffer.length < 3) {
             return null;
         }
 
@@ -162,8 +162,7 @@ public class AshFrame {
         int[] unstuffedData = new int[131];
         int outLength = 0;
         boolean escape = false;
-        for (int cnt = 0; cnt < length; cnt++) {
-            int data = buffer[cnt];
+        for (int data : buffer) {
             if (escape) {
                 escape = false;
                 if ((data & 0x20) == 0) {

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/ash/AshFrameHandlerTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/ash/AshFrameHandlerTest.java
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) 2016-2017 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.dongle.ember.ash;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import org.junit.Test;
+
+/**
+ *
+ * @author Chris Jackson
+ *
+ */
+public class AshFrameHandlerTest {
+
+    private int[] getPacket(int[] data) {
+        AshFrameHandler frameHandler = new AshFrameHandler(null);
+        byte[] bytedata = new byte[data.length];
+        int cnt = 0;
+        for (int value : data) {
+            bytedata[cnt++] = (byte) value;
+        }
+        ByteArrayInputStream stream = new ByteArrayInputStream(bytedata);
+
+        Method privateMethod;
+        try {
+            privateMethod = AshFrameHandler.class.getDeclaredMethod("getPacket", new Class[] { InputStream.class });
+            privateMethod.setAccessible(true);
+
+            return (int[]) privateMethod.invoke(frameHandler, stream);
+        } catch (NoSuchMethodException | SecurityException | IllegalArgumentException | IllegalAccessException
+                | InvocationTargetException e) {
+            // TODO Auto-generated catch block
+            e.printStackTrace();
+        }
+
+        return null;
+    }
+
+    @Test
+    public void testReceivePacket() {
+        int[] response = getPacket(new int[] { 0x01, 0x02, 0x03, 0x04, 0x7E });
+        assertNotNull(response);
+        assertEquals(4, response.length);
+        assertEquals(0x01, response[0]);
+    }
+
+    @Test
+    public void testReceivePacket_FlagStart() {
+        int[] response = getPacket(new int[] { 0x7E, 0x01, 0x02, 0x03, 0x04, 0x7E });
+        assertNotNull(response);
+        assertEquals(4, response.length);
+        assertEquals(0x01, response[0]);
+    }
+
+    @Test
+    public void testReceivePacket_IgnoreXonXoff() {
+        int[] response = getPacket(new int[] { 0x7E, 0x01, 0x02, 0x11, 0x03, 0x13, 0x04, 0x7E });
+        assertNotNull(response);
+        assertEquals(4, response.length);
+        assertEquals(0x01, response[0]);
+    }
+
+    @Test
+    public void testReceivePacket_Cancel() {
+        int[] response = getPacket(new int[] { 0x7E, 0x01, 0x02, 0x1A, 0x03, 0x04, 0x05, 0x06, 0x07, 0x7E });
+        assertNotNull(response);
+        assertEquals(5, response.length);
+        assertEquals(0x03, response[0]);
+    }
+
+    @Test
+    public void testReceivePacket_Substitute() {
+        int[] response = getPacket(new int[] { 0x7E, 0x01, 0x02, 0x18, 0x03, 0x04, 0x7E, 0x05, 0x06, 0x07, 0x7E });
+        assertNotNull(response);
+        assertEquals(3, response.length);
+        assertEquals(0x05, response[0]);
+    }
+
+    @Test
+    public void testRunning() {
+        AshFrameHandler frameHandler = new AshFrameHandler(null);
+        frameHandler.start(null, null);
+
+        assertTrue(frameHandler.isAlive());
+        frameHandler.close();
+        assertFalse(frameHandler.isAlive());
+    }
+
+}

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/ash/AshFrameTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/ash/AshFrameTest.java
@@ -7,12 +7,11 @@
  */
 package com.zsmartsystems.zigbee.dongle.ember.ash;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
-
-import com.zsmartsystems.zigbee.dongle.ember.ash.AshFrame;
-import com.zsmartsystems.zigbee.dongle.ember.ash.AshFrameData;
 
 public class AshFrameTest {
 
@@ -20,7 +19,7 @@ public class AshFrameTest {
     public void TestPacket_DataStuffed() {
         int[] buffer = new int[] { 0x7d, 0x3a, 0x43, 0xa1, 0xfa, 0x54, 0x0a, 0x15, 0xc9, 0x89 };
 
-        final AshFrame packet = AshFrame.createFromInput(buffer, buffer.length);
+        final AshFrame packet = AshFrame.createFromInput(buffer);
         assertNotNull(packet);
         assertTrue(packet instanceof AshFrameData);
 


### PR DESCRIPTION
This addresses #76. It rewrites the handler to allow testing and adds support for additional special characters in the ASH protocol.

@cschwer feel free to give this a try and see if it addresses your issue.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>