### PR TITLE
Add handling for receiving ZLL frames

### DIFF
--- a/com.zsmartsystems.zigbee.autocode/src/main/resources/zcl_definition.md
+++ b/com.zsmartsystems.zigbee.autocode/src/main/resources/zcl_definition.md
@@ -2625,7 +2625,3 @@ command that is still current.
 
 ### Received
 ### Generated
-
-## Touchlink [0x1000]
-### Received
-### Generated

--- a/com.zsmartsystems.zigbee.autocode/src/main/resources/zll_definition.md
+++ b/com.zsmartsystems.zigbee.autocode/src/main/resources/zll_definition.md
@@ -1,0 +1,7 @@
+# ZigBee Light Link [0xC05E]
+
+# Commissioning
+
+## Touchlink [0x1000]
+### Received
+### Generated

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeApsFrame.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeApsFrame.java
@@ -268,7 +268,7 @@ public class ZigBeeApsFrame {
         builder.append("/");
         builder.append(destinationEndpoint);
         builder.append(", profile=");
-        builder.append(profile);
+        builder.append(String.format("%04X", profile));
         builder.append(", cluster=");
         builder.append(cluster);
         builder.append(", addressMode=");

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
@@ -542,8 +542,9 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
         ZclFieldDeserializer fieldDeserializer = new ZclFieldDeserializer(deserializer);
 
         ZigBeeCommand command = null;
-        switch (apsFrame.getProfile()) {
+        switch (apsFrame.getProfile()) { // TODO: Use ZigBeeProfileType
             case 0x0000:
+            case 0xC05E:
                 command = receiveZdoCommand(fieldDeserializer, apsFrame);
                 break;
             case 0x0104:

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeProfileType.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeProfileType.java
@@ -7,6 +7,9 @@
  */
 package com.zsmartsystems.zigbee;
 
+import java.util.Map;
+import java.util.HashMap;
+
 /**
  * Enumeration of ZigBee profile types
  * <p>
@@ -15,26 +18,65 @@ package com.zsmartsystems.zigbee;
  * @author Chris Jackson
  */
 public enum ZigBeeProfileType {
-    HOME_AUTOMATION(0x0104, "Home Automation");
+    UNKNOWN(-1, "Unknown Profile"),
+    HOME_AUTOMATION(0x0104, "Home Automation"),
+    ZIGBEE_LIGHT_LINK(0xc05e, "ZigBee Light Link");
 
+    /*
+     * The ZigBee profile ID
+     */
     private final int profileId;
+
+    /*
+     * The ZigBee profile label
+     */
     private final String label;
+
+    /**
+     * Map containing the link of profile type value to the enum
+     */
+    private static Map<Integer, ZigBeeProfileType> map = null;
 
     ZigBeeProfileType(final int profileId, final String label) {
         this.profileId = profileId;
         this.label = label;
     }
 
+    /*
+     * Get the ZigBee profile ID
+     *
+     * @ return the profile ID
+     */
     public int getId() {
         return profileId;
     }
 
+    /*
+     * Get the ZigBee profile label
+     *
+     * @ return the profile label
+     */
     public String getLabel() {
         return label;
     }
 
-    public String toString() {
-        return label;
-    }
+    /**
+     * Get a {@link ZigBeeProfileType} from an integer
+     *
+     * @param profileTypeValue integer value defining the profile type
+     * @return {@link ZigBeeProfileType} or {@link #UNKNOWN} if the value could not be converted
+     */
+    public static ZigBeeProfileType getProfileType(int profileTypeValue) {
+        if (map == null) {
+            map = new HashMap<Integer, ZigBeeProfileType>();
+            for (ZigBeeProfileType profileType : values()) {
+                map.put(profileType.profileId, profileType);
+            }
+        }
 
+        if (map.get(profileTypeValue) == null) {
+            return UNKNOWN;
+        }
+        return map.get(profileTypeValue);
+    }
 }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/protocol/ZclClusterType.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/protocol/ZclClusterType.java
@@ -96,8 +96,8 @@ public enum ZclClusterType {
     APPLIANCE_STATISTICS(0x0B03, ZigBeeProfileType.HOME_AUTOMATION, ZclApplianceStatisticsCluster.class, "Appliance Statistics"),
     ELECTRICAL_MEASUREMENT(0x0B04, ZigBeeProfileType.HOME_AUTOMATION, ZclElectricalMeasurementCluster.class, "Electrical Measurement"),
     DIAGNOSTICS(0x0B05, ZigBeeProfileType.HOME_AUTOMATION, ZclDiagnosticsCluster.class, "Diagnostics"),
-    TOUCHLINK(0x1000, ZigBeeProfileType.HOME_AUTOMATION, ZclTouchlinkCluster.class, "Touchlink"),
-    GENERAL(0xFFFF, ZigBeeProfileType.HOME_AUTOMATION, ZclGeneralCluster.class, "General");
+    GENERAL(0xFFFF, ZigBeeProfileType.HOME_AUTOMATION, ZclGeneralCluster.class, "General"),
+    TOUCHLINK(0x1000, ZigBeeProfileType.ZIGBEE_LIGHT_LINK, ZclTouchlinkCluster.class, "Touchlink");
 
     private static final Map<Integer, ZclClusterType> idValueMap = new HashMap<Integer, ZclClusterType>();
 

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeApsFrameTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeApsFrameTest.java
@@ -37,6 +37,8 @@ public class ZigBeeApsFrameTest {
 
         frame.setSecurityEnable(false);
         assertFalse(frame.isSecurityEnable());
+
+        System.out.println(frame);
     }
 
     @Test
@@ -58,6 +60,7 @@ public class ZigBeeApsFrameTest {
     @Test
     public void testGroupAddress() {
         ZigBeeApsFrame frame = new ZigBeeApsFrame();
+        System.out.println(frame);
 
         frame.setGroupAddress(1);
         assertEquals(1, frame.getGroupAddress());

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeProfileTypeTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeProfileTypeTest.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2016-2017 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+/**
+ *
+ * @author Chris Jackson
+ *
+ */
+public class ZigBeeProfileTypeTest {
+    @Test
+    public void testTypes() {
+        assertEquals(ZigBeeProfileType.UNKNOWN, ZigBeeProfileType.getProfileType(0x0001));
+        assertEquals(ZigBeeProfileType.HOME_AUTOMATION, ZigBeeProfileType.getProfileType(0x0104));
+        assertEquals(ZigBeeProfileType.ZIGBEE_LIGHT_LINK, ZigBeeProfileType.getProfileType(0xC05E));
+    }
+}


### PR DESCRIPTION
This adds the ZLL profile as a separate definition file so it's added to the ```ZigBeeProfileType``` and then doesn't ignore ZCL commands with the ZLL profile if they are received.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>