### PR TITLE
Improve robustness of OTA server.

### DIFF
--- a/com.zsmartsystems.zigbee.console/pom.xml
+++ b/com.zsmartsystems.zigbee.console/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.zsmartsystems</groupId>
         <artifactId>zigbee</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>1.0.2-SNAPSHOT</version>
     </parent>
 
     <dependencies>
@@ -17,31 +17,31 @@
         <dependency>
             <groupId>com.zsmartsystems.zigbee</groupId>
             <artifactId>com.zsmartsystems.zigbee</artifactId>
-            <version>1.0.1-SNAPSHOT</version>
+            <version>1.0.2-SNAPSHOT</version>
         </dependency>
 
         <dependency>
             <groupId>com.zsmartsystems.zigbee</groupId>
             <artifactId>com.zsmartsystems.zigbee.serial</artifactId>
-            <version>1.0.1-SNAPSHOT</version>
+            <version>1.0.2-SNAPSHOT</version>
         </dependency>
 
         <dependency>
             <groupId>com.zsmartsystems.zigbee</groupId>
             <artifactId>com.zsmartsystems.zigbee.dongle.cc2531</artifactId>
-            <version>1.0.1-SNAPSHOT</version>
+            <version>1.0.2-SNAPSHOT</version>
         </dependency>
 
         <dependency>
             <groupId>com.zsmartsystems.zigbee</groupId>
             <artifactId>com.zsmartsystems.zigbee.dongle.ember</artifactId>
-            <version>1.0.1-SNAPSHOT</version>
+            <version>1.0.2-SNAPSHOT</version>
         </dependency>
 
         <dependency>
             <groupId>com.zsmartsystems.zigbee</groupId>
             <artifactId>com.zsmartsystems.zigbee.dongle.telegesis</artifactId>
-            <version>1.0.1-SNAPSHOT</version>
+            <version>1.0.2-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/com.zsmartsystems.zigbee.dongle.cc2531/pom.xml
+++ b/com.zsmartsystems.zigbee.dongle.cc2531/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.zsmartsystems</groupId>
         <artifactId>zigbee</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>1.0.2-SNAPSHOT</version>
     </parent>
 
     <dependencies>
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>com.zsmartsystems.zigbee</groupId>
             <artifactId>com.zsmartsystems.zigbee</artifactId>
-            <version>1.0.1-SNAPSHOT</version>
+            <version>1.0.2-SNAPSHOT</version>
         </dependency>
 
     </dependencies>

--- a/com.zsmartsystems.zigbee.dongle.ember/pom.xml
+++ b/com.zsmartsystems.zigbee.dongle.ember/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.zsmartsystems</groupId>
         <artifactId>zigbee</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>1.0.2-SNAPSHOT</version>
     </parent>
 
     <dependencies>
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>com.zsmartsystems.zigbee</groupId>
             <artifactId>com.zsmartsystems.zigbee</artifactId>
-            <version>1.0.1-SNAPSHOT</version>
+            <version>1.0.2-SNAPSHOT</version>
         </dependency>
 
     </dependencies>

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
@@ -294,6 +294,10 @@ public class ZigBeeDongleEzsp implements ZigBeeTransportTransmit, ZigBeeTranspor
 
     @Override
     public void shutdown() {
+        if (ashHandler == null) {
+            return;
+        }
+
         ashHandler.setClosing();
         serialPort.close();
         ashHandler.close();

--- a/com.zsmartsystems.zigbee.dongle.telegesis/pom.xml
+++ b/com.zsmartsystems.zigbee.dongle.telegesis/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.zsmartsystems</groupId>
         <artifactId>zigbee</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>1.0.2-SNAPSHOT</version>
     </parent>
 
     <dependencies>
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>com.zsmartsystems.zigbee</groupId>
             <artifactId>com.zsmartsystems.zigbee</artifactId>
-            <version>1.0.1-SNAPSHOT</version>
+            <version>1.0.2-SNAPSHOT</version>
         </dependency>
 
     </dependencies>

--- a/com.zsmartsystems.zigbee.serial/pom.xml
+++ b/com.zsmartsystems.zigbee.serial/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.zsmartsystems</groupId>
         <artifactId>zigbee</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>1.0.2-SNAPSHOT</version>
     </parent>
 
     <properties>
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>com.zsmartsystems.zigbee</groupId>
             <artifactId>com.zsmartsystems.zigbee</artifactId>
-            <version>1.0.1-SNAPSHOT</version>
+            <version>1.0.2-SNAPSHOT</version>
         </dependency>
         
         <dependency>

--- a/com.zsmartsystems.zigbee.test/pom.xml
+++ b/com.zsmartsystems.zigbee.test/pom.xml
@@ -8,29 +8,29 @@
     <parent>
         <groupId>com.zsmartsystems</groupId>
         <artifactId>zigbee</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>1.0.2-SNAPSHOT</version>
     </parent>
 
     <dependencies>
         <dependency>
             <groupId>com.zsmartsystems.zigbee</groupId>
             <artifactId>com.zsmartsystems.zigbee</artifactId>
-            <version>1.0.1-SNAPSHOT</version>
+            <version>1.0.2-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.zsmartsystems.zigbee</groupId>
             <artifactId>com.zsmartsystems.zigbee.dongle.cc2531</artifactId>
-            <version>1.0.1-SNAPSHOT</version>
+            <version>1.0.2-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.zsmartsystems.zigbee</groupId>
             <artifactId>com.zsmartsystems.zigbee.dongle.ember</artifactId>
-            <version>1.0.1-SNAPSHOT</version>
+            <version>1.0.2-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.zsmartsystems.zigbee</groupId>
             <artifactId>com.zsmartsystems.zigbee.dongle.telegesis</artifactId>
-            <version>1.0.1-SNAPSHOT</version>
+            <version>1.0.2-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/com.zsmartsystems.zigbee/pom.xml
+++ b/com.zsmartsystems.zigbee/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.zsmartsystems</groupId>
         <artifactId>zigbee</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>1.0.2-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
@@ -732,8 +732,8 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
                                 synchronized (future) {
                                     future.notify();
                                 }
-                                removeCommandExecution(commandExecution);
                             }
