### PR TITLE
Add dump of coordinator children during Ember startup

### DIFF
--- a/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeNetworkStateSerializerImpl.java
+++ b/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeNetworkStateSerializerImpl.java
@@ -11,12 +11,10 @@ import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
-import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -127,7 +125,7 @@ public class ZigBeeNetworkStateSerializerImpl implements ZigBeeNetworkStateSeria
                     // object));
                 }
             }
-        } catch (UnsupportedEncodingException | FileNotFoundException e) {
+        } catch (Exception e) {
             e.printStackTrace();
         }
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
@@ -28,10 +28,14 @@ import com.zsmartsystems.zigbee.dongle.ember.ezsp.EzspFrameRequest;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspAddEndpointRequest;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspAddEndpointResponse;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspChildJoinHandler;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspGetChildDataRequest;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspGetChildDataResponse;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspGetCurrentSecurityStateRequest;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspGetCurrentSecurityStateResponse;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspGetNetworkParametersRequest;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspGetNetworkParametersResponse;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspGetParentChildParametersRequest;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspGetParentChildParametersResponse;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspIncomingMessageHandler;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspLaunchStandaloneBootloaderRequest;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspLaunchStandaloneBootloaderResponse;
@@ -305,6 +309,17 @@ public class ZigBeeDongleEzsp implements ZigBeeTransportTransmit, ZigBeeTranspor
         EmberCurrentSecurityState currentSecurityState = getCurrentSecurityState();
         logger.debug("Current Security State = {}", currentSecurityState);
 
+        EzspGetParentChildParametersRequest childParametersRequest = new EzspGetParentChildParametersRequest();
+        EzspTransaction childParametersTransaction = ashHandler.sendEzspTransaction(
+                new EzspSingleResponseTransaction(childParametersRequest, EzspGetParentChildParametersResponse.class));
+        EzspGetParentChildParametersResponse childParametersResponse = (EzspGetParentChildParametersResponse) childParametersTransaction
+                .getResponse();
+
+        logger.debug("Current Parent Child Information = {}", childParametersResponse);
+        for (int childId = 0; childId < childParametersResponse.getChildCount(); childId++) {
+            getChildInformation(childId);
+        }
+
         logger.debug("EZSP dongle startup done.");
 
         return true;
@@ -359,6 +374,17 @@ public class ZigBeeDongleEzsp implements ZigBeeTransportTransmit, ZigBeeTranspor
         EzspGetNetworkParametersResponse networkParametersResponse = (EzspGetNetworkParametersResponse) networkParametersTransaction
                 .getResponse();
         logger.debug(networkParametersResponse.toString());
+    }
+
+    private EzspGetChildDataResponse getChildInformation(int childId) {
+        EzspGetChildDataRequest childDataRequest = new EzspGetChildDataRequest();
+        childDataRequest.setIndex(childId);
+        EzspTransaction childDataTransaction = ashHandler.sendEzspTransaction(
+                new EzspSingleResponseTransaction(childDataRequest, EzspGetChildDataResponse.class));
+        EzspGetChildDataResponse childDataResponse = (EzspGetChildDataResponse) childDataTransaction.getResponse();
+        logger.debug(childDataResponse.toString());
+
+        return childDataResponse;
     }
 
     /**


### PR DESCRIPTION
This adds a dump of all current children of the Ember coordinator to the Ember startup. This is currently just added for debug information.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>