### PR TITLE
Refactor to ensure that node IEEE address is immutable

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/IeeeAddress.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/IeeeAddress.java
@@ -17,7 +17,7 @@ import java.util.Objects;
  * @author Chris Jackson
  *
  */
-public class IeeeAddress {
+public class IeeeAddress implements Comparable {
     private int[] address;
 
     /**
@@ -110,5 +110,24 @@ public class IeeeAddress {
         }
 
         return builder.toString();
+    }
+
+    @Override
+    public int compareTo(Object object) {
+        if (object == null) {
+            return -1;
+        }
+        if (!IeeeAddress.class.isAssignableFrom(object.getClass())) {
+            return -1;
+        }
+        final IeeeAddress other = (IeeeAddress) object;
+        for (int cnt = 0; cnt < 8; cnt++) {
+            if (other.getValue()[cnt] == address[cnt]) {
+                continue;
+            }
+
+            return other.getValue()[cnt] < address[cnt] ? 1 : -1;
+        }
+        return 0;
     }
 }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkMeshMonitor.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkMeshMonitor.java
@@ -7,10 +7,8 @@
  */
 package com.zsmartsystems.zigbee;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
@@ -207,9 +205,9 @@ public class ZigBeeNetworkMeshMonitor implements ZigBeeCommandListener {
                 try {
                     boolean update = false;
 
-                    List<Integer> associations = null;
-                    List<NeighborTable> neighbors = null;
-                    List<RoutingTable> routes = null;
+                    Set<Integer> associations = null;
+                    Set<NeighborTable> neighbors = null;
+                    Set<RoutingTable> routes = null;
 
                     // We request the neighbor table for all devices
                     neighbors = getNeighborTable(nodeNetworkAddress);
@@ -267,13 +265,13 @@ public class ZigBeeNetworkMeshMonitor implements ZigBeeCommandListener {
      * @throws ExecutionException
      * @throws InterruptedException
      */
-    private List<Integer> getAssociatedNodes(final int networkAddress) throws InterruptedException, ExecutionException {
+    private Set<Integer> getAssociatedNodes(final int networkAddress) throws InterruptedException, ExecutionException {
         // Start index for the list is 0
         int retries = 0;
         int startIndex = 0;
         int totalNodes = 0;
 
-        List<Integer> nodes = new ArrayList<Integer>();
+        Set<Integer> nodes = new HashSet<Integer>();
         do {
             // Request extended response, start index for associated list is 0
             final IeeeAddressRequest ieeeAddressRequest = new IeeeAddressRequest();
@@ -316,13 +314,13 @@ public class ZigBeeNetworkMeshMonitor implements ZigBeeCommandListener {
      * @throws ExecutionException
      * @throws InterruptedException
      */
-    private List<NeighborTable> getNeighborTable(final int networkAddress)
+    private Set<NeighborTable> getNeighborTable(final int networkAddress)
             throws InterruptedException, ExecutionException {
         // Start index for the list is 0
         int retries = 0;
         int startIndex = 0;
         int totalNeighbors = 0;
-        List<NeighborTable> neighbors = new ArrayList<NeighborTable>();
+        Set<NeighborTable> neighbors = new HashSet<NeighborTable>();
         do {
             final ManagementLqiRequest neighborRequest = new ManagementLqiRequest();
             neighborRequest.setDestinationAddress(new ZigBeeEndpointAddress(networkAddress));
@@ -372,13 +370,13 @@ public class ZigBeeNetworkMeshMonitor implements ZigBeeCommandListener {
      * @throws ExecutionException
      * @throws InterruptedException
      */
-    private List<RoutingTable> getRoutingTable(final int networkAddress)
+    private Set<RoutingTable> getRoutingTable(final int networkAddress)
             throws InterruptedException, ExecutionException {
         // Start index for the list is 0
         int retries = 0;
         int startIndex = 0;
         int totalRoutes = 0;
-        List<RoutingTable> routes = new ArrayList<RoutingTable>();
+        Set<RoutingTable> routes = new HashSet<RoutingTable>();
         do {
             final ManagementRoutingRequest routeRequest = new ManagementRoutingRequest();
             routeRequest.setDestinationAddress(new ZigBeeEndpointAddress(networkAddress));

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNode.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNode.java
@@ -11,8 +11,10 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Future;
@@ -55,7 +57,7 @@ public class ZigBeeNode implements ZigBeeCommandListener {
     /**
      * The extended {@link IeeeAddress} for the node
      */
-    private IeeeAddress ieeeAddress;
+    private final IeeeAddress ieeeAddress;
 
     /**
      * The 16 bit network address for the node
@@ -86,22 +88,22 @@ public class ZigBeeNode implements ZigBeeCommandListener {
     /**
      * List of associated devices for the node, specified in a {@link List} {@link Integer}
      */
-    private final List<Integer> associatedDevices = new ArrayList<Integer>();
+    private final Set<Integer> associatedDevices = new HashSet<Integer>();
 
     /**
      * List of neighbors for the node, specified in a {@link NeighborTable}
      */
-    private final List<NeighborTable> neighbors = new ArrayList<NeighborTable>();
+    private final Set<NeighborTable> neighbors = new HashSet<NeighborTable>();
 
     /**
      * List of routes within the node, specified in a {@link RoutingTable}
      */
-    private final List<RoutingTable> routes = new ArrayList<RoutingTable>();
+    private final Set<RoutingTable> routes = new HashSet<RoutingTable>();
 
     /**
      * List of binding records
      */
-    private final List<BindingTable> bindingTable = new ArrayList<BindingTable>();
+    private final Set<BindingTable> bindingTable = new HashSet<BindingTable>();
 
     /**
      * List of endpoints this node exposes
@@ -124,20 +126,18 @@ public class ZigBeeNode implements ZigBeeCommandListener {
      * Constructor
      *
      * @param networkManager the {@link ZigBeeNetworkManager}
+     * @param ieeeAddress the {@link IeeeAddress} of the node
+     * @throws {@link IllegalArgumentException} if ieeeAddress is null
      */
-    public ZigBeeNode(ZigBeeNetworkManager networkManager) {
+    public ZigBeeNode(ZigBeeNetworkManager networkManager, IeeeAddress ieeeAddress) {
+        if (ieeeAddress == null) {
+            throw new IllegalArgumentException("IeeeAddress can't be null when creating ZigBeeNode");
+        }
+
         this.networkManager = networkManager;
+        this.ieeeAddress = ieeeAddress;
 
         networkManager.addCommandListener(this);
-    }
-
-    /**
-     * Sets the {@link IeeeAddress} of the node
-     *
-     * param ieeeAddress the {@link IeeeAddress} of the node
-     */
-    public void setIeeeAddress(IeeeAddress ieeeAddress) {
-        this.ieeeAddress = ieeeAddress;
     }
 
     /**
@@ -323,11 +323,11 @@ public class ZigBeeNode implements ZigBeeCommandListener {
      * Gets the current binding table for the device. Note that this doesn't retrieve the table from the device, to do
      * this use the {@link #updateBindingTable()} method.
      *
-     * @return {@link List} of {@link BindingTable} for the device
+     * @return {@link Set} of {@link BindingTable} for the device
      */
-    public List<BindingTable> getBindingTable() {
+    public Set<BindingTable> getBindingTable() {
         synchronized (bindingTable) {
-            return new ArrayList<BindingTable>(bindingTable);
+            return new HashSet<BindingTable>(bindingTable);
         }
     }
 
@@ -482,11 +482,11 @@ public class ZigBeeNode implements ZigBeeCommandListener {
     /**
      * Get the list of neighbors as a {@link NeighborTable}
      *
-     * @return current list of neighbors as a {@link NeighborTable}
+     * @return current {@link Set} of neighbors as a {@link NeighborTable}
      */
-    public List<NeighborTable> getNeighbors() {
+    public Set<NeighborTable> getNeighbors() {
         synchronized (neighbors) {
-            return new ArrayList<NeighborTable>(neighbors);
+            return new HashSet<NeighborTable>(neighbors);
         }
     }
 
@@ -499,45 +499,27 @@ public class ZigBeeNode implements ZigBeeCommandListener {
      * @param neighbors list of neighbors as a {@link NeighborTable}. Setting to null will remove all neighbors.
      * @return true if the neighbor table was updated
      */
-    public boolean setNeighbors(List<NeighborTable> neighbors) {
-        boolean changes = false;
-        synchronized (this.neighbors) {
-            if (neighbors == null) {
-                if (this.neighbors.size() != 0) {
-                    this.neighbors.clear();
-                    changes = true;
-                }
-            } else if (this.neighbors.size() != neighbors.size()) {
-                changes = true;
-            } else {
-                for (NeighborTable neighbor : this.neighbors) {
-                    if (!neighbors.contains(neighbor)) {
-                        changes = true;
-                        break;
-                    }
-                }
-            }
-
-            // Update the list if needed
-            if (changes) {
-                this.neighbors.clear();
-                if (neighbors != null) {
-                    this.neighbors.addAll(neighbors);
-                }
-            }
+    public boolean setNeighbors(Set<NeighborTable> neighbors) {
+        if (this.neighbors.equals(neighbors)) {
+            return false;
         }
 
-        return changes;
+        synchronized (this.neighbors) {
+            this.neighbors.clear();
+            this.neighbors.addAll(neighbors);
+        }
+
+        return true;
     }
 
     /**
      * Get the list of associated devices as a {@link List} of {@link Integer}
      *
-     * @return current list of associated devices as a {@link List} of {@link Integer}
+     * @return current list of associated devices as a {@link Set} of {@link Integer}
      */
-    public List<Integer> getAssociatedDevices() {
+    public Set<Integer> getAssociatedDevices() {
         synchronized (associatedDevices) {
-            return new ArrayList<Integer>(associatedDevices);
+            return new HashSet<Integer>(associatedDevices);
         }
     }
 
@@ -550,45 +532,27 @@ public class ZigBeeNode implements ZigBeeCommandListener {
      * @param neighbors list of neighbors as a {@link NeighborTable}. Setting to null will remove all neighbors.
      * @return true if the neighbor table was updated
      */
-    public boolean setAssociatedDevices(List<Integer> associatedDevices) {
-        boolean changes = false;
-        synchronized (this.associatedDevices) {
-            if (associatedDevices == null) {
-                if (this.associatedDevices.size() != 0) {
-                    this.associatedDevices.clear();
-                    changes = true;
-                }
-            } else if (this.associatedDevices.size() != associatedDevices.size()) {
-                changes = true;
-            } else {
-                for (Integer neighbor : this.associatedDevices) {
-                    if (!associatedDevices.contains(neighbor)) {
-                        changes = true;
-                        break;
-                    }
-                }
-            }
-
-            // Update the list if needed
-            if (changes) {
-                this.associatedDevices.clear();
-                if (associatedDevices != null) {
-                    this.associatedDevices.addAll(associatedDevices);
-                }
-            }
+    public boolean setAssociatedDevices(Set<Integer> associatedDevices) {
+        if (this.associatedDevices.equals(associatedDevices)) {
+            return false;
         }
 
-        return changes;
+        synchronized (this.associatedDevices) {
+            this.associatedDevices.clear();
+            this.associatedDevices.addAll(associatedDevices);
+        }
+
+        return true;
     }
 
     /**
      * Get the list of routes as a {@link RoutingTable}
      *
-     * @return list of routes as a {@link RoutingTable}
+     * @return {@link Set} of routes as a {@link RoutingTable}
      */
-    public List<RoutingTable> getRoutes() {
+    public Collection<RoutingTable> getRoutes() {
         synchronized (routes) {
-            return new ArrayList<RoutingTable>(routes);
+            return new HashSet<RoutingTable>(routes);
         }
     }
 
@@ -601,35 +565,17 @@ public class ZigBeeNode implements ZigBeeCommandListener {
      * @param routes list of routes as a {@link RoutingTable}. Setting to null will remove all routes.
      * @return true if the route table was updated
      */
-    public boolean setRoutes(List<RoutingTable> routes) {
-        boolean changes = false;
-        synchronized (this.routes) {
-            if (routes == null) {
-                if (this.routes.size() != 0) {
-                    this.routes.clear();
-                    changes = true;
-                }
-            } else if (this.routes.size() != routes.size()) {
-                changes = true;
-            } else {
-                for (RoutingTable route : this.routes) {
-                    if (!routes.contains(route)) {
-                        changes = true;
-                        break;
-                    }
-                }
-            }
-
-            // Update the list if needed
-            if (changes) {
-                this.routes.clear();
-                if (routes != null) {
-                    this.routes.addAll(routes);
-                }
-            }
+    public boolean setRoutes(Set<RoutingTable> routes) {
+        if (this.routes.equals(routes)) {
+            return false;
         }
 
-        return changes;
+        synchronized (this.routes) {
+            this.routes.clear();
+            this.routes.addAll(routes);
+        }
+
+        return true;
     }
 
     /**
@@ -732,5 +678,71 @@ public class ZigBeeNode implements ZigBeeCommandListener {
 
         return "ZigBeeNode [IEEE=" + ieeeAddress + ", NWK=" + String.format("%04X", networkAddress) + ", Type="
                 + nodeDescriptor.getLogicalType() + "]";
+    }
+
+    /**
+     * Updates the node. This will copy data from another node into this node. Updated elements are checked for equality
+     * and the method will only return true if the node data has been changed.
+     *
+     * @param node the {@link ZigBeeNode} that contains the newer node data.
+     * @return true if there were changes made as a result of the update
+     */
+    protected boolean updateNode(ZigBeeNode node) {
+        if (!node.getIeeeAddress().equals(ieeeAddress)) {
+            return false;
+        }
+
+        boolean updated = false;
+
+        if (!networkAddress.equals(node.getNetworkAddress())) {
+            updated = true;
+            networkAddress = node.getNetworkAddress();
+        }
+
+        if (!nodeDescriptor.equals(node.getNodeDescriptor())) {
+            updated = true;
+            nodeDescriptor = node.getNodeDescriptor();
+        }
+
+        if (!powerDescriptor.equals(node.getPowerDescriptor())) {
+            updated = true;
+            powerDescriptor = node.getPowerDescriptor();
+        }
+
+        synchronized (associatedDevices) {
+            if (!associatedDevices.equals(node.getAssociatedDevices())) {
+                updated = true;
+                associatedDevices.clear();
+                associatedDevices.addAll(node.getAssociatedDevices());
+            }
+        }
+
+        synchronized (bindingTable) {
+            if (!bindingTable.equals(node.getBindingTable())) {
+                updated = true;
+                bindingTable.clear();
+                bindingTable.addAll(node.getBindingTable());
+            }
+        }
+
+        synchronized (neighbors) {
+            if (!neighbors.equals(node.getNeighbors())) {
+                updated = true;
+                neighbors.clear();
+                neighbors.addAll(node.getNeighbors());
+            }
+        }
+
+        synchronized (routes) {
+            if (!routes.equals(node.getRoutes())) {
+                updated = true;
+                routes.clear();
+                routes.addAll(node.getRoutes());
+            }
+        }
+
+        // TODO: How to deal with endpoints
+
+        return updated;
     }
 }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/dao/ZigBeeNodeDao.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/dao/ZigBeeNodeDao.java
@@ -102,8 +102,7 @@ public class ZigBeeNodeDao {
     }
 
     public static ZigBeeNode createFromZigBeeDao(ZigBeeNetworkManager networkManager, ZigBeeNodeDao nodeDao) {
-        ZigBeeNode node = new ZigBeeNode(networkManager);
-        node.setIeeeAddress(new IeeeAddress(nodeDao.getIeeeAddress()));
+        ZigBeeNode node = new ZigBeeNode(networkManager, new IeeeAddress(nodeDao.getIeeeAddress()));
         node.setNetworkAddress(nodeDao.getNetworkAddress());
         node.setNodeDescriptor(nodeDao.getNodeDescriptor());
         node.setPowerDescriptor(nodeDao.getPowerDescriptor());

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/field/BindingTable.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/field/BindingTable.java
@@ -134,6 +134,64 @@ public class BindingTable {
     }
 
     @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + clusterId;
+        result = prime * result + dstAddrMode;
+        result = prime * result + dstGroupAddr;
+        result = prime * result + ((dstNodeAddr == null) ? 0 : dstNodeAddr.hashCode());
+        result = prime * result + dstNodeEndpoint;
+        result = prime * result + ((srcAddr == null) ? 0 : srcAddr.hashCode());
+        result = prime * result + srcEndpoint;
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        BindingTable other = (BindingTable) obj;
+        if (clusterId != other.clusterId) {
+            return false;
+        }
+        if (dstAddrMode != other.dstAddrMode) {
+            return false;
+        }
+        if (dstGroupAddr != other.dstGroupAddr) {
+            return false;
+        }
+        if (dstNodeAddr == null) {
+            if (other.dstNodeAddr != null) {
+                return false;
+            }
+        } else if (!dstNodeAddr.equals(other.dstNodeAddr)) {
+            return false;
+        }
+        if (dstNodeEndpoint != other.dstNodeEndpoint) {
+            return false;
+        }
+        if (srcAddr == null) {
+            if (other.srcAddr != null) {
+                return false;
+            }
+        } else if (!srcAddr.equals(other.srcAddr)) {
+            return false;
+        }
+        if (srcEndpoint != other.srcEndpoint) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
     public String toString() {
         StringBuilder builder = new StringBuilder(120);
         builder.append("BindingTable [srcAddr=");

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/field/ComplexDescriptor.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/field/ComplexDescriptor.java
@@ -9,7 +9,7 @@ package com.zsmartsystems.zigbee.zdo.field;
 
 /**
  * Complex Descriptor
- * 
+ *
  * @author Chris Jackson
  *
  */
@@ -34,5 +34,11 @@ public class ComplexDescriptor {
 
     public String getSerialNumber() {
         return serialNumber;
+    }
+
+    @Override
+    public String toString() {
+        return "ComplexDescriptor [manufacturerName=" + manufacturerName + ", modelName=" + modelName
+                + ", serialNumber=" + serialNumber + "]";
     }
 }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/field/NeighborTable.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/field/NeighborTable.java
@@ -7,8 +7,6 @@
  */
 package com.zsmartsystems.zigbee.zdo.field;
 
-import java.util.Objects;
-
 import com.zsmartsystems.zigbee.ExtendedPanId;
 import com.zsmartsystems.zigbee.IeeeAddress;
 import com.zsmartsystems.zigbee.serialization.ZigBeeDeserializer;
@@ -191,21 +189,80 @@ public class NeighborTable {
 
     @Override
     public int hashCode() {
-        return Objects.hash(extendedAddress, networkAddress, lqi);
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((depth == null) ? 0 : depth.hashCode());
+        result = prime * result + ((deviceType == null) ? 0 : deviceType.hashCode());
+        result = prime * result + ((extendedAddress == null) ? 0 : extendedAddress.hashCode());
+        result = prime * result + ((extendedPanId == null) ? 0 : extendedPanId.hashCode());
+        result = prime * result + ((lqi == null) ? 0 : lqi.hashCode());
+        result = prime * result + ((networkAddress == null) ? 0 : networkAddress.hashCode());
+        result = prime * result + ((permitJoining == null) ? 0 : permitJoining.hashCode());
+        result = prime * result + ((relationship == null) ? 0 : relationship.hashCode());
+        result = prime * result + ((rxOnWhenIdle == null) ? 0 : rxOnWhenIdle.hashCode());
+        return result;
     }
 
     @Override
     public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
         if (obj == null) {
             return false;
         }
-        if (!NeighborTable.class.isAssignableFrom(obj.getClass())) {
+        if (getClass() != obj.getClass()) {
             return false;
         }
-        final NeighborTable other = (NeighborTable) obj;
-        return (getExtendedAddress().equals(other.getExtendedAddress())
-                && getNetworkAddress().equals(other.getNetworkAddress()) && getLqi().equals(other.getLqi())) ? true
-                        : false;
+        NeighborTable other = (NeighborTable) obj;
+        if (depth == null) {
+            if (other.depth != null) {
+                return false;
+            }
+        } else if (!depth.equals(other.depth)) {
+            return false;
+        }
+        if (deviceType != other.deviceType) {
+            return false;
+        }
+        if (extendedAddress == null) {
+            if (other.extendedAddress != null) {
+                return false;
+            }
+        } else if (!extendedAddress.equals(other.extendedAddress)) {
+            return false;
+        }
+        if (extendedPanId == null) {
+            if (other.extendedPanId != null) {
+                return false;
+            }
+        } else if (!extendedPanId.equals(other.extendedPanId)) {
+            return false;
+        }
+        if (lqi == null) {
+            if (other.lqi != null) {
+                return false;
+            }
+        } else if (!lqi.equals(other.lqi)) {
+            return false;
+        }
+        if (networkAddress == null) {
+            if (other.networkAddress != null) {
+                return false;
+            }
+        } else if (!networkAddress.equals(other.networkAddress)) {
+            return false;
+        }
+        if (permitJoining != other.permitJoining) {
+            return false;
+        }
+        if (relationship != other.relationship) {
+            return false;
+        }
+        if (rxOnWhenIdle != other.rxOnWhenIdle) {
+            return false;
+        }
+        return true;
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/field/NodeDescriptor.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/field/NodeDescriptor.java
@@ -276,6 +276,92 @@ public class NodeDescriptor {
     }
 
     @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + apsFlags;
+        result = prime * result + bufferSize;
+        result = prime * result + (complexDescriptorAvailable ? 1231 : 1237);
+        result = prime * result + (extendedEndpointListAvailable ? 1231 : 1237);
+        result = prime * result + (extendedSimpleDescriptorListAvailable ? 1231 : 1237);
+        result = prime * result + ((frequencyBands == null) ? 0 : frequencyBands.hashCode());
+        result = prime * result + incomingTransferSize;
+        result = prime * result + ((logicalType == null) ? 0 : logicalType.hashCode());
+        result = prime * result + ((macCapabilities == null) ? 0 : macCapabilities.hashCode());
+        result = prime * result + manufacturerCode;
+        result = prime * result + outgoingTransferSize;
+        result = prime * result + ((serverCapabilities == null) ? 0 : serverCapabilities.hashCode());
+        result = prime * result + (userDescriptorAvailable ? 1231 : 1237);
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        NodeDescriptor other = (NodeDescriptor) obj;
+        if (apsFlags != other.apsFlags) {
+            return false;
+        }
+        if (bufferSize != other.bufferSize) {
+            return false;
+        }
+        if (complexDescriptorAvailable != other.complexDescriptorAvailable) {
+            return false;
+        }
+        if (extendedEndpointListAvailable != other.extendedEndpointListAvailable) {
+            return false;
+        }
+        if (extendedSimpleDescriptorListAvailable != other.extendedSimpleDescriptorListAvailable) {
+            return false;
+        }
+        if (frequencyBands == null) {
+            if (other.frequencyBands != null) {
+                return false;
+            }
+        } else if (!frequencyBands.equals(other.frequencyBands)) {
+            return false;
+        }
+        if (incomingTransferSize != other.incomingTransferSize) {
+            return false;
+        }
+        if (logicalType != other.logicalType) {
+            return false;
+        }
+        if (macCapabilities == null) {
+            if (other.macCapabilities != null) {
+                return false;
+            }
+        } else if (!macCapabilities.equals(other.macCapabilities)) {
+            return false;
+        }
+        if (manufacturerCode != other.manufacturerCode) {
+            return false;
+        }
+        if (outgoingTransferSize != other.outgoingTransferSize) {
+            return false;
+        }
+        if (serverCapabilities == null) {
+            if (other.serverCapabilities != null) {
+                return false;
+            }
+        } else if (!serverCapabilities.equals(other.serverCapabilities)) {
+            return false;
+        }
+        if (userDescriptorAvailable != other.userDescriptorAvailable) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
     public String toString() {
         return "NodeDescriptor [apsFlags=" + apsFlags + ", bufferSize=" + bufferSize + ", complexDescriptorAvailable="
                 + complexDescriptorAvailable + ", manufacturerCode=" + manufacturerCode + ", logicalType=" + logicalType

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/field/PowerDescriptor.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/field/PowerDescriptor.java
@@ -192,7 +192,7 @@ public class PowerDescriptor {
 
     /**
      * Sets the current power mode for the descriptor
-     * 
+     *
      * @param currentPowerMode the {@link CurrentPowerModeType}
      */
     public void setCurrentPowerMode(int currentPowerMode) {
@@ -264,6 +264,48 @@ public class PowerDescriptor {
         setAvailablePowerSources(byte1 >> 4 & 0x0f);
         setCurrentPowerSource(byte2 & 0x0f);
         setCurrentPowerLevel(byte2 >> 4 & 0x0f);
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((availablePowerSources == null) ? 0 : availablePowerSources.hashCode());
+        result = prime * result + ((currentPowerMode == null) ? 0 : currentPowerMode.hashCode());
+        result = prime * result + ((currentPowerSource == null) ? 0 : currentPowerSource.hashCode());
+        result = prime * result + ((powerLevel == null) ? 0 : powerLevel.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        PowerDescriptor other = (PowerDescriptor) obj;
+        if (availablePowerSources == null) {
+            if (other.availablePowerSources != null) {
+                return false;
+            }
+        } else if (!availablePowerSources.equals(other.availablePowerSources)) {
+            return false;
+        }
+        if (currentPowerMode != other.currentPowerMode) {
+            return false;
+        }
+        if (currentPowerSource != other.currentPowerSource) {
+            return false;
+        }
+        if (powerLevel != other.powerLevel) {
+            return false;
+        }
+        return true;
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/field/RoutingTable.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/field/RoutingTable.java
@@ -7,8 +7,6 @@
  */
 package com.zsmartsystems.zigbee.zdo.field;
 
-import java.util.Objects;
-
 import com.zsmartsystems.zigbee.serialization.ZigBeeDeserializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
@@ -126,21 +124,56 @@ public class RoutingTable {
 
     @Override
     public int hashCode() {
-        return Objects.hash(status, destinationAddress, nextHopAddress, routeRecordRequired);
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((destinationAddress == null) ? 0 : destinationAddress.hashCode());
+        result = prime * result + (manyToOne ? 1231 : 1237);
+        result = prime * result + (memoryConstrained ? 1231 : 1237);
+        result = prime * result + ((nextHopAddress == null) ? 0 : nextHopAddress.hashCode());
+        result = prime * result + (routeRecordRequired ? 1231 : 1237);
+        result = prime * result + ((status == null) ? 0 : status.hashCode());
+        return result;
     }
 
     @Override
     public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
         if (obj == null) {
             return false;
         }
-        if (!RoutingTable.class.isAssignableFrom(obj.getClass())) {
+        if (getClass() != obj.getClass()) {
             return false;
         }
-        final RoutingTable other = (RoutingTable) obj;
-        return (getStatus().equals(other.getStatus()) && getDestinationAddress().equals(other.getDestinationAddress())
-                && getNextHopAddress().equals(other.getNextHopAddress())
-                && isRouteRecordRequired() == (other.isRouteRecordRequired())) ? true : false;
+        RoutingTable other = (RoutingTable) obj;
+        if (destinationAddress == null) {
+            if (other.destinationAddress != null) {
+                return false;
+            }
+        } else if (!destinationAddress.equals(other.destinationAddress)) {
+            return false;
+        }
+        if (manyToOne != other.manyToOne) {
+            return false;
+        }
+        if (memoryConstrained != other.memoryConstrained) {
+            return false;
+        }
+        if (nextHopAddress == null) {
+            if (other.nextHopAddress != null) {
+                return false;
+            }
+        } else if (!nextHopAddress.equals(other.nextHopAddress)) {
+            return false;
+        }
+        if (routeRecordRequired != other.routeRecordRequired) {
+            return false;
+        }
+        if (status != other.status) {
+            return false;
+        }
+        return true;
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/field/SimpleDescriptor.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/field/SimpleDescriptor.java
@@ -110,6 +110,60 @@ public class SimpleDescriptor {
     }
 
     @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + deviceId;
+        result = prime * result + deviceVersion;
+        result = prime * result + endpoint;
+        result = prime * result + ((inputClusterList == null) ? 0 : inputClusterList.hashCode());
+        result = prime * result + ((outputClusterList == null) ? 0 : outputClusterList.hashCode());
+        result = prime * result + profileId;
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        SimpleDescriptor other = (SimpleDescriptor) obj;
+        if (deviceId != other.deviceId) {
+            return false;
+        }
+        if (deviceVersion != other.deviceVersion) {
+            return false;
+        }
+        if (endpoint != other.endpoint) {
+            return false;
+        }
+        if (inputClusterList == null) {
+            if (other.inputClusterList != null) {
+                return false;
+            }
+        } else if (!inputClusterList.equals(other.inputClusterList)) {
+            return false;
+        }
+        if (outputClusterList == null) {
+            if (other.outputClusterList != null) {
+                return false;
+            }
+        } else if (!outputClusterList.equals(other.outputClusterList)) {
+            return false;
+        }
+        if (profileId != other.profileId) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
     public String toString() {
         return "SimpleDescriptor [endpoint=" + endpoint + ", profileId=" + String.format("%04X", profileId)
                 + ", deviceId=" + deviceId + ", deviceVersion=" + deviceVersion + ", inputClusterList="

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/IeeeAddressTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/IeeeAddressTest.java
@@ -53,4 +53,27 @@ public class IeeeAddressTest {
         IeeeAddress address = new IeeeAddress("17880100dc880b");
         assertEquals("0017880100DC880B", address.toString());
     }
+
+    @Test
+    public void testCompareTo() {
+        IeeeAddress address1 = new IeeeAddress("17880100dc880b");
+
+        IeeeAddress address2 = new IeeeAddress("17880100dc880b");
+        assertEquals(0, address1.compareTo(address2));
+
+        address2 = new IeeeAddress("17880100dc880c");
+        assertEquals(-1, address1.compareTo(address2));
+
+        address2 = new IeeeAddress("17880100dc880a");
+        assertEquals(1, address1.compareTo(address2));
+
+        address2 = new IeeeAddress("27880100dc880c");
+        assertEquals(-1, address1.compareTo(address2));
+
+        address2 = new IeeeAddress("17880120dc880c");
+        assertEquals(-1, address1.compareTo(address2));
+
+        address2 = new IeeeAddress("16880100dc880b");
+        assertEquals(1, address1.compareTo(address2));
+    }
 }

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeEndpointTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeEndpointTest.java
@@ -113,7 +113,7 @@ public class ZigBeeEndpointTest {
     private ZigBeeEndpoint getDevice() {
         ZigBeeTransportTransmit mockedTransport = Mockito.mock(ZigBeeTransportTransmit.class);
         ZigBeeNetworkManager networkManager = new ZigBeeNetworkManager(mockedTransport);
-        ZigBeeNode node = new ZigBeeNode(networkManager);
+        ZigBeeNode node = new ZigBeeNode(networkManager, new IeeeAddress());
         node.setNetworkAddress(1234);
         return new ZigBeeEndpoint(networkManager, node, 5);
     }

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeNetworkManagerTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeNetworkManagerTest.java
@@ -50,9 +50,10 @@ public class ZigBeeNetworkManagerTest implements ZigBeeNetworkNodeListener, ZigB
     public void testAddRemoveNode() {
         ZigBeeNetworkManager networkManager = mockZigBeeNetworkManager();
 
-        ZigBeeNode node1 = new ZigBeeNode(Mockito.mock(ZigBeeNetworkManager.class));
+        ZigBeeNode node1 = new ZigBeeNode(Mockito.mock(ZigBeeNetworkManager.class), new IeeeAddress());
         node1.setNetworkAddress(1234);
-        ZigBeeNode node2 = new ZigBeeNode(Mockito.mock(ZigBeeNetworkManager.class));
+        ZigBeeNode node2 = new ZigBeeNode(Mockito.mock(ZigBeeNetworkManager.class),
+                new IeeeAddress("123456789ABCDEF0"));
         node2.setNetworkAddress(5678);
 
         // Add a node and make sure it's in the list
@@ -98,11 +99,8 @@ public class ZigBeeNetworkManagerTest implements ZigBeeNetworkNodeListener, ZigB
         foundNode = networkManager.getNode(1234);
         assertNull(networkManager.getNode(1234));
 
-        node2.setIeeeAddress(new IeeeAddress("123456789ABCDEF0"));
         networkManager.updateNode(node2);
-        org.awaitility.Awaitility.await().until(nodeListenerUpdated(), org.hamcrest.Matchers.equalTo(4));
-        networkManager.updateNode(null);
-        org.awaitility.Awaitility.await().until(nodeListenerUpdated(), org.hamcrest.Matchers.equalTo(4));
+        org.awaitility.Awaitility.await().until(nodeListenerUpdated(), org.hamcrest.Matchers.equalTo(3));
         assertEquals(1, networkManager.getNodes().size());
 
         // Check we can also get using the IEEE address
@@ -117,6 +115,24 @@ public class ZigBeeNetworkManagerTest implements ZigBeeNetworkNodeListener, ZigB
         networkManager.addNetworkNodeListener(null);
         networkManager.removeNetworkNodeListener(null);
         networkManager.removeNetworkNodeListener(mockedNodeListener);
+    }
+
+    @Test
+    public void testAddExistingNode() {
+        String address = "123456789ABCDEF0";
+        ZigBeeNetworkManager networkManager = mockZigBeeNetworkManager();
+
+        ZigBeeNode node1 = new ZigBeeNode(Mockito.mock(ZigBeeNetworkManager.class), new IeeeAddress(address));
+        node1.setNetworkAddress(1234);
+        ZigBeeNode node2 = new ZigBeeNode(Mockito.mock(ZigBeeNetworkManager.class), new IeeeAddress(address));
+        node2.setNetworkAddress(5678);
+        networkManager.addNode(node1);
+        assertEquals(1, networkManager.getNodes().size());
+        ZigBeeNode nodeWeGot = networkManager.getNode(new IeeeAddress(address));
+        assertEquals(Integer.valueOf(1234), nodeWeGot.getNetworkAddress());
+        networkManager.addNode(node2);
+        assertEquals(1, networkManager.getNodes().size());
+        assertEquals(Integer.valueOf(5678), nodeWeGot.getNetworkAddress());
     }
 
     @Test

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeNodeTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeNodeTest.java
@@ -14,12 +14,13 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.lang.reflect.Field;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import com.zsmartsystems.zigbee.serialization.DefaultDeserializer;
 import com.zsmartsystems.zigbee.zdo.field.NeighborTable;
 import com.zsmartsystems.zigbee.zdo.field.NodeDescriptor;
 import com.zsmartsystems.zigbee.zdo.field.NodeDescriptor.LogicalType;
@@ -33,7 +34,7 @@ import com.zsmartsystems.zigbee.zdo.field.RoutingTable.DiscoveryState;
 public class ZigBeeNodeTest {
     @Test
     public void testAddDescriptors() {
-        ZigBeeNode node = new ZigBeeNode(Mockito.mock(ZigBeeNetworkManager.class));
+        ZigBeeNode node = new ZigBeeNode(Mockito.mock(ZigBeeNetworkManager.class), new IeeeAddress());
 
         // Not null by default
         assertNotNull(node.getNodeDescriptor());
@@ -49,8 +50,7 @@ public class ZigBeeNodeTest {
 
     @Test
     public void testSetIeeeAddress() {
-        ZigBeeNode node = new ZigBeeNode(Mockito.mock(ZigBeeNetworkManager.class));
-        node.setIeeeAddress(new IeeeAddress("17880100dc880b"));
+        ZigBeeNode node = new ZigBeeNode(Mockito.mock(ZigBeeNetworkManager.class), new IeeeAddress("17880100dc880b"));
         assertEquals(new IeeeAddress("17880100dc880b"), node.getIeeeAddress());
 
         System.out.println(node.toString());
@@ -59,7 +59,7 @@ public class ZigBeeNodeTest {
     @Test
     public void testSetPowerDescriptor() {
         PowerDescriptor descriptor = new PowerDescriptor(1, 2, 4, 0xc);
-        ZigBeeNode node = new ZigBeeNode(Mockito.mock(ZigBeeNetworkManager.class));
+        ZigBeeNode node = new ZigBeeNode(Mockito.mock(ZigBeeNetworkManager.class), new IeeeAddress());
         node.setPowerDescriptor(descriptor);
         assertEquals(CurrentPowerModeType.RECEIVER_ON_PERIODICALLY, node.getPowerDescriptor().getCurrentPowerMode());
         assertEquals(PowerSourceType.DISPOSABLE_BATTERY, node.getPowerDescriptor().getCurrentPowerSource());
@@ -99,42 +99,38 @@ public class ZigBeeNodeTest {
 
     @Test
     public void testNeighborTableUpdate() {
-        ZigBeeNode node = new ZigBeeNode(Mockito.mock(ZigBeeNetworkManager.class));
-        List<NeighborTable> neighbors;
+        ZigBeeNode node = new ZigBeeNode(Mockito.mock(ZigBeeNetworkManager.class), new IeeeAddress());
+        Set<NeighborTable> neighbors;
 
         NeighborTable neighbor1 = getNeighborTable(12345, "123456789", 0);
         NeighborTable neighbor2 = getNeighborTable(12345, "123456789", 0);
         NeighborTable neighbor3 = getNeighborTable(54321, "987654321", 0);
 
-        assertFalse(node.setNeighbors(null));
-
-        neighbors = new ArrayList<NeighborTable>();
+        neighbors = new HashSet<NeighborTable>();
         neighbors.add(neighbor1);
         assertTrue(node.setNeighbors(neighbors));
 
-        neighbors = new ArrayList<NeighborTable>();
+        neighbors = new HashSet<NeighborTable>();
         neighbors.add(neighbor2);
         assertFalse(node.setNeighbors(neighbors));
 
-        neighbors = new ArrayList<NeighborTable>();
+        neighbors = new HashSet<NeighborTable>();
         neighbors.add(neighbor3);
         neighbors.add(neighbor1);
         assertTrue(node.setNeighbors(neighbors));
 
-        neighbors = new ArrayList<NeighborTable>();
+        neighbors = new HashSet<NeighborTable>();
         neighbors.add(neighbor1);
         neighbors.add(neighbor3);
         assertFalse(node.setNeighbors(neighbors));
 
         assertEquals(2, node.getNeighbors().size());
-        assertTrue(node.setNeighbors(null));
-        assertEquals(0, node.getNeighbors().size());
     }
 
     @Test
     public void testRoutingTableUpdate() {
-        ZigBeeNode node = new ZigBeeNode(Mockito.mock(ZigBeeNetworkManager.class));
-        List<RoutingTable> routes;
+        ZigBeeNode node = new ZigBeeNode(Mockito.mock(ZigBeeNetworkManager.class), new IeeeAddress());
+        Set<RoutingTable> routes;
 
         RoutingTable route1 = new RoutingTable();
         route1.setDestinationAddress(12345);
@@ -160,33 +156,29 @@ public class ZigBeeNodeTest {
         route4.setStatus(DiscoveryState.INACTIVE);
         route4.setRouteRecordRequired(false);
 
-        assertFalse(node.setRoutes(null));
-
-        routes = new ArrayList<RoutingTable>();
+        routes = new HashSet<RoutingTable>();
         routes.add(route1);
         assertTrue(node.setRoutes(routes));
 
-        routes = new ArrayList<RoutingTable>();
+        routes = new HashSet<RoutingTable>();
         routes.add(route2);
         assertFalse(node.setRoutes(routes));
 
-        routes = new ArrayList<RoutingTable>();
+        routes = new HashSet<RoutingTable>();
         routes.add(route3);
         assertTrue(node.setRoutes(routes));
 
-        routes = new ArrayList<RoutingTable>();
+        routes = new HashSet<RoutingTable>();
         routes.add(route1);
         routes.add(route4);
         assertTrue(node.setRoutes(routes));
 
         assertEquals(2, node.getRoutes().size());
-        assertTrue(node.setRoutes(null));
-        assertEquals(0, node.getRoutes().size());
     }
 
     @Test
     public void testDeviceTypes() {
-        ZigBeeNode node = new ZigBeeNode(Mockito.mock(ZigBeeNetworkManager.class));
+        ZigBeeNode node = new ZigBeeNode(Mockito.mock(ZigBeeNetworkManager.class), new IeeeAddress());
         assertFalse(node.isFullFuntionDevice());
         assertFalse(node.isReducedFuntionDevice());
         assertFalse(node.isPrimaryTrustCenter());
@@ -222,7 +214,7 @@ public class ZigBeeNodeTest {
 
     @Test
     public void testLastUpdate() {
-        ZigBeeNode node = new ZigBeeNode(Mockito.mock(ZigBeeNetworkManager.class));
+        ZigBeeNode node = new ZigBeeNode(Mockito.mock(ZigBeeNetworkManager.class), new IeeeAddress());
         assertNull(node.getLastUpdateTime());
         node.setLastUpdateTime();
         assertNotNull(node.getLastUpdateTime());
@@ -230,7 +222,7 @@ public class ZigBeeNodeTest {
 
     @Test
     public void testJoiningEnabled() {
-        ZigBeeNode node = new ZigBeeNode(Mockito.mock(ZigBeeNetworkManager.class));
+        ZigBeeNode node = new ZigBeeNode(Mockito.mock(ZigBeeNetworkManager.class), new IeeeAddress());
 
         node.setJoining(true);
         assertTrue(node.isJoiningEnabled());
@@ -238,14 +230,14 @@ public class ZigBeeNodeTest {
 
     @Test
     public void testAssociatedDevices() {
-        ZigBeeNode node = new ZigBeeNode(Mockito.mock(ZigBeeNetworkManager.class));
+        ZigBeeNode node = new ZigBeeNode(Mockito.mock(ZigBeeNetworkManager.class), new IeeeAddress());
 
         // Check list is empty to start
         assertNotNull(node.getAssociatedDevices());
         assertEquals(0, node.getAssociatedDevices().size());
 
         // Add 3 nodes
-        List<Integer> associatedDevices = new ArrayList<Integer>();
+        Set<Integer> associatedDevices = new HashSet<Integer>();
         associatedDevices.add(1);
         associatedDevices.add(2);
         associatedDevices.add(3);
@@ -254,102 +246,127 @@ public class ZigBeeNodeTest {
         assertEquals(3, node.getAssociatedDevices().size());
 
         // Remove 1 node
-        associatedDevices = new ArrayList<Integer>();
+        associatedDevices = new HashSet<Integer>();
         associatedDevices.add(1);
         associatedDevices.add(3);
         changed = node.setAssociatedDevices(associatedDevices);
         assertTrue(changed);
         assertEquals(2, node.getAssociatedDevices().size());
-        assertEquals(Integer.valueOf(1), node.getAssociatedDevices().get(0));
-        assertEquals(Integer.valueOf(3), node.getAssociatedDevices().get(1));
+
+        Integer[] devices = new Integer[2];
+        node.getAssociatedDevices().toArray(devices);
+        assertEquals(Integer.valueOf(1), devices[0]);
+        assertEquals(Integer.valueOf(3), devices[1]);
 
         // Add the same list and make sure it shows no change
         changed = node.setAssociatedDevices(associatedDevices);
         assertFalse(changed);
 
         // Add a new node
-        associatedDevices = new ArrayList<Integer>();
+        associatedDevices = new HashSet<Integer>();
         associatedDevices.add(1);
         associatedDevices.add(3);
         associatedDevices.add(4);
         changed = node.setAssociatedDevices(associatedDevices);
         assertTrue(changed);
         assertEquals(3, node.getAssociatedDevices().size());
-        assertEquals(Integer.valueOf(1), node.getAssociatedDevices().get(0));
-        assertEquals(Integer.valueOf(3), node.getAssociatedDevices().get(1));
-        assertEquals(Integer.valueOf(4), node.getAssociatedDevices().get(2));
+
+        devices = new Integer[3];
+        node.getAssociatedDevices().toArray(devices);
+        assertEquals(Integer.valueOf(1), devices[0]);
+        assertEquals(Integer.valueOf(3), devices[1]);
+        assertEquals(Integer.valueOf(4), devices[2]);
 
         // Keep number the same, but change the list
-        associatedDevices = new ArrayList<Integer>();
+        associatedDevices = new HashSet<Integer>();
         associatedDevices.add(2);
         associatedDevices.add(3);
         associatedDevices.add(4);
         changed = node.setAssociatedDevices(associatedDevices);
         assertTrue(changed);
         assertEquals(3, node.getAssociatedDevices().size());
-        assertEquals(Integer.valueOf(2), node.getAssociatedDevices().get(0));
-        assertEquals(Integer.valueOf(3), node.getAssociatedDevices().get(1));
-        assertEquals(Integer.valueOf(4), node.getAssociatedDevices().get(2));
 
-        // Set to null
-        changed = node.setAssociatedDevices(null);
-        assertTrue(changed);
-        assertNotNull(node.getAssociatedDevices());
-        assertEquals(0, node.getAssociatedDevices().size());
+        devices = new Integer[3];
+        node.getAssociatedDevices().toArray(devices);
+        assertEquals(Integer.valueOf(2), devices[0]);
+        assertEquals(Integer.valueOf(3), devices[1]);
+        assertEquals(Integer.valueOf(4), devices[2]);
     }
 
-    /**
-     * @Test
-     *       public void testAddRemoveDevice() {
-     *       ZigBeeNetworkManager networkManager = mockZigBeeNetworkManager();
-     *
-     *       ZigBeeDevice device1 = new ZigBeeDevice(networkManager);
-     *       device1.setDeviceAddress(new ZigBeeDeviceAddress(1234, 5));
-     *       networkManager.addDevice(device1);
-     *       assertEquals(1, networkManager.getDevices().size());
-     *
-     *       ZigBeeDevice device2 = new ZigBeeDevice(networkManager);
-     *       device2.setDeviceAddress(new ZigBeeDeviceAddress(6789, 0));
-     *       networkManager.addDevice(device2);
-     *       assertEquals(2, networkManager.getDevices().size());
-     *
-     *       device2 = new ZigBeeDevice(networkManager);
-     *       device2.setDeviceAddress(new ZigBeeDeviceAddress(1234, 1));
-     *       device2.setIeeeAddress(new IeeeAddress("1234567890ABCDEF"));
-     *       networkManager.addDevice(device2);
-     *       device2 = new ZigBeeDevice(networkManager);
-     *       device2.setDeviceAddress(new ZigBeeDeviceAddress(1234, 2));
-     *       device2.setIeeeAddress(new IeeeAddress("1234567890ABCDEF"));
-     *       networkManager.addDevice(device2);
-     *       device2 = new ZigBeeDevice(networkManager);
-     *       device2.setDeviceAddress(new ZigBeeDeviceAddress(1234, 3));
-     *       device2.setIeeeAddress(new IeeeAddress("1234567890ABCDEF"));
-     *       networkManager.addDevice(device2);
-     *       device2 = new ZigBeeDevice(networkManager);
-     *       device2.setDeviceAddress(new ZigBeeDeviceAddress(1234, 4));
-     *       device2.setIeeeAddress(new IeeeAddress("1234567890ABCDEF"));
-     *       networkManager.addDevice(device2);
-     *
-     *       // We should now have 6 devices, 5 of then in node 1234, and 4 of them have IEEE address
-     *       assertEquals(6, networkManager.getDevices().size());
-     *       assertEquals(5, networkManager.getNodeDevices(1234).size());
-     *       assertEquals(4, networkManager.getNodeDevices(new IeeeAddress("1234567890ABCDEF")).size());
-     *
-     *       device2 = networkManager.getDevice(new ZigBeeDeviceAddress(6789, 0));
-     *       device2.setLabel("Device Label");
-     *       networkManager.updateDevice(device2);
-     *       assertEquals(6, networkManager.getDevices().size());
-     *       assertEquals("Device Label", networkManager.getDevice(new ZigBeeDeviceAddress(6789, 0)).getLabel());
-     *
-     *       networkManager.removeDevice(new ZigBeeDeviceAddress(6789, 0));
-     *       assertEquals(5, networkManager.getDevices().size());
-     *
-     *       assertNull(networkManager.getDevice(null));
-     *       assertNull(networkManager.getDevice(new ZigBeeGroupAddress(1)));
-     *
-     *       networkManager.addNetworkDeviceListener(null);
-     *       networkManager.removeNetworkDeviceListener(null);
-     *       networkManager.removeNetworkDeviceListener(mockedDeviceListener);
-     *       }
-     */
+    private NeighborTable getNeighborTable(int[] packet) {
+        DefaultDeserializer deserializer = new DefaultDeserializer(packet);
+
+        NeighborTable neighbor = new NeighborTable();
+        neighbor.deserialize(deserializer);
+
+        return neighbor;
+    }
+
+    @Test
+    public void testUpdated() {
+        ZigBeeNode node = new ZigBeeNode(Mockito.mock(ZigBeeNetworkManager.class), new IeeeAddress("1234567890"));
+        ZigBeeNode newNode = new ZigBeeNode(Mockito.mock(ZigBeeNetworkManager.class), new IeeeAddress("1234567890"));
+        node.setNetworkAddress(1234);
+        newNode.setNetworkAddress(1234);
+
+        assertFalse(node.updateNode(newNode));
+
+        newNode.setNetworkAddress(5678);
+        assertTrue(node.updateNode(newNode));
+
+        Set<Integer> associated = new HashSet<Integer>();
+        associated.add(1);
+        associated.add(2);
+        associated.add(3);
+        node.setAssociatedDevices(associated);
+        associated = new HashSet<Integer>();
+        associated.add(1);
+        associated.add(2);
+        associated.add(3);
+        newNode.setAssociatedDevices(associated);
+        assertFalse(node.updateNode(newNode));
+
+        associated = new HashSet<Integer>();
+        associated.add(3);
+        associated.add(2);
+        associated.add(1);
+        newNode.setAssociatedDevices(associated);
+        assertFalse(node.updateNode(newNode));
+
+        associated = new HashSet<Integer>();
+        associated.add(1);
+        associated.add(3);
+        newNode.setAssociatedDevices(associated);
+        assertTrue(node.updateNode(newNode));
+
+        Set<NeighborTable> neighbors = new HashSet<NeighborTable>();
+        neighbors.add(getNeighborTable(new int[] { 0xB1, 0x68, 0xDE, 0x3A, 0x00, 0x00, 0x00, 0x00, 0x86, 0x06, 0x00,
+                0x00, 0x00, 0xEE, 0x1F, 0x00, 0xA9, 0x44, 0x25, 0x02, 0x0F, 0xE2 }));
+        node.setNeighbors(neighbors);
+
+        neighbors = new HashSet<NeighborTable>();
+        neighbors.add(getNeighborTable(new int[] { 0xB1, 0x68, 0xDE, 0x3A, 0x00, 0x00, 0x00, 0x00, 0x86, 0x06, 0x00,
+                0x00, 0x00, 0xEE, 0x1F, 0x00, 0xA9, 0x44, 0x25, 0x02, 0x0F, 0xE2 }));
+        newNode.setNeighbors(neighbors);
+        assertFalse(node.updateNode(newNode));
+
+        neighbors = new HashSet<NeighborTable>();
+        neighbors.add(getNeighborTable(new int[] { 0xB1, 0x68, 0xDE, 0x3A, 0x00, 0x00, 0x00, 0x00, 0x86, 0x06, 0x00,
+                0x00, 0x00, 0xEE, 0x1F, 0x00, 0xA9, 0x44, 0x25, 0x02, 0x0F, 0xE2 }));
+        neighbors.add(getNeighborTable(new int[] { 0xB1, 0x68, 0xDE, 0x3A, 0x00, 0x00, 0x00, 0x00, 0x84, 0x06, 0x00,
+                0x00, 0x00, 0xEE, 0x1F, 0x00, 0xA9, 0x44, 0x25, 0x02, 0x0F, 0xE2 }));
+        newNode.setNeighbors(neighbors);
+        assertTrue(node.updateNode(newNode));
+
+        neighbors = new HashSet<NeighborTable>();
+        neighbors.add(getNeighborTable(new int[] { 0xB1, 0x68, 0xDE, 0x3A, 0x00, 0x00, 0x00, 0x00, 0x86, 0x06, 0x00,
+                0x00, 0x00, 0xEE, 0x1F, 0x00, 0xA9, 0x44, 0x25, 0x02, 0x0F, 0xE2 }));
+        neighbors.add(getNeighborTable(new int[] { 0xB0, 0x68, 0xDE, 0x3A, 0x00, 0x00, 0x00, 0x00, 0x84, 0x06, 0x00,
+                0x00, 0x00, 0xEE, 0x1F, 0x00, 0xA9, 0x44, 0x25, 0x02, 0x0F, 0xE2 }));
+        newNode.setNeighbors(neighbors);
+        assertTrue(node.updateNode(newNode));
+
+        newNode.setNeighbors(neighbors);
+        assertFalse(node.updateNode(newNode));
+    }
 }

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/dao/ZigBeeNodeDaoTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/dao/ZigBeeNodeDaoTest.java
@@ -28,8 +28,7 @@ public class ZigBeeNodeDaoTest {
     public void testSerialize() {
         ZigBeeTransportTransmit mockedTransport = Mockito.mock(ZigBeeTransportTransmit.class);
         ZigBeeNetworkManager networkManager = new ZigBeeNetworkManager(mockedTransport);
-        ZigBeeNode node = new ZigBeeNode(networkManager);
-        node.setIeeeAddress(new IeeeAddress("1234567890ABCDEF"));
+        ZigBeeNode node = new ZigBeeNode(networkManager, new IeeeAddress("1234567890ABCDEF"));
         node.setNetworkAddress(12345);
 
         ZigBeeEndpoint endpoint;

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/otaserver/ZigBeeOtaServerTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/otaserver/ZigBeeOtaServerTest.java
@@ -53,9 +53,8 @@ public class ZigBeeOtaServerTest implements ZigBeeOtaStatusCallback {
         IeeeAddress ieeeAddress = new IeeeAddress("1234567890ABCDEF");
         ZigBeeEndpointAddress networkAddress = new ZigBeeEndpointAddress(1234, 56);
         ZigBeeNetworkManager mockedNetworkManager = Mockito.mock(ZigBeeNetworkManager.class);
-        ZigBeeNode node = new ZigBeeNode(mockedNetworkManager);
+        ZigBeeNode node = new ZigBeeNode(mockedNetworkManager, ieeeAddress);
         node.setNetworkAddress(networkAddress.getAddress());
-        node.setIeeeAddress(ieeeAddress);
         node.setNodeDescriptor(nodeDescriptor);
         ZigBeeEndpoint endpoint = new ZigBeeEndpoint(mockedNetworkManager, node, networkAddress.getEndpoint());
         // device.setIeeeAddress(ieeeAddress);

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zcl/ZclClusterTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zcl/ZclClusterTest.java
@@ -16,6 +16,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 import com.zsmartsystems.zigbee.CommandResponseMatcher;
+import com.zsmartsystems.zigbee.IeeeAddress;
 import com.zsmartsystems.zigbee.ZigBeeCommand;
 import com.zsmartsystems.zigbee.ZigBeeEndpoint;
 import com.zsmartsystems.zigbee.ZigBeeNetworkManager;
@@ -51,7 +52,7 @@ public class ZclClusterTest {
     public void getReporting() {
         createNetworkManager();
 
-        ZigBeeNode node = new ZigBeeNode(networkManager);
+        ZigBeeNode node = new ZigBeeNode(networkManager, new IeeeAddress());
         node.setNetworkAddress(1234);
         ZigBeeEndpoint device = new ZigBeeEndpoint(networkManager, node, 5);
         ZclCluster cluster = new ZclOnOffCluster(networkManager, device);
@@ -72,7 +73,7 @@ public class ZclClusterTest {
     public void setReporting() {
         createNetworkManager();
 
-        ZigBeeNode node = new ZigBeeNode(networkManager);
+        ZigBeeNode node = new ZigBeeNode(networkManager, new IeeeAddress());
         node.setNetworkAddress(1234);
         ZigBeeEndpoint device = new ZigBeeEndpoint(networkManager, node, 5);
         ZclCluster cluster = new ZclOnOffCluster(networkManager, device);
@@ -93,7 +94,7 @@ public class ZclClusterTest {
     public void getClusterId() {
         createNetworkManager();
 
-        ZigBeeNode node = new ZigBeeNode(networkManager);
+        ZigBeeNode node = new ZigBeeNode(networkManager, new IeeeAddress());
         node.setNetworkAddress(1234);
         ZigBeeEndpoint device = new ZigBeeEndpoint(networkManager, node, 5);
         ZclCluster cluster = new ZclOnOffCluster(networkManager, device);
@@ -104,7 +105,7 @@ public class ZclClusterTest {
     public void getClusterName() {
         createNetworkManager();
 
-        ZigBeeNode node = new ZigBeeNode(networkManager);
+        ZigBeeNode node = new ZigBeeNode(networkManager, new IeeeAddress());
         node.setNetworkAddress(1234);
         ZigBeeEndpoint device = new ZigBeeEndpoint(networkManager, node, 5);
         ZclCluster cluster = new ZclLevelControlCluster(networkManager, device);

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zdo/field/NeighborTableTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zdo/field/NeighborTableTest.java
@@ -5,7 +5,7 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  */
-package com.zsmartsystems.zigbee.zdo.descriptors;
+package com.zsmartsystems.zigbee.zdo.field;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zdo/field/NodeDescriptorTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zdo/field/NodeDescriptorTest.java
@@ -5,7 +5,7 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  */
-package com.zsmartsystems.zigbee.zdo.descriptors;
+package com.zsmartsystems.zigbee.zdo.field;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;


### PR DESCRIPTION
This makes the IEEE address in a node immutable. It is now included in the node constructor, and there's no ability to change it. The addNode method has been refactored to avoid adding duplicates, and to update the node appropriately.

This ensures that a network address change doesn't cause a duplicate node if the IEEE address exists.

Closes #106 

Signed-off-by: Chris Jackson <chris@cd-jackson.com>