### PR TITLE
Improve handling of broken list responses

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/ZclFieldDeserializer.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/ZclFieldDeserializer.java
@@ -20,7 +20,6 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * @author Chris Jackson
  */
 public class ZclFieldDeserializer {
-
     /**
      * Delegate deserializer.
      */
@@ -56,22 +55,26 @@ public class ZclFieldDeserializer {
     /**
      * Deserializes a field.
      *
-     * @param dataType the data type of the field.
+     * @param dataType the {@link ZclDataType} of the field.
      * @return the value
      */
     public Object deserialize(final ZclDataType dataType) {
         if (ZclListItemField.class.isAssignableFrom(dataType.getDataClass())) {
             final Class dataTypeClass = dataType.getDataClass();
             final List<ZclListItemField> list = new ArrayList<ZclListItemField>();
-            while (deserializer.getSize() - deserializer.getPosition() > 0) {
-                final ZclListItemField item;
-                try {
-                    item = (ZclListItemField) dataTypeClass.newInstance();
-                } catch (final Exception e) {
-                    throw new IllegalArgumentException("Error deserializing field: " + dataType.getLabel(), e);
+            try {
+                while (deserializer.getSize() - deserializer.getPosition() > 0) {
+                    final ZclListItemField item;
+                    try {
+                        item = (ZclListItemField) dataTypeClass.newInstance();
+                    } catch (final Exception e) {
+                        throw new IllegalArgumentException("Error deserializing field: " + dataType.getLabel(), e);
+                    }
+                    item.deserialize(this.deserializer);
+                    list.add(item);
                 }
-                item.deserialize(this.deserializer);
-                list.add(item);
+            } catch (ArrayIndexOutOfBoundsException e) {
+                // Eat the exception - this terminates the list!
             }
             return list;
         }


### PR DESCRIPTION
Some (older) Hue bulbs are sending broken responses ```DiscoverAttributesResponse```. There is an extra byte on the end which looks like the next attribute number, but the ```AttributeInformation``` data is not complete.
This adds a test with the broken packet, and then catches the ```ArrayIndexOutOfBoundsException``` if there's an overrun and returns the list with the current (complete) values.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>