### PR TITLE
Initial addition of the electrical measurement cluster

### DIFF
--- a/com.zsmartsystems.zigbee.autocode/src/main/resources/zcl_definition.md
+++ b/com.zsmartsystems.zigbee.autocode/src/main/resources/zcl_definition.md
@@ -2666,6 +2666,105 @@ command that is still current.
 ### Generated
 
 ## Electrical Measurement [0x0B04]
+This cluster provides a mechanism for querying data about the electrical properties as measured
+by the device. This cluster may be implemented on any device type and be implemented on a per-endpoint
+basis. For example, a power  strip device could represent each outlet on a  different endpoint and
+report electrical  information for each individual outlet. The only caveat is that if you implement
+an attribute that has an associated multiplier and divisor, then you must implement the associated
+multiplier and divisor attributes. For example if you implement DCVoltage, you must also implement
+DCVoltageMultiplier and DCVoltageDivisor.
+
+If you are interested in reading information about the power supply or battery level on the device,
+please see the Power Configuration cluster.
+
+### Attributes
+
+|Id     |Name                             |Type                       |Access     |Implement |Reporting |
+|-------|---------------------------------|---------------------------|-----------|----------|----------|
+|0x0000 |MeasurementType                  |32-bit Bitmap              |Read only  |Mandatory |          |
+|0x0300 |ACFrequency                      |Unsigned 16-bit Integer    |Read only  |Optional  |          |
+|0x0304 |TotalActivePower                 |Signed 32-bit Integer      |Read only  |Optional  |          |
+|0x0305 |TotalReactivePower               |Signed 32-bit Integer      |Read only  |Optional  |          |
+|0x0306 |TotalApparentPower               |Unsigned 32-bit Integer    |Read only  |Optional  |          |
+|0x0505 |RMSVoltage                       |Unsigned 16-bit Integer    |Read only  |Optional  |          |
+|0x0508 |RMSCurrent                       |Unsigned 16-bit Integer    |Read only  |Optional  |          |
+|0x050B |ActivePower                      |Signed 16-bit Integer      |Read only  |Optional  |          |
+|0x0602 |ACCurrentMultiplier              |Unsigned 16-bit Integer    |Read only  |Optional  |          |
+|0x0603 |ACCurrentDivisor                 |Unsigned 16-bit Integer    |Read only  |Optional  |          |
+|0x0604 |ACPowerMultiplier                |Unsigned 16-bit Integer    |Read only  |Optional  |          |
+|0x0605 |ACPowerDivisor                   |Unsigned 16-bit Integer    |Read only  |Optional  |          |
+
+
+
+#### MeasurementType Attribute
+This attribute indicates a device’s measurement capabilities. This will be indicated by setting
+the desire measurement bits to 1.
+
+|Id     |Name                      |
+|-------|--------------------------|
+|0x0000 |AC Active Measurement     |
+|0x0001 |AC Reactive Measurement   |
+|0x0002 |AC Apparent Measurement   |
+|0x0004 |Phase A Measurement       |
+|0x0008 |Phase B Measurement       |
+|0x0010 |Phase C Measurement       |
+|0x0020 |DC Measurement            |
+|0x0040 |Harmonics Measurement     |
+|0x0080 |Power Quality Measurement |
+
+####  ACFrequency Attribute
+The ACFrequency attribute represents the most recent AC Frequency reading in Hertz (Hz).
+If the frequency cannot be measured, a value of 0xFFFF is returned. 
+
+#### TotalActivePower Attribute
+Active power represents the current demand of active power delivered or received at the
+premises, in kW. Positive values indicate power delivered to the premises where negative
+values indicate power received from the premises. In case if device is capable of measuring
+multi elements or phases then this will be net active power value.
+
+#### TotalReactivePower Attribute
+Reactive power represents the  current demand of reactive power delivered or 
+received at the premises, in kVAr. Positive values indicate power delivered to
+the premises where negative values indicate power received from the premises. In
+case if device is capable of measuring multi elements or phases then this will be net reactive
+power value.
+
+#### TotalApparentPower Attribute
+Represents the current demand of apparent power, in kVA. In case if device is capable of
+measuring multi elements or phases then this will be net apparent power value.
+
+#### RMSVoltage Attribute
+Represents the  most recent RMS voltage reading in Volts (V). If the RMS voltage cannot be
+measured, a value of 0xFFFF is returned.
+
+#### RMSCurrent Attribute
+Represents the most recent RMS current reading in Amps (A). If the power cannot be measured,
+a value of 0xFFFF is returned. 
+
+#### ActivePower Attribute
+Represents the single phase or Phase A, current demand of active power delivered or received at
+the premises, in Watts (W). Positive values indicate power delivered to the premises where negative
+values indicate power received from the premises.
+
+#### ACCurrentMultiplier Attribute
+Provides a value to be multiplied against the InstantaneousCurrent and RMSCurrentattributes. 
+his attribute must be used in conjunction with the ACCurrentDivisorattribute. 0x0000 is an invalid value for this attribute.
+
+#### ACCurrentDivisor Attribute
+Provides  a  value  to  be  divided  against the ACCurrent, InstantaneousCurrent and
+RMSCurrentattributes. This attribute must be used in conjunction with the ACCurrentMultiplierattribute
+0x0000 is an invalid value for this attribute.
+ 
+#### ACPowerMultiplier Attribute
+Provides a value to be multiplied against the InstantaneousPower and ActivePowerattributes.
+This attribute must be used in conjunction with the ACPowerDivisorattribute. 0x0000 is an invalid
+value for this attribute
+
+#### ACPowerDivisor Attribute
+Provides a value to be divided against the InstantaneousPower and ActivePowerattributes.
+This  attribute must be used in conjunction with the ACPowerMultiplierattribute. 0x0000 is an
+invalid value for this attribute.
+ 
 ### Received
 ### Generated
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/serialization/DefaultDeserializer.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/serialization/DefaultDeserializer.java
@@ -174,6 +174,7 @@ public class DefaultDeserializer implements ZigBeeDeserializer {
                     value[0] = Integer.valueOf(s & 0xFFFF);
                 }
                 break;
