### PR TITLE
Cancel ASH retry timer when ASH handler is closed

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
@@ -279,6 +279,7 @@ public class ZigBeeDongleEzsp implements ZigBeeTransportTransmit, EzspFrameHandl
         ashHandler.setClosing();
         serialPort.close();
         ashHandler.close();
+        ashHandler = null;
     }
 
     /**
@@ -348,6 +349,9 @@ public class ZigBeeDongleEzsp implements ZigBeeTransportTransmit, EzspFrameHandl
 
     @Override
     public void sendCommand(final ZigBeeApsFrame apsFrame) throws ZigBeeException {
+        if (ashHandler == null) {
+            return;
+        }
         EzspFrameRequest emberCommand;
 
         EmberApsFrame emberApsFrame = new EmberApsFrame();


### PR DESCRIPTION
If timer isn't cancelled then the handler can remain running after it's closed.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>