### PR TITLE
Update MatchDescriptor and code generator to handle list sizer better

### DIFF
--- a/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleMain.java
+++ b/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleMain.java
@@ -179,6 +179,8 @@ public class ZigBeeConsoleMain {
         ZigBeeNetworkMeshMonitor meshMonitor = new ZigBeeNetworkMeshMonitor(networkManager);
         meshMonitor.startup(60);
 
+        networkManager.addSupportedCluster(ZclIasZoneCluster.CLUSTER_ID);
+
         console.start();
 
         System.out.println("Console closed.");

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/CommandResultFuture.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/CommandResultFuture.java
@@ -36,9 +36,9 @@ public class CommandResultFuture implements Future<CommandResult> {
     private CommandResult result;
 
     /**
-     * Constructor which sets the simple ZigBee API this future belongs to.
+     * Constructor which sets the {@link ZigBeeNetworkManager} to which this future belongs.
      *
-     * @param zigBeeNetworkManager the simple ZigBee API
+     * @param {@link ZigBeeNetworkManager} the ZigBee network
      */
     public CommandResultFuture(ZigBeeNetworkManager zigBeeNetworkManager) {
         this.networkManager = zigBeeNetworkManager;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
@@ -772,9 +772,8 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
             final ZigBeeCommandListener commandListener = new ZigBeeCommandListener() {
                 @Override
                 public void commandReceived(ZigBeeCommand receivedCommand) {
-                    // Ensure that received command is not processed before
-                    // command is sent and hence transaction ID for the command
-                    // set.
+                    // Ensure that received command is not processed before command is sent
+                    // and hence transaction ID for the command set.
                     synchronized (command) {
                         if (responseMatcher.isTransactionMatch(command, receivedCommand)) {
                             synchronized (future) {

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkMeshMonitor.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkMeshMonitor.java
@@ -291,8 +291,8 @@ public class ZigBeeNetworkMeshMonitor implements ZigBeeCommandListener {
 
                 // Continue with next request
                 // TODO: Differentiate between total devices, and devices in this request
-                startIndex += ieeeAddressResponse.getNumAssocDev() == null ? 0 : ieeeAddressResponse.getNumAssocDev();
-                totalNodes = ieeeAddressResponse.getNumAssocDev() == null ? 0 : ieeeAddressResponse.getNumAssocDev();
+                startIndex += ieeeAddressResponse.getNwkAddrAssocDevList().size();
+                totalNodes = ieeeAddressResponse.getNwkAddrAssocDevList().size();
             } else {
                 logger.debug("{}: Ieee Address request returned {}", networkAddress, ieeeAddressResponse);
 
@@ -342,7 +342,7 @@ public class ZigBeeNetworkMeshMonitor implements ZigBeeCommandListener {
                 }
 
                 // Continue with next request
-                startIndex += neighborResponse.getNeighborTableListCount();
+                startIndex += neighborResponse.getNeighborTableList().size();
                 totalNeighbors = neighborResponse.getNeighborTableEntries();
             } else {
                 logger.debug("{}: ManagementLqiRequest returned {}", networkAddress, neighborResponse);
@@ -388,7 +388,7 @@ public class ZigBeeNetworkMeshMonitor implements ZigBeeCommandListener {
                 routes.addAll(routingResponse.getRoutingTableList());
 
                 // Continue with next request
-                startIndex += routingResponse.getRoutingTableListCount();
+                startIndex += routingResponse.getRoutingTableList().size();
                 totalRoutes = routingResponse.getRoutingTableEntries();
             } else {
                 logger.debug("{}: ManagementRoutingRequest returned {}", networkAddress, routingResponse);

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNode.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNode.java
@@ -355,7 +355,7 @@ public class ZigBeeNode implements ZigBeeCommandListener {
                     ManagementBindResponse response = (ManagementBindResponse) result.getResponse();
                     if (response.getStartIndex() == index) {
                         tableSize = response.getBindingTableEntries();
-                        index += response.getBindingTableListCount();
+                        index += response.getBindingTableList().size();
                         bindingTable.addAll(response.getBindingTableList());
                     }
                 } while (index < tableSize);

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/iasclient/ZigBeeIasCieApp.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/iasclient/ZigBeeIasCieApp.java
@@ -153,9 +153,11 @@ public class ZigBeeIasCieApp implements ZigBeeApplication {
         iasZoneCluster = (ZclIasZoneCluster) cluster;
 
         Integer currentState = iasZoneCluster.getZoneState(0);
-        ZoneStateEnum currentStateEnum = ZoneStateEnum.getByValue(currentState);
-        logger.debug("{}: IAS CIE state is currently {}[{}]", iasZoneCluster.getZigBeeAddress(), currentStateEnum,
-                currentState);
+        if (currentState != null) {
+            ZoneStateEnum currentStateEnum = ZoneStateEnum.getByValue(currentState);
+            logger.debug("{}: IAS CIE state is currently {}[{}]", iasZoneCluster.getZigBeeAddress(), currentStateEnum,
+                    currentState);
+        }
 
         IeeeAddress currentIeeeAddress = iasZoneCluster.getIascieAddress(0);
         logger.debug("{}: IAS CIE address is currently {}", iasZoneCluster.getZigBeeAddress(), currentIeeeAddress);

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/internal/ZigBeeNetworkDiscoverer.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/internal/ZigBeeNetworkDiscoverer.java
@@ -459,10 +459,8 @@ public class ZigBeeNetworkDiscoverer
                     if (startIndex.equals(ieeeAddressResponse.getStartIndex())) {
                         associatedDevices.addAll(ieeeAddressResponse.getNwkAddrAssocDevList());
 
-                        startIndex += ieeeAddressResponse.getNumAssocDev() == null ? 0
-                                : ieeeAddressResponse.getNumAssocDev();
-                        totalAssociatedDevices = ieeeAddressResponse.getNumAssocDev() == null ? 0
-                                : ieeeAddressResponse.getNumAssocDev();
+                        startIndex += ieeeAddressResponse.getNwkAddrAssocDevList().size();
+                        totalAssociatedDevices = ieeeAddressResponse.getNwkAddrAssocDevList().size();
                     }
                 }
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ActiveEndpointsResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ActiveEndpointsResponse.java
@@ -32,11 +32,6 @@ public class ActiveEndpointsResponse extends ZdoResponse {
     private Integer nwkAddrOfInterest;
 
     /**
-     * ActiveEPCnt command message field.
-     */
-    private Integer activeEpCnt;
-
-    /**
      * ActiveEPList command message field.
      */
     private List<Integer> activeEpList;
@@ -67,24 +62,6 @@ public class ActiveEndpointsResponse extends ZdoResponse {
     }
 
     /**
-     * Gets ActiveEPCnt.
-     *
-     * @return the ActiveEPCnt
-     */
-    public Integer getActiveEpCnt() {
-        return activeEpCnt;
-    }
-
-    /**
-     * Sets ActiveEPCnt.
-     *
-     * @param activeEpCnt the ActiveEPCnt
-     */
-    public void setActiveEpCnt(final Integer activeEpCnt) {
-        this.activeEpCnt = activeEpCnt;
-    }
-
-    /**
      * Gets ActiveEPList.
      *
      * @return the ActiveEPList
@@ -108,7 +85,7 @@ public class ActiveEndpointsResponse extends ZdoResponse {
 
         serializer.serialize(status, ZclDataType.ZDO_STATUS);
         serializer.serialize(nwkAddrOfInterest, ZclDataType.NWK_ADDRESS);
-        serializer.serialize(activeEpCnt, ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        serializer.serialize(activeEpList.size(), ZclDataType.UNSIGNED_8_BIT_INTEGER);
         for (int cnt = 0; cnt < activeEpList.size(); cnt++) {
             serializer.serialize(activeEpList.get(cnt), ZclDataType.ENDPOINT);
         }
@@ -127,7 +104,7 @@ public class ActiveEndpointsResponse extends ZdoResponse {
             return;
         }
         nwkAddrOfInterest = (Integer) deserializer.deserialize(ZclDataType.NWK_ADDRESS);
-        activeEpCnt = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        Integer activeEpCnt = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
         if (activeEpCnt != null) {
             for (int cnt = 0; cnt < activeEpCnt; cnt++) {
                 activeEpList.add((Integer) deserializer.deserialize(ZclDataType.ENDPOINT));
@@ -144,8 +121,6 @@ public class ActiveEndpointsResponse extends ZdoResponse {
         builder.append(status);
         builder.append(", nwkAddrOfInterest=");
         builder.append(nwkAddrOfInterest);
-        builder.append(", activeEpCnt=");
-        builder.append(activeEpCnt);
         builder.append(", activeEpList=");
         builder.append(activeEpList);
         builder.append(']');

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/BindRegisterResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/BindRegisterResponse.java
@@ -33,11 +33,6 @@ public class BindRegisterResponse extends ZdoResponse {
     private Integer bindingTableEntries;
 
     /**
-     * BindingTableListCount command message field.
-     */
-    private Integer bindingTableListCount;
-
-    /**
      * BindingTableList command message field.
      */
     private List<List<BindingTable>> bindingTableList;
@@ -68,24 +63,6 @@ public class BindRegisterResponse extends ZdoResponse {
     }
 
     /**
-     * Gets BindingTableListCount.
-     *
-     * @return the BindingTableListCount
-     */
-    public Integer getBindingTableListCount() {
-        return bindingTableListCount;
-    }
-
-    /**
-     * Sets BindingTableListCount.
-     *
-     * @param bindingTableListCount the BindingTableListCount
-     */
-    public void setBindingTableListCount(final Integer bindingTableListCount) {
-        this.bindingTableListCount = bindingTableListCount;
-    }
-
-    /**
      * Gets BindingTableList.
      *
      * @return the BindingTableList
@@ -109,7 +86,7 @@ public class BindRegisterResponse extends ZdoResponse {
 
         serializer.serialize(status, ZclDataType.ZDO_STATUS);
         serializer.serialize(bindingTableEntries, ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        serializer.serialize(bindingTableListCount, ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        serializer.serialize(bindingTableList.size(), ZclDataType.UNSIGNED_16_BIT_INTEGER);
         for (int cnt = 0; cnt < bindingTableList.size(); cnt++) {
             serializer.serialize(bindingTableList.get(cnt), ZclDataType.N_X_BINDING_TABLE);
         }
@@ -128,7 +105,7 @@ public class BindRegisterResponse extends ZdoResponse {
             return;
         }
         bindingTableEntries = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        bindingTableListCount = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        Integer bindingTableListCount = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
         if (bindingTableListCount != null) {
             for (int cnt = 0; cnt < bindingTableListCount; cnt++) {
                 bindingTableList.add((List<BindingTable>) deserializer.deserialize(ZclDataType.N_X_BINDING_TABLE));
@@ -145,8 +122,6 @@ public class BindRegisterResponse extends ZdoResponse {
         builder.append(status);
         builder.append(", bindingTableEntries=");
         builder.append(bindingTableEntries);
-        builder.append(", bindingTableListCount=");
-        builder.append(bindingTableListCount);
         builder.append(", bindingTableList=");
         builder.append(bindingTableList);
         builder.append(']');

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/EndDeviceBindRequest.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/EndDeviceBindRequest.java
@@ -49,19 +49,9 @@ public class EndDeviceBindRequest extends ZdoRequest {
     private Integer profileId;
 
     /**
-     * InClusterCount command message field.
-     */
-    private Integer inClusterCount;
-
-    /**
      * InClusterList command message field.
      */
     private List<Integer> inClusterList;
-
-    /**
-     * OutClusterCount command message field.
-     */
-    private Integer outClusterCount;
 
     /**
      * OutClusterList command message field.
@@ -148,24 +138,6 @@ public class EndDeviceBindRequest extends ZdoRequest {
     }
 
     /**
-     * Gets InClusterCount.
-     *
-     * @return the InClusterCount
-     */
-    public Integer getInClusterCount() {
-        return inClusterCount;
-    }
-
-    /**
-     * Sets InClusterCount.
-     *
-     * @param inClusterCount the InClusterCount
-     */
-    public void setInClusterCount(final Integer inClusterCount) {
-        this.inClusterCount = inClusterCount;
-    }
-
-    /**
      * Gets InClusterList.
      *
      * @return the InClusterList
@@ -181,24 +153,6 @@ public class EndDeviceBindRequest extends ZdoRequest {
      */
     public void setInClusterList(final List<Integer> inClusterList) {
         this.inClusterList = inClusterList;
-    }
-
-    /**
-     * Gets OutClusterCount.
-     *
-     * @return the OutClusterCount
-     */
-    public Integer getOutClusterCount() {
-        return outClusterCount;
-    }
-
-    /**
-     * Sets OutClusterCount.
-     *
-     * @param outClusterCount the OutClusterCount
-     */
-    public void setOutClusterCount(final Integer outClusterCount) {
-        this.outClusterCount = outClusterCount;
     }
 
     /**
@@ -227,11 +181,11 @@ public class EndDeviceBindRequest extends ZdoRequest {
         serializer.serialize(srcAddress, ZclDataType.IEEE_ADDRESS);
         serializer.serialize(srcEndpoint, ZclDataType.UNSIGNED_8_BIT_INTEGER);
         serializer.serialize(profileId, ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        serializer.serialize(inClusterCount, ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        serializer.serialize(inClusterList.size(), ZclDataType.UNSIGNED_8_BIT_INTEGER);
         for (int cnt = 0; cnt < inClusterList.size(); cnt++) {
             serializer.serialize(inClusterList.get(cnt), ZclDataType.CLUSTERID);
         }
-        serializer.serialize(outClusterCount, ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        serializer.serialize(outClusterList.size(), ZclDataType.UNSIGNED_8_BIT_INTEGER);
         for (int cnt = 0; cnt < outClusterList.size(); cnt++) {
             serializer.serialize(outClusterList.get(cnt), ZclDataType.CLUSTERID);
         }
@@ -249,13 +203,13 @@ public class EndDeviceBindRequest extends ZdoRequest {
         srcAddress = (IeeeAddress) deserializer.deserialize(ZclDataType.IEEE_ADDRESS);
         srcEndpoint = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
         profileId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        inClusterCount = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        Integer inClusterCount = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
         if (inClusterCount != null) {
             for (int cnt = 0; cnt < inClusterCount; cnt++) {
                 inClusterList.add((Integer) deserializer.deserialize(ZclDataType.CLUSTERID));
             }
         }
-        outClusterCount = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        Integer outClusterCount = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
         if (outClusterCount != null) {
             for (int cnt = 0; cnt < outClusterCount; cnt++) {
                 outClusterList.add((Integer) deserializer.deserialize(ZclDataType.CLUSTERID));
@@ -276,12 +230,8 @@ public class EndDeviceBindRequest extends ZdoRequest {
         builder.append(srcEndpoint);
         builder.append(", profileId=");
         builder.append(profileId);
-        builder.append(", inClusterCount=");
-        builder.append(inClusterCount);
         builder.append(", inClusterList=");
         builder.append(inClusterList);
-        builder.append(", outClusterCount=");
-        builder.append(outClusterCount);
         builder.append(", outClusterList=");
         builder.append(outClusterList);
         builder.append(']');

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/IeeeAddressResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/IeeeAddressResponse.java
@@ -39,11 +39,6 @@ public class IeeeAddressResponse extends ZdoResponse {
     private Integer nwkAddrRemoteDev;
 
     /**
-     * NumAssocDev command message field.
-     */
-    private Integer numAssocDev;
-
-    /**
      * StartIndex command message field.
      */
     private Integer startIndex;
@@ -97,24 +92,6 @@ public class IeeeAddressResponse extends ZdoResponse {
     }
 
     /**
-     * Gets NumAssocDev.
-     *
-     * @return the NumAssocDev
-     */
-    public Integer getNumAssocDev() {
-        return numAssocDev;
-    }
-
-    /**
-     * Sets NumAssocDev.
-     *
-     * @param numAssocDev the NumAssocDev
-     */
-    public void setNumAssocDev(final Integer numAssocDev) {
-        this.numAssocDev = numAssocDev;
-    }
-
-    /**
      * Gets StartIndex.
      *
      * @return the StartIndex
@@ -157,7 +134,7 @@ public class IeeeAddressResponse extends ZdoResponse {
         serializer.serialize(status, ZclDataType.ZDO_STATUS);
         serializer.serialize(ieeeAddrRemoteDev, ZclDataType.IEEE_ADDRESS);
         serializer.serialize(nwkAddrRemoteDev, ZclDataType.NWK_ADDRESS);
-        serializer.serialize(numAssocDev, ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        serializer.serialize(nwkAddrAssocDevList.size(), ZclDataType.UNSIGNED_8_BIT_INTEGER);
         serializer.serialize(startIndex, ZclDataType.UNSIGNED_8_BIT_INTEGER);
         for (int cnt = 0; cnt < nwkAddrAssocDevList.size(); cnt++) {
             serializer.serialize(nwkAddrAssocDevList.get(cnt), ZclDataType.NWK_ADDRESS);
@@ -181,10 +158,7 @@ public class IeeeAddressResponse extends ZdoResponse {
         if (deserializer.isEndOfStream()) {
             return;
         }
-        numAssocDev = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        if (numAssocDev == 0) {
-            return;
-        }
+        Integer numAssocDev = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
         startIndex = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
         if (numAssocDev != null) {
             for (int cnt = 0; cnt < numAssocDev; cnt++) {
@@ -204,8 +178,6 @@ public class IeeeAddressResponse extends ZdoResponse {
         builder.append(ieeeAddrRemoteDev);
         builder.append(", nwkAddrRemoteDev=");
         builder.append(nwkAddrRemoteDev);
-        builder.append(", numAssocDev=");
-        builder.append(numAssocDev);
         builder.append(", startIndex=");
         builder.append(startIndex);
         builder.append(", nwkAddrAssocDevList=");

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ManagementBindResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ManagementBindResponse.java
@@ -39,11 +39,6 @@ public class ManagementBindResponse extends ZdoResponse {
     private Integer startIndex;
 
     /**
-     * BindingTableListCount command message field.
-     */
-    private Integer bindingTableListCount;
-
-    /**
      * BindingTableList command message field.
      */
     private List<BindingTable> bindingTableList;
@@ -92,24 +87,6 @@ public class ManagementBindResponse extends ZdoResponse {
     }
 
     /**
-     * Gets BindingTableListCount.
-     *
-     * @return the BindingTableListCount
-     */
-    public Integer getBindingTableListCount() {
-        return bindingTableListCount;
-    }
-
-    /**
-     * Sets BindingTableListCount.
-     *
-     * @param bindingTableListCount the BindingTableListCount
-     */
-    public void setBindingTableListCount(final Integer bindingTableListCount) {
-        this.bindingTableListCount = bindingTableListCount;
-    }
-
-    /**
      * Gets BindingTableList.
      *
      * @return the BindingTableList
@@ -134,7 +111,7 @@ public class ManagementBindResponse extends ZdoResponse {
         serializer.serialize(status, ZclDataType.ZDO_STATUS);
         serializer.serialize(bindingTableEntries, ZclDataType.UNSIGNED_8_BIT_INTEGER);
         serializer.serialize(startIndex, ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        serializer.serialize(bindingTableListCount, ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        serializer.serialize(bindingTableList.size(), ZclDataType.UNSIGNED_8_BIT_INTEGER);
         for (int cnt = 0; cnt < bindingTableList.size(); cnt++) {
             serializer.serialize(bindingTableList.get(cnt), ZclDataType.BINDING_TABLE);
         }
@@ -154,7 +131,7 @@ public class ManagementBindResponse extends ZdoResponse {
         }
         bindingTableEntries = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
         startIndex = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        bindingTableListCount = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        Integer bindingTableListCount = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
         if (bindingTableListCount != null) {
             for (int cnt = 0; cnt < bindingTableListCount; cnt++) {
                 bindingTableList.add((BindingTable) deserializer.deserialize(ZclDataType.BINDING_TABLE));
@@ -173,8 +150,6 @@ public class ManagementBindResponse extends ZdoResponse {
         builder.append(bindingTableEntries);
         builder.append(", startIndex=");
         builder.append(startIndex);
-        builder.append(", bindingTableListCount=");
-        builder.append(bindingTableListCount);
         builder.append(", bindingTableList=");
         builder.append(bindingTableList);
         builder.append(']');

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ManagementLqiResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ManagementLqiResponse.java
@@ -39,11 +39,6 @@ public class ManagementLqiResponse extends ZdoResponse {
     private Integer startIndex;
 
     /**
-     * NeighborTableListCount command message field.
-     */
-    private Integer neighborTableListCount;
-
-    /**
      * NeighborTableList command message field.
      */
     private List<NeighborTable> neighborTableList;
@@ -92,24 +87,6 @@ public class ManagementLqiResponse extends ZdoResponse {
     }
 
     /**
-     * Gets NeighborTableListCount.
-     *
-     * @return the NeighborTableListCount
-     */
-    public Integer getNeighborTableListCount() {
-        return neighborTableListCount;
-    }
-
-    /**
-     * Sets NeighborTableListCount.
-     *
-     * @param neighborTableListCount the NeighborTableListCount
-     */
-    public void setNeighborTableListCount(final Integer neighborTableListCount) {
-        this.neighborTableListCount = neighborTableListCount;
-    }
-
-    /**
      * Gets NeighborTableList.
      *
      * @return the NeighborTableList
@@ -134,7 +111,7 @@ public class ManagementLqiResponse extends ZdoResponse {
         serializer.serialize(status, ZclDataType.ZDO_STATUS);
         serializer.serialize(neighborTableEntries, ZclDataType.UNSIGNED_8_BIT_INTEGER);
         serializer.serialize(startIndex, ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        serializer.serialize(neighborTableListCount, ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        serializer.serialize(neighborTableList.size(), ZclDataType.UNSIGNED_8_BIT_INTEGER);
         for (int cnt = 0; cnt < neighborTableList.size(); cnt++) {
             serializer.serialize(neighborTableList.get(cnt), ZclDataType.NEIGHBOR_TABLE);
         }
@@ -154,7 +131,7 @@ public class ManagementLqiResponse extends ZdoResponse {
         }
         neighborTableEntries = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
         startIndex = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        neighborTableListCount = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        Integer neighborTableListCount = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
         if (neighborTableListCount != null) {
             for (int cnt = 0; cnt < neighborTableListCount; cnt++) {
                 neighborTableList.add((NeighborTable) deserializer.deserialize(ZclDataType.NEIGHBOR_TABLE));
@@ -173,8 +150,6 @@ public class ManagementLqiResponse extends ZdoResponse {
         builder.append(neighborTableEntries);
         builder.append(", startIndex=");
         builder.append(startIndex);
-        builder.append(", neighborTableListCount=");
-        builder.append(neighborTableListCount);
         builder.append(", neighborTableList=");
         builder.append(neighborTableList);
         builder.append(']');

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ManagementNetworkUpdateNotify.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ManagementNetworkUpdateNotify.java
@@ -53,11 +53,6 @@ public class ManagementNetworkUpdateNotify extends ZdoResponse {
     private Integer transmissionFailures;
 
     /**
-     * ScannedChannelsListCount command message field.
-     */
-    private Integer scannedChannelsListCount;
-
-    /**
      * EnergyValues command message field.
      */
     private List<Integer> energyValues;
@@ -124,24 +119,6 @@ public class ManagementNetworkUpdateNotify extends ZdoResponse {
     }
 
     /**
-     * Gets ScannedChannelsListCount.
-     *
-     * @return the ScannedChannelsListCount
-     */
-    public Integer getScannedChannelsListCount() {
-        return scannedChannelsListCount;
-    }
-
-    /**
-     * Sets ScannedChannelsListCount.
-     *
-     * @param scannedChannelsListCount the ScannedChannelsListCount
-     */
-    public void setScannedChannelsListCount(final Integer scannedChannelsListCount) {
-        this.scannedChannelsListCount = scannedChannelsListCount;
-    }
-
-    /**
      * Gets EnergyValues.
      *
      * @return the EnergyValues
@@ -167,7 +144,7 @@ public class ManagementNetworkUpdateNotify extends ZdoResponse {
         serializer.serialize(scannedChannels, ZclDataType.UNSIGNED_32_BIT_INTEGER);
         serializer.serialize(totalTransmissions, ZclDataType.UNSIGNED_16_BIT_INTEGER);
         serializer.serialize(transmissionFailures, ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        serializer.serialize(scannedChannelsListCount, ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        serializer.serialize(energyValues.size(), ZclDataType.UNSIGNED_8_BIT_INTEGER);
         for (int cnt = 0; cnt < energyValues.size(); cnt++) {
             serializer.serialize(energyValues.get(cnt), ZclDataType.UNSIGNED_8_BIT_INTEGER);
         }
@@ -188,7 +165,7 @@ public class ManagementNetworkUpdateNotify extends ZdoResponse {
         scannedChannels = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
         totalTransmissions = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
         transmissionFailures = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        scannedChannelsListCount = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        Integer scannedChannelsListCount = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
         if (scannedChannelsListCount != null) {
             for (int cnt = 0; cnt < scannedChannelsListCount; cnt++) {
                 energyValues.add((Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER));
@@ -209,8 +186,6 @@ public class ManagementNetworkUpdateNotify extends ZdoResponse {
         builder.append(totalTransmissions);
         builder.append(", transmissionFailures=");
         builder.append(transmissionFailures);
-        builder.append(", scannedChannelsListCount=");
-        builder.append(scannedChannelsListCount);
         builder.append(", energyValues=");
         builder.append(energyValues);
         builder.append(']');

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ManagementRoutingResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ManagementRoutingResponse.java
@@ -39,11 +39,6 @@ public class ManagementRoutingResponse extends ZdoResponse {
     private Integer startIndex;
 
     /**
-     * RoutingTableListCount command message field.
-     */
-    private Integer routingTableListCount;
-
-    /**
      * RoutingTableList command message field.
      */
     private List<RoutingTable> routingTableList;
@@ -92,24 +87,6 @@ public class ManagementRoutingResponse extends ZdoResponse {
     }
 
     /**
-     * Gets RoutingTableListCount.
-     *
-     * @return the RoutingTableListCount
-     */
-    public Integer getRoutingTableListCount() {
-        return routingTableListCount;
-    }
-
-    /**
-     * Sets RoutingTableListCount.
-     *
-     * @param routingTableListCount the RoutingTableListCount
-     */
-    public void setRoutingTableListCount(final Integer routingTableListCount) {
-        this.routingTableListCount = routingTableListCount;
-    }
-
-    /**
      * Gets RoutingTableList.
      *
      * @return the RoutingTableList
@@ -134,7 +111,7 @@ public class ManagementRoutingResponse extends ZdoResponse {
         serializer.serialize(status, ZclDataType.ZDO_STATUS);
         serializer.serialize(routingTableEntries, ZclDataType.UNSIGNED_8_BIT_INTEGER);
         serializer.serialize(startIndex, ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        serializer.serialize(routingTableListCount, ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        serializer.serialize(routingTableList.size(), ZclDataType.UNSIGNED_8_BIT_INTEGER);
         for (int cnt = 0; cnt < routingTableList.size(); cnt++) {
             serializer.serialize(routingTableList.get(cnt), ZclDataType.ROUTING_TABLE);
         }
@@ -154,7 +131,7 @@ public class ManagementRoutingResponse extends ZdoResponse {
         }
         routingTableEntries = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
         startIndex = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        routingTableListCount = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        Integer routingTableListCount = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
         if (routingTableListCount != null) {
             for (int cnt = 0; cnt < routingTableListCount; cnt++) {
                 routingTableList.add((RoutingTable) deserializer.deserialize(ZclDataType.ROUTING_TABLE));
@@ -173,8 +150,6 @@ public class ManagementRoutingResponse extends ZdoResponse {
         builder.append(routingTableEntries);
         builder.append(", startIndex=");
         builder.append(startIndex);
-        builder.append(", routingTableListCount=");
-        builder.append(routingTableListCount);
         builder.append(", routingTableList=");
         builder.append(routingTableList);
         builder.append(']');

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/MatchDescriptorRequest.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/MatchDescriptorRequest.java
@@ -39,19 +39,9 @@ public class MatchDescriptorRequest extends ZdoRequest {
     private Integer profileId;
 
     /**
-     * InClusterCount command message field.
-     */
-    private Integer inClusterCount;
-
-    /**
      * InClusterList command message field.
      */
     private List<Integer> inClusterList;
-
-    /**
-     * OutClusterCount command message field.
-     */
-    private Integer outClusterCount;
 
     /**
      * OutClusterList command message field.
@@ -102,24 +92,6 @@ public class MatchDescriptorRequest extends ZdoRequest {
     }
 
     /**
-     * Gets InClusterCount.
-     *
-     * @return the InClusterCount
-     */
-    public Integer getInClusterCount() {
-        return inClusterCount;
-    }
-
-    /**
-     * Sets InClusterCount.
-     *
-     * @param inClusterCount the InClusterCount
-     */
-    public void setInClusterCount(final Integer inClusterCount) {
-        this.inClusterCount = inClusterCount;
-    }
-
-    /**
      * Gets InClusterList.
      *
      * @return the InClusterList
@@ -135,24 +107,6 @@ public class MatchDescriptorRequest extends ZdoRequest {
      */
     public void setInClusterList(final List<Integer> inClusterList) {
         this.inClusterList = inClusterList;
-    }
-
-    /**
-     * Gets OutClusterCount.
-     *
-     * @return the OutClusterCount
-     */
-    public Integer getOutClusterCount() {
-        return outClusterCount;
-    }
-
-    /**
-     * Sets OutClusterCount.
-     *
-     * @param outClusterCount the OutClusterCount
-     */
-    public void setOutClusterCount(final Integer outClusterCount) {
-        this.outClusterCount = outClusterCount;
     }
 
     /**
@@ -179,11 +133,11 @@ public class MatchDescriptorRequest extends ZdoRequest {
 
         serializer.serialize(nwkAddrOfInterest, ZclDataType.NWK_ADDRESS);
         serializer.serialize(profileId, ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        serializer.serialize(inClusterCount, ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        serializer.serialize(inClusterList.size(), ZclDataType.UNSIGNED_8_BIT_INTEGER);
         for (int cnt = 0; cnt < inClusterList.size(); cnt++) {
             serializer.serialize(inClusterList.get(cnt), ZclDataType.CLUSTERID);
         }
-        serializer.serialize(outClusterCount, ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        serializer.serialize(outClusterList.size(), ZclDataType.UNSIGNED_8_BIT_INTEGER);
         for (int cnt = 0; cnt < outClusterList.size(); cnt++) {
             serializer.serialize(outClusterList.get(cnt), ZclDataType.CLUSTERID);
         }
@@ -199,13 +153,13 @@ public class MatchDescriptorRequest extends ZdoRequest {
 
         nwkAddrOfInterest = (Integer) deserializer.deserialize(ZclDataType.NWK_ADDRESS);
         profileId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        inClusterCount = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        Integer inClusterCount = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
         if (inClusterCount != null) {
             for (int cnt = 0; cnt < inClusterCount; cnt++) {
                 inClusterList.add((Integer) deserializer.deserialize(ZclDataType.CLUSTERID));
             }
         }
-        outClusterCount = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        Integer outClusterCount = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
         if (outClusterCount != null) {
             for (int cnt = 0; cnt < outClusterCount; cnt++) {
                 outClusterList.add((Integer) deserializer.deserialize(ZclDataType.CLUSTERID));
@@ -222,12 +176,8 @@ public class MatchDescriptorRequest extends ZdoRequest {
         builder.append(nwkAddrOfInterest);
         builder.append(", profileId=");
         builder.append(profileId);
-        builder.append(", inClusterCount=");
-        builder.append(inClusterCount);
         builder.append(", inClusterList=");
         builder.append(inClusterList);
-        builder.append(", outClusterCount=");
-        builder.append(outClusterCount);
         builder.append(", outClusterList=");
         builder.append(outClusterList);
         builder.append(']');

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/MatchDescriptorResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/MatchDescriptorResponse.java
@@ -32,11 +32,6 @@ public class MatchDescriptorResponse extends ZdoResponse {
     private Integer nwkAddrOfInterest;
 
     /**
-     * MatchLength command message field.
-     */
-    private Integer matchLength;
-
-    /**
      * MatchList command message field.
      */
     private List<Integer> matchList;
@@ -67,24 +62,6 @@ public class MatchDescriptorResponse extends ZdoResponse {
     }
 
     /**
-     * Gets MatchLength.
-     *
-     * @return the MatchLength
-     */
-    public Integer getMatchLength() {
-        return matchLength;
-    }
-
-    /**
-     * Sets MatchLength.
-     *
-     * @param matchLength the MatchLength
-     */
-    public void setMatchLength(final Integer matchLength) {
-        this.matchLength = matchLength;
-    }
-
-    /**
      * Gets MatchList.
      *
      * @return the MatchList
@@ -108,7 +85,7 @@ public class MatchDescriptorResponse extends ZdoResponse {
 
         serializer.serialize(status, ZclDataType.ZDO_STATUS);
         serializer.serialize(nwkAddrOfInterest, ZclDataType.NWK_ADDRESS);
-        serializer.serialize(matchLength, ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        serializer.serialize(matchList.size(), ZclDataType.UNSIGNED_8_BIT_INTEGER);
         for (int cnt = 0; cnt < matchList.size(); cnt++) {
             serializer.serialize(matchList.get(cnt), ZclDataType.ENDPOINT);
         }
@@ -127,7 +104,7 @@ public class MatchDescriptorResponse extends ZdoResponse {
             return;
         }
         nwkAddrOfInterest = (Integer) deserializer.deserialize(ZclDataType.NWK_ADDRESS);
-        matchLength = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        Integer matchLength = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
         if (matchLength != null) {
             for (int cnt = 0; cnt < matchLength; cnt++) {
                 matchList.add((Integer) deserializer.deserialize(ZclDataType.ENDPOINT));
@@ -144,8 +121,6 @@ public class MatchDescriptorResponse extends ZdoResponse {
         builder.append(status);
         builder.append(", nwkAddrOfInterest=");
         builder.append(nwkAddrOfInterest);
-        builder.append(", matchLength=");
-        builder.append(matchLength);
         builder.append(", matchList=");
         builder.append(matchList);
         builder.append(']');

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/NetworkAddressResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/NetworkAddressResponse.java
@@ -39,11 +39,6 @@ public class NetworkAddressResponse extends ZdoResponse {
     private Integer nwkAddrRemoteDev;
 
     /**
-     * NumAssocDev command message field.
-     */
-    private Integer numAssocDev;
-
-    /**
      * StartIndex command message field.
      */
     private Integer startIndex;
@@ -97,24 +92,6 @@ public class NetworkAddressResponse extends ZdoResponse {
     }
 
     /**
-     * Gets NumAssocDev.
-     *
-     * @return the NumAssocDev
-     */
-    public Integer getNumAssocDev() {
-        return numAssocDev;
-    }
-
-    /**
-     * Sets NumAssocDev.
-     *
-     * @param numAssocDev the NumAssocDev
-     */
-    public void setNumAssocDev(final Integer numAssocDev) {
-        this.numAssocDev = numAssocDev;
-    }
-
-    /**
      * Gets StartIndex.
      *
      * @return the StartIndex
@@ -157,7 +134,7 @@ public class NetworkAddressResponse extends ZdoResponse {
         serializer.serialize(status, ZclDataType.ZDO_STATUS);
         serializer.serialize(ieeeAddrRemoteDev, ZclDataType.IEEE_ADDRESS);
         serializer.serialize(nwkAddrRemoteDev, ZclDataType.NWK_ADDRESS);
-        serializer.serialize(numAssocDev, ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        serializer.serialize(nwkAddrAssocDevList.size(), ZclDataType.UNSIGNED_8_BIT_INTEGER);
         serializer.serialize(startIndex, ZclDataType.UNSIGNED_8_BIT_INTEGER);
         for (int cnt = 0; cnt < nwkAddrAssocDevList.size(); cnt++) {
             serializer.serialize(nwkAddrAssocDevList.get(cnt), ZclDataType.NWK_ADDRESS);
@@ -178,7 +155,7 @@ public class NetworkAddressResponse extends ZdoResponse {
         }
         ieeeAddrRemoteDev = (IeeeAddress) deserializer.deserialize(ZclDataType.IEEE_ADDRESS);
         nwkAddrRemoteDev = (Integer) deserializer.deserialize(ZclDataType.NWK_ADDRESS);
-        numAssocDev = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        Integer numAssocDev = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
         startIndex = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
         if (numAssocDev != null) {
             for (int cnt = 0; cnt < numAssocDev; cnt++) {
@@ -198,8 +175,6 @@ public class NetworkAddressResponse extends ZdoResponse {
         builder.append(ieeeAddrRemoteDev);
         builder.append(", nwkAddrRemoteDev=");
         builder.append(nwkAddrRemoteDev);
-        builder.append(", numAssocDev=");
-        builder.append(numAssocDev);
         builder.append(", startIndex=");
         builder.append(startIndex);
         builder.append(", nwkAddrAssocDevList=");

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/internal/ClusterMatcherTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/internal/ClusterMatcherTest.java
@@ -5,7 +5,7 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  */
-package com.zsmartsystems.zigbee;
+package com.zsmartsystems.zigbee.internal;
 
 import static org.junit.Assert.assertEquals;
 
@@ -18,7 +18,9 @@ import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
-import com.zsmartsystems.zigbee.internal.ClusterMatcher;
+import com.zsmartsystems.zigbee.ZigBeeCommand;
+import com.zsmartsystems.zigbee.ZigBeeEndpointAddress;
+import com.zsmartsystems.zigbee.ZigBeeNetworkManager;
 import com.zsmartsystems.zigbee.zdo.command.MatchDescriptorRequest;
 
 /**
@@ -51,6 +53,7 @@ public class ClusterMatcherTest {
         List<Integer> clusterListIn = new ArrayList<Integer>();
         List<Integer> clusterListOut = new ArrayList<Integer>();
         MatchDescriptorRequest request = new MatchDescriptorRequest();
+        request.setSourceAddress(new ZigBeeEndpointAddress(1234, 5));
         request.setProfileId(0x104);
         request.setInClusterList(clusterListIn);
         request.setOutClusterList(clusterListOut);
@@ -69,6 +72,7 @@ public class ClusterMatcherTest {
         List<Integer> clusterListOut = new ArrayList<Integer>();
         clusterListIn.add(0x500);
         MatchDescriptorRequest request = new MatchDescriptorRequest();
+        request.setSourceAddress(new ZigBeeEndpointAddress(1234, 5));
         request.setProfileId(0x104);
         request.setInClusterList(clusterListIn);
         request.setOutClusterList(clusterListOut);
@@ -87,6 +91,7 @@ public class ClusterMatcherTest {
         List<Integer> clusterListOut = new ArrayList<Integer>();
         clusterListOut.add(0x500);
         MatchDescriptorRequest request = new MatchDescriptorRequest();
+        request.setSourceAddress(new ZigBeeEndpointAddress(1234, 5));
         request.setProfileId(0x104);
         request.setInClusterList(clusterListIn);
         request.setOutClusterList(clusterListOut);
@@ -106,6 +111,7 @@ public class ClusterMatcherTest {
         clusterListIn.add(0x500);
         clusterListOut.add(0x500);
         MatchDescriptorRequest request = new MatchDescriptorRequest();
+        request.setSourceAddress(new ZigBeeEndpointAddress(1234, 5));
         request.setProfileId(0x104);
         request.setInClusterList(clusterListIn);
         request.setOutClusterList(clusterListOut);

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/internal/ZigBeeNetworkDiscovererTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/internal/ZigBeeNetworkDiscovererTest.java
@@ -23,7 +23,6 @@ import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
-import com.zsmartsystems.zigbee.ZigBeeTransactionMatcher;
 import com.zsmartsystems.zigbee.CommandResult;
 import com.zsmartsystems.zigbee.CommandResultFuture;
 import com.zsmartsystems.zigbee.IeeeAddress;
@@ -31,6 +30,7 @@ import com.zsmartsystems.zigbee.ZigBeeCommand;
 import com.zsmartsystems.zigbee.ZigBeeEndpointAddress;
 import com.zsmartsystems.zigbee.ZigBeeNetworkManager;
 import com.zsmartsystems.zigbee.ZigBeeNode;
+import com.zsmartsystems.zigbee.ZigBeeTransactionMatcher;
 import com.zsmartsystems.zigbee.transport.ZigBeeTransportState;
 import com.zsmartsystems.zigbee.zdo.ZdoCommandType;
 import com.zsmartsystems.zigbee.zdo.ZdoStatus;
@@ -95,7 +95,6 @@ public class ZigBeeNetworkDiscovererTest {
         ieeeResponse.setSourceAddress(new ZigBeeEndpointAddress(0));
         ieeeResponse.setDestinationAddress(new ZigBeeEndpointAddress(0));
         ieeeResponse.setIeeeAddrRemoteDev(new IeeeAddress("1234567890ABCDEF"));
-        ieeeResponse.setNumAssocDev(0);
         responses.put(ZdoCommandType.IEEE_ADDRESS_REQUEST.getClusterId(), ieeeResponse);
 
         NodeDescriptorResponse nodeResponse = new NodeDescriptorResponse();
@@ -121,7 +120,6 @@ public class ZigBeeNetworkDiscovererTest {
         endpointsResponse.setSourceAddress(new ZigBeeEndpointAddress(0));
         endpointsResponse.setDestinationAddress(new ZigBeeEndpointAddress(0));
         endpointsResponse.setNwkAddrOfInterest(0);
-        endpointsResponse.setActiveEpCnt(1);
         List<Integer> activeEpList = new ArrayList<Integer>();
         activeEpList.add(1);
         endpointsResponse.setActiveEpList(activeEpList);

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zdo/command/ManagementBindResponseTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zdo/command/ManagementBindResponseTest.java
@@ -40,7 +40,6 @@ public class ManagementBindResponseTest extends CommandTest {
         System.out.println(response);
 
         assertEquals(1, (int) response.getBindingTableEntries());
-        assertEquals(1, (int) response.getBindingTableListCount());
         assertEquals(0, (int) response.getStartIndex());
 
         List<BindingTable> table = response.getBindingTableList();

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zdo/command/ManagementLqiResponseTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zdo/command/ManagementLqiResponseTest.java
@@ -46,7 +46,6 @@ public class ManagementLqiResponseTest extends CommandTest {
         System.out.println(lqiResponse);
 
         assertEquals(2, (int) lqiResponse.getNeighborTableEntries());
-        assertEquals(2, (int) lqiResponse.getNeighborTableListCount());
         assertEquals(0, (int) lqiResponse.getStartIndex());
 
         List<NeighborTable> neighbors = lqiResponse.getNeighborTableList();

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zdo/command/ManagementRoutingResponseTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zdo/command/ManagementRoutingResponseTest.java
@@ -41,7 +41,6 @@ public class ManagementRoutingResponseTest extends CommandTest {
         System.out.println(routingResponse);
 
         assertEquals(1, (int) routingResponse.getRoutingTableEntries());
-        assertEquals(1, (int) routingResponse.getRoutingTableListCount());
         assertEquals(0, (int) routingResponse.getStartIndex());
 
         List<RoutingTable> routes = routingResponse.getRoutingTableList();

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zdo/command/MatchDescriptorRequestTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zdo/command/MatchDescriptorRequestTest.java
@@ -37,8 +37,8 @@ public class MatchDescriptorRequestTest extends CommandTest {
 
         assertEquals(Integer.valueOf(65533), request.getNwkAddrOfInterest());
         assertEquals(Integer.valueOf(260), request.getProfileId());
-        assertEquals(Integer.valueOf(0), request.getInClusterCount());
-        assertEquals(Integer.valueOf(1), request.getOutClusterCount());
+        assertEquals(0, request.getInClusterList().size());
+        assertEquals(1, request.getOutClusterList().size());
         assertEquals(Integer.valueOf(1280), request.getOutClusterList().get(0));
     }
 }

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zdo/command/MatchDescriptorResponseTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zdo/command/MatchDescriptorResponseTest.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2016-2017 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.zdo.command;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+
+import com.zsmartsystems.zigbee.CommandTest;
+import com.zsmartsystems.zigbee.ZigBeeEndpointAddress;
+import com.zsmartsystems.zigbee.serialization.DefaultSerializer;
+import com.zsmartsystems.zigbee.serialization.ZigBeeSerializer;
+import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
+import com.zsmartsystems.zigbee.zdo.ZdoStatus;
+
+/**
+ *
+ * @author Chris Jackson
+ *
+ */
+public class MatchDescriptorResponseTest extends CommandTest {
+
+    @Test
+    public void testSendEndpoint1() {
+        MatchDescriptorResponse matchResponse = new MatchDescriptorResponse();
+        matchResponse.setStatus(ZdoStatus.SUCCESS);
+        List<Integer> matchList = new ArrayList<Integer>();
+        matchList.add(1);
+        matchResponse.setMatchList(matchList);
+
+        matchResponse.setDestinationAddress(new ZigBeeEndpointAddress(1234, 5));
+        matchResponse.setNwkAddrOfInterest(1234);
+        System.out.println(matchResponse);
+
+        ZigBeeSerializer serializer = new DefaultSerializer();
+        ZclFieldSerializer fieldSerializer = new ZclFieldSerializer(serializer);
+        matchResponse.serialize(fieldSerializer);
+        assertTrue(Arrays.equals(getPacketData("00 00 D2 04 01 01"), serializer.getPayload()));
+    }
+
+    @Test
+    public void testSendEndpoint2() {
+        MatchDescriptorResponse matchResponse = new MatchDescriptorResponse();
+        matchResponse.setStatus(ZdoStatus.SUCCESS);
+        List<Integer> matchList = new ArrayList<Integer>();
+        matchList.add(1);
+        matchList.add(2);
+        matchResponse.setMatchList(matchList);
+
+        matchResponse.setDestinationAddress(new ZigBeeEndpointAddress(1234, 5));
+        matchResponse.setNwkAddrOfInterest(1234);
+        System.out.println(matchResponse);
+
+        ZigBeeSerializer serializer = new DefaultSerializer();
+        ZclFieldSerializer fieldSerializer = new ZclFieldSerializer(serializer);
+        matchResponse.serialize(fieldSerializer);
+        assertTrue(Arrays.equals(getPacketData("00 00 D2 04 02 01 02"), serializer.getPayload()));
+    }
+}


### PR DESCRIPTION
This fixes issues with the implementation of the ClusterMatcher.

Note that this also modifies the code generator to remove getter and setter methods to get the size of auto sized lists in ZDO commands - this needs to be established from the list itself.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>