### PR TITLE
Provide a mechanism to search for and discover a node based on IeeeAdress

### DIFF
--- a/com.zsmartsystems.zigbee.autocode/src/main/java/com/zsmartsystems/zigbee/autocode/ZclProtocolCodeGenerator.java
+++ b/com.zsmartsystems.zigbee.autocode/src/main/java/com/zsmartsystems/zigbee/autocode/ZclProtocolCodeGenerator.java
@@ -2110,9 +2110,12 @@ public class ZclProtocolCodeGenerator {
                             }
 
                             if (field.listSizer != null) {
-                                out.println("        for (int cnt = 0; cnt < " + field.listSizer + "; cnt++) {");
-                                out.println("            " + field.nameLowerCamelCase + ".add((" + field.dataTypeClass
-                                        + ") deserializer.deserialize(" + "ZclDataType." + field.dataType + "));");
+                                out.println("        if (" + field.listSizer + " != null) {");
+                                out.println("            for (int cnt = 0; cnt < " + field.listSizer + "; cnt++) {");
+                                out.println("                " + field.nameLowerCamelCase + ".add(("
+                                        + field.dataTypeClass + ") deserializer.deserialize(" + "ZclDataType."
+                                        + field.dataType + "));");
+                                out.println("            }");
                                 out.println("        }");
                             } else {
                                 out.println("        " + field.nameLowerCamelCase + " = (" + field.dataTypeClass

--- a/com.zsmartsystems.zigbee.autocode/src/main/resources/zdp_definition.md
+++ b/com.zsmartsystems.zigbee.autocode/src/main/resources/zdp_definition.md
@@ -569,7 +569,7 @@ destination addressing on this command is unicast.
 |NWKAddrRemoteDev           |NWK address                |
 |NumAssocDev                |Unsigned 8-bit integer     |
 |StartIndex                 |Unsigned 8-bit integer     |
-|NWKAddrAssocDevList        |N X NWK Address            | 
+|NWKAddrAssocDevList        |NWK Address[NumAssocDev]   | 
 
 
 #### IEEE Address Response [0x8001]

--- a/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsole.java
+++ b/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsole.java
@@ -166,6 +166,8 @@ public final class ZigBeeConsole {
 
         commands.put("trustcentre", new TrustCentreCommand());
 
+        commands.put("rediscover", new RediscoverCommand());
+
         this.networkManager = networkManager;
         zigBeeApi = new ZigBeeApi(networkManager);
 
@@ -2720,6 +2722,43 @@ public final class ZigBeeConsole {
             });
 
             out.println("Starting dongle firmware update...");
+            return true;
+        }
+    }
+
+    /**
+     * Rediscover a node from its IEEE address.
+     */
+    private class RediscoverCommand implements ConsoleCommand {
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public String getDescription() {
+            return "Rediscover a node from its IEEE address.";
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public String getSyntax() {
+            return "rediscover IEEEADDRESS";
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public boolean process(final ZigBeeApi zigbeeApi, final String[] args, PrintStream out) throws Exception {
+            if (args.length != 2) {
+                return false;
+            }
+
+            IeeeAddress address = new IeeeAddress(args[1]);
+
+            print("Sending rediscovery request for address " + address, out);
+            networkManager.rediscoverNode(address);
             return true;
         }
     }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
@@ -41,6 +41,7 @@ import com.zsmartsystems.zigbee.zdo.ZdoCommand;
 import com.zsmartsystems.zigbee.zdo.ZdoCommandType;
 import com.zsmartsystems.zigbee.zdo.command.ManagementLeaveRequest;
 import com.zsmartsystems.zigbee.zdo.command.ManagementPermitJoiningRequest;
+import com.zsmartsystems.zigbee.zdo.command.NetworkAddressRequest;
 
 /**
  * Implements functions for managing the ZigBee interfaces.
@@ -963,6 +964,16 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
             modifiedListeners.remove(networkNodeListener);
             nodeListeners = Collections.unmodifiableList(modifiedListeners);
         }
+    }
+
+    /**
+     * Starts a rediscovery on a node. This will send a {@link NetworkAddressRequest} as a broadcast and will receive
+     * the response to trigger a full discovery.
+     *
+     * @param ieeeAddress the {@link IeeeAddress} of the node to rediscover
+     */
+    public void rediscoverNode(IeeeAddress address) {
+        networkDiscoverer.rediscoverNode(address);
     }
 
     /**

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/serialization/DefaultDeserializer.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/serialization/DefaultDeserializer.java
@@ -62,6 +62,10 @@ public class DefaultDeserializer implements ZigBeeDeserializer {
      * {@inheritDoc}
      */
     public Object readZigBeeType(ZclDataType type) {
+        if (index == payload.length) {
+            return null;
+        }
+
         Object[] value = new Object[1];
         switch (type) {
             case BOOLEAN:
@@ -113,7 +117,6 @@ public class DefaultDeserializer implements ZigBeeDeserializer {
                 break;
             case N_X_READ_ATTRIBUTE_STATUS_RECORD:
                 break;
-            case N_X_NWK_ADDRESS:
             case N_X_UNSIGNED_16_BIT_INTEGER:
                 int cntN16 = Integer.valueOf((byte) payload[index++] & 0xFF);
                 List<Integer> arrayN16 = new ArrayList<Integer>(cntN16);

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/serialization/DefaultSerializer.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/serialization/DefaultSerializer.java
@@ -102,7 +102,6 @@ public class DefaultSerializer implements ZigBeeSerializer {
                 break;
             case N_X_READ_ATTRIBUTE_STATUS_RECORD:
                 break;
-            case N_X_NWK_ADDRESS:
             case N_X_UNSIGNED_16_BIT_INTEGER:
                 List<Integer> intArray16 = (List<Integer>) data;
                 buffer[length++] = intArray16.size();

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/protocol/ZclDataType.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/protocol/ZclDataType.java
@@ -70,7 +70,6 @@ public enum ZclDataType {
     NWK_ADDRESS("NWK address", Integer.class, 0x00, false),
     N_X_BINDING_TABLE("N x Binding Table", BindingTable.class, 0x00, false),
     N_X_IEEE_ADDRESS("N X IEEE Address", Long.class, 0x00, false),
-    N_X_NWK_ADDRESS("N X NWK Address", Integer.class, 0x00, false),
     POWER_DESCRIPTOR("Power Descriptor", PowerDescriptor.class, 0x00, false),
     ROUTING_TABLE("Routing Table", RoutingTable.class, 0x00, false),
     SIMPLE_DESCRIPTOR("Simple Descriptor", SimpleDescriptor.class, 0x00, false),

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ActiveEndpointsResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ActiveEndpointsResponse.java
@@ -128,8 +128,10 @@ public class ActiveEndpointsResponse extends ZdoResponse {
         }
         nwkAddrOfInterest = (Integer) deserializer.deserialize(ZclDataType.NWK_ADDRESS);
         activeEpCnt = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        for (int cnt = 0; cnt < activeEpCnt; cnt++) {
-            activeEpList.add((Integer) deserializer.deserialize(ZclDataType.ENDPOINT));
+        if (activeEpCnt != null) {
+            for (int cnt = 0; cnt < activeEpCnt; cnt++) {
+                activeEpList.add((Integer) deserializer.deserialize(ZclDataType.ENDPOINT));
+            }
         }
     }
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/BindRegisterResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/BindRegisterResponse.java
@@ -129,8 +129,10 @@ public class BindRegisterResponse extends ZdoResponse {
         }
         bindingTableEntries = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
         bindingTableListCount = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        for (int cnt = 0; cnt < bindingTableListCount; cnt++) {
-            bindingTableList.add((List<BindingTable>) deserializer.deserialize(ZclDataType.N_X_BINDING_TABLE));
+        if (bindingTableListCount != null) {
+            for (int cnt = 0; cnt < bindingTableListCount; cnt++) {
+                bindingTableList.add((List<BindingTable>) deserializer.deserialize(ZclDataType.N_X_BINDING_TABLE));
+            }
         }
     }
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/EndDeviceBindRequest.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/EndDeviceBindRequest.java
@@ -250,12 +250,16 @@ public class EndDeviceBindRequest extends ZdoRequest {
         srcEndpoint = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
         profileId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
         inClusterCount = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        for (int cnt = 0; cnt < inClusterCount; cnt++) {
-            inClusterList.add((Integer) deserializer.deserialize(ZclDataType.CLUSTERID));
+        if (inClusterCount != null) {
+            for (int cnt = 0; cnt < inClusterCount; cnt++) {
+                inClusterList.add((Integer) deserializer.deserialize(ZclDataType.CLUSTERID));
+            }
         }
         outClusterCount = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        for (int cnt = 0; cnt < outClusterCount; cnt++) {
-            outClusterList.add((Integer) deserializer.deserialize(ZclDataType.CLUSTERID));
+        if (outClusterCount != null) {
+            for (int cnt = 0; cnt < outClusterCount; cnt++) {
+                outClusterList.add((Integer) deserializer.deserialize(ZclDataType.CLUSTERID));
+            }
         }
     }
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/IeeeAddressResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/IeeeAddressResponse.java
@@ -186,8 +186,10 @@ public class IeeeAddressResponse extends ZdoResponse {
             return;
         }
         startIndex = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        for (int cnt = 0; cnt < numAssocDev; cnt++) {
-            nwkAddrAssocDevList.add((Integer) deserializer.deserialize(ZclDataType.NWK_ADDRESS));
+        if (numAssocDev != null) {
+            for (int cnt = 0; cnt < numAssocDev; cnt++) {
+                nwkAddrAssocDevList.add((Integer) deserializer.deserialize(ZclDataType.NWK_ADDRESS));
+            }
         }
     }
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ManagementBindResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ManagementBindResponse.java
@@ -155,8 +155,10 @@ public class ManagementBindResponse extends ZdoResponse {
         bindingTableEntries = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
         startIndex = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
         bindingTableListCount = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        for (int cnt = 0; cnt < bindingTableListCount; cnt++) {
-            bindingTableList.add((BindingTable) deserializer.deserialize(ZclDataType.BINDING_TABLE));
+        if (bindingTableListCount != null) {
+            for (int cnt = 0; cnt < bindingTableListCount; cnt++) {
+                bindingTableList.add((BindingTable) deserializer.deserialize(ZclDataType.BINDING_TABLE));
+            }
         }
     }
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ManagementLqiResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ManagementLqiResponse.java
@@ -155,8 +155,10 @@ public class ManagementLqiResponse extends ZdoResponse {
         neighborTableEntries = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
         startIndex = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
         neighborTableListCount = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        for (int cnt = 0; cnt < neighborTableListCount; cnt++) {
-            neighborTableList.add((NeighborTable) deserializer.deserialize(ZclDataType.NEIGHBOR_TABLE));
+        if (neighborTableListCount != null) {
+            for (int cnt = 0; cnt < neighborTableListCount; cnt++) {
+                neighborTableList.add((NeighborTable) deserializer.deserialize(ZclDataType.NEIGHBOR_TABLE));
+            }
         }
     }
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ManagementNetworkUpdateNotify.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ManagementNetworkUpdateNotify.java
@@ -189,8 +189,10 @@ public class ManagementNetworkUpdateNotify extends ZdoResponse {
         totalTransmissions = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
         transmissionFailures = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
         scannedChannelsListCount = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        for (int cnt = 0; cnt < scannedChannelsListCount; cnt++) {
-            energyValues.add((Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER));
+        if (scannedChannelsListCount != null) {
+            for (int cnt = 0; cnt < scannedChannelsListCount; cnt++) {
+                energyValues.add((Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER));
+            }
         }
     }
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ManagementRoutingResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ManagementRoutingResponse.java
@@ -155,8 +155,10 @@ public class ManagementRoutingResponse extends ZdoResponse {
         routingTableEntries = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
         startIndex = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
         routingTableListCount = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        for (int cnt = 0; cnt < routingTableListCount; cnt++) {
-            routingTableList.add((RoutingTable) deserializer.deserialize(ZclDataType.ROUTING_TABLE));
+        if (routingTableListCount != null) {
+            for (int cnt = 0; cnt < routingTableListCount; cnt++) {
+                routingTableList.add((RoutingTable) deserializer.deserialize(ZclDataType.ROUTING_TABLE));
+            }
         }
     }
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/MatchDescriptorRequest.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/MatchDescriptorRequest.java
@@ -200,12 +200,16 @@ public class MatchDescriptorRequest extends ZdoRequest {
         nwkAddrOfInterest = (Integer) deserializer.deserialize(ZclDataType.NWK_ADDRESS);
         profileId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
         inClusterCount = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        for (int cnt = 0; cnt < inClusterCount; cnt++) {
-            inClusterList.add((Integer) deserializer.deserialize(ZclDataType.CLUSTERID));
+        if (inClusterCount != null) {
+            for (int cnt = 0; cnt < inClusterCount; cnt++) {
+                inClusterList.add((Integer) deserializer.deserialize(ZclDataType.CLUSTERID));
+            }
         }
         outClusterCount = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        for (int cnt = 0; cnt < outClusterCount; cnt++) {
-            outClusterList.add((Integer) deserializer.deserialize(ZclDataType.CLUSTERID));
+        if (outClusterCount != null) {
+            for (int cnt = 0; cnt < outClusterCount; cnt++) {
+                outClusterList.add((Integer) deserializer.deserialize(ZclDataType.CLUSTERID));
+            }
         }
     }
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/MatchDescriptorResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/MatchDescriptorResponse.java
@@ -128,8 +128,10 @@ public class MatchDescriptorResponse extends ZdoResponse {
         }
         nwkAddrOfInterest = (Integer) deserializer.deserialize(ZclDataType.NWK_ADDRESS);
         matchLength = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        for (int cnt = 0; cnt < matchLength; cnt++) {
-            matchList.add((Integer) deserializer.deserialize(ZclDataType.ENDPOINT));
+        if (matchLength != null) {
+            for (int cnt = 0; cnt < matchLength; cnt++) {
+                matchList.add((Integer) deserializer.deserialize(ZclDataType.ENDPOINT));
+            }
         }
     }
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/NetworkAddressResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/NetworkAddressResponse.java
@@ -159,12 +159,17 @@ public class NetworkAddressResponse extends ZdoResponse {
         serializer.serialize(nwkAddrRemoteDev, ZclDataType.NWK_ADDRESS);
         serializer.serialize(numAssocDev, ZclDataType.UNSIGNED_8_BIT_INTEGER);
         serializer.serialize(startIndex, ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        serializer.serialize(nwkAddrAssocDevList, ZclDataType.N_X_NWK_ADDRESS);
+        for (int cnt = 0; cnt < nwkAddrAssocDevList.size(); cnt++) {
+            serializer.serialize(nwkAddrAssocDevList.get(cnt), ZclDataType.NWK_ADDRESS);
+        }
     }
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
         super.deserialize(deserializer);
+
+        // Create lists
+        nwkAddrAssocDevList = new ArrayList<Integer>();
 
         status = (ZdoStatus) deserializer.deserialize(ZclDataType.ZDO_STATUS);
         if (status != ZdoStatus.SUCCESS) {
@@ -175,7 +180,11 @@ public class NetworkAddressResponse extends ZdoResponse {
         nwkAddrRemoteDev = (Integer) deserializer.deserialize(ZclDataType.NWK_ADDRESS);
         numAssocDev = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
         startIndex = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        nwkAddrAssocDevList = (List<Integer>) deserializer.deserialize(ZclDataType.N_X_NWK_ADDRESS);
+        if (numAssocDev != null) {
+            for (int cnt = 0; cnt < numAssocDev; cnt++) {
+                nwkAddrAssocDevList.add((Integer) deserializer.deserialize(ZclDataType.NWK_ADDRESS));
+            }
+        }
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/serialization/SerializerIntegrationTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/serialization/SerializerIntegrationTest.java
@@ -96,13 +96,6 @@ public class SerializerIntegrationTest {
     }
 
     @Test
-    public void testDeserialize_N_X_NWK_ADDRESS() {
-        List<Integer> valIn = Arrays
-                .asList(new Integer[] { 1111, 2222, 3333, 4444, 5555, 6666, 7777, 8888, 9999, 0x8888 });
-        testSerializer(valIn, ZclDataType.N_X_NWK_ADDRESS);
-    }
-
-    @Test
     public void testDeserialize_ENUMERATION_8_BIT() {
         int valIn = 0x91;
         testSerializer(valIn, ZclDataType.ENUMERATION_8_BIT);

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zdo/command/NetworkAddressResponseTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zdo/command/NetworkAddressResponseTest.java
@@ -5,36 +5,41 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  */
-package com.zsmartsystems.zigbee.zcl.clusters.general;
+package com.zsmartsystems.zigbee.zdo.command;
 
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 
 import com.zsmartsystems.zigbee.CommandTest;
+import com.zsmartsystems.zigbee.IeeeAddress;
 import com.zsmartsystems.zigbee.serialization.DefaultDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
+import com.zsmartsystems.zigbee.zdo.ZdoStatus;
 
 /**
  *
  * @author Chris Jackson
  *
  */
-public class DiscoverCommandsGeneratedResponseTest extends CommandTest {
+public class NetworkAddressResponseTest extends CommandTest {
+
     @Test
     public void testReceive() {
-        int[] packet = getPacketData("01");
+        int[] packet = getPacketData("00 00 43 1D A5 00 AA 3E B0 7C 74 3B");
 
-        DiscoverCommandsGeneratedResponse response = new DiscoverCommandsGeneratedResponse();
+        NetworkAddressResponse addressResponse = new NetworkAddressResponse();
 
         DefaultDeserializer deserializer = new DefaultDeserializer(packet);
         ZclFieldDeserializer fieldDeserializer = new ZclFieldDeserializer(deserializer);
 
-        response.deserialize(fieldDeserializer);
+        addressResponse.deserialize(fieldDeserializer);
 
-        System.out.println(response);
+        System.out.println(addressResponse);
 
-        assertNull(response.getCommandIdentifiers());
+        assertEquals(new IeeeAddress("7CB03EAA00A51D43"), addressResponse.getIeeeAddrRemoteDev());
+        assertEquals(0x8000, (int) addressResponse.getClusterId());
+        assertEquals(ZdoStatus.SUCCESS, addressResponse.getStatus());
     }
 
 }


### PR DESCRIPTION
The primary change in this PR is to add a ```ZigBeeNetworkManager.rediscoverNode(IeeeAddress)``` method. This searches for the node with the specified address and gets its network address and completes a discovery on the node.

This PR also adds null checks to cope with short frames caused by optional fields in packets.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>