### PR TITLE
Improve the rediscovery option in the network discovery handler

### DIFF
--- a/com.zsmartsystems.zigbee.autocode/src/main/java/com/zsmartsystems/zigbee/autocode/ZclProtocolCodeGenerator.java
+++ b/com.zsmartsystems.zigbee.autocode/src/main/java/com/zsmartsystems/zigbee/autocode/ZclProtocolCodeGenerator.java
@@ -1912,7 +1912,6 @@ public class ZclProtocolCodeGenerator {
                     // out.println("import java.util.HashMap;");
 
                     for (final Field field : fields) {
-
                         String packageName;
                         if (field.dataTypeClass.endsWith("Descriptor")) {
                             packageName = packageZdpDescriptors;
@@ -1999,6 +1998,11 @@ public class ZclProtocolCodeGenerator {
 
                         out.println("    /**");
                         out.println("     * " + field.fieldLabel + " command message field.");
+                        if (field.description.size() != 0) {
+                            for (String line : field.description) {
+                                out.println("     * " + line);
+                            }
+                        }
                         out.println("     */");
                         out.println("    private " + getFieldType(field) + " " + field.nameLowerCamelCase + ";");
                         out.println();
@@ -2034,6 +2038,12 @@ public class ZclProtocolCodeGenerator {
                         out.println();
                         out.println("    /**");
                         out.println("     * Gets " + field.fieldLabel + ".");
+                        if (field.description.size() != 0) {
+                            out.println("     * <p>");
+                            for (String line : field.description) {
+                                out.println("     * " + line);
+                            }
+                        }
                         out.println("     *");
                         out.println("     * @return the " + field.fieldLabel);
                         out.println("     */");
@@ -2043,6 +2053,12 @@ public class ZclProtocolCodeGenerator {
                         out.println();
                         out.println("    /**");
                         out.println("     * Sets " + field.fieldLabel + ".");
+                        if (field.description.size() != 0) {
+                            out.println("     * <p>");
+                            for (String line : field.description) {
+                                out.println("     * " + line);
+                            }
+                        }
                         out.println("     *");
                         out.println("     * @param " + field.nameLowerCamelCase + " the " + field.fieldLabel);
                         out.println("     */");

--- a/com.zsmartsystems.zigbee.autocode/src/main/java/com/zsmartsystems/zigbee/autocode/ZclProtocolDefinitionParser.java
+++ b/com.zsmartsystems.zigbee.autocode/src/main/java/com/zsmartsystems/zigbee/autocode/ZclProtocolDefinitionParser.java
@@ -137,6 +137,8 @@ public class ZclProtocolDefinitionParser {
     }
 
     private static void parseCommands(Context context) {
+        boolean addBreak = false;
+        Field field = null;
         while (context.lines.size() > 0) {
             final String line = context.lines.remove(0);
 
@@ -148,6 +150,22 @@ public class ZclProtocolDefinitionParser {
 
             if (line.startsWith("##### Expected Response")) {
                 parseExpectedResponse(context);
+                continue;
+            }
+
+            if (line.startsWith("##### ")) {
+                addBreak = false;
+
+                for (Field fieldLoop : context.command.fields.values()) {
+                    if (fieldLoop.fieldLabel.equals(line.trim().substring(6))) {
+                        field = fieldLoop;
+                        break;
+                    }
+                }
+                if (field == null) {
+                    System.out.println("Error finding field \"" + line.trim().substring(6) + "\"");
+                }
+                continue;
             }
 
             if (line.startsWith("#### ")) {
@@ -184,8 +202,27 @@ public class ZclProtocolDefinitionParser {
                         + context.command.commandLabel);
 
                 parseField(context);
+                continue;
             }
+
+            if (field == null) {
+                continue;
+            }
+
+            if (field.description.size() == 0 && line.trim().length() == 0) {
+                continue;
+            }
+            if (line.trim().length() == 0) {
+                addBreak = true;
+                continue;
+            }
+            if (addBreak && field.description.size() > 0) {
+                field.description.add("<p>");
+                addBreak = false;
+            }
+            field.description.add(line.trim());
         }
+
     }
 
     private static void parseField(Context context) {
@@ -204,6 +241,7 @@ public class ZclProtocolDefinitionParser {
                 final String row = line.trim().substring(1, line.length() - 1);
                 final String[] columns = row.split("\\|");
                 final Field field = new Field();
+                field.description = new ArrayList<String>();
                 field.fieldId = fieldIndex;
 
                 field.fieldLabel = columns[0].trim();

--- a/com.zsmartsystems.zigbee.autocode/src/main/java/com/zsmartsystems/zigbee/autocode/zcl/Field.java
+++ b/com.zsmartsystems.zigbee.autocode/src/main/java/com/zsmartsystems/zigbee/autocode/zcl/Field.java
@@ -1,5 +1,7 @@
 package com.zsmartsystems.zigbee.autocode.zcl;
 
+import java.util.List;
+
 /**
  * Created by tlaukkan on 4/10/2016.
  */
@@ -15,4 +17,5 @@ public class Field {
     public boolean completeOnZero;
     public String condition;
     public String conditionOperator;
+    public List<String> description;
 }

--- a/com.zsmartsystems.zigbee.autocode/src/main/resources/zdp_definition.md
+++ b/com.zsmartsystems.zigbee.autocode/src/main/resources/zdp_definition.md
@@ -21,6 +21,16 @@ devices for which macRxOnWhenIdle = TRUE.
 |RequestType                |Unsigned 8-bit integer     |
 |StartIndex                 |Unsigned 8-bit integer     |
 
+##### RequestType
+Request type for this command:
+0x00 – Single device response
+0x01 – Extended response
+0x02-0xFF – reserved
+
+##### Expected Response
+Packet: Network Address Response
+Match: IEEEAddr == IEEEAddrRemoteDev
+
 
 #### IEEE Address Request [0x0001]
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkMeshMonitor.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkMeshMonitor.java
@@ -13,7 +13,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -80,13 +79,6 @@ public class ZigBeeNetworkMeshMonitor implements ZigBeeCommandListener {
      * Refresh period for the mesh update - in seconds
      */
     private int updatePeriod;
-
-    /**
-     * Executor service to execute update threads. We use a {@link Executors.newFixedThreadPool}
-     * to provide a fixed number of threads as otherwise this could result in a large number of
-     * simultaneous threads in large networks.
-     */
-    private static ExecutorService executorService = Executors.newFixedThreadPool(2);
 
     /**
      * Scheduler to run the service
@@ -196,7 +188,7 @@ public class ZigBeeNetworkMeshMonitor implements ZigBeeCommandListener {
             nodesInProgress.add(nodeNetworkAddress);
         }
 
-        executorService.execute(new Runnable() {
+        networkManager.executeTask(new Runnable() {
             @Override
             public void run() {
                 logger.debug("{}: Starting mesh update", nodeNetworkAddress);

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/NetworkAddressRequest.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/NetworkAddressRequest.java
@@ -11,6 +11,9 @@ import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 import com.zsmartsystems.zigbee.zdo.ZdoRequest;
+import com.zsmartsystems.zigbee.ZigBeeCommand;
+import com.zsmartsystems.zigbee.CommandResponseMatcher;
+import com.zsmartsystems.zigbee.zdo.command.NetworkAddressResponse;
 import com.zsmartsystems.zigbee.IeeeAddress;
 
 /**
@@ -23,7 +26,7 @@ import com.zsmartsystems.zigbee.IeeeAddress;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-public class NetworkAddressRequest extends ZdoRequest {
+public class NetworkAddressRequest extends ZdoRequest implements CommandResponseMatcher {
     /**
      * IEEEAddr command message field.
      */
@@ -31,6 +34,10 @@ public class NetworkAddressRequest extends ZdoRequest {
 
     /**
      * RequestType command message field.
+     * Request type for this command:
+     * 0x00 – Single device response
+     * 0x01 – Extended response
+     * 0x02-0xFF – reserved
      */
     private Integer requestType;
 
@@ -66,6 +73,11 @@ public class NetworkAddressRequest extends ZdoRequest {
 
     /**
      * Gets RequestType.
+     * <p>
+     * Request type for this command:
+     * 0x00 – Single device response
+     * 0x01 – Extended response
+     * 0x02-0xFF – reserved
      *
      * @return the RequestType
      */
@@ -75,6 +87,11 @@ public class NetworkAddressRequest extends ZdoRequest {
 
     /**
      * Sets RequestType.
+     * <p>
+     * Request type for this command:
+     * 0x00 – Single device response
+     * 0x01 – Extended response
+     * 0x02-0xFF – reserved
      *
      * @param requestType the RequestType
      */
@@ -116,6 +133,16 @@ public class NetworkAddressRequest extends ZdoRequest {
         ieeeAddr = (IeeeAddress) deserializer.deserialize(ZclDataType.IEEE_ADDRESS);
         requestType = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
         startIndex = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+    }
+
+    @Override
+    public boolean isMatch(ZigBeeCommand request, ZigBeeCommand response) {
+        if (!(response instanceof NetworkAddressResponse)) {
+            return false;
+        }
+
+        return (((NetworkAddressRequest) request).getIeeeAddr()
+                .equals(((NetworkAddressResponse) response).getIeeeAddrRemoteDev()));
     }
 
     @Override


### PR DESCRIPTION
Centralise the executor used for mesh and discovery into the network manager to better manage threads.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>