### PR TITLE
Add attribute normaliser and handler for Integer to BOOLEAN data type

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/ZclAttributeNormalizer.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/ZclAttributeNormalizer.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2016-2017 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.zcl;
+
+import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
+
+/**
+ * The attribute normalizer allows attribute type conversion to ensure that attribute data stored in the
+ * {@link ZclAttribute} class is always of the type defined in the library. This ensures that any devices not conforming
+ * to the ZCL definition of the attribute type can be normalized before updating the {@link ZclAttribute}. This in turn
+ * guarantees that applications can rely on the data type.
+ *
+ * @author Chris Jackson
+ *
+ */
+public class ZclAttributeNormalizer {
+
+    protected Object normalizeZclData(ZclDataType dataType, Object data) {
+        switch (dataType) {
+            case BOOLEAN:
+                if (data instanceof Integer) {
+                    return Boolean.valueOf(!data.equals(0));
+                }
+                break;
+            default:
+                break;
+        }
+        return data;
+    }
+}

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zcl/ZclAttributeNormalizerTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zcl/ZclAttributeNormalizerTest.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2016-2017 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.zcl;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
+
+/**
+ *
+ * @author Chris Jackson
+ *
+ */
+public class ZclAttributeNormalizerTest {
+    @Test
+    public void testNormalizeBoolean() {
+        ZclAttributeNormalizer normalizer = new ZclAttributeNormalizer();
+
+        assertEquals(Boolean.TRUE, normalizer.normalizeZclData(ZclDataType.BOOLEAN, Integer.valueOf(1)));
+        assertEquals(Boolean.TRUE, normalizer.normalizeZclData(ZclDataType.BOOLEAN, Integer.valueOf(100)));
+        assertEquals(Boolean.FALSE, normalizer.normalizeZclData(ZclDataType.BOOLEAN, Integer.valueOf(0)));
+    }
+}

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zcl/ZclClusterTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zcl/ZclClusterTest.java
@@ -11,24 +11,29 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
-import com.zsmartsystems.zigbee.ZigBeeTransactionMatcher;
 import com.zsmartsystems.zigbee.IeeeAddress;
 import com.zsmartsystems.zigbee.ZigBeeCommand;
 import com.zsmartsystems.zigbee.ZigBeeEndpoint;
 import com.zsmartsystems.zigbee.ZigBeeEndpointAddress;
 import com.zsmartsystems.zigbee.ZigBeeNetworkManager;
 import com.zsmartsystems.zigbee.ZigBeeNode;
+import com.zsmartsystems.zigbee.ZigBeeTransactionMatcher;
 import com.zsmartsystems.zigbee.transport.ZigBeeTransportTransmit;
 import com.zsmartsystems.zigbee.zcl.clusters.ZclLevelControlCluster;
 import com.zsmartsystems.zigbee.zcl.clusters.ZclOnOffCluster;
 import com.zsmartsystems.zigbee.zcl.clusters.general.ConfigureReportingCommand;
 import com.zsmartsystems.zigbee.zcl.clusters.general.ReadReportingConfigurationCommand;
 import com.zsmartsystems.zigbee.zcl.field.AttributeRecord;
+import com.zsmartsystems.zigbee.zcl.field.AttributeReport;
 import com.zsmartsystems.zigbee.zcl.field.AttributeReportingConfigurationRecord;
+import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 import com.zsmartsystems.zigbee.zdo.command.BindRequest;
 import com.zsmartsystems.zigbee.zdo.command.UnbindRequest;
 
@@ -163,6 +168,27 @@ public class ZclClusterTest {
         ZigBeeEndpoint device = new ZigBeeEndpoint(networkManager, node, 5);
         ZclCluster cluster = new ZclLevelControlCluster(networkManager, device);
         assertEquals("Level Control", cluster.getClusterName());
+    }
+
+    @Test
+    public void handleAttributeReport() {
+        createNetworkManager();
+
+        ZigBeeNode node = new ZigBeeNode(networkManager, new IeeeAddress());
+        node.setNetworkAddress(1234);
+        ZigBeeEndpoint device = new ZigBeeEndpoint(networkManager, node, 5);
+        ZclCluster cluster = new ZclOnOffCluster(networkManager, device);
+
+        List<AttributeReport> attributeList = new ArrayList<AttributeReport>();
+        AttributeReport report;
+        report = new AttributeReport();
+        report.setAttributeDataType(ZclDataType.SIGNED_8_BIT_INTEGER);
+        report.setAttributeIdentifier(0);
+        report.setAttributeValue(Integer.valueOf(1));
+        attributeList.add(report);
+        cluster.handleAttributeReport(attributeList);
+        ZclAttribute attribute = cluster.getAttribute(0);
+        assertTrue(attribute.getLastValue() instanceof Boolean);
     }
 
 }


### PR DESCRIPTION
This ensures that attributes can be converted to the data type expected by the library, which in turn ensures that applications can rely on the type when getting attribute values.

Currently this just implements a conversion from Integer when data type is BOOLEAN in order to close #160.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>