### PR TITLE
Support secondary responses to come messages that only provide a ZclStatus

### DIFF
--- a/com.zsmartsystems.zigbee.autocode/src/main/java/com/zsmartsystems/zigbee/autocode/ZclProtocolCodeGenerator.java
+++ b/com.zsmartsystems.zigbee.autocode/src/main/java/com/zsmartsystems/zigbee/autocode/ZclProtocolCodeGenerator.java
@@ -1097,7 +1097,14 @@ public class ZclProtocolCodeGenerator {
                             // if listSizer != null and contains && then check the param bit
 
                             if (field.listSizer != null) {
-                                if (field.conditionOperator != null) {
+                                if (field.listSizer.equals("statusResponse")) {
+                                    // Special case where a ZclStatus may be sent, or, a list of results.
+                                    // This checks for a single response
+                                    out.println("        if (status == ZclStatus.SUCCESS) {");
+                                    out.println("            serializer.serialize(status, ZclDataType.ZCL_STATUS);");
+                                    out.println("            return;");
+                                    out.println("        }");
+                                } else if (field.conditionOperator != null) {
                                     if (field.conditionOperator == "&&") {
                                         out.println("        if ((" + field.listSizer + " & " + field.condition
                                                 + ") != 0) {");
@@ -1127,7 +1134,15 @@ public class ZclProtocolCodeGenerator {
                         out.println("    public void deserialize(final ZclFieldDeserializer deserializer) {");
                         for (final Field field : fields) {
                             if (field.listSizer != null) {
-                                if (field.conditionOperator != null) {
+                                if (field.listSizer.equals("statusResponse")) {
+                                    // Special case where a ZclStatus may be sent, or, a list of results.
+                                    // This checks for a single response
+                                    out.println("        if (deserializer.getRemainingLength() == 1) {");
+                                    out.println(
+                                            "            status = (ZclStatus) deserializer.deserialize(ZclDataType.ZCL_STATUS);");
+                                    out.println("            return;");
+                                    out.println("        }");
+                                } else if (field.conditionOperator != null) {
                                     if (field.conditionOperator == "&&") {
                                         out.println("        if ((" + field.listSizer + " & " + field.condition
                                                 + ") != 0) {");

--- a/com.zsmartsystems.zigbee.autocode/src/main/resources/zcl_definition.md
+++ b/com.zsmartsystems.zigbee.autocode/src/main/resources/zcl_definition.md
@@ -97,9 +97,23 @@ additional attributes available.
 The Configure Reporting Response command is generated in response to a
 Configure Reporting command. 
 
-|Field Name                 |Data Type                  |
-|---------------------------|---------------------------|
-|Records                    |N X Attribute status record|
+|Field Name                 |Data Type                    |
+|---------------------------|-----------------------------|
+|Status                     |Zcl Status [status-response] |
+|Records                    |N X Attribute status record  |
+
+
+##### Status
+Status is only provided if the command was successful, and the 
+attribute status records are not included for successfully
+written attributes, in order to save bandwidth.
+
+##### Records
+Note that attribute status records are not included for successfully
+configured attributes in order to save bandwidth.  In the case of successful
+configuration of all attributes, only a single attribute status record SHALL
+be included in the command, with the status field set to SUCCESS and the direction and
+attribute identifier fields omitted.
 
 #### Read Reporting Configuration Command [0x08]
 
@@ -203,19 +217,45 @@ change the values of one or more attributes located on another device. Each writ
 attribute record shall contain the identifier and the actual value of the attribute, or
 element thereof, to be written.
 
-|Field Name                 |Data Type                  |
-|---------------------------|---------------------------|
-|Attribute selectors        |N X Attribute selector     |
+|Field Name                 |Data Type                    |
+|---------------------------|-----------------------------|
+|Status                     |Zcl Status [status-response] |
+|Attribute selectors        |N X Attribute selector       |
+
+
+##### Status
+Status is only provided if the command was successful, and the 
+attribute selector records are not included for successfully
+written attributes, in order to save bandwidth.
+
+##### Attribute selectors
+Note that write attribute status records are not included for successfully
+written attributes, in order to save bandwidth. In the case of successful 
+writing of all attributes, only a single  write attribute status record
+SHALL be included in the command, with the status field set to SUCCESS and the
+attribute identifier and selector fields omitted.
 
 #### Write Attributes Structured Response Command [0x10]
 
 The write attributes structured response command is generated in response to a
 write attributes structured command.
 
-|Field Name                 |Data Type                  |
-|---------------------------|---------------------------|
+|Field Name                 |Data Type                         |
+|---------------------------|----------------------------------|
+|Status                     |Zcl Status[status-response]       |
 |Records                    |N X Write attribute status record |
 
+##### Status
+Status is only provided if the command was successful, and the write
+attribute status records are not included for successfully
+written attributes, in order to save bandwidth.
+
+##### Records
+Note that write attribute status records are not included for successfully
+written attributes, in order to save bandwidth.  In the case of successful
+writing of all attributes, only a single write attribute status record
+SHALL be included in the command, with the status field set to SUCCESS and the
+attribute identifier field omitted.
 
 #### Discover Commands Received [0x11]
 

--- a/com.zsmartsystems.zigbee.dongle.telegesis/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/ZigBeeDongleTelegesis.java
+++ b/com.zsmartsystems.zigbee.dongle.telegesis/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/ZigBeeDongleTelegesis.java
@@ -722,7 +722,15 @@ public class ZigBeeDongleTelegesis
     public boolean setTcLinkKey(ZigBeeKey key) {
         linkKey = key;
 
-        return false;
+        TelegesisSetTrustCentreLinkKeyCommand linkKeyCommand = new TelegesisSetTrustCentreLinkKeyCommand();
+        linkKeyCommand.setLinkKey(linkKey);
+        linkKeyCommand.setPassword(telegesisPassword);
+        if (frameHandler.sendRequest(linkKeyCommand) == null) {
+            logger.debug("Error setting Telegesis link key");
+            return false;
+        }
+
+        return true;
     }
 
     @SuppressWarnings("unchecked")
@@ -744,6 +752,12 @@ public class ZigBeeDongleTelegesis
                     case TRUST_CENTRE_JOIN_MODE:
                         configuration.setResult(option,
                                 setTcJoinMode((TrustCentreJoinMode) configuration.getValue(option)));
+                        break;
+
+                    case TRUST_CENTRE_LINK_KEY:
+                        configuration.setResult(option,
+                                setTcLinkKey((ZigBeeKey) configuration.getValue(option)) ? TransportConfigResult.SUCCESS
+                                        : TransportConfigResult.FAILURE);
                         break;
 
                     default:

--- a/com.zsmartsystems.zigbee.dongle.telegesis/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/internal/TelegesisFrameHandler.java
+++ b/com.zsmartsystems.zigbee.dongle.telegesis/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/internal/TelegesisFrameHandler.java
@@ -313,8 +313,7 @@ public class TelegesisFrameHandler {
     /**
      * Notify any transaction listeners when we receive a response.
      *
-     * @param response
-     *            the response data received
+     * @param response the response data received
      * @return true if the response was processed
      */
     private boolean notifyTransactionComplete(final TelegesisCommand response) {
@@ -323,8 +322,12 @@ public class TelegesisFrameHandler {
         logger.debug("Telegesis command complete: {}", response);
         synchronized (transactionListeners) {
             for (TelegesisListener listener : transactionListeners) {
-                if (listener.transactionEvent(response)) {
-                    processed = true;
+                try {
+                    if (listener.transactionEvent(response)) {
+                        processed = true;
+                    }
+                } catch (Exception e) {
+                    logger.debug("Exception processing Telegesis frame: {}: ", response, e);
                 }
             }
         }
@@ -357,7 +360,11 @@ public class TelegesisFrameHandler {
         logger.debug("Telegesis event received: {}", event);
         synchronized (eventListeners) {
             for (TelegesisEventListener listener : eventListeners) {
-                listener.telegesisEventReceived(event);
+                try {
+                    listener.telegesisEventReceived(event);
+                } catch (Exception e) {
+                    logger.debug("Exception processing Telegesis frame: {}: ", event, e);
+                }
             }
         }
     }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
@@ -260,13 +260,15 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
         ZigBeeInitializeResponse transportResponse = transport.initialize();
 
         IeeeAddress address = transport.getIeeeAddress();
-        ZigBeeNode node = getNode(address);
-        if (node == null) {
-            node = new ZigBeeNode(this);
-            node.setIeeeAddress(address);
-            node.setNetworkAddress(0);
+        if (address != null) {
+            ZigBeeNode node = getNode(address);
+            if (node == null) {
+                node = new ZigBeeNode(this);
+                node.setIeeeAddress(address);
+                node.setNetworkAddress(0);
 
-            addNode(node);
+                addNode(node);
+            }
         }
 
         networkDiscoverer.startup();

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transport/TransportConfigResult.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transport/TransportConfigResult.java
@@ -19,13 +19,17 @@ public enum TransportConfigResult {
      */
     SUCCESS,
     /**
-     * A configuration for the requested option has not been set 
-     */
-    ERROR_REQUEST_NOT_SET,
-    /**
-     * The transport has not yet set a result for this request.
+     * The transport has not set a result for this request. This could mean it did not process the request.
      */
     ERROR_NO_RESULT,
+    /**
+     * There was an error implementing the request.
+     */
+    FAILURE,
+    /**
+     * A configuration for the requested option has not been set
+     */
+    ERROR_REQUEST_NOT_SET,
     /**
      * The transport was unable to implement a configuration option as it was in an invalid mode
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transport/ZigBeeTransportTransmit.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transport/ZigBeeTransportTransmit.java
@@ -72,7 +72,7 @@ public interface ZigBeeTransportTransmit {
     /**
      * Returns the {@link IeeeAddress} of the local device
      *
-     * @return the {@link IeeeAddress} of the local device
+     * @return the {@link IeeeAddress} of the local device. May return null if the address is not known.
      */
     IeeeAddress getIeeeAddress();
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/ZclFieldDeserializer.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/ZclFieldDeserializer.java
@@ -28,14 +28,25 @@ public class ZclFieldDeserializer {
 
     /**
      * Constructor for setting the payload and start index.
+     *
+     * @param deserializer the {@link ZigBeeDeserializer} to use for deserialization
      */
     public ZclFieldDeserializer(final ZigBeeDeserializer deserializer) {
         this.deserializer = deserializer;
     }
 
     /**
+     * Gets the remaining payload length
+     *
+     * @return the number of bytes remaining in the input stream
+     */
+    public int getRemainingLength() {
+        return deserializer.getSize() - deserializer.getPosition();
+    }
+
+    /**
      * Checks if there are further bytes to be read
-     * 
+     *
      * @return true if we are at the end of the input stream
      */
     public boolean isEndOfStream() {

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclGeneralCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclGeneralCluster.java
@@ -238,13 +238,15 @@ public class ZclGeneralCluster extends ZclCluster {
      * The Configure Reporting Response command is generated in response to a
      * Configure Reporting command.
      *
+     * @param status {@link ZclStatus} Status
      * @param records {@link List<AttributeStatusRecord>} Records
      * @return the {@link Future<CommandResult>} command result future
      */
-    public Future<CommandResult> configureReportingResponse(List<AttributeStatusRecord> records) {
+    public Future<CommandResult> configureReportingResponse(ZclStatus status, List<AttributeStatusRecord> records) {
         ConfigureReportingResponse command = new ConfigureReportingResponse();
 
         // Set the fields
+        command.setStatus(status);
         command.setRecords(records);
 
         return send(command);
@@ -397,13 +399,15 @@ public class ZclGeneralCluster extends ZclCluster {
      * attribute record shall contain the identifier and the actual value of the attribute, or
      * element thereof, to be written.
      *
+     * @param status {@link ZclStatus} Status
      * @param attributeSelectors {@link Object} Attribute selectors
      * @return the {@link Future<CommandResult>} command result future
      */
-    public Future<CommandResult> writeAttributesStructuredCommand(Object attributeSelectors) {
+    public Future<CommandResult> writeAttributesStructuredCommand(ZclStatus status, Object attributeSelectors) {
         WriteAttributesStructuredCommand command = new WriteAttributesStructuredCommand();
 
         // Set the fields
+        command.setStatus(status);
         command.setAttributeSelectors(attributeSelectors);
 
         return send(command);
@@ -415,13 +419,15 @@ public class ZclGeneralCluster extends ZclCluster {
      * The write attributes structured response command is generated in response to a
      * write attributes structured command.
      *
+     * @param status {@link ZclStatus} Status
      * @param records {@link List<WriteAttributeStatusRecord>} Records
      * @return the {@link Future<CommandResult>} command result future
      */
-    public Future<CommandResult> writeAttributesStructuredResponse(List<WriteAttributeStatusRecord> records) {
+    public Future<CommandResult> writeAttributesStructuredResponse(ZclStatus status, List<WriteAttributeStatusRecord> records) {
         WriteAttributesStructuredResponse command = new WriteAttributesStructuredResponse();
 
         // Set the fields
+        command.setStatus(status);
         command.setRecords(records);
 
         return send(command);

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/ConfigureReportingResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/ConfigureReportingResponse.java
@@ -14,6 +14,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 
 import java.util.List;
+import com.zsmartsystems.zigbee.zcl.ZclStatus;
 import com.zsmartsystems.zigbee.zcl.field.AttributeStatusRecord;
 
 /**
@@ -29,7 +30,22 @@ import com.zsmartsystems.zigbee.zcl.field.AttributeStatusRecord;
  */
 public class ConfigureReportingResponse extends ZclCommand {
     /**
+     * Status command message field.
+     *
+     * Status is only provided if the command was successful, and the
+     * attribute status records are not included for successfully
+     * written attributes, in order to save bandwidth.
+     */
+    private ZclStatus status;
+
+    /**
      * Records command message field.
+     *
+     * Note that attribute status records are not included for successfully
+     * configured attributes in order to save bandwidth.  In the case of successful
+     * configuration of all attributes, only a single attribute status record SHALL
+     * be included in the command, with the status field set to SUCCESS and the direction and
+     * attribute identifier fields omitted.
      */
     private List<AttributeStatusRecord> records;
 
@@ -56,7 +72,39 @@ public class ConfigureReportingResponse extends ZclCommand {
     }
 
     /**
+     * Gets Status.
+     *
+     * Status is only provided if the command was successful, and the
+     * attribute status records are not included for successfully
+     * written attributes, in order to save bandwidth.
+     *
+     * @return the Status
+     */
+    public ZclStatus getStatus() {
+        return status;
+    }
+
+    /**
+     * Sets Status.
+     *
+     * Status is only provided if the command was successful, and the
+     * attribute status records are not included for successfully
+     * written attributes, in order to save bandwidth.
+     *
+     * @param status the Status
+     */
+    public void setStatus(final ZclStatus status) {
+        this.status = status;
+    }
+
+    /**
      * Gets Records.
+     *
+     * Note that attribute status records are not included for successfully
+     * configured attributes in order to save bandwidth.  In the case of successful
+     * configuration of all attributes, only a single attribute status record SHALL
+     * be included in the command, with the status field set to SUCCESS and the direction and
+     * attribute identifier fields omitted.
      *
      * @return the Records
      */
@@ -67,6 +115,12 @@ public class ConfigureReportingResponse extends ZclCommand {
     /**
      * Sets Records.
      *
+     * Note that attribute status records are not included for successfully
+     * configured attributes in order to save bandwidth.  In the case of successful
+     * configuration of all attributes, only a single attribute status record SHALL
+     * be included in the command, with the status field set to SUCCESS and the direction and
+     * attribute identifier fields omitted.
+     *
      * @param records the Records
      */
     public void setRecords(final List<AttributeStatusRecord> records) {
@@ -75,19 +129,29 @@ public class ConfigureReportingResponse extends ZclCommand {
 
     @Override
     public void serialize(final ZclFieldSerializer serializer) {
+        if (status == ZclStatus.SUCCESS) {
+            serializer.serialize(status, ZclDataType.ZCL_STATUS);
+            return;
+        }
         serializer.serialize(records, ZclDataType.N_X_ATTRIBUTE_STATUS_RECORD);
     }
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
+        if (deserializer.getRemainingLength() == 1) {
+            status = (ZclStatus) deserializer.deserialize(ZclDataType.ZCL_STATUS);
+            return;
+        }
         records = (List<AttributeStatusRecord>) deserializer.deserialize(ZclDataType.N_X_ATTRIBUTE_STATUS_RECORD);
     }
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(56);
+        final StringBuilder builder = new StringBuilder(82);
         builder.append("ConfigureReportingResponse [");
         builder.append(super.toString());
+        builder.append(", status=");
+        builder.append(status);
         builder.append(", records=");
         builder.append(records);
         builder.append(']');

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/WriteAttributesStructuredCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/WriteAttributesStructuredCommand.java
@@ -12,6 +12,7 @@ import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
+import com.zsmartsystems.zigbee.zcl.ZclStatus;
 
 /**
  * Write Attributes Structured Command value object class.
@@ -28,7 +29,22 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  */
 public class WriteAttributesStructuredCommand extends ZclCommand {
     /**
+     * Status command message field.
+     *
+     * Status is only provided if the command was successful, and the
+     * attribute selector records are not included for successfully
+     * written attributes, in order to save bandwidth.
+     */
+    private ZclStatus status;
+
+    /**
      * Attribute selectors command message field.
+     *
+     * Note that write attribute status records are not included for successfully
+     * written attributes, in order to save bandwidth. In the case of successful
+     * writing of all attributes, only a single  write attribute status record
+     * SHALL be included in the command, with the status field set to SUCCESS and the
+     * attribute identifier and selector fields omitted.
      */
     private Object attributeSelectors;
 
@@ -55,7 +71,39 @@ public class WriteAttributesStructuredCommand extends ZclCommand {
     }
 
     /**
+     * Gets Status.
+     *
+     * Status is only provided if the command was successful, and the
+     * attribute selector records are not included for successfully
+     * written attributes, in order to save bandwidth.
+     *
+     * @return the Status
+     */
+    public ZclStatus getStatus() {
+        return status;
+    }
+
+    /**
+     * Sets Status.
+     *
+     * Status is only provided if the command was successful, and the
+     * attribute selector records are not included for successfully
+     * written attributes, in order to save bandwidth.
+     *
+     * @param status the Status
+     */
+    public void setStatus(final ZclStatus status) {
+        this.status = status;
+    }
+
+    /**
      * Gets Attribute selectors.
+     *
+     * Note that write attribute status records are not included for successfully
+     * written attributes, in order to save bandwidth. In the case of successful
+     * writing of all attributes, only a single  write attribute status record
+     * SHALL be included in the command, with the status field set to SUCCESS and the
+     * attribute identifier and selector fields omitted.
      *
      * @return the Attribute selectors
      */
@@ -66,6 +114,12 @@ public class WriteAttributesStructuredCommand extends ZclCommand {
     /**
      * Sets Attribute selectors.
      *
+     * Note that write attribute status records are not included for successfully
+     * written attributes, in order to save bandwidth. In the case of successful
+     * writing of all attributes, only a single  write attribute status record
+     * SHALL be included in the command, with the status field set to SUCCESS and the
+     * attribute identifier and selector fields omitted.
+     *
      * @param attributeSelectors the Attribute selectors
      */
     public void setAttributeSelectors(final Object attributeSelectors) {
@@ -74,19 +128,29 @@ public class WriteAttributesStructuredCommand extends ZclCommand {
 
     @Override
     public void serialize(final ZclFieldSerializer serializer) {
+        if (status == ZclStatus.SUCCESS) {
+            serializer.serialize(status, ZclDataType.ZCL_STATUS);
+            return;
+        }
         serializer.serialize(attributeSelectors, ZclDataType.N_X_ATTRIBUTE_SELECTOR);
     }
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
+        if (deserializer.getRemainingLength() == 1) {
+            status = (ZclStatus) deserializer.deserialize(ZclDataType.ZCL_STATUS);
+            return;
+        }
         attributeSelectors = (Object) deserializer.deserialize(ZclDataType.N_X_ATTRIBUTE_SELECTOR);
     }
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(73);
+        final StringBuilder builder = new StringBuilder(99);
         builder.append("WriteAttributesStructuredCommand [");
         builder.append(super.toString());
+        builder.append(", status=");
+        builder.append(status);
         builder.append(", attributeSelectors=");
         builder.append(attributeSelectors);
         builder.append(']');

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/WriteAttributesStructuredResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/WriteAttributesStructuredResponse.java
@@ -14,6 +14,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 
 import java.util.List;
+import com.zsmartsystems.zigbee.zcl.ZclStatus;
 import com.zsmartsystems.zigbee.zcl.field.WriteAttributeStatusRecord;
 
 /**
@@ -29,7 +30,22 @@ import com.zsmartsystems.zigbee.zcl.field.WriteAttributeStatusRecord;
  */
 public class WriteAttributesStructuredResponse extends ZclCommand {
     /**
+     * Status command message field.
+     *
+     * Status is only provided if the command was successful, and the write
+     * attribute status records are not included for successfully
+     * written attributes, in order to save bandwidth.
+     */
+    private ZclStatus status;
+
+    /**
      * Records command message field.
+     *
+     * Note that write attribute status records are not included for successfully
+     * written attributes, in order to save bandwidth.  In the case of successful
+     * writing of all attributes, only a single write attribute status record
+     * SHALL be included in the command, with the status field set to SUCCESS and the
+     * attribute identifier field omitted.
      */
     private List<WriteAttributeStatusRecord> records;
 
@@ -56,7 +72,39 @@ public class WriteAttributesStructuredResponse extends ZclCommand {
     }
 
     /**
+     * Gets Status.
+     *
+     * Status is only provided if the command was successful, and the write
+     * attribute status records are not included for successfully
+     * written attributes, in order to save bandwidth.
+     *
+     * @return the Status
+     */
+    public ZclStatus getStatus() {
+        return status;
+    }
+
+    /**
+     * Sets Status.
+     *
+     * Status is only provided if the command was successful, and the write
+     * attribute status records are not included for successfully
+     * written attributes, in order to save bandwidth.
+     *
+     * @param status the Status
+     */
+    public void setStatus(final ZclStatus status) {
+        this.status = status;
+    }
+
+    /**
      * Gets Records.
+     *
+     * Note that write attribute status records are not included for successfully
+     * written attributes, in order to save bandwidth.  In the case of successful
+     * writing of all attributes, only a single write attribute status record
+     * SHALL be included in the command, with the status field set to SUCCESS and the
+     * attribute identifier field omitted.
      *
      * @return the Records
      */
@@ -67,6 +115,12 @@ public class WriteAttributesStructuredResponse extends ZclCommand {
     /**
      * Sets Records.
      *
+     * Note that write attribute status records are not included for successfully
+     * written attributes, in order to save bandwidth.  In the case of successful
+     * writing of all attributes, only a single write attribute status record
+     * SHALL be included in the command, with the status field set to SUCCESS and the
+     * attribute identifier field omitted.
+     *
      * @param records the Records
      */
     public void setRecords(final List<WriteAttributeStatusRecord> records) {
@@ -75,19 +129,29 @@ public class WriteAttributesStructuredResponse extends ZclCommand {
 
     @Override
     public void serialize(final ZclFieldSerializer serializer) {
+        if (status == ZclStatus.SUCCESS) {
+            serializer.serialize(status, ZclDataType.ZCL_STATUS);
+            return;
+        }
         serializer.serialize(records, ZclDataType.N_X_WRITE_ATTRIBUTE_STATUS_RECORD);
     }
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
+        if (deserializer.getRemainingLength() == 1) {
+            status = (ZclStatus) deserializer.deserialize(ZclDataType.ZCL_STATUS);
+            return;
+        }
         records = (List<WriteAttributeStatusRecord>) deserializer.deserialize(ZclDataType.N_X_WRITE_ATTRIBUTE_STATUS_RECORD);
     }
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(63);
+        final StringBuilder builder = new StringBuilder(89);
         builder.append("WriteAttributesStructuredResponse [");
         builder.append(super.toString());
+        builder.append(", status=");
+        builder.append(status);
         builder.append(", records=");
         builder.append(records);
         builder.append(']');

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zcl/clusters/general/ConfigureReportingResponseTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zcl/clusters/general/ConfigureReportingResponseTest.java
@@ -8,6 +8,7 @@
 package com.zsmartsystems.zigbee.zcl.clusters.general;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import org.junit.Test;
 
@@ -34,15 +35,35 @@ public class ConfigureReportingResponseTest extends CommandTest {
         ZclFieldDeserializer fieldDeserializer = new ZclFieldDeserializer(deserializer);
 
         ZclHeader zclHeader = new ZclHeader(fieldDeserializer);
+        System.out.println(zclHeader);
         response.deserialize(fieldDeserializer);
+        System.out.println(response);
+
+        assertNull(response.getStatus());
 
         assertEquals(1, response.getRecords().size());
         AttributeStatusRecord record = response.getRecords().get(0);
 
         assertEquals(0, record.getAttributeIdentifier());
         assertEquals(ZclStatus.SUCCESS, record.getStatus());
+    }
 
+    @Test
+    public void testStatusOnly() {
+        int[] packet = getPacketData("18 11 07 00");
+
+        ConfigureReportingResponse response = new ConfigureReportingResponse();
+
+        DefaultDeserializer deserializer = new DefaultDeserializer(packet);
+        ZclFieldDeserializer fieldDeserializer = new ZclFieldDeserializer(deserializer);
+
+        ZclHeader zclHeader = new ZclHeader(fieldDeserializer);
         System.out.println(zclHeader);
+
+        response.deserialize(fieldDeserializer);
         System.out.println(response);
+
+        assertEquals(ZclStatus.SUCCESS, response.getStatus());
+        assertNull(response.getRecords());
     }
 }


### PR DESCRIPTION
Some messages do not return a full response. ZigBee allows in some cases a response of just ZclStatus.SUCCESS and not the full list that is defined in the spec. This adds a construct to the definition file that generates code to support this.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>