### PR TITLE
Add method to get dongle IEEE address to aid some dongle startup

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.cc2531/src/main/java/com/zsmartsystems/zigbee/dongle/cc2531/ZigBeeDongleTiCc2531.java
+++ b/com.zsmartsystems.zigbee.dongle.cc2531/src/main/java/com/zsmartsystems/zigbee/dongle/cc2531/ZigBeeDongleTiCc2531.java
@@ -14,6 +14,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.zsmartsystems.zigbee.ExtendedPanId;
+import com.zsmartsystems.zigbee.IeeeAddress;
 import com.zsmartsystems.zigbee.ZigBeeApsFrame;
 import com.zsmartsystems.zigbee.ZigBeeException;
 import com.zsmartsystems.zigbee.ZigBeeKey;
@@ -83,6 +84,11 @@ public class ZigBeeDongleTiCc2531
     private final HashMap<Integer, Integer> endpoint2Profile = new HashMap<Integer, Integer>();
 
     /**
+     * The IeeeAddress of the Ember NCP
+     */
+    private IeeeAddress ieeeAddress;
+
+    /**
      * The Ember version used in this system. Set during initialisation and saved in case the client is interested.
      */
     private String versionString = "Unknown";
@@ -125,6 +131,11 @@ public class ZigBeeDongleTiCc2531
         zigbeeNetworkReceive.setNetworkState(ZigBeeTransportState.INITIALISING);
 
         return ZigBeeInitializeResponse.JOINED;
+    }
+
+    @Override
+    public IeeeAddress getIeeeAddress() {
+        return ieeeAddress;
     }
 
     @Override

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
@@ -15,6 +15,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.zsmartsystems.zigbee.ExtendedPanId;
+import com.zsmartsystems.zigbee.IeeeAddress;
 import com.zsmartsystems.zigbee.ZigBeeApsFrame;
 import com.zsmartsystems.zigbee.ZigBeeException;
 import com.zsmartsystems.zigbee.ZigBeeKey;
@@ -125,6 +126,11 @@ public class ZigBeeDongleEzsp implements ZigBeeTransportTransmit, ZigBeeTranspor
      * The current network parameters as {@link EmberNetworkParameters}
      */
     private EmberNetworkParameters networkParameters = new EmberNetworkParameters();
+
+    /**
+     * The IeeeAddress of the Ember NCP
+     */
+    private IeeeAddress ieeeAddress;
 
     /**
      * The Ember version used in this system. Set during initialisation and saved in case the client is interested.
@@ -314,6 +320,11 @@ public class ZigBeeDongleEzsp implements ZigBeeTransportTransmit, ZigBeeTranspor
         serialPort.close();
         ashHandler.close();
         ashHandler = null;
+    }
+
+    @Override
+    public IeeeAddress getIeeeAddress() {
+        return ieeeAddress;
     }
 
     /**

--- a/com.zsmartsystems.zigbee.dongle.telegesis/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/ZigBeeDongleTelegesis.java
+++ b/com.zsmartsystems.zigbee.dongle.telegesis/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/ZigBeeDongleTelegesis.java
@@ -14,6 +14,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.zsmartsystems.zigbee.ExtendedPanId;
+import com.zsmartsystems.zigbee.IeeeAddress;
 import com.zsmartsystems.zigbee.ZigBeeApsFrame;
 import com.zsmartsystems.zigbee.ZigBeeChannelMask;
 import com.zsmartsystems.zigbee.ZigBeeException;
@@ -132,6 +133,11 @@ public class ZigBeeDongleTelegesis
      * The current extended pan ID
      */
     private ExtendedPanId extendedPanId;
+
+    /**
+     * The IeeeAddress of the Telegesis radio
+     */
+    private IeeeAddress ieeeAddress;
 
     /**
      * The Telegesis version used in this system.
@@ -361,6 +367,8 @@ public class ZigBeeDongleTelegesis
             builder.append("Version=R");
             builder.append(productInfo.getFirmwareRevision());
             versionString = builder.toString();
+
+            ieeeAddress = productInfo.getIeeeAddress();
         }
 
         // Get network information
@@ -424,6 +432,11 @@ public class ZigBeeDongleTelegesis
         serialPort.close();
         frameHandler.close();
         logger.debug("Telegesis dongle shutdown.");
+    }
+
+    @Override
+    public IeeeAddress getIeeeAddress() {
+        return ieeeAddress;
     }
 
     private void initialiseNetwork() {

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNode.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNode.java
@@ -65,12 +65,12 @@ public class ZigBeeNode implements ZigBeeCommandListener {
     /**
      * The {@link NodeDescriptor} for the node
      */
-    private NodeDescriptor nodeDescriptor;
+    private NodeDescriptor nodeDescriptor = new NodeDescriptor();
 
     /**
      * The {@link PowerDescriptor} for the node
      */