+                            removeCommandExecution(commandExecution);
                         }
                     }
                 }
@@ -780,8 +780,7 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
     /**
      * Adds command listener and removes expired command listeners.
      *
-     * @param commandExecution
-     *            the command execution
+     * @param commandExecution the command execution
      */
     private void addCommandExecution(final CommandExecution commandExecution) {
         synchronized (commandExecutions) {
@@ -803,14 +802,15 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
     /**
      * Removes command execution.
      *
-     * @param expiredCommandExecution
-     *            the command execution
+     * @param expiredCommandExecution the command execution
      */
     protected void removeCommandExecution(CommandExecution expiredCommandExecution) {
-        commandExecutions.remove(expiredCommandExecution);
-        removeCommandListener(expiredCommandExecution.getCommandListener());
-        synchronized (expiredCommandExecution.getFuture()) {
-            expiredCommandExecution.getFuture().notify();
+        synchronized (commandExecutions) {
+            commandExecutions.remove(expiredCommandExecution);
+            removeCommandListener(expiredCommandExecution.getCommandListener());
+            synchronized (expiredCommandExecution.getFuture()) {
+                expiredCommandExecution.getFuture().notify();
+            }
         }
     }
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/otaserver/ZigBeeOtaServerStatus.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/otaserver/ZigBeeOtaServerStatus.java
@@ -7,10 +7,8 @@
  */
 package com.zsmartsystems.zigbee.otaserver;
 
-import com.zsmartsystems.zigbee.zcl.clusters.otaupgrade.UpgradeEndResponse;
-
 /**
- * An enumeration defining the {@link ZigBeeOtaServer} status provided by the {@link ZigBeeStatusCallback}
+ * An enumeration defining the {@link ZigBeeOtaServer} status provided to the {@link ZigBeeStatusCallback}
  *
  * @author Chris Jackson
  *
@@ -20,29 +18,46 @@ public enum ZigBeeOtaServerStatus {
      * The OTA server is uninitialized. No firmware is currently set.
      */
     OTA_UNINITIALISED,
+
     /**
      * The OTA server is waiting for the client to request an update
      */
     OTA_WAITING,
+
     /**
      * The OTA server is currently progressing a transfer
      */
     OTA_TRANSFER_IN_PROGRESS,
+
     /**
      * The OTA transfer is complete. The firmware has not been executed.
      */
     OTA_TRANSFER_COMPLETE,
+
     /**
      * The transfer is complete, and the server has told the client to execute the upgrade with a delay
      */
     OTA_UPGRADE_WAITING,
+
     /**
-     * The OTA upgrade is complete.
+     * The OTA upgrade is complete, and the device firmware is restarting.
+     */
+    OTA_UPGRADE_FIRMWARE_RESTARTING,
+
+    /**
+     * The OTA upgrade is complete and an acknowledgement was received from the device to confirm the firmware version
+     * is consistent with the new file.
      */
     OTA_UPGRADE_COMPLETE,
+
     /**
-     * The OTA upgrade failed. This is caused when the {@link UpgradeEndResponse} is not acked.
+     * The OTA upgrade was cancelled by user request. A new transfer can be started by setting a new OTA firmware
+     */
+    OTA_CANCELLED,
+
+    /**
+     * The OTA upgrade failed. This may be caused due to a timeout or unexpected response, or the firmware version was
+     * inconsistent on completion.
      */
     OTA_UPGRADE_FAILED;
-
 }

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.zsmartsystems</groupId>
     <artifactId>zigbee</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.0.2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>


### PR DESCRIPTION
Adds timer to cancel transfers after specified time with no client requests, and ensures packets received from client are received in correct order. A check is added after the transfer is complete to check the running firmware version is consistent with the loaded file.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>