### PR TITLE
Cluster support discovery

### DIFF
--- a/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsole.java
+++ b/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsole.java
@@ -58,15 +58,11 @@ import com.zsmartsystems.zigbee.zcl.ZclStatus;
 import com.zsmartsystems.zigbee.zcl.clusters.ZclBasicCluster;
 import com.zsmartsystems.zigbee.zcl.clusters.ZclOtaUpgradeCluster;
 import com.zsmartsystems.zigbee.zcl.clusters.general.ConfigureReportingResponse;
-import com.zsmartsystems.zigbee.zcl.clusters.general.DiscoverAttributesResponse;
-import com.zsmartsystems.zigbee.zcl.clusters.general.DiscoverCommandsGeneratedResponse;
-import com.zsmartsystems.zigbee.zcl.clusters.general.DiscoverCommandsReceivedResponse;
 import com.zsmartsystems.zigbee.zcl.clusters.general.ReadAttributesResponse;
 import com.zsmartsystems.zigbee.zcl.clusters.general.ReportAttributesCommand;
 import com.zsmartsystems.zigbee.zcl.clusters.general.WriteAttributesResponse;
 import com.zsmartsystems.zigbee.zcl.clusters.groups.GetGroupMembershipResponse;
 import com.zsmartsystems.zigbee.zcl.clusters.groups.ViewGroupResponse;
-import com.zsmartsystems.zigbee.zcl.field.AttributeInformation;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 import com.zsmartsystems.zigbee.zdo.field.NeighborTable;
 import com.zsmartsystems.zigbee.zdo.field.RoutingTable;
@@ -1900,31 +1896,27 @@ public final class ZigBeeConsole {
                 }
             }
 
-            Future<CommandResult> future = cluster.discoverCommandsReceived();
-            CommandResult result = future.get();
+            Future<Boolean> future = cluster.discoverCommandsReceived(false);
+            Boolean result = future.get();
 
