### PR TITLE
Remember Telegesis network settings

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.telegesis/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/ZigBeeDongleTelegesis.java
+++ b/com.zsmartsystems.zigbee.dongle.telegesis/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/ZigBeeDongleTelegesis.java
@@ -361,6 +361,10 @@ public class ZigBeeDongleTelegesis implements ZigBeeTransportTransmit, Telegesis
             return false;
         }
 
+        radioChannel = networkInfo.getChannel();
+        panId = networkInfo.getPanId();
+        extendedPanId = networkInfo.getEpanId();
+
         zigbeeTransportReceive.setNetworkState(ZigBeeTransportState.ONLINE);
         return true;
     }

--- a/com.zsmartsystems.zigbee.dongle.telegesis/src/test/java/com/zsmartsystems/zigbee/dongle/telegesis/ZigBeeDongleTelegesisTest.java
+++ b/com.zsmartsystems.zigbee.dongle.telegesis/src/test/java/com/zsmartsystems/zigbee/dongle/telegesis/ZigBeeDongleTelegesisTest.java
@@ -21,11 +21,6 @@ import com.zsmartsystems.zigbee.ExtendedPanId;
 public class ZigBeeDongleTelegesisTest {
 
     @Test
-    public void test() {
-        ZigBeeDongleTelegesis dongle = new ZigBeeDongleTelegesis(null);
-    }
-
-    @Test
     public void setZigBeeExtendedPanId() {
         ZigBeeDongleTelegesis dongle = new ZigBeeDongleTelegesis(null);
 


### PR DESCRIPTION
Remember the network information during initialisation so that it's available later.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>