### PR TITLE
Protect against Telegesis receive buffer overrun

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.telegesis/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/ZigBeeDongleTelegesis.java
+++ b/com.zsmartsystems.zigbee.dongle.telegesis/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/ZigBeeDongleTelegesis.java
@@ -156,7 +156,7 @@ public class ZigBeeDongleTelegesis
      * <br>
      * + Bit 4: Set: Send Network key encrypted with the link key to nodes joining
      * <br>
-     * Bit 3: Set: Do not allow nodes to re-join unsecured
+     * - Bit 3: Set: Do not allow nodes to re-join unsecured
      * <br>
      * + Bit 2: Set: Send Network key encrypted with the link key to nodes re-joining unsecured
      * <br>

--- a/com.zsmartsystems.zigbee.dongle.telegesis/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/internal/TelegesisFrameHandler.java
+++ b/com.zsmartsystems.zigbee.dongle.telegesis/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/internal/TelegesisFrameHandler.java
@@ -156,8 +156,16 @@ public class TelegesisFrameHandler {
         while (!closeHandler) {
             int val = serialPort.read();
             if (val == -1) {
+                // Timeout
                 continue;
             }
+            if (inputBufferLength >= inputBuffer.length) {
+                // If we overrun the buffer, reset and go to WAITING mode
+                inputBufferLength = 0;
+                rxState = RxStateMachine.WAITING;
+                logger.debug("TELEGESIS RX buffer overrun - resetting!");
+            }
+
             logger.trace("TELEGESIS RX: {}", String.format("%02X %c", val, val));
 
             switch (rxState) {


### PR DESCRIPTION
Adds a check to protect from RX buffer overrun in the telegesis driver.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>