-    private PowerDescriptor powerDescriptor;
+    private PowerDescriptor powerDescriptor = new PowerDescriptor();
 
     /**
      * A flag indicating if this node is configured to allow joining
@@ -335,7 +335,7 @@ public class ZigBeeNode implements ZigBeeCommandListener {
      * Request an update of the binding table for this node.
      * <p>
      * This method returns a future to a boolean. Upon success the caller should call {@link #getBindingTable()}
-     * 
+     *
      * @return {@link Future} returning a {@link Boolean}
      */
     public Future<Boolean> updateBindingTable() {

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transport/ZigBeeTransportTransmit.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transport/ZigBeeTransportTransmit.java
@@ -10,6 +10,7 @@ package com.zsmartsystems.zigbee.transport;
 import java.util.Map;
 
 import com.zsmartsystems.zigbee.ExtendedPanId;
+import com.zsmartsystems.zigbee.IeeeAddress;
 import com.zsmartsystems.zigbee.ZigBeeApsFrame;
 import com.zsmartsystems.zigbee.ZigBeeException;
 import com.zsmartsystems.zigbee.ZigBeeKey;
@@ -29,10 +30,6 @@ import com.zsmartsystems.zigbee.serialization.ZigBeeSerializer;
  * while allowing the transport implementation (eg dongle) to format the data as per its needs. The payload is
  * serialised by the framework using the {@link ZigBeeSerializer} and {@link ZigBeeDeserializer} interfaces, thus
  * allowing the format to be set for different hardware implementations.
- * <p>
- * The ZDO interface exchanges only command classes. This is different to the ZCL interface since different sticks
- * tend to implement ZDO functionality as individual commands rather than allowing a binary ZDO packet to be sent and
- * received.
  *
  * @author Chris Jackson
  */
@@ -43,6 +40,9 @@ public interface ZigBeeTransportTransmit {
      * <p>
      * During the initialize() method, the provider must initialize the ports and perform any configuration required to
      * get the stack ready for use. If the dongle has already joined a network, then this method will return true.
+     * <p>
+     * At the completion of the initialize method, the {@link #getIeeeAddress()} method must return the valid address
+     * for the coordinator.
      *
      * @return {@link ZigBeeInitializeResponse}
      */
@@ -68,6 +68,13 @@ public interface ZigBeeTransportTransmit {
      * Get the transport layer version string
      */
     String getVersionString();
+
+    /**
+     * Returns the {@link IeeeAddress} of the local device
+     *
+     * @return the {@link IeeeAddress} of the local device
+     */
+    IeeeAddress getIeeeAddress();
 
     /**
      * Sends ZigBee Cluster Library command without waiting for response. Responses are provided to the framework

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/field/NodeDescriptor.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/field/NodeDescriptor.java
@@ -25,7 +25,7 @@ public class NodeDescriptor {
     private int bufferSize;
     private boolean complexDescriptorAvailable;
     private int manufacturerCode;
-    private LogicalType logicalType;
+    private LogicalType logicalType = LogicalType.UNKNOWN;
     private Set<ServerCapabilitiesType> serverCapabilities = new HashSet<ServerCapabilitiesType>();
     private int incomingTransferSize;
     private int outgoingTransferSize;

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeNetworkManagerTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeNetworkManagerTest.java
@@ -32,8 +32,8 @@ import com.zsmartsystems.zigbee.zcl.ZclHeader;
 import com.zsmartsystems.zigbee.zcl.clusters.general.ReadAttributesCommand;
 import com.zsmartsystems.zigbee.zcl.clusters.onoff.OnCommand;
 
-public class ZigBeeNetworkManagerTest
-        implements ZigBeeNetworkNodeListener, ZigBeeNetworkStateListener, ZigBeeNetworkEndpointListener, ZigBeeCommandListener {
+public class ZigBeeNetworkManagerTest implements ZigBeeNetworkNodeListener, ZigBeeNetworkStateListener,
+        ZigBeeNetworkEndpointListener, ZigBeeCommandListener {
     private ZigBeeNetworkNodeListener mockedNodeListener;
     private List<ZigBeeNode> nodeNodeListenerCapture;
     private ZigBeeNetworkEndpointListener mockedDeviceListener;

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeNodeTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeNodeTest.java
@@ -34,7 +34,14 @@ public class ZigBeeNodeTest {
     @Test
     public void testAddDescriptors() {
         ZigBeeNode node = new ZigBeeNode(Mockito.mock(ZigBeeNetworkManager.class));
+
+        // Not null by default
+        assertNotNull(node.getNodeDescriptor());
+        assertNotNull(node.getPowerDescriptor());
+
         node.setPowerDescriptor(null);
+        assertEquals(null, node.getPowerDescriptor());
+        node.setNodeDescriptor(null);
         assertEquals(null, node.getPowerDescriptor());
 
         System.out.println(node.toString());
@@ -184,6 +191,8 @@ public class ZigBeeNodeTest {
         assertFalse(node.isReducedFuntionDevice());
         assertFalse(node.isPrimaryTrustCenter());
         assertFalse(node.isSecurityCapable());
+
+        assertEquals(LogicalType.UNKNOWN, node.getLogicalType());
 
         NodeDescriptor nodeDescriptor = new NodeDescriptor();
         node.setNodeDescriptor(nodeDescriptor);


### PR DESCRIPTION
This allows the node 0 address to be set even if the dongle isn't immediately responding to IEEE address requests. It's not mandatory for dongles to implement this.

This also adds a set of default descriptors so that requests for information doesn't NPE.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>