### PR TITLE
Refactor zdo.descriptor package to zdo.field to provide consistency between ZDO and ZCL

### DIFF
--- a/com.zsmartsystems.zigbee.autocode/src/main/java/com/zsmartsystems/zigbee/autocode/ZclProtocolCodeGenerator.java
+++ b/com.zsmartsystems.zigbee.autocode/src/main/java/com/zsmartsystems/zigbee/autocode/ZclProtocolCodeGenerator.java
@@ -43,9 +43,10 @@ public class ZclProtocolCodeGenerator {
     static String packageZclProtocolCommand = packageZclCluster;
 
     static String packageZdp = ".zdo";
+    static String packageZdpField = packageZdp + ".field";
     static String packageZdpCommand = packageZdp + ".command";
     static String packageZdpTransaction = packageZdp + ".transaction";
-    static String packageZdpDescriptors = packageZdp + ".descriptors";
+    static String packageZdpDescriptors = packageZdpField;
 
     /**
      * The main method for running the code generator.
@@ -1784,7 +1785,10 @@ public class ZclProtocolCodeGenerator {
                                 out.println("import " + packageRootPrefix + packageZdp + ".ZdoStatus;");
                                 continue;
                             case "BindingTable":
-                                out.println("import " + packageRootPrefix + packageZclField + ".BindingTable;");
+                                out.println("import " + packageRootPrefix + packageZdpField + ".BindingTable;");
+                                continue;
+                            case "NeighborTable":
+                                out.println("import " + packageRootPrefix + packageZdpField + ".NeighborTable;");
                                 continue;
                         }
 

--- a/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsole.java
+++ b/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsole.java
@@ -45,8 +45,8 @@ import com.zsmartsystems.zigbee.zcl.clusters.general.WriteAttributesResponse;
 import com.zsmartsystems.zigbee.zcl.clusters.groups.GetGroupMembershipResponse;
 import com.zsmartsystems.zigbee.zcl.clusters.groups.ViewGroupResponse;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
-import com.zsmartsystems.zigbee.zdo.descriptors.NeighborTable;
-import com.zsmartsystems.zigbee.zdo.descriptors.RoutingTable;
+import com.zsmartsystems.zigbee.zdo.field.NeighborTable;
+import com.zsmartsystems.zigbee.zdo.field.RoutingTable;
 
 /**
  * ZigBee command line console is an example usage of simple ZigBee API.

--- a/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeNetworkStateSerializerImpl.java
+++ b/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeNetworkStateSerializerImpl.java
@@ -32,10 +32,10 @@ import com.zsmartsystems.zigbee.ZigBeeNetworkStateSerializer;
 import com.zsmartsystems.zigbee.ZigBeeNode;
 import com.zsmartsystems.zigbee.dao.ZigBeeDeviceDao;
 import com.zsmartsystems.zigbee.dao.ZigBeeNodeDao;
-import com.zsmartsystems.zigbee.zdo.descriptors.NodeDescriptor.FrequencyBandType;
-import com.zsmartsystems.zigbee.zdo.descriptors.NodeDescriptor.MacCapabilitiesType;
-import com.zsmartsystems.zigbee.zdo.descriptors.NodeDescriptor.ServerCapabilitiesType;
-import com.zsmartsystems.zigbee.zdo.descriptors.PowerDescriptor.PowerSourceType;
+import com.zsmartsystems.zigbee.zdo.field.NodeDescriptor.FrequencyBandType;
+import com.zsmartsystems.zigbee.zdo.field.NodeDescriptor.MacCapabilitiesType;
+import com.zsmartsystems.zigbee.zdo.field.NodeDescriptor.ServerCapabilitiesType;
+import com.zsmartsystems.zigbee.zdo.field.PowerDescriptor.PowerSourceType;
 
 /**
  * Serializes and deserializes the ZigBee network state.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkMeshMonitor.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkMeshMonitor.java
@@ -32,9 +32,9 @@ import com.zsmartsystems.zigbee.zdo.command.ManagementLqiRequest;
 import com.zsmartsystems.zigbee.zdo.command.ManagementLqiResponse;
 import com.zsmartsystems.zigbee.zdo.command.ManagementRoutingRequest;
 import com.zsmartsystems.zigbee.zdo.command.ManagementRoutingResponse;
-import com.zsmartsystems.zigbee.zdo.descriptors.NeighborTable;
-import com.zsmartsystems.zigbee.zdo.descriptors.NeighborTable.NeighborTableJoining;
-import com.zsmartsystems.zigbee.zdo.descriptors.RoutingTable;
+import com.zsmartsystems.zigbee.zdo.field.NeighborTable;
+import com.zsmartsystems.zigbee.zdo.field.RoutingTable;
+import com.zsmartsystems.zigbee.zdo.field.NeighborTable.NeighborTableJoining;
 
 /**
  * {@link ZigBeeNetworkMeshMonitor} is used to walk through the network getting information about the mesh network.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNode.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNode.java
@@ -14,13 +14,13 @@ import java.util.List;
 import com.zsmartsystems.zigbee.zdo.ZdoResponseMatcher;
 import com.zsmartsystems.zigbee.zdo.command.ManagementBindRequest;
 import com.zsmartsystems.zigbee.zdo.command.ManagementPermitJoiningRequest;
-import com.zsmartsystems.zigbee.zdo.descriptors.NeighborTable;
-import com.zsmartsystems.zigbee.zdo.descriptors.NodeDescriptor;
-import com.zsmartsystems.zigbee.zdo.descriptors.NodeDescriptor.LogicalType;
-import com.zsmartsystems.zigbee.zdo.descriptors.NodeDescriptor.MacCapabilitiesType;
-import com.zsmartsystems.zigbee.zdo.descriptors.NodeDescriptor.ServerCapabilitiesType;
-import com.zsmartsystems.zigbee.zdo.descriptors.PowerDescriptor;
-import com.zsmartsystems.zigbee.zdo.descriptors.RoutingTable;
+import com.zsmartsystems.zigbee.zdo.field.NeighborTable;
+import com.zsmartsystems.zigbee.zdo.field.NodeDescriptor;
+import com.zsmartsystems.zigbee.zdo.field.PowerDescriptor;
+import com.zsmartsystems.zigbee.zdo.field.RoutingTable;
+import com.zsmartsystems.zigbee.zdo.field.NodeDescriptor.LogicalType;
+import com.zsmartsystems.zigbee.zdo.field.NodeDescriptor.MacCapabilitiesType;
+import com.zsmartsystems.zigbee.zdo.field.NodeDescriptor.ServerCapabilitiesType;
 
 /**
  * Defines a ZigBee Node. A node is a physical entity on the network and will

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/dao/ZigBeeNodeDao.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/dao/ZigBeeNodeDao.java
@@ -10,8 +10,8 @@ package com.zsmartsystems.zigbee.dao;
 import com.zsmartsystems.zigbee.IeeeAddress;
 import com.zsmartsystems.zigbee.ZigBeeNetworkManager;
 import com.zsmartsystems.zigbee.ZigBeeNode;
-import com.zsmartsystems.zigbee.zdo.descriptors.NodeDescriptor;
-import com.zsmartsystems.zigbee.zdo.descriptors.PowerDescriptor;
+import com.zsmartsystems.zigbee.zdo.field.NodeDescriptor;
+import com.zsmartsystems.zigbee.zdo.field.PowerDescriptor;
 
 /**
  *

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/internal/ZigBeeNetworkDiscoverer.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/internal/ZigBeeNetworkDiscoverer.java
@@ -42,7 +42,7 @@ import com.zsmartsystems.zigbee.zdo.command.PowerDescriptorRequest;
 import com.zsmartsystems.zigbee.zdo.command.PowerDescriptorResponse;
 import com.zsmartsystems.zigbee.zdo.command.SimpleDescriptorRequest;
 import com.zsmartsystems.zigbee.zdo.command.SimpleDescriptorResponse;
-import com.zsmartsystems.zigbee.zdo.descriptors.SimpleDescriptor;
+import com.zsmartsystems.zigbee.zdo.field.SimpleDescriptor;
 
 /**
  * {@link ZigBeeNetworkDiscoverer} is used to discover devices in the network.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/serialization/DefaultDeserializer.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/serialization/DefaultDeserializer.java
@@ -15,11 +15,11 @@ import com.zsmartsystems.zigbee.IeeeAddress;
 import com.zsmartsystems.zigbee.zcl.ZclStatus;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 import com.zsmartsystems.zigbee.zdo.ZdoStatus;
-import com.zsmartsystems.zigbee.zdo.descriptors.NeighborTable;
-import com.zsmartsystems.zigbee.zdo.descriptors.NodeDescriptor;
-import com.zsmartsystems.zigbee.zdo.descriptors.PowerDescriptor;
-import com.zsmartsystems.zigbee.zdo.descriptors.RoutingTable;
-import com.zsmartsystems.zigbee.zdo.descriptors.SimpleDescriptor;
+import com.zsmartsystems.zigbee.zdo.field.NeighborTable;
+import com.zsmartsystems.zigbee.zdo.field.NodeDescriptor;
+import com.zsmartsystems.zigbee.zdo.field.PowerDescriptor;
+import com.zsmartsystems.zigbee.zdo.field.RoutingTable;
+import com.zsmartsystems.zigbee.zdo.field.SimpleDescriptor;
 
 /**
  * The default implementation of the {@link ZigBeeDeserializer}

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/protocol/ZclDataType.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/protocol/ZclDataType.java
@@ -13,7 +13,7 @@ import java.util.Map;
 import com.zsmartsystems.zigbee.zcl.field.*;
 import com.zsmartsystems.zigbee.zcl.ZclStatus;
 import com.zsmartsystems.zigbee.zdo.ZdoStatus;
-import com.zsmartsystems.zigbee.zdo.descriptors.*;
+import com.zsmartsystems.zigbee.zdo.field.*;
 import com.zsmartsystems.zigbee.IeeeAddress;
 import com.zsmartsystems.zigbee.ExtendedPanId;
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/BindRegisterResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/BindRegisterResponse.java
@@ -15,7 +15,7 @@ import com.zsmartsystems.zigbee.zdo.ZdoResponse;
 import java.util.List;
 import java.util.ArrayList;
 import com.zsmartsystems.zigbee.zdo.ZdoStatus;
-import com.zsmartsystems.zigbee.zcl.field.BindingTable;
+import com.zsmartsystems.zigbee.zdo.field.BindingTable;
 
 /**
  * Bind Register Response value object class.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ComplexDescriptorResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ComplexDescriptorResponse.java
@@ -12,7 +12,7 @@ import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 import com.zsmartsystems.zigbee.zdo.ZdoResponse;
 import com.zsmartsystems.zigbee.zdo.ZdoStatus;
-import com.zsmartsystems.zigbee.zdo.descriptors.ComplexDescriptor;
+import com.zsmartsystems.zigbee.zdo.field.ComplexDescriptor;
 
 /**
  * Complex Descriptor Response value object class.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ManagementBindResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ManagementBindResponse.java
@@ -15,7 +15,7 @@ import com.zsmartsystems.zigbee.zdo.ZdoResponse;
 import java.util.List;
 import java.util.ArrayList;
 import com.zsmartsystems.zigbee.zdo.ZdoStatus;
-import com.zsmartsystems.zigbee.zcl.field.BindingTable;
+import com.zsmartsystems.zigbee.zdo.field.BindingTable;
 
 /**
  * Management Bind Response value object class.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ManagementLqiResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ManagementLqiResponse.java
@@ -15,7 +15,7 @@ import com.zsmartsystems.zigbee.zdo.ZdoResponse;
 import java.util.List;
 import java.util.ArrayList;
 import com.zsmartsystems.zigbee.zdo.ZdoStatus;
-import com.zsmartsystems.zigbee.zdo.descriptors.NeighborTable;
+import com.zsmartsystems.zigbee.zdo.field.NeighborTable;
 
 /**
  * Management LQI Response value object class.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ManagementRoutingResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ManagementRoutingResponse.java
@@ -15,7 +15,7 @@ import com.zsmartsystems.zigbee.zdo.ZdoResponse;
 import java.util.List;
 import java.util.ArrayList;
 import com.zsmartsystems.zigbee.zdo.ZdoStatus;
-import com.zsmartsystems.zigbee.zdo.descriptors.RoutingTable;
+import com.zsmartsystems.zigbee.zdo.field.RoutingTable;
 
 /**
  * Management Routing Response value object class.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/NodeDescriptorResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/NodeDescriptorResponse.java
@@ -12,7 +12,7 @@ import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 import com.zsmartsystems.zigbee.zdo.ZdoResponse;
 import com.zsmartsystems.zigbee.zdo.ZdoStatus;
-import com.zsmartsystems.zigbee.zdo.descriptors.NodeDescriptor;
+import com.zsmartsystems.zigbee.zdo.field.NodeDescriptor;
 
 /**
  * Node Descriptor Response value object class.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/PowerDescriptorResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/PowerDescriptorResponse.java
@@ -12,7 +12,7 @@ import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 import com.zsmartsystems.zigbee.zdo.ZdoResponse;
 import com.zsmartsystems.zigbee.zdo.ZdoStatus;
-import com.zsmartsystems.zigbee.zdo.descriptors.PowerDescriptor;
+import com.zsmartsystems.zigbee.zdo.field.PowerDescriptor;
 
 /**
  * Power Descriptor Response value object class.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/SimpleDescriptorResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/SimpleDescriptorResponse.java
@@ -12,7 +12,7 @@ import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 import com.zsmartsystems.zigbee.zdo.ZdoResponse;
 import com.zsmartsystems.zigbee.zdo.ZdoStatus;
-import com.zsmartsystems.zigbee.zdo.descriptors.SimpleDescriptor;
+import com.zsmartsystems.zigbee.zdo.field.SimpleDescriptor;
 
 /**
  * Simple Descriptor Response value object class.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/UserDescriptorResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/UserDescriptorResponse.java
@@ -12,7 +12,7 @@ import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 import com.zsmartsystems.zigbee.zdo.ZdoResponse;
 import com.zsmartsystems.zigbee.zdo.ZdoStatus;
-import com.zsmartsystems.zigbee.zdo.descriptors.UserDescriptor;
+import com.zsmartsystems.zigbee.zdo.field.UserDescriptor;
 
 /**
  * User Descriptor Response value object class.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/field/BindingTable.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/field/BindingTable.java
@@ -5,7 +5,7 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  */
-package com.zsmartsystems.zigbee.zcl.field;
+package com.zsmartsystems.zigbee.zdo.field;
 
 import com.zsmartsystems.zigbee.serialization.ZigBeeDeserializer;
 import com.zsmartsystems.zigbee.serialization.ZigBeeSerializer;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/field/ComplexDescriptor.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/field/ComplexDescriptor.java
@@ -5,7 +5,7 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  */
-package com.zsmartsystems.zigbee.zdo.descriptors;
+package com.zsmartsystems.zigbee.zdo.field;
 
 /**
  * Complex Descriptor

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/field/NeighborTable.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/field/NeighborTable.java
@@ -5,7 +5,7 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  */
-package com.zsmartsystems.zigbee.zdo.descriptors;
+package com.zsmartsystems.zigbee.zdo.field;
 
 import java.util.Objects;
 
@@ -13,7 +13,7 @@ import com.zsmartsystems.zigbee.ExtendedPanId;
 import com.zsmartsystems.zigbee.IeeeAddress;
 import com.zsmartsystems.zigbee.serialization.ZigBeeDeserializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
-import com.zsmartsystems.zigbee.zdo.descriptors.NodeDescriptor.LogicalType;
+import com.zsmartsystems.zigbee.zdo.field.NodeDescriptor.LogicalType;
 
 /**
  * Class representing the ZigBee neighbor table

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/field/NodeDescriptor.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/field/NodeDescriptor.java
@@ -5,7 +5,7 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  */
-package com.zsmartsystems.zigbee.zdo.descriptors;
+package com.zsmartsystems.zigbee.zdo.field;
 
 import java.util.HashSet;
 import java.util.Set;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/field/PowerDescriptor.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/field/PowerDescriptor.java
@@ -5,7 +5,7 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  */
-package com.zsmartsystems.zigbee.zdo.descriptors;
+package com.zsmartsystems.zigbee.zdo.field;
 
 import java.util.HashSet;
 import java.util.Set;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/field/RoutingTable.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/field/RoutingTable.java
@@ -5,7 +5,7 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  */
-package com.zsmartsystems.zigbee.zdo.descriptors;
+package com.zsmartsystems.zigbee.zdo.field;
 
 import java.util.Objects;
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/field/SimpleDescriptor.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/field/SimpleDescriptor.java
@@ -5,7 +5,7 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  */
-package com.zsmartsystems.zigbee.zdo.descriptors;
+package com.zsmartsystems.zigbee.zdo.field;
 
 import java.util.List;
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/field/UserDescriptor.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/field/UserDescriptor.java
@@ -5,7 +5,7 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  */
-package com.zsmartsystems.zigbee.zdo.descriptors;
+package com.zsmartsystems.zigbee.zdo.field;
 
 /**
  * Simple Descriptor

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeNodeTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeNodeTest.java
@@ -19,15 +19,15 @@ import java.util.List;
 
 import org.junit.Test;
 
-import com.zsmartsystems.zigbee.zdo.descriptors.NeighborTable;
-import com.zsmartsystems.zigbee.zdo.descriptors.NodeDescriptor;
-import com.zsmartsystems.zigbee.zdo.descriptors.NodeDescriptor.LogicalType;
-import com.zsmartsystems.zigbee.zdo.descriptors.PowerDescriptor;
-import com.zsmartsystems.zigbee.zdo.descriptors.PowerDescriptor.CurrentPowerModeType;
-import com.zsmartsystems.zigbee.zdo.descriptors.PowerDescriptor.PowerLevelType;
-import com.zsmartsystems.zigbee.zdo.descriptors.PowerDescriptor.PowerSourceType;
-import com.zsmartsystems.zigbee.zdo.descriptors.RoutingTable;
-import com.zsmartsystems.zigbee.zdo.descriptors.RoutingTable.DiscoveryState;
+import com.zsmartsystems.zigbee.zdo.field.NeighborTable;
+import com.zsmartsystems.zigbee.zdo.field.NodeDescriptor;
+import com.zsmartsystems.zigbee.zdo.field.PowerDescriptor;
+import com.zsmartsystems.zigbee.zdo.field.RoutingTable;
+import com.zsmartsystems.zigbee.zdo.field.NodeDescriptor.LogicalType;
+import com.zsmartsystems.zigbee.zdo.field.PowerDescriptor.CurrentPowerModeType;
+import com.zsmartsystems.zigbee.zdo.field.PowerDescriptor.PowerLevelType;
+import com.zsmartsystems.zigbee.zdo.field.PowerDescriptor.PowerSourceType;
+import com.zsmartsystems.zigbee.zdo.field.RoutingTable.DiscoveryState;
 
 public class ZigBeeNodeTest {
     @Test

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zdo/command/ManagementLqiResponseTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zdo/command/ManagementLqiResponseTest.java
@@ -17,11 +17,11 @@ import com.zsmartsystems.zigbee.CommandTest;
 import com.zsmartsystems.zigbee.IeeeAddress;
 import com.zsmartsystems.zigbee.serialization.DefaultDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
-import com.zsmartsystems.zigbee.zdo.descriptors.NeighborTable;
-import com.zsmartsystems.zigbee.zdo.descriptors.NeighborTable.NeighborTableJoining;
-import com.zsmartsystems.zigbee.zdo.descriptors.NeighborTable.NeighborTableRelationship;
-import com.zsmartsystems.zigbee.zdo.descriptors.NeighborTable.NeighborTableRxState;
-import com.zsmartsystems.zigbee.zdo.descriptors.NodeDescriptor.LogicalType;
+import com.zsmartsystems.zigbee.zdo.field.NeighborTable;
+import com.zsmartsystems.zigbee.zdo.field.NeighborTable.NeighborTableJoining;
+import com.zsmartsystems.zigbee.zdo.field.NeighborTable.NeighborTableRelationship;
+import com.zsmartsystems.zigbee.zdo.field.NeighborTable.NeighborTableRxState;
+import com.zsmartsystems.zigbee.zdo.field.NodeDescriptor.LogicalType;
 
 /**
  *

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zdo/command/ManagementRoutingResponseTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zdo/command/ManagementRoutingResponseTest.java
@@ -16,8 +16,8 @@ import org.junit.Test;
 import com.zsmartsystems.zigbee.CommandTest;
 import com.zsmartsystems.zigbee.serialization.DefaultDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
-import com.zsmartsystems.zigbee.zdo.descriptors.RoutingTable;
-import com.zsmartsystems.zigbee.zdo.descriptors.RoutingTable.DiscoveryState;
+import com.zsmartsystems.zigbee.zdo.field.RoutingTable;
+import com.zsmartsystems.zigbee.zdo.field.RoutingTable.DiscoveryState;
 
 /**
  *

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zdo/command/NodeDescriptorResponseTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zdo/command/NodeDescriptorResponseTest.java
@@ -14,7 +14,7 @@ import org.junit.Test;
 import com.zsmartsystems.zigbee.CommandTest;
 import com.zsmartsystems.zigbee.serialization.DefaultDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
-import com.zsmartsystems.zigbee.zdo.descriptors.NodeDescriptor;
+import com.zsmartsystems.zigbee.zdo.field.NodeDescriptor;
 
 /**
  *

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zdo/command/PowerDescriptorResponseTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zdo/command/PowerDescriptorResponseTest.java
@@ -15,10 +15,10 @@ import com.zsmartsystems.zigbee.CommandTest;
 import com.zsmartsystems.zigbee.serialization.DefaultDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zdo.ZdoStatus;
-import com.zsmartsystems.zigbee.zdo.descriptors.PowerDescriptor;
-import com.zsmartsystems.zigbee.zdo.descriptors.PowerDescriptor.CurrentPowerModeType;
-import com.zsmartsystems.zigbee.zdo.descriptors.PowerDescriptor.PowerLevelType;
-import com.zsmartsystems.zigbee.zdo.descriptors.PowerDescriptor.PowerSourceType;
+import com.zsmartsystems.zigbee.zdo.field.PowerDescriptor;
+import com.zsmartsystems.zigbee.zdo.field.PowerDescriptor.CurrentPowerModeType;
+import com.zsmartsystems.zigbee.zdo.field.PowerDescriptor.PowerLevelType;
+import com.zsmartsystems.zigbee.zdo.field.PowerDescriptor.PowerSourceType;
 
 /**
  *

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zdo/command/SimpleDescriptorResponseTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zdo/command/SimpleDescriptorResponseTest.java
@@ -17,7 +17,7 @@ import com.zsmartsystems.zigbee.CommandTest;
 import com.zsmartsystems.zigbee.serialization.DefaultDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zdo.ZdoStatus;
-import com.zsmartsystems.zigbee.zdo.descriptors.SimpleDescriptor;
+import com.zsmartsystems.zigbee.zdo.field.SimpleDescriptor;
 
 /**
  *

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zdo/descriptors/NeighborTableTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zdo/descriptors/NeighborTableTest.java
@@ -20,10 +20,11 @@ import com.zsmartsystems.zigbee.CommandTest;
 import com.zsmartsystems.zigbee.ExtendedPanId;
 import com.zsmartsystems.zigbee.IeeeAddress;
 import com.zsmartsystems.zigbee.serialization.DefaultDeserializer;
-import com.zsmartsystems.zigbee.zdo.descriptors.NeighborTable.NeighborTableJoining;
-import com.zsmartsystems.zigbee.zdo.descriptors.NeighborTable.NeighborTableRelationship;
-import com.zsmartsystems.zigbee.zdo.descriptors.NeighborTable.NeighborTableRxState;
-import com.zsmartsystems.zigbee.zdo.descriptors.NodeDescriptor.LogicalType;
+import com.zsmartsystems.zigbee.zdo.field.NeighborTable;
+import com.zsmartsystems.zigbee.zdo.field.NeighborTable.NeighborTableJoining;
+import com.zsmartsystems.zigbee.zdo.field.NeighborTable.NeighborTableRelationship;
+import com.zsmartsystems.zigbee.zdo.field.NeighborTable.NeighborTableRxState;
+import com.zsmartsystems.zigbee.zdo.field.NodeDescriptor.LogicalType;
 
 /**
  *

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zdo/descriptors/NodeDescriptorTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zdo/descriptors/NodeDescriptorTest.java
@@ -14,10 +14,11 @@ import org.junit.Test;
 
 import com.zsmartsystems.zigbee.CommandTest;
 import com.zsmartsystems.zigbee.serialization.DefaultDeserializer;
-import com.zsmartsystems.zigbee.zdo.descriptors.NodeDescriptor.FrequencyBandType;
-import com.zsmartsystems.zigbee.zdo.descriptors.NodeDescriptor.LogicalType;
-import com.zsmartsystems.zigbee.zdo.descriptors.NodeDescriptor.MacCapabilitiesType;
-import com.zsmartsystems.zigbee.zdo.descriptors.NodeDescriptor.ServerCapabilitiesType;
+import com.zsmartsystems.zigbee.zdo.field.NodeDescriptor;
+import com.zsmartsystems.zigbee.zdo.field.NodeDescriptor.FrequencyBandType;
+import com.zsmartsystems.zigbee.zdo.field.NodeDescriptor.LogicalType;
+import com.zsmartsystems.zigbee.zdo.field.NodeDescriptor.MacCapabilitiesType;
+import com.zsmartsystems.zigbee.zdo.field.NodeDescriptor.ServerCapabilitiesType;
 
 /**
  *


### PR DESCRIPTION
This provides a common structure between ZDO and ZCL packages and allows all ZDO structures to be placed into the ```fields``` package. Previously this was named ```descriptors``` but it now contains more than just descriptors.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>