### PR TITLE
Add method to override defined flow control

### DIFF
--- a/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleMain.java
+++ b/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleMain.java
@@ -23,6 +23,7 @@ import com.zsmartsystems.zigbee.serial.ZigBeeSerialPort;
 import com.zsmartsystems.zigbee.serialization.DefaultDeserializer;
 import com.zsmartsystems.zigbee.serialization.DefaultSerializer;
 import com.zsmartsystems.zigbee.transport.ZigBeePort;
+import com.zsmartsystems.zigbee.transport.ZigBeePort.FlowControl;
 import com.zsmartsystems.zigbee.transport.ZigBeeTransportTransmit;
 
 /**
@@ -95,9 +96,9 @@ public class ZigBeeConsoleMain {
             return;
         }
 
-        boolean flowControl = false;
+        FlowControl flowControl = FlowControl.FLOWCONTROL_OUT_NONE;
         if (dongleName.toUpperCase().equals("EMBER")) {
-            flowControl = true;
+            flowControl = FlowControl.FLOWCONTROL_OUT_RTSCTS;
         }
 
         final ZigBeePort serialPort = new ZigBeeSerialPort(serialPortName, serialBaud, flowControl);

--- a/com.zsmartsystems.zigbee.dongle.cc2531/src/test/java/com/zsmartsystems/zigbee/dongle/cc2531/Cc2351TestPacket.java
+++ b/com.zsmartsystems.zigbee.dongle.cc2531/src/test/java/com/zsmartsystems/zigbee/dongle/cc2531/Cc2351TestPacket.java
@@ -100,6 +100,11 @@ public class Cc2351TestPacket {
         }
 
         @Override
+        public boolean open(int baudRate, FlowControl flowControl) {
+            return false;
+        }
+
+        @Override
         public void purgeRxBuffer() {
         }
     }

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/ash/AshFrameHandlerTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/ash/AshFrameHandlerTest.java
@@ -155,6 +155,11 @@ public class AshFrameHandlerTest {
         }
 
         @Override
+        public boolean open(int baudRate, FlowControl flowControl) {
+            return false;
+        }
+
+        @Override
         public void purgeRxBuffer() {
         }
     }

--- a/com.zsmartsystems.zigbee.dongle.telegesis/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/internal/TelegesisFirmwareUpdateHandler.java
+++ b/com.zsmartsystems.zigbee.dongle.telegesis/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/internal/TelegesisFirmwareUpdateHandler.java
@@ -15,6 +15,7 @@ import org.slf4j.LoggerFactory;
 
 import com.zsmartsystems.zigbee.dongle.telegesis.ZigBeeDongleTelegesis;
 import com.zsmartsystems.zigbee.transport.ZigBeePort;
+import com.zsmartsystems.zigbee.transport.ZigBeePort.FlowControl;
 import com.zsmartsystems.zigbee.transport.ZigBeeTransportFirmwareCallback;
 import com.zsmartsystems.zigbee.transport.ZigBeeTransportFirmwareStatus;
 
@@ -83,7 +84,7 @@ public class TelegesisFirmwareUpdateHandler {
             @Override
             public void run() {
                 logger.debug("Telegesis bootloader: Starting.");
-                if (!serialPort.open(BOOTLOAD_BAUD_RATE)) {
+                if (!serialPort.open(BOOTLOAD_BAUD_RATE, FlowControl.FLOWCONTROL_OUT_NONE)) {
                     logger.debug("Telegesis bootloader: Failed to open serial port.");
                     transferComplete(ZigBeeTransportFirmwareStatus.FIRMWARE_UPDATE_FAILED);
                     return;

--- a/com.zsmartsystems.zigbee.dongle.telegesis/src/test/java/com/zsmartsystems/zigbee/dongle/telegesis/internal/TelegesisFirmwareUpdateHandlerTest.java
+++ b/com.zsmartsystems.zigbee.dongle.telegesis/src/test/java/com/zsmartsystems/zigbee/dongle/telegesis/internal/TelegesisFirmwareUpdateHandlerTest.java
@@ -191,6 +191,11 @@ public class TelegesisFirmwareUpdateHandlerTest {
         }
 
         @Override
+        public boolean open(int baudRate, FlowControl flowControl) {
+            return false;
+        }
+
+        @Override
         public void purgeRxBuffer() {
         }
 

--- a/com.zsmartsystems.zigbee.dongle.telegesis/src/test/java/com/zsmartsystems/zigbee/dongle/telegesis/internal/TelegesisFrameHandlerTest.java
+++ b/com.zsmartsystems.zigbee.dongle.telegesis/src/test/java/com/zsmartsystems/zigbee/dongle/telegesis/internal/TelegesisFrameHandlerTest.java
@@ -213,6 +213,11 @@ public class TelegesisFrameHandlerTest {
         }
 
         @Override
+        public boolean open(int baudRate, FlowControl flowControl) {
+            return false;
+        }
+
+        @Override
         public void purgeRxBuffer() {
         }
     }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transport/ZigBeePort.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transport/ZigBeePort.java
@@ -35,6 +35,18 @@ public interface ZigBeePort {
     boolean open(int baudRate);
 
     /**
+     * Open the port with the specified baud rate and flow control.
+     * <p>
+     * This method allows the transport to override the baud rate if required - for example
+     * when entering a bootloader that may operate at a different speed to the coordinator.
+     *
+     * @param baudRate the speed to use when opening the port
+     * @param flowControl the {@link FlowControl} to use when opening the port
+     * @return true if port was opened successfully.
+     */
+    boolean open(int baudRate, FlowControl flowControl);
+
+    /**
      * Close the port. Closing the port should abort any read and write operations to allow a clean closure of the port.
      */
     void close();
@@ -65,4 +77,22 @@ public interface ZigBeePort {
      * Purge all data currently in the receive buffer
      */
     void purgeRxBuffer();
+
+    /**
+     * Enumeration of flow control options
+     */
+    public enum FlowControl {
+        /**
+         * No flow control
+         */
+        FLOWCONTROL_OUT_NONE,
+        /**
+         * XOn / XOff (software) flow control
+         */
+        FLOWCONTROL_OUT_XONOFF,
+        /**
+         * RTS / CTS (hardware) flow control
+         */
+        FLOWCONTROL_OUT_RTSCTS
+    }
 }


### PR DESCRIPTION
Bootloaders may need to open the serial port with defined parameters that are different to those defined by the user for the main application.
For example, the Ember bootloader does not use flow control and may use a different speed than defined for the EZSP stack so the system needs to ability to override both these parameters from the user specified values.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>