+            case BITMAP_32_BIT:
             case SIGNED_32_BIT_INTEGER:
             case UNSIGNED_32_BIT_INTEGER:
                 value[0] = payload[index++] + (payload[index++] << 8) + (payload[index++] << 16)

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/serialization/DefaultSerializer.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/serialization/DefaultSerializer.java
@@ -155,6 +155,7 @@ public class DefaultSerializer implements ZigBeeSerializer {
                 buffer[length++] = (intValue >> 16) & 0xFF;
                 buffer[length++] = (intValue >> 24) & 0xFF;
                 break;
+            case BITMAP_32_BIT:
             case UNSIGNED_32_BIT_INTEGER:
                 final int uintValue = (Integer) data;
                 buffer[length++] = uintValue & 0xFF;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/ZclCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/ZclCluster.java
@@ -12,6 +12,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.ExecutionException;
@@ -94,7 +95,7 @@ public abstract class ZclCluster {
      * After initialisation, the list will contain an empty list. Once a successful call to
      * {@link #discoverAttributes()} has been made, the list will reflect the attributes supported by the remote device.
      */
-    private final Set<Integer> supportedAttributes = new HashSet<Integer>();
+    private final Set<Integer> supportedAttributes = new TreeSet<Integer>();
 
     /**
      * The list of supported commands that the remote device can generate

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclElectricalMeasurementCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclElectricalMeasurementCluster.java
@@ -7,15 +7,31 @@
  */
 package com.zsmartsystems.zigbee.zcl.clusters;
 
+import com.zsmartsystems.zigbee.CommandResult;
 import com.zsmartsystems.zigbee.ZigBeeEndpoint;
 import com.zsmartsystems.zigbee.ZigBeeNetworkManager;
 import com.zsmartsystems.zigbee.zcl.ZclAttribute;
 import com.zsmartsystems.zigbee.zcl.ZclCluster;
+import com.zsmartsystems.zigbee.zcl.protocol.ZclClusterType;
+import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
+import java.util.Calendar;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Future;
 
 /**
  * <b>Electrical Measurement</b> cluster implementation (<i>Cluster ID 0x0B04</i>).
+ * <p>
+ * This cluster provides a mechanism for querying data about the electrical properties as measured
+ * by the device. This cluster may be implemented on any device type and be implemented on a per-endpoint
+ * basis. For example, a power  strip device could represent each outlet on a  different endpoint and
+ * report electrical  information for each individual outlet. The only caveat is that if you implement
+ * an attribute that has an associated multiplier and divisor, then you must implement the associated
+ * multiplier and divisor attributes. For example if you implement DCVoltage, you must also implement
+ * DCVoltageMultiplier and DCVoltageDivisor.
+ * <p>
+ * If you are interested in reading information about the power supply or battery level on the device,
+ * please see the Power Configuration cluster.
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
@@ -30,9 +46,93 @@ public class ZclElectricalMeasurementCluster extends ZclCluster {
      */
     public static final String CLUSTER_NAME = "Electrical Measurement";
 
+    // Attribute constants
+    /**
+     * This attribute indicates a device’s measurement capabilities. This will be indicated by setting
+     * the desire measurement bits to 1.
+     */
+    public static final int ATTR_MEASUREMENTTYPE = 0x0000;
+    /**
+     * The ACFrequency attribute represents the most recent AC Frequency reading in Hertz (Hz).
+     * If the frequency cannot be measured, a value of 0xFFFF is returned.
+     */
+    public static final int ATTR_ACFREQUENCY = 0x0300;
+    /**
+     * Active power represents the current demand of active power delivered or received at the
+     * premises, in kW. Positive values indicate power delivered to the premises where negative
+     * values indicate power received from the premises. In case if device is capable of measuring
+     * multi elements or phases then this will be net active power value.
+     */
+    public static final int ATTR_TOTALACTIVEPOWER = 0x0304;
+    /**
+     * Reactive power represents the  current demand of reactive power delivered or
+     * received at the premises, in kVAr. Positive values indicate power delivered to
+     * the premises where negative values indicate power received from the premises. In
+     * case if device is capable of measuring multi elements or phases then this will be net reactive
+     * power value.
+     */
+    public static final int ATTR_TOTALREACTIVEPOWER = 0x0305;
+    /**
+     * Represents the current demand of apparent power, in kVA. In case if device is capable of
+     * measuring multi elements or phases then this will be net apparent power value.
+     */
+    public static final int ATTR_TOTALAPPARENTPOWER = 0x0306;
+    /**
+     * Represents the  most recent RMS voltage reading in Volts (V). If the RMS voltage cannot be
+     * measured, a value of 0xFFFF is returned.
+     */
+    public static final int ATTR_RMSVOLTAGE = 0x0505;
+    /**
+     * Represents the most recent RMS current reading in Amps (A). If the power cannot be measured,
+     * a value of 0xFFFF is returned.
+     */
+    public static final int ATTR_RMSCURRENT = 0x0508;
+    /**
+     * Represents the single phase or Phase A, current demand of active power delivered or received at
+     * the premises, in Watts (W). Positive values indicate power delivered to the premises where negative
+     * values indicate power received from the premises.
+     */
+    public static final int ATTR_ACTIVEPOWER = 0x050B;
+    /**
+     * Provides a value to be multiplied against the InstantaneousCurrent and RMSCurrentattributes.
+     * his attribute must be used in conjunction with the ACCurrentDivisorattribute. 0x0000 is an invalid value for this attribute.
+     */
+    public static final int ATTR_ACCURRENTMULTIPLIER = 0x0602;
+    /**
+     * Provides  a  value  to  be  divided  against the ACCurrent, InstantaneousCurrent and
+     * RMSCurrentattributes. This attribute must be used in conjunction with the ACCurrentMultiplierattribute
+     * 0x0000 is an invalid value for this attribute.
+     */
+    public static final int ATTR_ACCURRENTDIVISOR = 0x0603;
+    /**
+     * Provides a value to be multiplied against the InstantaneousPower and ActivePowerattributes.
+     * This attribute must be used in conjunction with the ACPowerDivisorattribute. 0x0000 is an invalid
+     * value for this attribute
+     */
+    public static final int ATTR_ACPOWERMULTIPLIER = 0x0604;
+    /**
+     * Provides a value to be divided against the InstantaneousPower and ActivePowerattributes.
+     * This  attribute must be used in conjunction with the ACPowerMultiplierattribute. 0x0000 is an
+     * invalid value for this attribute.
+     */
+    public static final int ATTR_ACPOWERDIVISOR = 0x0605;
+
     // Attribute initialisation
     protected Map<Integer, ZclAttribute> initializeAttributes() {
-        Map<Integer, ZclAttribute> attributeMap = new ConcurrentHashMap<Integer, ZclAttribute>(0);
+        Map<Integer, ZclAttribute> attributeMap = new ConcurrentHashMap<Integer, ZclAttribute>(12);
+
+        attributeMap.put(ATTR_MEASUREMENTTYPE, new ZclAttribute(ZclClusterType.ELECTRICAL_MEASUREMENT, ATTR_MEASUREMENTTYPE, "MeasurementType", ZclDataType.BITMAP_32_BIT, true, true, false, false));
+        attributeMap.put(ATTR_ACFREQUENCY, new ZclAttribute(ZclClusterType.ELECTRICAL_MEASUREMENT, ATTR_ACFREQUENCY, "ACFrequency", ZclDataType.UNSIGNED_16_BIT_INTEGER, false, true, false, false));
+        attributeMap.put(ATTR_TOTALACTIVEPOWER, new ZclAttribute(ZclClusterType.ELECTRICAL_MEASUREMENT, ATTR_TOTALACTIVEPOWER, "TotalActivePower", ZclDataType.SIGNED_32_BIT_INTEGER, false, true, false, false));
+        attributeMap.put(ATTR_TOTALREACTIVEPOWER, new ZclAttribute(ZclClusterType.ELECTRICAL_MEASUREMENT, ATTR_TOTALREACTIVEPOWER, "TotalReactivePower", ZclDataType.SIGNED_32_BIT_INTEGER, false, true, false, false));
+        attributeMap.put(ATTR_TOTALAPPARENTPOWER, new ZclAttribute(ZclClusterType.ELECTRICAL_MEASUREMENT, ATTR_TOTALAPPARENTPOWER, "TotalApparentPower", ZclDataType.UNSIGNED_32_BIT_INTEGER, false, true, false, false));
+        attributeMap.put(ATTR_RMSVOLTAGE, new ZclAttribute(ZclClusterType.ELECTRICAL_MEASUREMENT, ATTR_RMSVOLTAGE, "RMSVoltage", ZclDataType.UNSIGNED_16_BIT_INTEGER, false, true, false, false));
+        attributeMap.put(ATTR_RMSCURRENT, new ZclAttribute(ZclClusterType.ELECTRICAL_MEASUREMENT, ATTR_RMSCURRENT, "RMSCurrent", ZclDataType.UNSIGNED_16_BIT_INTEGER, false, true, false, false));
+        attributeMap.put(ATTR_ACTIVEPOWER, new ZclAttribute(ZclClusterType.ELECTRICAL_MEASUREMENT, ATTR_ACTIVEPOWER, "ActivePower", ZclDataType.SIGNED_16_BIT_INTEGER, false, true, false, false));
+        attributeMap.put(ATTR_ACCURRENTMULTIPLIER, new ZclAttribute(ZclClusterType.ELECTRICAL_MEASUREMENT, ATTR_ACCURRENTMULTIPLIER, "ACCurrentMultiplier", ZclDataType.UNSIGNED_16_BIT_INTEGER, false, true, false, false));
+        attributeMap.put(ATTR_ACCURRENTDIVISOR, new ZclAttribute(ZclClusterType.ELECTRICAL_MEASUREMENT, ATTR_ACCURRENTDIVISOR, "ACCurrentDivisor", ZclDataType.UNSIGNED_16_BIT_INTEGER, false, true, false, false));
+        attributeMap.put(ATTR_ACPOWERMULTIPLIER, new ZclAttribute(ZclClusterType.ELECTRICAL_MEASUREMENT, ATTR_ACPOWERMULTIPLIER, "ACPowerMultiplier", ZclDataType.UNSIGNED_16_BIT_INTEGER, false, true, false, false));
+        attributeMap.put(ATTR_ACPOWERDIVISOR, new ZclAttribute(ZclClusterType.ELECTRICAL_MEASUREMENT, ATTR_ACPOWERDIVISOR, "ACPowerDivisor", ZclDataType.UNSIGNED_16_BIT_INTEGER, false, true, false, false));
 
         return attributeMap;
     }
@@ -47,4 +147,598 @@ public class ZclElectricalMeasurementCluster extends ZclCluster {
         super(zigbeeManager, zigbeeEndpoint, CLUSTER_ID, CLUSTER_NAME);
     }
 
+
+    /**
+     * Get the <i>MeasurementType</i> attribute [attribute ID <b>0</b>].
+     * <p>
+     * This attribute indicates a device’s measurement capabilities. This will be indicated by setting
+     * the desire measurement bits to 1.
+     * <p>
+     * The attribute is of type {@link Integer}.
+     * <p>
+     * The implementation of this attribute by a device is MANDATORY
+     *
+     * @return the {@link Future<CommandResult>} command result future
+     */
+    public Future<CommandResult> getMeasurementTypeAsync() {
+        return read(attributes.get(ATTR_MEASUREMENTTYPE));
+    }
+
+
+    /**
+     * Synchronously get the <i>MeasurementType</i> attribute [attribute ID <b>0</b>].
+     * <p>
+     * This attribute indicates a device’s measurement capabilities. This will be indicated by setting
+     * the desire measurement bits to 1.
+     * <p>
+     * This method can return cached data if the attribute has already been received.
+     * The parameter <i>refreshPeriod</i> is used to control this. If the attribute has been received
+     * within <i>refreshPeriod</i> milliseconds, then the method will immediately return the last value
+     * received. If <i>refreshPeriod</i> is set to 0, then the attribute will always be updated.
+     * <p>
+     * This method will block until the response is received or a timeout occurs unless the current value is returned.
+     * <p>
+     * The attribute is of type {@link Integer}.
+     * <p>
+     * The implementation of this attribute by a device is MANDATORY
+     *
+     * @param refreshPeriod the maximum age of the data (in milliseconds) before an update is needed
+     * @return the {@link Integer} attribute value, or null on error
+     */
+    public Integer getMeasurementType(final long refreshPeriod) {
+        if(refreshPeriod > 0 && attributes.get(ATTR_MEASUREMENTTYPE).getLastReportTime() != null) {
+            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
+            if(attributes.get(ATTR_MEASUREMENTTYPE).getLastReportTime().getTimeInMillis() < refreshTime) {
+                return (Integer) attributes.get(ATTR_MEASUREMENTTYPE).getLastValue();
+            }
+        }
+
+        return (Integer) readSync(attributes.get(ATTR_MEASUREMENTTYPE));
+    }
+
+    /**
+     * Get the <i>ACFrequency</i> attribute [attribute ID <b>768</b>].
+     * <p>
+     * The ACFrequency attribute represents the most recent AC Frequency reading in Hertz (Hz).
+     * If the frequency cannot be measured, a value of 0xFFFF is returned.
+     * <p>
+     * The attribute is of type {@link Integer}.
+     * <p>
+     * The implementation of this attribute by a device is OPTIONAL
+     *
+     * @return the {@link Future<CommandResult>} command result future
+     */
+    public Future<CommandResult> getAcFrequencyAsync() {
+        return read(attributes.get(ATTR_ACFREQUENCY));
+    }
+
+
+    /**
+     * Synchronously get the <i>ACFrequency</i> attribute [attribute ID <b>768</b>].
+     * <p>
+     * The ACFrequency attribute represents the most recent AC Frequency reading in Hertz (Hz).
+     * If the frequency cannot be measured, a value of 0xFFFF is returned.
+     * <p>
+     * This method can return cached data if the attribute has already been received.
+     * The parameter <i>refreshPeriod</i> is used to control this. If the attribute has been received
+     * within <i>refreshPeriod</i> milliseconds, then the method will immediately return the last value
+     * received. If <i>refreshPeriod</i> is set to 0, then the attribute will always be updated.
+     * <p>
+     * This method will block until the response is received or a timeout occurs unless the current value is returned.
+     * <p>
+     * The attribute is of type {@link Integer}.
+     * <p>
+     * The implementation of this attribute by a device is OPTIONAL
+     *
+     * @param refreshPeriod the maximum age of the data (in milliseconds) before an update is needed
+     * @return the {@link Integer} attribute value, or null on error
+     */
+    public Integer getAcFrequency(final long refreshPeriod) {
+        if(refreshPeriod > 0 && attributes.get(ATTR_ACFREQUENCY).getLastReportTime() != null) {
+            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
+            if(attributes.get(ATTR_ACFREQUENCY).getLastReportTime().getTimeInMillis() < refreshTime) {
+                return (Integer) attributes.get(ATTR_ACFREQUENCY).getLastValue();
+            }
+        }
+
+        return (Integer) readSync(attributes.get(ATTR_ACFREQUENCY));
+    }
+
+    /**
+     * Get the <i>TotalActivePower</i> attribute [attribute ID <b>772</b>].
+     * <p>
+     * Active power represents the current demand of active power delivered or received at the
+     * premises, in kW. Positive values indicate power delivered to the premises where negative
+     * values indicate power received from the premises. In case if device is capable of measuring
+     * multi elements or phases then this will be net active power value.
+     * <p>
+     * The attribute is of type {@link Integer}.
+     * <p>
+     * The implementation of this attribute by a device is OPTIONAL
+     *
+     * @return the {@link Future<CommandResult>} command result future
+     */
+    public Future<CommandResult> getTotalActivePowerAsync() {
+        return read(attributes.get(ATTR_TOTALACTIVEPOWER));
+    }
+
+
+    /**
+     * Synchronously get the <i>TotalActivePower</i> attribute [attribute ID <b>772</b>].
+     * <p>
+     * Active power represents the current demand of active power delivered or received at the
+     * premises, in kW. Positive values indicate power delivered to the premises where negative
+     * values indicate power received from the premises. In case if device is capable of measuring
+     * multi elements or phases then this will be net active power value.
+     * <p>
+     * This method can return cached data if the attribute has already been received.
+     * The parameter <i>refreshPeriod</i> is used to control this. If the attribute has been received
+     * within <i>refreshPeriod</i> milliseconds, then the method will immediately return the last value
+     * received. If <i>refreshPeriod</i> is set to 0, then the attribute will always be updated.
+     * <p>
+     * This method will block until the response is received or a timeout occurs unless the current value is returned.
+     * <p>
+     * The attribute is of type {@link Integer}.
+     * <p>
+     * The implementation of this attribute by a device is OPTIONAL
+     *
+     * @param refreshPeriod the maximum age of the data (in milliseconds) before an update is needed
+     * @return the {@link Integer} attribute value, or null on error
+     */
+    public Integer getTotalActivePower(final long refreshPeriod) {
+        if(refreshPeriod > 0 && attributes.get(ATTR_TOTALACTIVEPOWER).getLastReportTime() != null) {
+            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
+            if(attributes.get(ATTR_TOTALACTIVEPOWER).getLastReportTime().getTimeInMillis() < refreshTime) {
+                return (Integer) attributes.get(ATTR_TOTALACTIVEPOWER).getLastValue();
+            }
+        }
+
+        return (Integer) readSync(attributes.get(ATTR_TOTALACTIVEPOWER));
+    }
+
+    /**
+     * Get the <i>TotalReactivePower</i> attribute [attribute ID <b>773</b>].
+     * <p>
+     * Reactive power represents the  current demand of reactive power delivered or
+     * received at the premises, in kVAr. Positive values indicate power delivered to
+     * the premises where negative values indicate power received from the premises. In
+     * case if device is capable of measuring multi elements or phases then this will be net reactive
+     * power value.
+     * <p>
+     * The attribute is of type {@link Integer}.
+     * <p>
+     * The implementation of this attribute by a device is OPTIONAL
+     *
+     * @return the {@link Future<CommandResult>} command result future
+     */
+    public Future<CommandResult> getTotalReactivePowerAsync() {
+        return read(attributes.get(ATTR_TOTALREACTIVEPOWER));
+    }
+
+
+    /**
+     * Synchronously get the <i>TotalReactivePower</i> attribute [attribute ID <b>773</b>].
+     * <p>
+     * Reactive power represents the  current demand of reactive power delivered or
+     * received at the premises, in kVAr. Positive values indicate power delivered to
+     * the premises where negative values indicate power received from the premises. In
+     * case if device is capable of measuring multi elements or phases then this will be net reactive
+     * power value.
+     * <p>
+     * This method can return cached data if the attribute has already been received.
+     * The parameter <i>refreshPeriod</i> is used to control this. If the attribute has been received
+     * within <i>refreshPeriod</i> milliseconds, then the method will immediately return the last value
+     * received. If <i>refreshPeriod</i> is set to 0, then the attribute will always be updated.
+     * <p>
+     * This method will block until the response is received or a timeout occurs unless the current value is returned.
+     * <p>
+     * The attribute is of type {@link Integer}.
+     * <p>
+     * The implementation of this attribute by a device is OPTIONAL
+     *
+     * @param refreshPeriod the maximum age of the data (in milliseconds) before an update is needed
+     * @return the {@link Integer} attribute value, or null on error
+     */
+    public Integer getTotalReactivePower(final long refreshPeriod) {
+        if(refreshPeriod > 0 && attributes.get(ATTR_TOTALREACTIVEPOWER).getLastReportTime() != null) {
+            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
+            if(attributes.get(ATTR_TOTALREACTIVEPOWER).getLastReportTime().getTimeInMillis() < refreshTime) {
+                return (Integer) attributes.get(ATTR_TOTALREACTIVEPOWER).getLastValue();
+            }
+        }
+
+        return (Integer) readSync(attributes.get(ATTR_TOTALREACTIVEPOWER));
+    }
+
+    /**
+     * Get the <i>TotalApparentPower</i> attribute [attribute ID <b>774</b>].
+     * <p>
+     * Represents the current demand of apparent power, in kVA. In case if device is capable of
+     * measuring multi elements or phases then this will be net apparent power value.
+     * <p>
+     * The attribute is of type {@link Integer}.
+     * <p>
+     * The implementation of this attribute by a device is OPTIONAL
+     *
+     * @return the {@link Future<CommandResult>} command result future
+     */
+    public Future<CommandResult> getTotalApparentPowerAsync() {
+        return read(attributes.get(ATTR_TOTALAPPARENTPOWER));
+    }
+
+
+    /**
+     * Synchronously get the <i>TotalApparentPower</i> attribute [attribute ID <b>774</b>].
+     * <p>
+     * Represents the current demand of apparent power, in kVA. In case if device is capable of
+     * measuring multi elements or phases then this will be net apparent power value.
+     * <p>
+     * This method can return cached data if the attribute has already been received.
+     * The parameter <i>refreshPeriod</i> is used to control this. If the attribute has been received
+     * within <i>refreshPeriod</i> milliseconds, then the method will immediately return the last value
+     * received. If <i>refreshPeriod</i> is set to 0, then the attribute will always be updated.
+     * <p>
+     * This method will block until the response is received or a timeout occurs unless the current value is returned.
+     * <p>
+     * The attribute is of type {@link Integer}.
+     * <p>
+     * The implementation of this attribute by a device is OPTIONAL
+     *
+     * @param refreshPeriod the maximum age of the data (in milliseconds) before an update is needed
+     * @return the {@link Integer} attribute value, or null on error
+     */
+    public Integer getTotalApparentPower(final long refreshPeriod) {
+        if(refreshPeriod > 0 && attributes.get(ATTR_TOTALAPPARENTPOWER).getLastReportTime() != null) {
+            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
+            if(attributes.get(ATTR_TOTALAPPARENTPOWER).getLastReportTime().getTimeInMillis() < refreshTime) {
+                return (Integer) attributes.get(ATTR_TOTALAPPARENTPOWER).getLastValue();
+            }
+        }
+
+        return (Integer) readSync(attributes.get(ATTR_TOTALAPPARENTPOWER));
+    }
+
+    /**
+     * Get the <i>RMSVoltage</i> attribute [attribute ID <b>1285</b>].
+     * <p>
+     * Represents the  most recent RMS voltage reading in Volts (V). If the RMS voltage cannot be
+     * measured, a value of 0xFFFF is returned.
+     * <p>
+     * The attribute is of type {@link Integer}.
+     * <p>
+     * The implementation of this attribute by a device is OPTIONAL
+     *
+     * @return the {@link Future<CommandResult>} command result future
+     */
+    public Future<CommandResult> getRmsVoltageAsync() {
+        return read(attributes.get(ATTR_RMSVOLTAGE));
+    }
+
+
+    /**
+     * Synchronously get the <i>RMSVoltage</i> attribute [attribute ID <b>1285</b>].
+     * <p>
+     * Represents the  most recent RMS voltage reading in Volts (V). If the RMS voltage cannot be
+     * measured, a value of 0xFFFF is returned.
+     * <p>
+     * This method can return cached data if the attribute has already been received.
+     * The parameter <i>refreshPeriod</i> is used to control this. If the attribute has been received
+     * within <i>refreshPeriod</i> milliseconds, then the method will immediately return the last value
+     * received. If <i>refreshPeriod</i> is set to 0, then the attribute will always be updated.
+     * <p>
+     * This method will block until the response is received or a timeout occurs unless the current value is returned.
+     * <p>
+     * The attribute is of type {@link Integer}.
+     * <p>
+     * The implementation of this attribute by a device is OPTIONAL
+     *
+     * @param refreshPeriod the maximum age of the data (in milliseconds) before an update is needed
+     * @return the {@link Integer} attribute value, or null on error
+     */
+    public Integer getRmsVoltage(final long refreshPeriod) {
+        if(refreshPeriod > 0 && attributes.get(ATTR_RMSVOLTAGE).getLastReportTime() != null) {
+            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
+            if(attributes.get(ATTR_RMSVOLTAGE).getLastReportTime().getTimeInMillis() < refreshTime) {
+                return (Integer) attributes.get(ATTR_RMSVOLTAGE).getLastValue();
+            }
+        }
+
+        return (Integer) readSync(attributes.get(ATTR_RMSVOLTAGE));
+    }
+
+    /**
+     * Get the <i>RMSCurrent</i> attribute [attribute ID <b>1288</b>].
+     * <p>
+     * Represents the most recent RMS current reading in Amps (A). If the power cannot be measured,
+     * a value of 0xFFFF is returned.
+     * <p>
+     * The attribute is of type {@link Integer}.
+     * <p>
+     * The implementation of this attribute by a device is OPTIONAL
+     *
+     * @return the {@link Future<CommandResult>} command result future
+     */
+    public Future<CommandResult> getRmsCurrentAsync() {
+        return read(attributes.get(ATTR_RMSCURRENT));
+    }
+
+
+    /**
+     * Synchronously get the <i>RMSCurrent</i> attribute [attribute ID <b>1288</b>].
+     * <p>
+     * Represents the most recent RMS current reading in Amps (A). If the power cannot be measured,
+     * a value of 0xFFFF is returned.
+     * <p>
+     * This method can return cached data if the attribute has already been received.
+     * The parameter <i>refreshPeriod</i> is used to control this. If the attribute has been received
+     * within <i>refreshPeriod</i> milliseconds, then the method will immediately return the last value
+     * received. If <i>refreshPeriod</i> is set to 0, then the attribute will always be updated.
+     * <p>
+     * This method will block until the response is received or a timeout occurs unless the current value is returned.
+     * <p>
+     * The attribute is of type {@link Integer}.
+     * <p>
+     * The implementation of this attribute by a device is OPTIONAL
+     *
+     * @param refreshPeriod the maximum age of the data (in milliseconds) before an update is needed
+     * @return the {@link Integer} attribute value, or null on error
+     */
+    public Integer getRmsCurrent(final long refreshPeriod) {
+        if(refreshPeriod > 0 && attributes.get(ATTR_RMSCURRENT).getLastReportTime() != null) {
+            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
+            if(attributes.get(ATTR_RMSCURRENT).getLastReportTime().getTimeInMillis() < refreshTime) {
+                return (Integer) attributes.get(ATTR_RMSCURRENT).getLastValue();
+            }
+        }
+
+        return (Integer) readSync(attributes.get(ATTR_RMSCURRENT));
+    }
+
+    /**
+     * Get the <i>ActivePower</i> attribute [attribute ID <b>1291</b>].
+     * <p>
+     * Represents the single phase or Phase A, current demand of active power delivered or received at
+     * the premises, in Watts (W). Positive values indicate power delivered to the premises where negative
+     * values indicate power received from the premises.
+     * <p>
+     * The attribute is of type {@link Integer}.
+     * <p>
+     * The implementation of this attribute by a device is OPTIONAL
+     *
+     * @return the {@link Future<CommandResult>} command result future
+     */
+    public Future<CommandResult> getActivePowerAsync() {
+        return read(attributes.get(ATTR_ACTIVEPOWER));
+    }
+
+
+    /**
+     * Synchronously get the <i>ActivePower</i> attribute [attribute ID <b>1291</b>].
+     * <p>
+     * Represents the single phase or Phase A, current demand of active power delivered or received at
+     * the premises, in Watts (W). Positive values indicate power delivered to the premises where negative
+     * values indicate power received from the premises.
+     * <p>
+     * This method can return cached data if the attribute has already been received.
+     * The parameter <i>refreshPeriod</i> is used to control this. If the attribute has been received
+     * within <i>refreshPeriod</i> milliseconds, then the method will immediately return the last value
+     * received. If <i>refreshPeriod</i> is set to 0, then the attribute will always be updated.
+     * <p>
+     * This method will block until the response is received or a timeout occurs unless the current value is returned.
+     * <p>
+     * The attribute is of type {@link Integer}.
+     * <p>
+     * The implementation of this attribute by a device is OPTIONAL
+     *
+     * @param refreshPeriod the maximum age of the data (in milliseconds) before an update is needed
+     * @return the {@link Integer} attribute value, or null on error
+     */
+    public Integer getActivePower(final long refreshPeriod) {
+        if(refreshPeriod > 0 && attributes.get(ATTR_ACTIVEPOWER).getLastReportTime() != null) {
+            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
+            if(attributes.get(ATTR_ACTIVEPOWER).getLastReportTime().getTimeInMillis() < refreshTime) {
+                return (Integer) attributes.get(ATTR_ACTIVEPOWER).getLastValue();
+            }
+        }
+
+        return (Integer) readSync(attributes.get(ATTR_ACTIVEPOWER));
+    }
+
+    /**
+     * Get the <i>ACCurrentMultiplier</i> attribute [attribute ID <b>1538</b>].
+     * <p>
+     * Provides a value to be multiplied against the InstantaneousCurrent and RMSCurrentattributes.
+     * his attribute must be used in conjunction with the ACCurrentDivisorattribute. 0x0000 is an invalid value for this attribute.
+     * <p>
+     * The attribute is of type {@link Integer}.
+     * <p>
+     * The implementation of this attribute by a device is OPTIONAL
+     *
+     * @return the {@link Future<CommandResult>} command result future
+     */
+    public Future<CommandResult> getAcCurrentMultiplierAsync() {
+        return read(attributes.get(ATTR_ACCURRENTMULTIPLIER));
+    }
+
+
+    /**
+     * Synchronously get the <i>ACCurrentMultiplier</i> attribute [attribute ID <b>1538</b>].
+     * <p>
+     * Provides a value to be multiplied against the InstantaneousCurrent and RMSCurrentattributes.
+     * his attribute must be used in conjunction with the ACCurrentDivisorattribute. 0x0000 is an invalid value for this attribute.
+     * <p>
+     * This method can return cached data if the attribute has already been received.
+     * The parameter <i>refreshPeriod</i> is used to control this. If the attribute has been received
+     * within <i>refreshPeriod</i> milliseconds, then the method will immediately return the last value
+     * received. If <i>refreshPeriod</i> is set to 0, then the attribute will always be updated.
+     * <p>
+     * This method will block until the response is received or a timeout occurs unless the current value is returned.
+     * <p>
+     * The attribute is of type {@link Integer}.
+     * <p>
+     * The implementation of this attribute by a device is OPTIONAL
+     *
+     * @param refreshPeriod the maximum age of the data (in milliseconds) before an update is needed
+     * @return the {@link Integer} attribute value, or null on error
+     */
+    public Integer getAcCurrentMultiplier(final long refreshPeriod) {
+        if(refreshPeriod > 0 && attributes.get(ATTR_ACCURRENTMULTIPLIER).getLastReportTime() != null) {
+            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
+            if(attributes.get(ATTR_ACCURRENTMULTIPLIER).getLastReportTime().getTimeInMillis() < refreshTime) {
+                return (Integer) attributes.get(ATTR_ACCURRENTMULTIPLIER).getLastValue();
+            }
+        }
+
+        return (Integer) readSync(attributes.get(ATTR_ACCURRENTMULTIPLIER));
+    }
+
+    /**
+     * Get the <i>ACCurrentDivisor</i> attribute [attribute ID <b>1539</b>].
+     * <p>
+     * Provides  a  value  to  be  divided  against the ACCurrent, InstantaneousCurrent and
+     * RMSCurrentattributes. This attribute must be used in conjunction with the ACCurrentMultiplierattribute
+     * 0x0000 is an invalid value for this attribute.
+     * <p>
+     * The attribute is of type {@link Integer}.
+     * <p>
+     * The implementation of this attribute by a device is OPTIONAL
+     *
+     * @return the {@link Future<CommandResult>} command result future
+     */
+    public Future<CommandResult> getAcCurrentDivisorAsync() {
+        return read(attributes.get(ATTR_ACCURRENTDIVISOR));
+    }
+
+
+    /**
+     * Synchronously get the <i>ACCurrentDivisor</i> attribute [attribute ID <b>1539</b>].
+     * <p>
+     * Provides  a  value  to  be  divided  against the ACCurrent, InstantaneousCurrent and
+     * RMSCurrentattributes. This attribute must be used in conjunction with the ACCurrentMultiplierattribute
+     * 0x0000 is an invalid value for this attribute.
+     * <p>
+     * This method can return cached data if the attribute has already been received.
+     * The parameter <i>refreshPeriod</i> is used to control this. If the attribute has been received
+     * within <i>refreshPeriod</i> milliseconds, then the method will immediately return the last value
+     * received. If <i>refreshPeriod</i> is set to 0, then the attribute will always be updated.
+     * <p>
+     * This method will block until the response is received or a timeout occurs unless the current value is returned.
+     * <p>
+     * The attribute is of type {@link Integer}.
+     * <p>
+     * The implementation of this attribute by a device is OPTIONAL
+     *
+     * @param refreshPeriod the maximum age of the data (in milliseconds) before an update is needed
+     * @return the {@link Integer} attribute value, or null on error
+     */
+    public Integer getAcCurrentDivisor(final long refreshPeriod) {
+        if(refreshPeriod > 0 && attributes.get(ATTR_ACCURRENTDIVISOR).getLastReportTime() != null) {
+            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
+            if(attributes.get(ATTR_ACCURRENTDIVISOR).getLastReportTime().getTimeInMillis() < refreshTime) {
+                return (Integer) attributes.get(ATTR_ACCURRENTDIVISOR).getLastValue();
+            }
+        }
+
+        return (Integer) readSync(attributes.get(ATTR_ACCURRENTDIVISOR));
+    }
+
+    /**
+     * Get the <i>ACPowerMultiplier</i> attribute [attribute ID <b>1540</b>].
+     * <p>
+     * Provides a value to be multiplied against the InstantaneousPower and ActivePowerattributes.
+     * This attribute must be used in conjunction with the ACPowerDivisorattribute. 0x0000 is an invalid
+     * value for this attribute
+     * <p>
+     * The attribute is of type {@link Integer}.
+     * <p>
+     * The implementation of this attribute by a device is OPTIONAL
+     *
+     * @return the {@link Future<CommandResult>} command result future
+     */
+    public Future<CommandResult> getAcPowerMultiplierAsync() {
+        return read(attributes.get(ATTR_ACPOWERMULTIPLIER));
+    }
+
+
+    /**
+     * Synchronously get the <i>ACPowerMultiplier</i> attribute [attribute ID <b>1540</b>].
+     * <p>
+     * Provides a value to be multiplied against the InstantaneousPower and ActivePowerattributes.
+     * This attribute must be used in conjunction with the ACPowerDivisorattribute. 0x0000 is an invalid
+     * value for this attribute
+     * <p>
+     * This method can return cached data if the attribute has already been received.
+     * The parameter <i>refreshPeriod</i> is used to control this. If the attribute has been received
+     * within <i>refreshPeriod</i> milliseconds, then the method will immediately return the last value
+     * received. If <i>refreshPeriod</i> is set to 0, then the attribute will always be updated.
+     * <p>
+     * This method will block until the response is received or a timeout occurs unless the current value is returned.
+     * <p>
+     * The attribute is of type {@link Integer}.
+     * <p>
+     * The implementation of this attribute by a device is OPTIONAL
+     *
+     * @param refreshPeriod the maximum age of the data (in milliseconds) before an update is needed
+     * @return the {@link Integer} attribute value, or null on error
+     */
+    public Integer getAcPowerMultiplier(final long refreshPeriod) {
+        if(refreshPeriod > 0 && attributes.get(ATTR_ACPOWERMULTIPLIER).getLastReportTime() != null) {
+            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
+            if(attributes.get(ATTR_ACPOWERMULTIPLIER).getLastReportTime().getTimeInMillis() < refreshTime) {
+                return (Integer) attributes.get(ATTR_ACPOWERMULTIPLIER).getLastValue();
+            }
+        }
+
+        return (Integer) readSync(attributes.get(ATTR_ACPOWERMULTIPLIER));
+    }
+
+    /**
+     * Get the <i>ACPowerDivisor</i> attribute [attribute ID <b>1541</b>].
+     * <p>
+     * Provides a value to be divided against the InstantaneousPower and ActivePowerattributes.
+     * This  attribute must be used in conjunction with the ACPowerMultiplierattribute. 0x0000 is an
+     * invalid value for this attribute.
+     * <p>
+     * The attribute is of type {@link Integer}.
+     * <p>
+     * The implementation of this attribute by a device is OPTIONAL
+     *
+     * @return the {@link Future<CommandResult>} command result future
+     */
+    public Future<CommandResult> getAcPowerDivisorAsync() {
+        return read(attributes.get(ATTR_ACPOWERDIVISOR));
+    }
+
+
+    /**
+     * Synchronously get the <i>ACPowerDivisor</i> attribute [attribute ID <b>1541</b>].
+     * <p>
+     * Provides a value to be divided against the InstantaneousPower and ActivePowerattributes.
+     * This  attribute must be used in conjunction with the ACPowerMultiplierattribute. 0x0000 is an
+     * invalid value for this attribute.
+     * <p>
+     * This method can return cached data if the attribute has already been received.
+     * The parameter <i>refreshPeriod</i> is used to control this. If the attribute has been received
+     * within <i>refreshPeriod</i> milliseconds, then the method will immediately return the last value
+     * received. If <i>refreshPeriod</i> is set to 0, then the attribute will always be updated.
+     * <p>
+     * This method will block until the response is received or a timeout occurs unless the current value is returned.
+     * <p>
+     * The attribute is of type {@link Integer}.
+     * <p>
+     * The implementation of this attribute by a device is OPTIONAL
+     *
+     * @param refreshPeriod the maximum age of the data (in milliseconds) before an update is needed
+     * @return the {@link Integer} attribute value, or null on error
+     */
+    public Integer getAcPowerDivisor(final long refreshPeriod) {
+        if(refreshPeriod > 0 && attributes.get(ATTR_ACPOWERDIVISOR).getLastReportTime() != null) {
+            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
+            if(attributes.get(ATTR_ACPOWERDIVISOR).getLastReportTime().getTimeInMillis() < refreshTime) {
+                return (Integer) attributes.get(ATTR_ACPOWERDIVISOR).getLastValue();
+            }
+        }
+
+        return (Integer) readSync(attributes.get(ATTR_ACPOWERDIVISOR));
+    }
 }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/electricalmeasurement/MeasurementTypeEnum.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/electricalmeasurement/MeasurementTypeEnum.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2016-2017 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.zcl.clusters.electricalmeasurement;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Enumeration of Electrical Measurement attribute MeasurementType options.
+ * <p>
+ * Code is auto-generated. Modifications may be overwritten!
+ *
+ * @author Chris Jackson
+ */
+public enum MeasurementTypeEnum {
+    AC_ACTIVE_MEASUREMENT(0x0000),
+    AC_REACTIVE_MEASUREMENT(0x0001),
+    AC_APPARENT_MEASUREMENT(0x0002),
+    PHASE_A_MEASUREMENT(0x0004),
+    PHASE_B_MEASUREMENT(0x0008),
+    PHASE_C_MEASUREMENT(0x0010),
+    DC_MEASUREMENT(0x0020),
+    HARMONICS_MEASUREMENT(0x0040),
+    POWER_QUALITY_MEASUREMENT(0x0080);
+
+    /**
+     * A mapping between the integer code and its corresponding MeasurementTypeEnum type to facilitate lookup by value.
+     */
+    private static Map<Integer, MeasurementTypeEnum> idMap;
+
+    private final int key;
+
+    MeasurementTypeEnum(final int key) {
+        this.key = key;
+    }
+
+    public int getKey() {
+        return key;
+    }
+
+    public static MeasurementTypeEnum getByValue(final int value) {
+        if (idMap == null) {
+            idMap = new HashMap<Integer, MeasurementTypeEnum>();
+            for (MeasurementTypeEnum enumValue : values()) {
+                idMap.put(enumValue.key, enumValue);
+            }
+        }
+        return idMap.get(value);
+    }
+}

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/protocol/ZclDataType.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/protocol/ZclDataType.java
@@ -52,7 +52,7 @@ public enum ZclDataType {
     N_X_WRITE_ATTRIBUTE_STATUS_RECORD("N X Write attribute status record", WriteAttributeStatusRecord.class, 0x00, false),
     OCTET_STRING("Octet string", String.class, 0x41, false),
     SIGNED_16_BIT_INTEGER("Signed 16-bit Integer", Integer.class, 0x29, true),
-    SIGNED_32_BIT_INTEGER("Signed 32-bit integer", Integer.class, 0x2B, true),
+    SIGNED_32_BIT_INTEGER("Signed 32-bit Integer", Integer.class, 0x2B, true),
     SIGNED_8_BIT_INTEGER("Signed 8-bit Integer", Integer.class, 0x28, true),
     UNSIGNED_16_BIT_INTEGER("Unsigned 16-bit integer", Integer.class, 0x21, true),
     UNSIGNED_32_BIT_INTEGER("Unsigned 32-bit integer", Integer.class, 0x23, true),

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/serialization/SerializerIntegrationTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/serialization/SerializerIntegrationTest.java
@@ -84,6 +84,12 @@ public class SerializerIntegrationTest {
     }
 
     @Test
+    public void testDeserialize_BITMAP_32_BIT() {
+        int valIn = 0x9119;
+        testSerializer(valIn, ZclDataType.BITMAP_32_BIT);
+    }
+
+    @Test
     public void testDeserialize_BITMAP_16_BIT() {
         int valIn = 0x9119;
         testSerializer(valIn, ZclDataType.BITMAP_16_BIT);

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zcl/ZclClusterTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zcl/ZclClusterTest.java
@@ -8,11 +8,15 @@
 package com.zsmartsystems.zigbee.zcl;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import java.lang.reflect.Field;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -198,6 +202,41 @@ public class ZclClusterTest {
         assertEquals(ZclDataType.BOOLEAN, attribute.getDataType());
         assertEquals(0, attribute.getId());
         assertEquals(true, attribute.getLastValue());
+    }
+
+    private void setSupportedClusters(ZclCluster cluster, Set<Integer> supportedAttributes) {
+        try {
+            Field f = ZclCluster.class.getDeclaredField("supportedAttributes");
+            f.setAccessible(true);
+            f.set(cluster, supportedAttributes);
+        } catch (NoSuchFieldException x) {
+            x.printStackTrace();
+        } catch (IllegalArgumentException x) {
+            x.printStackTrace();
+        } catch (IllegalAccessException x) {
+            x.printStackTrace();
+        }
+    }
+
+    @Test
+    public void isAttributeSupported() {
+        createNetworkManager();
+
+        ZigBeeNode node = new ZigBeeNode(networkManager, new IeeeAddress());
+        node.setNetworkAddress(1234);
+        ZigBeeEndpoint device = new ZigBeeEndpoint(networkManager, node, 5);
+        ZclCluster cluster = new ZclOnOffCluster(networkManager, device);
+        Set<Integer> set = new HashSet<Integer>();
+        set.add(1);
+        set.add(4);
+        set.add(2);
+        setSupportedClusters(cluster, set);
+
+        assertEquals(3, cluster.getSupportedAttributes().size());
+
+        assertTrue(cluster.isAttributeSupported(1));
+        assertTrue(cluster.isAttributeSupported(2));
+        assertFalse(cluster.isAttributeSupported(3));
     }
 
 }


### PR DESCRIPTION
Adds initial set of attributes in the Electrical Measurement cluster to support CentraLite socket power measurement.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>