### PR TITLE
Fix handling of RSSI values that have a negative sign at the beginning

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.telegesis.autocode/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/autocode/CommandGenerator.java
+++ b/com.zsmartsystems.zigbee.dongle.telegesis.autocode/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/autocode/CommandGenerator.java
@@ -1048,7 +1048,7 @@ public class CommandGenerator extends ClassGenerator {
                 return "int[]";
             case "Dec8":
             case "Int8":
-            case "UInt8":
+            case "SInt8":
             case "Int16":
             case "Integer":
                 return "Integer";

--- a/com.zsmartsystems.zigbee.dongle.telegesis.autocode/src/main/resources/telegesis_at_protocol.xml
+++ b/com.zsmartsystems.zigbee.dongle.telegesis.autocode/src/main/resources/telegesis_at_protocol.xml
@@ -96,7 +96,7 @@
 				<description></description>
 			</parameter>
 			<parameter>
-				<data_type>UInt8</data_type>
+				<data_type>SInt8</data_type>
 				<name>rssi</name>
 				<description></description>
 				<optional>true</optional>
@@ -128,7 +128,7 @@
 				<description></description>
 			</parameter>
 			<parameter>
-				<data_type>UInt8</data_type>
+				<data_type>SInt8</data_type>
 				<name>rssi</name>
 				<description></description>
 				<optional>true</optional>
@@ -160,7 +160,7 @@
 				<description></description>
 			</parameter>
 			<parameter>
-				<data_type>UInt8</data_type>
+				<data_type>SInt8</data_type>
 				<name>rssi</name>
 				<description></description>
 				<optional>true</optional>
@@ -191,7 +191,7 @@
 				<description></description>
 			</parameter>
 			<parameter>
-				<data_type>UInt8</data_type>
+				<data_type>SInt8</data_type>
 				<name>rssi</name>
 				<description></description>
 				<optional>true</optional>
@@ -344,7 +344,7 @@
 				<description></description>
 			</parameter>
 			<parameter>
-				<data_type>UInt8</data_type>
+				<data_type>SInt8</data_type>
 				<name>rssi</name>
 				<description></description>
 				<optional>true</optional>
@@ -374,7 +374,7 @@
 				<description></description>
 			</parameter>
 			<parameter>
-				<data_type>UInt8</data_type>
+				<data_type>SInt8</data_type>
 				<name>rssi</name>
 				<description></description>
 				<optional>true</optional>
@@ -404,7 +404,7 @@
 				<description></description>
 			</parameter>
 			<parameter>
-				<data_type>UInt8</data_type>
+				<data_type>SInt8</data_type>
 				<name>rssi</name>
 				<description></description>
 				<optional>true</optional>
@@ -434,7 +434,7 @@
 				<description></description>
 			</parameter>
 			<parameter>
-				<data_type>UInt8</data_type>
+				<data_type>SInt8</data_type>
 				<name>rssi</name>
 				<description></description>
 				<optional>true</optional>
@@ -987,7 +987,7 @@
 				<description></description>
 			</parameter>
 			<parameter>
-				<data_type>UInt8</data_type>
+				<data_type>SInt8</data_type>
 				<name>rssi</name>
 				<description></description>
 				<optional>true</optional>

--- a/com.zsmartsystems.zigbee.dongle.telegesis/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/internal/protocol/TelegesisActiveScanCommand.java
+++ b/com.zsmartsystems.zigbee.dongle.telegesis/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/internal/protocol/TelegesisActiveScanCommand.java
@@ -155,7 +155,7 @@ public class TelegesisActiveScanCommand extends TelegesisFrame implements Telege
 
             // Deserialize field "rssi" [optional]
             pushDeserializer();
-            rssi = deserializeUInt8();
+            rssi = deserializeSInt8();
             if (rssi == null) {
                 popDeserializer();
             } else {

--- a/com.zsmartsystems.zigbee.dongle.telegesis/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/internal/protocol/TelegesisEndDeviceAnnounceEvent.java
+++ b/com.zsmartsystems.zigbee.dongle.telegesis/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/internal/protocol/TelegesisEndDeviceAnnounceEvent.java
@@ -92,7 +92,7 @@ public class TelegesisEndDeviceAnnounceEvent extends TelegesisFrame implements T
 
             // Deserialize field "rssi" [optional]
             pushDeserializer();
-            rssi = deserializeUInt8();
+            rssi = deserializeSInt8();
             if (rssi == null) {
                 popDeserializer();
             } else {

--- a/com.zsmartsystems.zigbee.dongle.telegesis/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/internal/protocol/TelegesisFrame.java
+++ b/com.zsmartsystems.zigbee.dongle.telegesis/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/internal/protocol/TelegesisFrame.java
@@ -190,20 +190,26 @@ public class TelegesisFrame {
     }
 
     /**
-     * Deserializes an 8 bit unsigned integer in hexadecimal
+     * Deserializes an 8 bit signed integer in hexadecimal
      *
      * @return the deserialized value
      */
-    protected Integer deserializeUInt8() {
+    protected Integer deserializeSInt8() {
         if (buffer.length < position + 2) {
             return null;
         }
 
+        boolean negate = false;
         StringBuilder builder = new StringBuilder();
+        if ((char) buffer[position] == '-') {
+            negate = true;
+            position++;
+        }
         builder.append((char) buffer[position++]);
         builder.append((char) buffer[position++]);
         try {
-            return Integer.parseInt(builder.toString(), 16) - 256;
+            Integer value = Integer.parseInt(builder.toString(), 16);
+            return negate ? (value * -1) : value;
         } catch (NumberFormatException e) {
             // Eat the exception
             return null;

--- a/com.zsmartsystems.zigbee.dongle.telegesis/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/internal/protocol/TelegesisMobileDeviceAnnounceEvent.java
+++ b/com.zsmartsystems.zigbee.dongle.telegesis/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/internal/protocol/TelegesisMobileDeviceAnnounceEvent.java
@@ -92,7 +92,7 @@ public class TelegesisMobileDeviceAnnounceEvent extends TelegesisFrame implement
 
             // Deserialize field "rssi" [optional]
             pushDeserializer();
-            rssi = deserializeUInt8();
+            rssi = deserializeSInt8();
             if (rssi == null) {
                 popDeserializer();
             } else {

--- a/com.zsmartsystems.zigbee.dongle.telegesis/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/internal/protocol/TelegesisReceiveBroadcastEvent.java
+++ b/com.zsmartsystems.zigbee.dongle.telegesis/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/internal/protocol/TelegesisReceiveBroadcastEvent.java
@@ -98,7 +98,7 @@ public class TelegesisReceiveBroadcastEvent extends TelegesisFrame implements Te
 
             // Deserialize field "rssi" [optional]
             pushDeserializer();
-            rssi = deserializeUInt8();
+            rssi = deserializeSInt8();
             if (rssi == null) {
                 popDeserializer();
             } else {

--- a/com.zsmartsystems.zigbee.dongle.telegesis/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/internal/protocol/TelegesisReceiveMessageEvent.java
+++ b/com.zsmartsystems.zigbee.dongle.telegesis/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/internal/protocol/TelegesisReceiveMessageEvent.java
@@ -183,7 +183,7 @@ public class TelegesisReceiveMessageEvent extends TelegesisFrame implements Tele
 
             // Deserialize field "rssi" [optional]
             pushDeserializer();
-            rssi = deserializeUInt8();
+            rssi = deserializeSInt8();
             if (rssi == null) {
                 popDeserializer();
             } else {

--- a/com.zsmartsystems.zigbee.dongle.telegesis/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/internal/protocol/TelegesisReceiveMulticastEvent.java
+++ b/com.zsmartsystems.zigbee.dongle.telegesis/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/internal/protocol/TelegesisReceiveMulticastEvent.java
@@ -98,7 +98,7 @@ public class TelegesisReceiveMulticastEvent extends TelegesisFrame implements Te
 
             // Deserialize field "rssi" [optional]
             pushDeserializer();
-            rssi = deserializeUInt8();
+            rssi = deserializeSInt8();
             if (rssi == null) {
                 popDeserializer();
             } else {

--- a/com.zsmartsystems.zigbee.dongle.telegesis/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/internal/protocol/TelegesisReceiveUnicastEvent.java
+++ b/com.zsmartsystems.zigbee.dongle.telegesis/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/internal/protocol/TelegesisReceiveUnicastEvent.java
@@ -97,7 +97,7 @@ public class TelegesisReceiveUnicastEvent extends TelegesisFrame implements Tele
 
             // Deserialize field "rssi" [optional]
             pushDeserializer();
-            rssi = deserializeUInt8();
+            rssi = deserializeSInt8();
             if (rssi == null) {
                 popDeserializer();
             } else {

--- a/com.zsmartsystems.zigbee.dongle.telegesis/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/internal/protocol/TelegesisRouterAnnounceEvent.java
+++ b/com.zsmartsystems.zigbee.dongle.telegesis/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/internal/protocol/TelegesisRouterAnnounceEvent.java
@@ -92,7 +92,7 @@ public class TelegesisRouterAnnounceEvent extends TelegesisFrame implements Tele
 
             // Deserialize field "rssi" [optional]
             pushDeserializer();
-            rssi = deserializeUInt8();
+            rssi = deserializeSInt8();
             if (rssi == null) {
                 popDeserializer();
             } else {

--- a/com.zsmartsystems.zigbee.dongle.telegesis/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/internal/protocol/TelegesisSleepyDeviceAnnounceEvent.java
+++ b/com.zsmartsystems.zigbee.dongle.telegesis/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/internal/protocol/TelegesisSleepyDeviceAnnounceEvent.java
@@ -92,7 +92,7 @@ public class TelegesisSleepyDeviceAnnounceEvent extends TelegesisFrame implement
 
             // Deserialize field "rssi" [optional]
             pushDeserializer();
-            rssi = deserializeUInt8();
+            rssi = deserializeSInt8();
             if (rssi == null) {
                 popDeserializer();
             } else {

--- a/com.zsmartsystems.zigbee.dongle.telegesis/src/test/java/com/zsmartsystems/zigbee/dongle/telegesis/internal/protocol/TelegesisEndDeviceAnnounceEventTest.java
+++ b/com.zsmartsystems.zigbee.dongle.telegesis/src/test/java/com/zsmartsystems/zigbee/dongle/telegesis/internal/protocol/TelegesisEndDeviceAnnounceEventTest.java
@@ -38,7 +38,7 @@ public class TelegesisEndDeviceAnnounceEventTest extends TelegesisFrameBaseTest 
         System.out.println(event);
         assertEquals(new IeeeAddress("1234567890ABCDEF"), event.getIeeeAddress());
         assertEquals(Integer.valueOf(0x9876), event.getNetworkAddress());
-        assertEquals(Integer.valueOf(-188), event.getRssi());
+        assertEquals(Integer.valueOf(68), event.getRssi());
         assertEquals(Integer.valueOf(0xAA), event.getLqi());
     }
 }

--- a/com.zsmartsystems.zigbee.dongle.telegesis/src/test/java/com/zsmartsystems/zigbee/dongle/telegesis/internal/protocol/TelegesisMobileDeviceAnnounceEventTest.java
+++ b/com.zsmartsystems.zigbee.dongle.telegesis/src/test/java/com/zsmartsystems/zigbee/dongle/telegesis/internal/protocol/TelegesisMobileDeviceAnnounceEventTest.java
@@ -34,11 +34,11 @@ public class TelegesisMobileDeviceAnnounceEventTest extends TelegesisFrameBaseTe
     @Test
     public void testExtended() {
         TelegesisMobileDeviceAnnounceEvent event = new TelegesisMobileDeviceAnnounceEvent();
-        event.deserialize(stringToIntArray("MED:1234567890ABCDEF,9876,44,AA"));
+        event.deserialize(stringToIntArray("MED:1234567890ABCDEF,9876,-44,AA"));
         System.out.println(event);
         assertEquals(new IeeeAddress("1234567890ABCDEF"), event.getIeeeAddress());
         assertEquals(Integer.valueOf(0x9876), event.getNetworkAddress());
-        assertEquals(Integer.valueOf(-188), event.getRssi());
+        assertEquals(Integer.valueOf(-68), event.getRssi());
         assertEquals(Integer.valueOf(0xAA), event.getLqi());
     }
 }

--- a/com.zsmartsystems.zigbee.dongle.telegesis/src/test/java/com/zsmartsystems/zigbee/dongle/telegesis/internal/protocol/TelegesisReceiveBroadcastEventTest.java
+++ b/com.zsmartsystems.zigbee.dongle.telegesis/src/test/java/com/zsmartsystems/zigbee/dongle/telegesis/internal/protocol/TelegesisReceiveBroadcastEventTest.java
@@ -38,7 +38,7 @@ public class TelegesisReceiveBroadcastEventTest extends TelegesisFrameBaseTest {
         System.out.println(event);
         assertEquals(new IeeeAddress("000D6F000005A666"), event.getRemoteAddress());
         assertTrue(Arrays.equals(stringToIntArray("test"), event.getMessageData()));
-        assertEquals(Integer.valueOf(-96), event.getRssi());
+        assertEquals(Integer.valueOf(160), event.getRssi());
         assertEquals(Integer.valueOf(69), event.getLqi());
     }
 
@@ -58,7 +58,7 @@ public class TelegesisReceiveBroadcastEventTest extends TelegesisFrameBaseTest {
         System.out.println(event);
         assertEquals(null, event.getRemoteAddress());
         assertTrue(Arrays.equals(stringToIntArray("test"), event.getMessageData()));
-        assertEquals(Integer.valueOf(-96), event.getRssi());
+        assertEquals(Integer.valueOf(160), event.getRssi());
         assertEquals(Integer.valueOf(69), event.getLqi());
     }
 }

--- a/com.zsmartsystems.zigbee.dongle.telegesis/src/test/java/com/zsmartsystems/zigbee/dongle/telegesis/internal/protocol/TelegesisReceiveMessageEventTest.java
+++ b/com.zsmartsystems.zigbee.dongle.telegesis/src/test/java/com/zsmartsystems/zigbee/dongle/telegesis/internal/protocol/TelegesisReceiveMessageEventTest.java
@@ -7,6 +7,8 @@
  */
 package com.zsmartsystems.zigbee.dongle.telegesis.internal.protocol;
 
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Test;
 
 /**
@@ -16,13 +18,30 @@ import org.junit.Test;
  */
 public class TelegesisReceiveMessageEventTest extends TelegesisFrameBaseTest {
     @Test
-    public void testRemoteAddress() {
+    public void testMessage1() {
         TelegesisReceiveMessageEvent event = new TelegesisReceiveMessageEvent();
         event.deserialize(new int[] { 0x52, 0x58, 0x3A, 0x30, 0x30, 0x30, 0x30, 0x2C, 0x30, 0x30, 0x30, 0x30, 0x2C,
                 0x30, 0x30, 0x2C, 0x30, 0x30, 0x2C, 0x38, 0x30, 0x30, 0x31, 0x2C, 0x30, 0x44, 0x3A, 0x00, 0x00, 0x62,
                 0x39, 0x05, 0x0D, 0x00, 0x6F, 0x0D, 0x00, 0x00, 0x00, 0x00, 0x2C, 0x30, 0x30, 0x2C, 0x46, 0x46 });
         System.out.println(event);
-        // assertEquals(Integer.valueOf(0x1234), event.getNetworkAddress());
-        // assertEquals(new IeeeAddress("1234567890ABCDEF"), event.getIeeeAddress());
+        assertEquals(Integer.valueOf(32769), event.getClusterId());
+        assertEquals(Integer.valueOf(0), event.getSourceEp());
+        assertEquals(Integer.valueOf(0), event.getRssi());
+        assertEquals(Integer.valueOf(255), event.getLqi());
+    }
+
+    @Test
+    public void testMessage2() {
+        TelegesisReceiveMessageEvent event = new TelegesisReceiveMessageEvent();
+        event.deserialize(new int[] { 0x52, 0x58, 0x3A, 0x44, 0x46, 0x46, 0x39, 0x2C, 0x30, 0x31, 0x30, 0x34, 0x2C,
+                0x30, 0x30, 0x2C, 0x30, 0x33, 0x2C, 0x30, 0x30, 0x30, 0x36, 0x2C, 0x30, 0x33, 0x3A, 0x18, 0x28, 0x01,
+                0x2C, 0x2D, 0x34, 0x35, 0x2C, 0x46, 0x46 });
+        System.out.println(event);
+        assertEquals(Integer.valueOf(57337), event.getNetworkAddress());
+        assertEquals(Integer.valueOf(6), event.getClusterId());
+        assertEquals(Integer.valueOf(3), event.getSourceEp());
+        assertEquals(Integer.valueOf(-69), event.getRssi());
+        assertEquals(Integer.valueOf(255), event.getLqi());
     }
 }
+//

--- a/com.zsmartsystems.zigbee.dongle.telegesis/src/test/java/com/zsmartsystems/zigbee/dongle/telegesis/internal/protocol/TelegesisReceiveMulticastEventTest.java
+++ b/com.zsmartsystems.zigbee.dongle.telegesis/src/test/java/com/zsmartsystems/zigbee/dongle/telegesis/internal/protocol/TelegesisReceiveMulticastEventTest.java
@@ -38,7 +38,7 @@ public class TelegesisReceiveMulticastEventTest extends TelegesisFrameBaseTest {
         System.out.println(event);
         assertEquals(new IeeeAddress("000D6F000005A666"), event.getRemoteAddress());
         assertTrue(Arrays.equals(stringToIntArray("test"), event.getMessageData()));
-        assertEquals(Integer.valueOf(-96), event.getRssi());
+        assertEquals(Integer.valueOf(160), event.getRssi());
         assertEquals(Integer.valueOf(69), event.getLqi());
     }
 
@@ -58,7 +58,7 @@ public class TelegesisReceiveMulticastEventTest extends TelegesisFrameBaseTest {
         System.out.println(event);
         assertEquals(null, event.getRemoteAddress());
         assertTrue(Arrays.equals(stringToIntArray("test"), event.getMessageData()));
-        assertEquals(Integer.valueOf(-96), event.getRssi());
+        assertEquals(Integer.valueOf(160), event.getRssi());
         assertEquals(Integer.valueOf(69), event.getLqi());
     }
 }

--- a/com.zsmartsystems.zigbee.dongle.telegesis/src/test/java/com/zsmartsystems/zigbee/dongle/telegesis/internal/protocol/TelegesisReceiveUnicastEventTest.java
+++ b/com.zsmartsystems.zigbee.dongle.telegesis/src/test/java/com/zsmartsystems/zigbee/dongle/telegesis/internal/protocol/TelegesisReceiveUnicastEventTest.java
@@ -38,7 +38,7 @@ public class TelegesisReceiveUnicastEventTest extends TelegesisFrameBaseTest {
         System.out.println(event);
         assertEquals(new IeeeAddress("000D6F000005A666"), event.getRemoteAddress());
         assertTrue(Arrays.equals(stringToIntArray("test"), event.getMessageData()));
-        assertEquals(Integer.valueOf(-96), event.getRssi());
+        assertEquals(Integer.valueOf(160), event.getRssi());
         assertEquals(Integer.valueOf(69), event.getLqi());
     }
 
@@ -58,7 +58,7 @@ public class TelegesisReceiveUnicastEventTest extends TelegesisFrameBaseTest {
         System.out.println(event);
         assertEquals(null, event.getRemoteAddress());
         assertTrue(Arrays.equals(stringToIntArray("test"), event.getMessageData()));
-        assertEquals(Integer.valueOf(-96), event.getRssi());
+        assertEquals(Integer.valueOf(160), event.getRssi());
         assertEquals(Integer.valueOf(69), event.getLqi());
     }
 }

--- a/com.zsmartsystems.zigbee.dongle.telegesis/src/test/java/com/zsmartsystems/zigbee/dongle/telegesis/internal/protocol/TelegesisRouterAnnounceEventTest.java
+++ b/com.zsmartsystems.zigbee.dongle.telegesis/src/test/java/com/zsmartsystems/zigbee/dongle/telegesis/internal/protocol/TelegesisRouterAnnounceEventTest.java
@@ -38,7 +38,7 @@ public class TelegesisRouterAnnounceEventTest extends TelegesisFrameBaseTest {
         System.out.println(event);
         assertEquals(new IeeeAddress("1234567890ABCDEF"), event.getIeeeAddress());
         assertEquals(Integer.valueOf(0x9876), event.getNetworkAddress());
-        assertEquals(Integer.valueOf(-188), event.getRssi());
+        assertEquals(Integer.valueOf(68), event.getRssi());
         assertEquals(Integer.valueOf(0xAA), event.getLqi());
     }
 }

--- a/com.zsmartsystems.zigbee.dongle.telegesis/src/test/java/com/zsmartsystems/zigbee/dongle/telegesis/internal/protocol/TelegesisSleepyDeviceAnnounceEventTest.java
+++ b/com.zsmartsystems.zigbee.dongle.telegesis/src/test/java/com/zsmartsystems/zigbee/dongle/telegesis/internal/protocol/TelegesisSleepyDeviceAnnounceEventTest.java
@@ -38,7 +38,7 @@ public class TelegesisSleepyDeviceAnnounceEventTest extends TelegesisFrameBaseTe
         System.out.println(event);
         assertEquals(new IeeeAddress("1234567890ABCDEF"), event.getIeeeAddress());
         assertEquals(Integer.valueOf(0x9876), event.getNetworkAddress());
-        assertEquals(Integer.valueOf(-188), event.getRssi());
+        assertEquals(Integer.valueOf(68), event.getRssi());
         assertEquals(Integer.valueOf(0xAA), event.getLqi());
     }
 }


### PR DESCRIPTION
Fix the handling of the signed hex values used for RSSI values.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>