### PR TITLE
Add cluster command listener

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNode.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNode.java
@@ -25,6 +25,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.zsmartsystems.zigbee.internal.NotificationService;
+import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zdo.ZdoResponseMatcher;
 import com.zsmartsystems.zigbee.zdo.ZdoStatus;
 import com.zsmartsystems.zigbee.zdo.command.ManagementBindRequest;
@@ -668,16 +669,20 @@ public class ZigBeeNode implements ZigBeeCommandListener {
                 logger.debug("Error sending MatchDescriptorResponse ", e);
             }
         }
-    }
 
-    @Override
-    public String toString() {
-        if (nodeDescriptor == null) {
-            return "ZigBeeNode [IEEE=" + ieeeAddress + ", NWK=" + String.format("%04X", networkAddress) + "]";
+        if (!(command instanceof ZclCommand)) {
+            return;
         }
 
-        return "ZigBeeNode [IEEE=" + ieeeAddress + ", NWK=" + String.format("%04X", networkAddress) + ", Type="
-                + nodeDescriptor.getLogicalType() + "]";
+        ZclCommand zclCommand = (ZclCommand) command;
+        ZigBeeEndpointAddress endpointAddress = (ZigBeeEndpointAddress) zclCommand.getSourceAddress();
+
+        ZigBeeEndpoint endpoint = endpoints.get(endpointAddress.getEndpoint());
+        if (endpoint == null) {
+            return;
+        }
+
+        endpoint.commandReceived(zclCommand);
     }
 
     /**
@@ -745,4 +750,15 @@ public class ZigBeeNode implements ZigBeeCommandListener {
 
         return updated;
     }
+
+    @Override
+    public String toString() {
+        if (nodeDescriptor == null) {
+            return "ZigBeeNode [IEEE=" + ieeeAddress + ", NWK=" + String.format("%04X", networkAddress) + "]";
+        }
+
+        return "ZigBeeNode [IEEE=" + ieeeAddress + ", NWK=" + String.format("%04X", networkAddress) + ", Type="
+                + nodeDescriptor.getLogicalType() + "]";
+    }
+
 }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/ZclCommandListener.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/ZclCommandListener.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2016-2017 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.zcl;
+
+/**
+ * Command listener. Listeners are called when an {@link ZclCommand} for the Cluster is received.
+ *
+ * @author Chris Jackson
+ *
+ */
+public interface ZclCommandListener {
+    /**
+     * Called when a {@link ZclCommand} is received for this cluster
+     *
+     * @param command the {@link ZclCommand} that has been received
+     */
+    void commandReceived(ZclCommand command);
+
+}

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zcl/ZclClusterTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zcl/ZclClusterTest.java
@@ -111,4 +111,5 @@ public class ZclClusterTest {
         ZclCluster cluster = new ZclLevelControlCluster(networkManager, device);
         assertEquals("Level Control", cluster.getClusterName());
     }
+
 }


### PR DESCRIPTION
Adds a listener to allow applications to be notified of received commands in a cluster.

This is also a small refactoring of the way commands are transferred out from the manager, to the node, to the endpoint. Previously, endpoints directly listened to all commands from the manager, as did nodes and even clusters. Now, nodes listen to the manager, and they perform address filtering and pass down to the endpoint which in turn passes out to the relevant cluster.

Closes #88 

Signed-off-by: Chris Jackson <chris@cd-jackson.com>