-            if (result.isSuccess()) {
-                final DiscoverCommandsReceivedResponse response = result.getResponse();
-
-                for (Integer cmd : response.getCommandIdentifiers()) {
-                    out.println("Cluster " + response.getClusterId() + ", Command=" + cmd);
+            if (result) {
+                for (Integer cmd : cluster.getSupportedCommandsReceived()) {
+                    out.println("Cluster " + cluster.getClusterId() + ", Command=" + cmd);
                 }
             } else {
-                out.println("Error executing command: " + result.getMessage());
+                out.println("Error getting list of commands received");
             }
 
-            future = cluster.discoverCommandsGenerated();
+            future = cluster.discoverCommandsGenerated(false);
             result = future.get();
 
-            if (result.isSuccess()) {
-                final DiscoverCommandsGeneratedResponse response = result.getResponse();
-
-                for (Integer cmd : response.getCommandIdentifiers()) {
-                    out.println("Cluster " + response.getClusterId() + ", Command=" + cmd);
+            if (result) {
+                for (Integer cmd : cluster.getSupportedCommandsGenerated()) {
+                    out.println("Cluster " + cluster.getClusterId() + ", Command=" + cmd);
                 }
 
             } else {
-                out.println("Error executing command: " + result.getMessage());
+                out.println("Error getting list of commands generated");
             }
 
             return true;
@@ -1982,25 +1974,23 @@ public final class ZigBeeConsole {
                 }
             }
 
-            final Future<CommandResult> future = cluster.discoverAttributes();
-            CommandResult result = future.get();
+            final Future<Boolean> future = cluster.discoverAttributes(false);
+            Boolean result = future.get();
 
-            if (result.isSuccess()) {
-                final DiscoverAttributesResponse response = result.getResponse();
-
-                for (AttributeInformation info : response.getInformation()) {
-                    ZclAttribute attribute = cluster.getAttribute(info.getIdentifier());
+            if (result) {
+                for (Integer attributeId : cluster.getSupportedAttributes()) {
+                    ZclAttribute attribute = cluster.getAttribute(attributeId);
                     String name = "unknown";
                     if (attribute != null) {
                         name = attribute.getName();
                     }
-                    out.println("Cluster " + response.getClusterId() + ", Attribute=" + info.getIdentifier()
-                            + ",  Type=" + info.getDataType() + ", " + name);
+                    out.println("Cluster " + cluster.getClusterId() + ", Attribute=" + attribute.getId() + ",  Type="
+                            + attribute.getDataType() + ", " + name);
                 }
 
                 return true;
             } else {
-                out.println("Error executing command: " + result.getMessage());
+                out.println("Failed to retrieve supported attributes");
                 return true;
             }
         }

--- a/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsole.java
+++ b/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsole.java
@@ -46,7 +46,7 @@ import com.zsmartsystems.zigbee.otaserver.ZigBeeOtaServerStatus;
 import com.zsmartsystems.zigbee.otaserver.ZigBeeOtaStatusCallback;
 import com.zsmartsystems.zigbee.transport.TransportConfig;
 import com.zsmartsystems.zigbee.transport.TransportConfigOption;
-import com.zsmartsystems.zigbee.transport.TrustCentreLinkMode;
+import com.zsmartsystems.zigbee.transport.TrustCentreJoinMode;
 import com.zsmartsystems.zigbee.transport.ZigBeeTransportFirmwareCallback;
 import com.zsmartsystems.zigbee.transport.ZigBeeTransportFirmwareStatus;
 import com.zsmartsystems.zigbee.transport.ZigBeeTransportFirmwareUpdate;
@@ -2642,7 +2642,7 @@ public final class ZigBeeConsole {
             }
 
             TransportConfig config = new TransportConfig(TransportConfigOption.TRUST_CENTRE_JOIN_MODE,
-                    TrustCentreLinkMode.valueOf(args[2].toUpperCase()));
+                    TrustCentreJoinMode.valueOf(args[2].toUpperCase()));
 
             dongle.updateTransportConfig(config);
             print("Trust Centre configuration returned "

--- a/com.zsmartsystems.zigbee.dongle.telegesis.autocode/src/main/resources/telegesis_at_protocol.xml
+++ b/com.zsmartsystems.zigbee.dongle.telegesis.autocode/src/main/resources/telegesis_at_protocol.xml
@@ -874,7 +874,7 @@
 			<prompt>ATS0A3=</prompt>
 			<parameter>
 				<data_type>Boolean</data_type>
-				<name>rejoin</name>
+				<name>Disallow Rejoin</name>
 				<description></description>
 			</parameter>
 			<parameter>
@@ -887,12 +887,12 @@
 
 	<command>
 		<name>Disallow TC Join</name>
-		<description>Set: Don’t allow nodes to join(TC setting)</description>
+		<description>Set: Don’t allow nodes to join (TC setting)</description>
 		<command_parameters>
 			<prompt>ATS0A5=</prompt>
 			<parameter>
 				<data_type>Boolean</data_type>
-				<name>join</name>
+				<name>Disallow Join</name>
 				<description></description>
 			</parameter>
 			<parameter>

--- a/com.zsmartsystems.zigbee.dongle.telegesis/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/internal/protocol/TelegesisDisallowTcJoinCommand.java
+++ b/com.zsmartsystems.zigbee.dongle.telegesis/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/internal/protocol/TelegesisDisallowTcJoinCommand.java
@@ -11,7 +11,7 @@ package com.zsmartsystems.zigbee.dongle.telegesis.internal.protocol;
 /**
  * Class to implement the Telegesis command <b>Disallow TC Join</b>.
  * <p>
- * Set: Don’t allow nodes to join(TC setting)
+ * Set: Don’t allow nodes to join (TC setting)
  * <p>
  * This class provides methods for processing Telegesis AT API commands.
  * <p>
@@ -23,7 +23,7 @@ public class TelegesisDisallowTcJoinCommand extends TelegesisFrame implements Te
     /**
      * Command field
      */
-    private Boolean join;
+    private Boolean disallowJoin;
 
     /**
      * Command field
@@ -32,10 +32,10 @@ public class TelegesisDisallowTcJoinCommand extends TelegesisFrame implements Te
 
     /**
      *
-     * @param join the join to set as {@link Boolean}
+     * @param disallowJoin the disallowJoin to set as {@link Boolean}
      */
-    public void setJoin(Boolean join) {
-        this.join = join;
+    public void setDisallowJoin(Boolean disallowJoin) {
+        this.disallowJoin = disallowJoin;
     }
 
     /**
@@ -50,7 +50,7 @@ public class TelegesisDisallowTcJoinCommand extends TelegesisFrame implements Te
     public int[] serialize() {
         // Serialize the command fields
         serializeCommand("ATS0A5=");
-        serializeBoolean(join);
+        serializeBoolean(disallowJoin);
         serializeDelimiter();
         serializeString(password);
 
@@ -75,8 +75,8 @@ public class TelegesisDisallowTcJoinCommand extends TelegesisFrame implements Te
         final StringBuilder builder = new StringBuilder(300);
         // First present the command parameters...
         // Then the responses later if they are available
-        builder.append("TelegesisDisallowTcJoinCommand [join=");
-        builder.append(join);
+        builder.append("TelegesisDisallowTcJoinCommand [disallowJoin=");
+        builder.append(disallowJoin);
         builder.append(", password=");
         builder.append(password);
         if (status != null) {

--- a/com.zsmartsystems.zigbee.dongle.telegesis/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/internal/protocol/TelegesisDisallowUnsecuredRejoinCommand.java
+++ b/com.zsmartsystems.zigbee.dongle.telegesis/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/internal/protocol/TelegesisDisallowUnsecuredRejoinCommand.java
@@ -23,7 +23,7 @@ public class TelegesisDisallowUnsecuredRejoinCommand extends TelegesisFrame impl
     /**
      * Command field
      */
-    private Boolean rejoin;
+    private Boolean disallowRejoin;
 
     /**
      * Command field
@@ -32,10 +32,10 @@ public class TelegesisDisallowUnsecuredRejoinCommand extends TelegesisFrame impl
 
     /**
      *
-     * @param rejoin the rejoin to set as {@link Boolean}
+     * @param disallowRejoin the disallowRejoin to set as {@link Boolean}
      */
-    public void setRejoin(Boolean rejoin) {
-        this.rejoin = rejoin;
+    public void setDisallowRejoin(Boolean disallowRejoin) {
+        this.disallowRejoin = disallowRejoin;
     }
 
     /**
@@ -50,7 +50,7 @@ public class TelegesisDisallowUnsecuredRejoinCommand extends TelegesisFrame impl
     public int[] serialize() {
         // Serialize the command fields
         serializeCommand("ATS0A3=");
-        serializeBoolean(rejoin);
+        serializeBoolean(disallowRejoin);
         serializeDelimiter();
         serializeString(password);
 
@@ -75,8 +75,8 @@ public class TelegesisDisallowUnsecuredRejoinCommand extends TelegesisFrame impl
         final StringBuilder builder = new StringBuilder(309);
         // First present the command parameters...
         // Then the responses later if they are available
-        builder.append("TelegesisDisallowUnsecuredRejoinCommand [rejoin=");
-        builder.append(rejoin);
+        builder.append("TelegesisDisallowUnsecuredRejoinCommand [disallowRejoin=");
+        builder.append(disallowRejoin);
         builder.append(", password=");
         builder.append(password);
         if (status != null) {

--- a/com.zsmartsystems.zigbee.dongle.telegesis/src/test/java/com/zsmartsystems/zigbee/dongle/telegesis/internal/protocol/TelegesisDisallowTcJoinCommandTest.java
+++ b/com.zsmartsystems.zigbee.dongle.telegesis/src/test/java/com/zsmartsystems/zigbee/dongle/telegesis/internal/protocol/TelegesisDisallowTcJoinCommandTest.java
@@ -20,13 +20,13 @@ public class TelegesisDisallowTcJoinCommandTest extends TelegesisFrameBaseTest {
     @Test
     public void test() {
         TelegesisDisallowTcJoinCommand command = new TelegesisDisallowTcJoinCommand();
-        command.setJoin(false);
+        command.setDisallowJoin(false);
         command.setPassword("password");
         System.out.println(command);
         assertEquals("ATS0A5=0:password\r\n", intArrayToString(command.serialize()));
 
         command = new TelegesisDisallowTcJoinCommand();
-        command.setJoin(true);
+        command.setDisallowJoin(true);
         command.setPassword("password");
         System.out.println(command);
         assertEquals("ATS0A5=1:password\r\n", intArrayToString(command.serialize()));

--- a/com.zsmartsystems.zigbee.dongle.telegesis/src/test/java/com/zsmartsystems/zigbee/dongle/telegesis/internal/protocol/TelegesisDisallowUnsecuredRejoinCommandTest.java
+++ b/com.zsmartsystems.zigbee.dongle.telegesis/src/test/java/com/zsmartsystems/zigbee/dongle/telegesis/internal/protocol/TelegesisDisallowUnsecuredRejoinCommandTest.java
@@ -20,13 +20,13 @@ public class TelegesisDisallowUnsecuredRejoinCommandTest extends TelegesisFrameB
     @Test
     public void test() {
         TelegesisDisallowUnsecuredRejoinCommand command = new TelegesisDisallowUnsecuredRejoinCommand();
-        command.setRejoin(false);
+        command.setDisallowRejoin(false);
         command.setPassword("password");
         System.out.println(command);
         assertEquals("ATS0A3=0:password\r\n", intArrayToString(command.serialize()));
 
         command = new TelegesisDisallowUnsecuredRejoinCommand();
-        command.setRejoin(true);
+        command.setDisallowRejoin(true);
         command.setPassword("password");
         System.out.println(command);
         assertEquals("ATS0A3=1:password\r\n", intArrayToString(command.serialize()));

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ExtendedPanId.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ExtendedPanId.java
@@ -48,7 +48,7 @@ public class ExtendedPanId {
     }
 
     /**
-     * Create an {@link ExtendedPanId} from a {@link String}
+     * Create an {@link ExtendedPanId} from a {@link String} defined in hexadecimal notation.
      *
      * @param panId the panId as a {@link String}
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
@@ -301,7 +301,7 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
      * @return true if the PAN Id was set correctly
      */
     public boolean setZigBeePanId(int panId) {
-        if ((panId < 0 || panId > 0x3fff) & panId != 0xffff) {
+        if (panId < 0 || panId > 0xfffe) {
             return false;
         }
         return transport.setZigBeePanId(panId);
@@ -391,7 +391,7 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
 
     /**
      * Schedules a runnable task for execution. This uses a fixed size scheduler to limit thread execution.
-     * 
+     *
      * @param runnableTask
      */
     public void executeTask(Runnable runnableTask) {

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNode.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNode.java
@@ -332,8 +332,11 @@ public class ZigBeeNode implements ZigBeeCommandListener {
     }
 
     /**
-     * Request an update of the binding table for this node
-     * TODO: This needs to handle the response and further requests if required to complete the table
+     * Request an update of the binding table for this node.
+     * <p>
+     * This method returns a future to a boolean. Upon success the caller should call {@link #getBindingTable()}
+     * 
+     * @return {@link Future} returning a {@link Boolean}
      */
     public Future<Boolean> updateBindingTable() {
         RunnableFuture<Boolean> future = new FutureTask<Boolean>(new Callable<Boolean>() {

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transport/TrustCentreJoinMode.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transport/TrustCentreJoinMode.java
@@ -8,22 +8,23 @@
 package com.zsmartsystems.zigbee.transport;
 
 /**
- * An enumeration with the Trust Center link mode
+ * An enumeration with the Trust Center join mode.
  *
  * @author Chris Jackson
  *
  */
-public enum TrustCentreLinkMode {
+public enum TrustCentreJoinMode {
     /**
-     * The TC should deny joins
+     * The TC should deny joins. Even if a router allows a device to join the network, the trust center will not support
+     * the request, and will not deliver the network key to the device.
      */
     TC_JOIN_DENY,
     /**
-     * The TC should allow joins using the link key, or a preconfigured link key / device specific install code
+     * The TC should allow joins using the link key, or a preconfigured link key / device specific install code.
      */
     TC_JOIN_INSECURE,
     /**
-     * The TC should allow joins only with a preconfigured link key / device specific install code
+     * The TC should allow joins only with a preconfigured link key / device specific install code.
      */
     TC_JOIN_SECURE
 }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclGeneralCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclGeneralCluster.java
@@ -351,16 +351,16 @@ public class ZclGeneralCluster extends ZclCluster {
      * The discover attributes response command is generated in response to a discover
      * attributes command.
      *
-     * @param commandIdentifier {@link Boolean} Command identifier
-     * @param information {@link List<AttributeInformation>} Information
+     * @param discoveryComplete {@link Boolean} Discovery Complete
+     * @param attributeInformation {@link List<AttributeInformation>} Attribute Information
      * @return the {@link Future<CommandResult>} command result future
      */
-    public Future<CommandResult> discoverAttributesResponse(Boolean commandIdentifier, List<AttributeInformation> information) {
+    public Future<CommandResult> discoverAttributesResponse(Boolean discoveryComplete, List<AttributeInformation> attributeInformation) {
         DiscoverAttributesResponse command = new DiscoverAttributesResponse();
 
         // Set the fields
-        command.setCommandIdentifier(commandIdentifier);
-        command.setInformation(information);
+        command.setDiscoveryComplete(discoveryComplete);
+        command.setAttributeInformation(attributeInformation);
 
         return send(command);
     }
@@ -449,11 +449,11 @@ public class ZclGeneralCluster extends ZclCluster {
      * The Discover Commands Received Response is generated in response to a Discover Commands Received
      * command.
      *
-     * @param discoveryComplete {@link Integer} Discovery complete
+     * @param discoveryComplete {@link Boolean} Discovery complete
      * @param commandIdentifiers {@link List<Integer>} Command identifiers
      * @return the {@link Future<CommandResult>} command result future
      */
-    public Future<CommandResult> discoverCommandsReceivedResponse(Integer discoveryComplete, List<Integer> commandIdentifiers) {
+    public Future<CommandResult> discoverCommandsReceivedResponse(Boolean discoveryComplete, List<Integer> commandIdentifiers) {
         DiscoverCommandsReceivedResponse command = new DiscoverCommandsReceivedResponse();
 
         // Set the fields
@@ -489,11 +489,11 @@ public class ZclGeneralCluster extends ZclCluster {
      * The Discover Commands Generated Response is generated in response to a Discover Commands Generated
      * command.
      *
-     * @param discoveryComplete {@link Integer} Discovery complete
+     * @param discoveryComplete {@link Boolean} Discovery complete
      * @param commandIdentifiers {@link List<Integer>} Command identifiers
      * @return the {@link Future<CommandResult>} command result future
      */
-    public Future<CommandResult> discoverCommandsGeneratedResponse(Integer discoveryComplete, List<Integer> commandIdentifiers) {
+    public Future<CommandResult> discoverCommandsGeneratedResponse(Boolean discoveryComplete, List<Integer> commandIdentifiers) {
         DiscoverCommandsGeneratedResponse command = new DiscoverCommandsGeneratedResponse();
 
         // Set the fields
@@ -530,16 +530,16 @@ public class ZclGeneralCluster extends ZclCluster {
      * The Discover Attributes Extended Response command is generated in response to a Discover Attributes
      * Extended command.
      *
-     * @param discoveryComplete {@link Integer} Discovery complete
-     * @param commandIdentifiers {@link List<ExtendedAttributeInformation>} Command identifiers
+     * @param discoveryComplete {@link Boolean} Discovery complete
+     * @param attributeInformation {@link List<ExtendedAttributeInformation>} Attribute Information
      * @return the {@link Future<CommandResult>} command result future
      */
-    public Future<CommandResult> discoverAttributesExtendedResponse(Integer discoveryComplete, List<ExtendedAttributeInformation> commandIdentifiers) {
+    public Future<CommandResult> discoverAttributesExtendedResponse(Boolean discoveryComplete, List<ExtendedAttributeInformation> attributeInformation) {
         DiscoverAttributesExtendedResponse command = new DiscoverAttributesExtendedResponse();
 
         // Set the fields
         command.setDiscoveryComplete(discoveryComplete);
-        command.setCommandIdentifiers(commandIdentifiers);
+        command.setAttributeInformation(attributeInformation);
 
         return send(command);
     }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclLevelControlCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclLevelControlCluster.java
@@ -49,15 +49,21 @@ public class ZclLevelControlCluster extends ZclCluster {
     public static final int ATTR_REMAININGTIME = 0x0001;
     public static final int ATTR_ONOFFTRANSITIONTIME = 0x0010;
     public static final int ATTR_ONLEVEL = 0x0011;
+    public static final int ATTR_ONTRANSITIONTIME = 0x0012;
+    public static final int ATTR_OFFTRANSITIONTIME = 0x0013;
+    public static final int ATTR_DEFAULTMOVERATE = 0x0014;
 
     // Attribute initialisation
     protected Map<Integer, ZclAttribute> initializeAttributes() {
-        Map<Integer, ZclAttribute> attributeMap = new ConcurrentHashMap<Integer, ZclAttribute>(4);
+        Map<Integer, ZclAttribute> attributeMap = new ConcurrentHashMap<Integer, ZclAttribute>(7);
 
         attributeMap.put(ATTR_CURRENTLEVEL, new ZclAttribute(ZclClusterType.LEVEL_CONTROL, ATTR_CURRENTLEVEL, "CurrentLevel", ZclDataType.UNSIGNED_8_BIT_INTEGER, true, true, false, true));
         attributeMap.put(ATTR_REMAININGTIME, new ZclAttribute(ZclClusterType.LEVEL_CONTROL, ATTR_REMAININGTIME, "RemainingTime", ZclDataType.UNSIGNED_16_BIT_INTEGER, false, true, false, false));
         attributeMap.put(ATTR_ONOFFTRANSITIONTIME, new ZclAttribute(ZclClusterType.LEVEL_CONTROL, ATTR_ONOFFTRANSITIONTIME, "OnOffTransitionTime", ZclDataType.UNSIGNED_16_BIT_INTEGER, false, true, true, false));
         attributeMap.put(ATTR_ONLEVEL, new ZclAttribute(ZclClusterType.LEVEL_CONTROL, ATTR_ONLEVEL, "OnLevel", ZclDataType.UNSIGNED_8_BIT_INTEGER, false, true, true, false));
+        attributeMap.put(ATTR_ONTRANSITIONTIME, new ZclAttribute(ZclClusterType.LEVEL_CONTROL, ATTR_ONTRANSITIONTIME, "OnTransitionTime", ZclDataType.UNSIGNED_16_BIT_INTEGER, false, true, true, false));
+        attributeMap.put(ATTR_OFFTRANSITIONTIME, new ZclAttribute(ZclClusterType.LEVEL_CONTROL, ATTR_OFFTRANSITIONTIME, "OffTransitionTime", ZclDataType.UNSIGNED_16_BIT_INTEGER, false, true, true, false));
+        attributeMap.put(ATTR_DEFAULTMOVERATE, new ZclAttribute(ZclClusterType.LEVEL_CONTROL, ATTR_DEFAULTMOVERATE, "DefaultMoveRate", ZclDataType.UNSIGNED_16_BIT_INTEGER, false, true, true, false));
 
         return attributeMap;
     }
@@ -77,7 +83,7 @@ public class ZclLevelControlCluster extends ZclCluster {
      * Get the <i>CurrentLevel</i> attribute [attribute ID <b>0</b>].
      * <p>
      * The CurrentLevel attribute represents the current level of this device. The
-     * meaning of 'level' is device dependent.
+     * meaning of 'level' is device dependent. Value is between 0 and 254.
      * <p>
      * The attribute is of type {@link Integer}.
      * <p>
@@ -94,7 +100,7 @@ public class ZclLevelControlCluster extends ZclCluster {
      * Synchronously get the <i>CurrentLevel</i> attribute [attribute ID <b>0</b>].
      * <p>
      * The CurrentLevel attribute represents the current level of this device. The
-     * meaning of 'level' is device dependent.
+     * meaning of 'level' is device dependent. Value is between 0 and 254.
      * <p>
      * This method can return cached data if the attribute has already been received.
      * The parameter <i>refreshPeriod</i> is used to control this. If the attribute has been received
@@ -126,7 +132,7 @@ public class ZclLevelControlCluster extends ZclCluster {
      * Set reporting for the <i>CurrentLevel</i> attribute [attribute ID <b>0</b>].
      * <p>
      * The CurrentLevel attribute represents the current level of this device. The
-     * meaning of 'level' is device dependent.
+     * meaning of 'level' is device dependent. Value is between 0 and 254.
      * <p>
      * The attribute is of type {@link Integer}.
      * <p>
@@ -339,8 +345,229 @@ public class ZclLevelControlCluster extends ZclCluster {
         return (Integer) readSync(attributes.get(ATTR_ONLEVEL));
     }
 
+
+    /**
+     * Set the <i>OnTransitionTime</i> attribute [attribute ID <b>18</b>].
+     * <p>
+     * The OnTransitionTime attribute represents the time taken to move the current level from the
+     * minimum level to the maximum level when an On command is received by an On/Off cluster on
+     * the same endpoint.  It is specified in 10ths of a second.  If this command is not implemented,
+     * or contains a value of 0xffff, the OnOffTransitionTime will be used instead.
+     * <p>
+     * The attribute is of type {@link Integer}.
+     * <p>
+     * The implementation of this attribute by a device is OPTIONAL
+     *
+     * @param onTransitionTime the {@link Integer} attribute value to be set
+     * @return the {@link Future<CommandResult>} command result future
+     */
+    public Future<CommandResult> setOnTransitionTime(final Object value) {
+        return write(attributes.get(ATTR_ONTRANSITIONTIME), value);
+    }
+
+    /**
+     * Get the <i>OnTransitionTime</i> attribute [attribute ID <b>18</b>].
+     * <p>
+     * The OnTransitionTime attribute represents the time taken to move the current level from the
+     * minimum level to the maximum level when an On command is received by an On/Off cluster on
+     * the same endpoint.  It is specified in 10ths of a second.  If this command is not implemented,
+     * or contains a value of 0xffff, the OnOffTransitionTime will be used instead.
+     * <p>
+     * The attribute is of type {@link Integer}.
+     * <p>
+     * The implementation of this attribute by a device is OPTIONAL
+     *
+     * @return the {@link Future<CommandResult>} command result future
+     */
+    public Future<CommandResult> getOnTransitionTimeAsync() {
+        return read(attributes.get(ATTR_ONTRANSITIONTIME));
+    }
+
+
+    /**
+     * Synchronously get the <i>OnTransitionTime</i> attribute [attribute ID <b>18</b>].
+     * <p>
+     * The OnTransitionTime attribute represents the time taken to move the current level from the
+     * minimum level to the maximum level when an On command is received by an On/Off cluster on
+     * the same endpoint.  It is specified in 10ths of a second.  If this command is not implemented,
+     * or contains a value of 0xffff, the OnOffTransitionTime will be used instead.
+     * <p>
+     * This method can return cached data if the attribute has already been received.
+     * The parameter <i>refreshPeriod</i> is used to control this. If the attribute has been received
+     * within <i>refreshPeriod</i> milliseconds, then the method will immediately return the last value
+     * received. If <i>refreshPeriod</i> is set to 0, then the attribute will always be updated.
+     * <p>
+     * This method will block until the response is received or a timeout occurs unless the current value is returned.
+     * <p>
+     * The attribute is of type {@link Integer}.
+     * <p>
+     * The implementation of this attribute by a device is OPTIONAL
+     *
+     * @param refreshPeriod the maximum age of the data (in milliseconds) before an update is needed
+     * @return the {@link Integer} attribute value, or null on error
+     */
+    public Integer getOnTransitionTime(final long refreshPeriod) {
+        if(refreshPeriod > 0 && attributes.get(ATTR_ONTRANSITIONTIME).getLastReportTime() != null) {
+            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
+            if(attributes.get(ATTR_ONTRANSITIONTIME).getLastReportTime().getTimeInMillis() < refreshTime) {
+                return (Integer) attributes.get(ATTR_ONTRANSITIONTIME).getLastValue();
+            }
+        }
+
+        return (Integer) readSync(attributes.get(ATTR_ONTRANSITIONTIME));
+    }
+
+
+    /**
+     * Set the <i>OffTransitionTime</i> attribute [attribute ID <b>19</b>].
+     * <p>
+     * The OffTransitionTime attribute represents the time taken to move the current level from the
+     * maximum level to the minimum level when an Off command is received by an On/Off cluster on
+     * the same endpoint.  It is specified in 10ths of a second.  If this command is not implemented,
+     * or contains a value of 0xffff, the OnOffTransitionTime will be used instead.
+     * <p>
+     * The attribute is of type {@link Integer}.
+     * <p>
+     * The implementation of this attribute by a device is OPTIONAL
+     *
+     * @param offTransitionTime the {@link Integer} attribute value to be set
+     * @return the {@link Future<CommandResult>} command result future
+     */
+    public Future<CommandResult> setOffTransitionTime(final Object value) {
+        return write(attributes.get(ATTR_OFFTRANSITIONTIME), value);
+    }
+
+    /**
+     * Get the <i>OffTransitionTime</i> attribute [attribute ID <b>19</b>].
+     * <p>
+     * The OffTransitionTime attribute represents the time taken to move the current level from the
+     * maximum level to the minimum level when an Off command is received by an On/Off cluster on
+     * the same endpoint.  It is specified in 10ths of a second.  If this command is not implemented,
+     * or contains a value of 0xffff, the OnOffTransitionTime will be used instead.
+     * <p>
+     * The attribute is of type {@link Integer}.
+     * <p>
+     * The implementation of this attribute by a device is OPTIONAL
+     *
+     * @return the {@link Future<CommandResult>} command result future
+     */
+    public Future<CommandResult> getOffTransitionTimeAsync() {
+        return read(attributes.get(ATTR_OFFTRANSITIONTIME));
+    }
+
+
+    /**
+     * Synchronously get the <i>OffTransitionTime</i> attribute [attribute ID <b>19</b>].
+     * <p>
+     * The OffTransitionTime attribute represents the time taken to move the current level from the
+     * maximum level to the minimum level when an Off command is received by an On/Off cluster on
+     * the same endpoint.  It is specified in 10ths of a second.  If this command is not implemented,
+     * or contains a value of 0xffff, the OnOffTransitionTime will be used instead.
+     * <p>
+     * This method can return cached data if the attribute has already been received.
+     * The parameter <i>refreshPeriod</i> is used to control this. If the attribute has been received
+     * within <i>refreshPeriod</i> milliseconds, then the method will immediately return the last value
+     * received. If <i>refreshPeriod</i> is set to 0, then the attribute will always be updated.
+     * <p>
+     * This method will block until the response is received or a timeout occurs unless the current value is returned.
+     * <p>
+     * The attribute is of type {@link Integer}.
+     * <p>
+     * The implementation of this attribute by a device is OPTIONAL
+     *
+     * @param refreshPeriod the maximum age of the data (in milliseconds) before an update is needed
+     * @return the {@link Integer} attribute value, or null on error
+     */
+    public Integer getOffTransitionTime(final long refreshPeriod) {
+        if(refreshPeriod > 0 && attributes.get(ATTR_OFFTRANSITIONTIME).getLastReportTime() != null) {
+            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
+            if(attributes.get(ATTR_OFFTRANSITIONTIME).getLastReportTime().getTimeInMillis() < refreshTime) {
+                return (Integer) attributes.get(ATTR_OFFTRANSITIONTIME).getLastValue();
+            }
+        }
+
+        return (Integer) readSync(attributes.get(ATTR_OFFTRANSITIONTIME));
+    }
+
+
+    /**
+     * Set the <i>DefaultMoveRate</i> attribute [attribute ID <b>20</b>].
+     * <p>
+     * The DefaultMoveRate attribute determines the movement rate, in units per second, when a Move
+     * command is received with a Rate parameter of 0xFF.
+     * <p>
+     * The attribute is of type {@link Integer}.
+     * <p>
+     * The implementation of this attribute by a device is OPTIONAL
+     *
+     * @param defaultMoveRate the {@link Integer} attribute value to be set
+     * @return the {@link Future<CommandResult>} command result future
+     */
+    public Future<CommandResult> setDefaultMoveRate(final Object value) {
+        return write(attributes.get(ATTR_DEFAULTMOVERATE), value);
+    }
+
+    /**
+     * Get the <i>DefaultMoveRate</i> attribute [attribute ID <b>20</b>].
+     * <p>
+     * The DefaultMoveRate attribute determines the movement rate, in units per second, when a Move
+     * command is received with a Rate parameter of 0xFF.
+     * <p>
+     * The attribute is of type {@link Integer}.
+     * <p>
+     * The implementation of this attribute by a device is OPTIONAL
+     *
+     * @return the {@link Future<CommandResult>} command result future
+     */
+    public Future<CommandResult> getDefaultMoveRateAsync() {
+        return read(attributes.get(ATTR_DEFAULTMOVERATE));
+    }
+
+
+    /**
+     * Synchronously get the <i>DefaultMoveRate</i> attribute [attribute ID <b>20</b>].
+     * <p>
+     * The DefaultMoveRate attribute determines the movement rate, in units per second, when a Move
+     * command is received with a Rate parameter of 0xFF.
+     * <p>
+     * This method can return cached data if the attribute has already been received.
+     * The parameter <i>refreshPeriod</i> is used to control this. If the attribute has been received
+     * within <i>refreshPeriod</i> milliseconds, then the method will immediately return the last value
+     * received. If <i>refreshPeriod</i> is set to 0, then the attribute will always be updated.
+     * <p>
+     * This method will block until the response is received or a timeout occurs unless the current value is returned.
+     * <p>
+     * The attribute is of type {@link Integer}.
+     * <p>
+     * The implementation of this attribute by a device is OPTIONAL
+     *
+     * @param refreshPeriod the maximum age of the data (in milliseconds) before an update is needed
+     * @return the {@link Integer} attribute value, or null on error
+     */
+    public Integer getDefaultMoveRate(final long refreshPeriod) {
+        if(refreshPeriod > 0 && attributes.get(ATTR_DEFAULTMOVERATE).getLastReportTime() != null) {
+            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
+            if(attributes.get(ATTR_DEFAULTMOVERATE).getLastReportTime().getTimeInMillis() < refreshTime) {
+                return (Integer) attributes.get(ATTR_DEFAULTMOVERATE).getLastValue();
+            }
+        }
+
+        return (Integer) readSync(attributes.get(ATTR_DEFAULTMOVERATE));
+    }
+
     /**
      * The Move to Level Command
+     * <p>
+     * On receipt of this command, a device SHALL move from its current level to the
+     * value given in the Level field. The meaning of ‘level’ is device dependent –e.g.,
+     * for a light it MAY mean brightness level.The movement SHALL be as continuous as
+     * technically practical, i.e., not a step function, and the time taken to move to
+     * the new level SHALL be equal to the value of the Transition time field, in tenths
+     * of a second, or as close to this as the device is able.If the Transition time field
+     * takes the value 0xffff then the time taken to move to the new level SHALL instead
+     * be determined by the OnOffTransitionTimeattribute. If OnOffTransitionTime, which is
+     * an optional attribute, is not present, the device SHALL move to its new level as fast
+     * as it is able.
      *
      * @param level {@link Integer} Level
      * @param transitionTime {@link Integer} Transition time

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/DiscoverAttributesCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/DiscoverAttributesCommand.java
@@ -28,11 +28,18 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 public class DiscoverAttributesCommand extends ZclCommand {
     /**
      * Start attribute identifier command message field.
+     *
+     * The start attribute identifier field is 16 bits in length and specifies the value
+     * of the identifier at which to begin the attribute discovery.
      */
     private Integer startAttributeIdentifier;
 
     /**
      * Maximum attribute identifiers command message field.
+     *
+     * The  maximum attribute identifiers field is 8 bits in length and specifies the
+     * maximum number of attribute identifiers that are to be returned in the resulting
+     * Discover Attributes Response command.
      */
     private Integer maximumAttributeIdentifiers;
 
@@ -61,6 +68,9 @@ public class DiscoverAttributesCommand extends ZclCommand {
     /**
      * Gets Start attribute identifier.
      *
+     * The start attribute identifier field is 16 bits in length and specifies the value
+     * of the identifier at which to begin the attribute discovery.
+     *
      * @return the Start attribute identifier
      */
     public Integer getStartAttributeIdentifier() {
@@ -69,6 +79,9 @@ public class DiscoverAttributesCommand extends ZclCommand {
 
     /**
      * Sets Start attribute identifier.
+     *
+     * The start attribute identifier field is 16 bits in length and specifies the value
+     * of the identifier at which to begin the attribute discovery.
      *
      * @param startAttributeIdentifier the Start attribute identifier
      */
@@ -79,6 +92,10 @@ public class DiscoverAttributesCommand extends ZclCommand {
     /**
      * Gets Maximum attribute identifiers.
      *
+     * The  maximum attribute identifiers field is 8 bits in length and specifies the
+     * maximum number of attribute identifiers that are to be returned in the resulting
+     * Discover Attributes Response command.
+     *
      * @return the Maximum attribute identifiers
      */
     public Integer getMaximumAttributeIdentifiers() {
@@ -87,6 +104,10 @@ public class DiscoverAttributesCommand extends ZclCommand {
 
     /**
      * Sets Maximum attribute identifiers.
+     *
+     * The  maximum attribute identifiers field is 8 bits in length and specifies the
+     * maximum number of attribute identifiers that are to be returned in the resulting
+     * Discover Attributes Response command.
      *
      * @param maximumAttributeIdentifiers the Maximum attribute identifiers
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/DiscoverAttributesExtendedResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/DiscoverAttributesExtendedResponse.java
@@ -31,12 +31,12 @@ public class DiscoverAttributesExtendedResponse extends ZclCommand {
     /**
      * Discovery complete command message field.
      */
-    private Integer discoveryComplete;
+    private Boolean discoveryComplete;
 
     /**
-     * Command identifiers command message field.
+     * Attribute Information command message field.
      */
-    private List<ExtendedAttributeInformation> commandIdentifiers;
+    private List<ExtendedAttributeInformation> attributeInformation;
 
     /**
      * Default constructor.
@@ -65,7 +65,7 @@ public class DiscoverAttributesExtendedResponse extends ZclCommand {
      *
      * @return the Discovery complete
      */
-    public Integer getDiscoveryComplete() {
+    public Boolean getDiscoveryComplete() {
         return discoveryComplete;
     }
 
@@ -74,49 +74,49 @@ public class DiscoverAttributesExtendedResponse extends ZclCommand {
      *
      * @param discoveryComplete the Discovery complete
      */
-    public void setDiscoveryComplete(final Integer discoveryComplete) {
+    public void setDiscoveryComplete(final Boolean discoveryComplete) {
         this.discoveryComplete = discoveryComplete;
     }
 
     /**
-     * Gets Command identifiers.
+     * Gets Attribute Information.
      *
-     * @return the Command identifiers
+     * @return the Attribute Information
      */
-    public List<ExtendedAttributeInformation> getCommandIdentifiers() {
-        return commandIdentifiers;
+    public List<ExtendedAttributeInformation> getAttributeInformation() {
+        return attributeInformation;
     }
 
     /**
-     * Sets Command identifiers.
+     * Sets Attribute Information.
      *
-     * @param commandIdentifiers the Command identifiers
+     * @param attributeInformation the Attribute Information
      */
-    public void setCommandIdentifiers(final List<ExtendedAttributeInformation> commandIdentifiers) {
-        this.commandIdentifiers = commandIdentifiers;
+    public void setAttributeInformation(final List<ExtendedAttributeInformation> attributeInformation) {
+        this.attributeInformation = attributeInformation;
     }
 
     @Override
     public void serialize(final ZclFieldSerializer serializer) {
-        serializer.serialize(discoveryComplete, ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        serializer.serialize(commandIdentifiers, ZclDataType.N_X_EXTENDED_ATTRIBUTE_INFORMATION);
+        serializer.serialize(discoveryComplete, ZclDataType.BOOLEAN);
+        serializer.serialize(attributeInformation, ZclDataType.N_X_EXTENDED_ATTRIBUTE_INFORMATION);
     }
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        discoveryComplete = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        commandIdentifiers = (List<ExtendedAttributeInformation>) deserializer.deserialize(ZclDataType.N_X_EXTENDED_ATTRIBUTE_INFORMATION);
+        discoveryComplete = (Boolean) deserializer.deserialize(ZclDataType.BOOLEAN);
+        attributeInformation = (List<ExtendedAttributeInformation>) deserializer.deserialize(ZclDataType.N_X_EXTENDED_ATTRIBUTE_INFORMATION);
     }
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(112);
+        final StringBuilder builder = new StringBuilder(114);
         builder.append("DiscoverAttributesExtendedResponse [");
         builder.append(super.toString());
         builder.append(", discoveryComplete=");
         builder.append(discoveryComplete);
-        builder.append(", commandIdentifiers=");
-        builder.append(commandIdentifiers);
+        builder.append(", attributeInformation=");
+        builder.append(attributeInformation);
         builder.append(']');
         return builder.toString();
     }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/DiscoverAttributesResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/DiscoverAttributesResponse.java
@@ -29,14 +29,23 @@ import com.zsmartsystems.zigbee.zcl.field.AttributeInformation;
  */
 public class DiscoverAttributesResponse extends ZclCommand {
     /**
-     * Command identifier command message field.
+     * Discovery Complete command message field.
+     *
+     * The discovery complete field is a Boolean field. A value of 0 indicates that there
+     * are more attributes to be discovered that have an attribute identifier value greater
+     * than the last attribute identifier in the last attribute information field. A value
+     * of 1 indicates that there are no more attributes to be discovered.
+     * The attribute identifier field SHALL contain the identifier of a discovered attribute.
+     * Attributes SHALL be included in ascending order, starting with the lowest attribute
+     * identifier that is greater than or equal to the start attribute identifier field of the
+     * received Discover Attributes command.
      */
-    private Boolean commandIdentifier;
+    private Boolean discoveryComplete;
 
     /**
-     * Information command message field.
+     * Attribute Information command message field.
      */
-    private List<AttributeInformation> information;
+    private List<AttributeInformation> attributeInformation;
 
     /**
      * Default constructor.
@@ -61,62 +70,80 @@ public class DiscoverAttributesResponse extends ZclCommand {
     }
 
     /**
-     * Gets Command identifier.
+     * Gets Discovery Complete.
      *
-     * @return the Command identifier
+     * The discovery complete field is a Boolean field. A value of 0 indicates that there
+     * are more attributes to be discovered that have an attribute identifier value greater
+     * than the last attribute identifier in the last attribute information field. A value
+     * of 1 indicates that there are no more attributes to be discovered.
+     * The attribute identifier field SHALL contain the identifier of a discovered attribute.
+     * Attributes SHALL be included in ascending order, starting with the lowest attribute
+     * identifier that is greater than or equal to the start attribute identifier field of the
+     * received Discover Attributes command.
+     *
+     * @return the Discovery Complete
      */
-    public Boolean getCommandIdentifier() {
-        return commandIdentifier;
+    public Boolean getDiscoveryComplete() {
+        return discoveryComplete;
     }
 
     /**
-     * Sets Command identifier.
+     * Sets Discovery Complete.
      *
-     * @param commandIdentifier the Command identifier
+     * The discovery complete field is a Boolean field. A value of 0 indicates that there
+     * are more attributes to be discovered that have an attribute identifier value greater
+     * than the last attribute identifier in the last attribute information field. A value
+     * of 1 indicates that there are no more attributes to be discovered.
+     * The attribute identifier field SHALL contain the identifier of a discovered attribute.
+     * Attributes SHALL be included in ascending order, starting with the lowest attribute
+     * identifier that is greater than or equal to the start attribute identifier field of the
+     * received Discover Attributes command.
+     *
+     * @param discoveryComplete the Discovery Complete
      */
-    public void setCommandIdentifier(final Boolean commandIdentifier) {
-        this.commandIdentifier = commandIdentifier;
+    public void setDiscoveryComplete(final Boolean discoveryComplete) {
+        this.discoveryComplete = discoveryComplete;
     }
 
     /**
-     * Gets Information.
+     * Gets Attribute Information.
      *
-     * @return the Information
+     * @return the Attribute Information
      */
-    public List<AttributeInformation> getInformation() {
-        return information;
+    public List<AttributeInformation> getAttributeInformation() {
+        return attributeInformation;
     }
 
     /**
-     * Sets Information.
+     * Sets Attribute Information.
      *
-     * @param information the Information
+     * @param attributeInformation the Attribute Information
      */
-    public void setInformation(final List<AttributeInformation> information) {
-        this.information = information;
+    public void setAttributeInformation(final List<AttributeInformation> attributeInformation) {
+        this.attributeInformation = attributeInformation;
     }
 
     @Override
     public void serialize(final ZclFieldSerializer serializer) {
-        serializer.serialize(commandIdentifier, ZclDataType.BOOLEAN);
-        serializer.serialize(information, ZclDataType.N_X_ATTRIBUTE_INFORMATION);
+        serializer.serialize(discoveryComplete, ZclDataType.BOOLEAN);
+        serializer.serialize(attributeInformation, ZclDataType.N_X_ATTRIBUTE_INFORMATION);
     }
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        commandIdentifier = (Boolean) deserializer.deserialize(ZclDataType.BOOLEAN);
-        information = (List<AttributeInformation>) deserializer.deserialize(ZclDataType.N_X_ATTRIBUTE_INFORMATION);
+        discoveryComplete = (Boolean) deserializer.deserialize(ZclDataType.BOOLEAN);
+        attributeInformation = (List<AttributeInformation>) deserializer.deserialize(ZclDataType.N_X_ATTRIBUTE_INFORMATION);
     }
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(97);
+        final StringBuilder builder = new StringBuilder(106);
         builder.append("DiscoverAttributesResponse [");
         builder.append(super.toString());
-        builder.append(", commandIdentifier=");
-        builder.append(commandIdentifier);
-        builder.append(", information=");
-        builder.append(information);
+        builder.append(", discoveryComplete=");
+        builder.append(discoveryComplete);
+        builder.append(", attributeInformation=");
+        builder.append(attributeInformation);
         builder.append(']');
         return builder.toString();
     }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/DiscoverCommandsGeneratedResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/DiscoverCommandsGeneratedResponse.java
@@ -30,7 +30,7 @@ public class DiscoverCommandsGeneratedResponse extends ZclCommand {
     /**
      * Discovery complete command message field.
      */
-    private Integer discoveryComplete;
+    private Boolean discoveryComplete;
 
     /**
      * Command identifiers command message field.
@@ -64,7 +64,7 @@ public class DiscoverCommandsGeneratedResponse extends ZclCommand {
      *
      * @return the Discovery complete
      */
-    public Integer getDiscoveryComplete() {
+    public Boolean getDiscoveryComplete() {
         return discoveryComplete;
     }
 
@@ -73,7 +73,7 @@ public class DiscoverCommandsGeneratedResponse extends ZclCommand {
      *
      * @param discoveryComplete the Discovery complete
      */
-    public void setDiscoveryComplete(final Integer discoveryComplete) {
+    public void setDiscoveryComplete(final Boolean discoveryComplete) {
         this.discoveryComplete = discoveryComplete;
     }
 
@@ -97,13 +97,13 @@ public class DiscoverCommandsGeneratedResponse extends ZclCommand {
 
     @Override
     public void serialize(final ZclFieldSerializer serializer) {
-        serializer.serialize(discoveryComplete, ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        serializer.serialize(discoveryComplete, ZclDataType.BOOLEAN);
         serializer.serialize(commandIdentifiers, ZclDataType.X_UNSIGNED_8_BIT_INTEGER);
     }
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        discoveryComplete = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        discoveryComplete = (Boolean) deserializer.deserialize(ZclDataType.BOOLEAN);
         commandIdentifiers = (List<Integer>) deserializer.deserialize(ZclDataType.X_UNSIGNED_8_BIT_INTEGER);
     }
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/DiscoverCommandsReceivedResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/DiscoverCommandsReceivedResponse.java
@@ -30,7 +30,7 @@ public class DiscoverCommandsReceivedResponse extends ZclCommand {
     /**
      * Discovery complete command message field.
      */
-    private Integer discoveryComplete;
+    private Boolean discoveryComplete;
 
     /**
      * Command identifiers command message field.
@@ -64,7 +64,7 @@ public class DiscoverCommandsReceivedResponse extends ZclCommand {
      *
      * @return the Discovery complete
      */
-    public Integer getDiscoveryComplete() {
+    public Boolean getDiscoveryComplete() {
         return discoveryComplete;
     }
 
@@ -73,7 +73,7 @@ public class DiscoverCommandsReceivedResponse extends ZclCommand {
      *
      * @param discoveryComplete the Discovery complete
      */
-    public void setDiscoveryComplete(final Integer discoveryComplete) {
+    public void setDiscoveryComplete(final Boolean discoveryComplete) {
         this.discoveryComplete = discoveryComplete;
     }
 
@@ -97,13 +97,13 @@ public class DiscoverCommandsReceivedResponse extends ZclCommand {
 
     @Override
     public void serialize(final ZclFieldSerializer serializer) {
-        serializer.serialize(discoveryComplete, ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        serializer.serialize(discoveryComplete, ZclDataType.BOOLEAN);
         serializer.serialize(commandIdentifiers, ZclDataType.X_UNSIGNED_8_BIT_INTEGER);
     }
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        discoveryComplete = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        discoveryComplete = (Boolean) deserializer.deserialize(ZclDataType.BOOLEAN);
         commandIdentifiers = (List<Integer>) deserializer.deserialize(ZclDataType.X_UNSIGNED_8_BIT_INTEGER);
     }
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/levelcontrol/MoveToLevelCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/levelcontrol/MoveToLevelCommand.java
@@ -16,6 +16,17 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 /**
  * Move to Level Command value object class.
  * <p>
+ * On receipt of this command, a device SHALL move from its current level to the
+ * value given in the Level field. The meaning of ‘level’ is device dependent –e.g.,
+ * for a light it MAY mean brightness level.The movement SHALL be as continuous as
+ * technically practical, i.e., not a step function, and the time taken to move to
+ * the new level SHALL be equal to the value of the Transition time field, in tenths
+ * of a second, or as close to this as the device is able.If the Transition time field
+ * takes the value 0xffff then the time taken to move to the new level SHALL instead
+ * be determined by the OnOffTransitionTimeattribute. If OnOffTransitionTime, which is
+ * an optional attribute, is not present, the device SHALL move to its new level as fast
+ * as it is able.
+ * <p>
  * Cluster: <b>Level Control</b>. Command is sent <b>TO</b> the server.
  * This command is a <b>specific</b> command used for the Level Control cluster.
  * <p>

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/transport/TransportConfigTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/transport/TransportConfigTest.java
@@ -27,16 +27,16 @@ public class TransportConfigTest {
         config = new TransportConfig();
         assertEquals(0, config.getOptions().size());
 
-        config = new TransportConfig(TransportConfigOption.TRUST_CENTRE_JOIN_MODE, TrustCentreLinkMode.TC_JOIN_DENY);
+        config = new TransportConfig(TransportConfigOption.TRUST_CENTRE_JOIN_MODE, TrustCentreJoinMode.TC_JOIN_DENY);
         assertEquals(1, config.getOptions().size());
 
         assertTrue(config.addOption(TransportConfigOption.CONCENTRATOR_TYPE, ConcentratorType.DISABLED));
         assertEquals(2, config.getOptions().size());
 
-        assertFalse(config.addOption(TransportConfigOption.TRUST_CENTRE_JOIN_MODE, TrustCentreLinkMode.TC_JOIN_DENY));
+        assertFalse(config.addOption(TransportConfigOption.TRUST_CENTRE_JOIN_MODE, TrustCentreJoinMode.TC_JOIN_DENY));
         assertEquals(2, config.getOptions().size());
 
-        assertEquals(TrustCentreLinkMode.TC_JOIN_DENY, config.getOption(TransportConfigOption.TRUST_CENTRE_JOIN_MODE));
+        assertEquals(TrustCentreJoinMode.TC_JOIN_DENY, config.getOption(TransportConfigOption.TRUST_CENTRE_JOIN_MODE));
         assertNull(config.getOption(TransportConfigOption.TRUST_CENTRE_LINK_KEY));
 
         assertTrue(config.setResult(TransportConfigOption.CONCENTRATOR_TYPE, TransportConfigResult.SUCCESS));

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zcl/clusters/general/DiscoverAttributesResponseTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zcl/clusters/general/DiscoverAttributesResponseTest.java
@@ -38,7 +38,7 @@ public class DiscoverAttributesResponseTest extends CommandTest {
 
         System.out.println(response);
 
-        List<AttributeInformation> records = response.getInformation();
+        List<AttributeInformation> records = response.getAttributeInformation();
         assertEquals(5, records.size());
 
         AttributeInformation record = records.get(0);


### PR DESCRIPTION
Improved cluster discovery methods. Covers the case where a single response does not return all responses, and ensures concurrency.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>