### PR TITLE
Fix Telegesis channel parsing in JPAN command

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.telegesis.autocode/src/main/resources/telegesis_at_protocol.xml
+++ b/com.zsmartsystems.zigbee.dongle.telegesis.autocode/src/main/resources/telegesis_at_protocol.xml
@@ -252,7 +252,7 @@
 		<response_parameters>
 			<prompt>JPAN</prompt>
 			<parameter>
-				<data_type>Int8</data_type>
+				<data_type>Integer</data_type>
 				<name>channel</name>
 				<description></description>
 			</parameter>

--- a/com.zsmartsystems.zigbee.dongle.telegesis/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/internal/protocol/TelegesisNetworkJoinedEvent.java
+++ b/com.zsmartsystems.zigbee.dongle.telegesis/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/internal/protocol/TelegesisNetworkJoinedEvent.java
@@ -70,7 +70,7 @@ public class TelegesisNetworkJoinedEvent extends TelegesisFrame implements Teleg
             setDeserializer(5);
 
             // Deserialize field "channel"
-            channel = deserializeInt8();
+            channel = deserializeInteger();
             stepDeserializer();
 
             // Deserialize field "Pan ID"

--- a/com.zsmartsystems.zigbee.dongle.telegesis/src/test/java/com/zsmartsystems/zigbee/dongle/telegesis/internal/protocol/TelegesisNetworkJoinedEventTest.java
+++ b/com.zsmartsystems.zigbee.dongle.telegesis/src/test/java/com/zsmartsystems/zigbee/dongle/telegesis/internal/protocol/TelegesisNetworkJoinedEventTest.java
@@ -24,7 +24,7 @@ public class TelegesisNetworkJoinedEventTest extends TelegesisFrameBaseTest {
         TelegesisNetworkJoinedEvent event = new TelegesisNetworkJoinedEvent();
         event.deserialize(stringToIntArray("JPAN:18,9876,0793E14FFB220A38"));
         System.out.println(event);
-        assertEquals(Integer.valueOf(24), event.getChannel());
+        assertEquals(Integer.valueOf(18), event.getChannel());
         assertEquals(Integer.valueOf(0x9876), event.getPanId());
         assertEquals(new ExtendedPanId("0793E14FFB220A38"), event.getEpanId());
     }


### PR DESCRIPTION
Channel seems to be decimal in this command.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>