### PR TITLE
close ashHanlder before closing serial port.

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
@@ -287,6 +287,7 @@ public class ZigBeeDongleEzsp implements ZigBeeTransportTransmit, EzspFrameHandl
 
     @Override
     public void shutdown() {
+        ashHandler.close();
         serialPort.close();
     }
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
@@ -287,8 +287,9 @@ public class ZigBeeDongleEzsp implements ZigBeeTransportTransmit, EzspFrameHandl
 
     @Override
     public void shutdown() {
-        ashHandler.close();
+        ashHandler.setClosing();
         serialPort.close();
+        ashHandler.close();
     }
 
     /**


### PR DESCRIPTION
closing serialPort but leaving ashHandler running can lead to an exception if using the rxtx library instead of jssc for serial port interface.  This PR closes the ashHandler before attempting to close the serial port.