### PR TITLE
Don't log stack trace for InterruptedException

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/ZclCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/ZclCluster.java
@@ -204,7 +204,10 @@ public abstract class ZclCluster {
         CommandResult result;
         try {
             result = read(attribute).get();
-        } catch (InterruptedException | ExecutionException e) {
+        } catch (InterruptedException e) {
+            logger.debug("readSync interrupted");
+            return null;
+        } catch (ExecutionException e) {
             logger.debug("readSync exception ", e);
             return null;
         }


### PR DESCRIPTION
Doesn't log the stack trace if there's an InterruptedException during a transaction in readSync.

Closes #169 

Signed-off-by: Chris Jackson <chris@cd-jackson.com>