### PR TITLE
Catch exception processing corrupt frame in the transaction handler

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.telegesis/src/test/java/com/zsmartsystems/zigbee/dongle/telegesis/internal/TelegesisEventFactoryTest.java
+++ b/com.zsmartsystems.zigbee.dongle.telegesis/src/test/java/com/zsmartsystems/zigbee/dongle/telegesis/internal/TelegesisEventFactoryTest.java
@@ -47,4 +47,11 @@ public class TelegesisEventFactoryTest extends TelegesisFrameBaseTest {
         assertNull(event);
     }
 
+    @Test
+    public void testCorruptMessage() {
+        TelegesisEvent event = TelegesisEventFactory.getTelegesisFrame(
+                new int[] { 0x52, 0x58, 0x3A, 0x33, 0x44, 0x45, 0x42, 0x2C, 0x30, 0x93, 0x05, 0x00, 0xEA, 0x11 });
+
+        assertNull(event);
+    }
 }

--- a/com.zsmartsystems.zigbee.dongle.telegesis/src/test/java/com/zsmartsystems/zigbee/dongle/telegesis/internal/protocol/TelegesisReceiveMessageEventTest.java
+++ b/com.zsmartsystems.zigbee.dongle.telegesis/src/test/java/com/zsmartsystems/zigbee/dongle/telegesis/internal/protocol/TelegesisReceiveMessageEventTest.java
@@ -43,5 +43,5 @@ public class TelegesisReceiveMessageEventTest extends TelegesisFrameBaseTest {
         assertEquals(Integer.valueOf(-69), event.getRssi());
         assertEquals(Integer.valueOf(255), event.getLqi());
     }
+
 }
-//


### PR DESCRIPTION
Catches exceptions processing corrupt frames in the Telegesis frame handler. If the frame is corrupt, we assume that this frame completed the transaction so that we can move on.

https://github.com/openhab/org.openhab.binding.zigbee/issues/57

Signed-off-by: Chris Jackson <chris@cd-jackson.com>