### PR TITLE
Add information about using the Qivicon dongle under Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ It is worth noting that EM3588 devices that have an embedded USB core will likel
 
 The library supports the Telegesis AT protocol over a serial interface. Currently implemented against R309. Note that some dongles such as the Qivicon Funkstick may use PID/VID codes that require special drivers or they will not be detected as a serial port.
 
+Under Linux you can add the Qivicon dongle without a custom made kernel with the following command -:
+
+``` 
+echo 10c4 89fb > /sys/bus/usb-serial/drivers/cp210x/new_id
+```
+
 ## Tested Hardware
  
 ## ZigBee Dongles and Chipsets


### PR DESCRIPTION
Original [reference](https://community.openhab.org/t/eu-zigbee-dongle/31069/37)

Signed-off-by: Chris Jackson <chris@cd-jackson.com>