### PR TITLE
Migrate EZSP5+ code from previous codebase with existing ASH2 Handler

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/ash/AshFrameData.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/ash/AshFrameData.java
@@ -69,7 +69,7 @@ public class AshFrameData extends AshFrame {
             }
             result.append(String.format("%02X", dataBuffer[i]));
         }
-        result.append("]");
+        result.append(']');
 
         return result.toString();
     }

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/ash/AshFrameError.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/ash/AshFrameError.java
@@ -43,11 +43,12 @@ public class AshFrameError extends AshFrame {
         final StringBuilder builder = new StringBuilder();
         builder.append("AshFrameError [version=");
         builder.append(version);
-        builder.append(". errorCode=");
+        builder.append(", errorCode=");
         builder.append(errorCode);
+        builder.append(", ");
         AshErrorCode ashError = AshErrorCode.getAshErrorCode(errorCode);
         builder.append(ashError.getDescription());
-        builder.append("]");
+        builder.append(']');
         return builder.toString();
     }
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/ash/AshFrameRstAck.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/ash/AshFrameRstAck.java
@@ -49,11 +49,12 @@ public class AshFrameRstAck extends AshFrame {
         final StringBuilder builder = new StringBuilder();
         builder.append("AshFrameRstAck [version=");
         builder.append(version);
-        builder.append(". resetCode=");
+        builder.append(", resetCode=");
         builder.append(resetCode);
+        builder.append(", ");
         AshErrorCode ashError = AshErrorCode.getAshErrorCode(resetCode);
         builder.append(ashError.getDescription());
-        builder.append("]");
+        builder.append(']');
         return builder.toString();
     }
 }

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/ezsp/EzspFrameRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/ezsp/EzspFrameRequest.java
@@ -18,10 +18,20 @@ import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.serializer.EzspSerial
  *
  * UG100: EZSP Reference Guide
  *
- * An EZSP Frame is made up as follows -:
+ * An EZSP V4 Frame is made up as follows -:
  * <ul>
  * <li>Sequence : 1 byte sequence number
  * <li>Frame Control: 1 byte
+ * <li>Frame ID : 1 byte
+ * <li>Parameters : variable length
+ * </ul>
+ * <p>
+ * An EZSP V5+ Frame is made up as follows -:
+ * <ul>
+ * <li>Sequence : 1 byte sequence number
+ * <li>Frame Control: 1 byte
+ * <li>Legacy Frame ID : 1 byte
+ * <li>Extended Frame Control : 1 byte
  * <li>Frame ID : 1 byte
  * <li>Parameters : variable length
  * </ul>
@@ -51,7 +61,12 @@ public abstract class EzspFrameRequest extends EzspFrame {
         serializer.serializeUInt8(sequenceNumber);
 
         // Output Frame Control Byte
-        serializer.serializeUInt8(0);
+        serializer.serializeUInt8(EZSP_FC_REQUEST);
+
+        if (ezspVersion > 4) {
+            serializer.serializeUInt8(EZSP_LEGACY_FRAME_ID);
+            serializer.serializeUInt8(0x00);
+        }
 
         // Output Frame ID
         serializer.serializeUInt8(frameId);

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/ezsp/EzspFrameResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/ezsp/EzspFrameResponse.java
@@ -42,51 +42,11 @@ public abstract class EzspFrameResponse extends EzspFrame {
         sequenceNumber = deserializer.deserializeUInt8();
         frameControl = deserializer.deserializeUInt8();
         frameId = deserializer.deserializeUInt8();
-        isResponse = (frameControl & 0x80) != 0;
+        if (frameId == EZSP_LEGACY_FRAME_ID) {
+            deserializer.deserializeUInt8();
+            frameId = deserializer.deserializeUInt8();
+        }
+        isResponse = (frameControl & EZSP_FC_RESPONSE) != 0;
     }
-
-    /*
-     * protected boolean initialiseEzspResponse(EzspDeserializer deserializer, int[] inputBuffer) {
-     * buffer = inputBuffer;
-     * position = 0;
-     *
-     * // Check the sequence number
-     * if (inputBuffer[0] != sequenceNumber) {
-     * return false;
-     * }
-     *
-     * // Make sure this is a response
-     * if ((inputBuffer[1] & 0x80) == 0) {
-     * return false;
-     * }
-     *
-     * position = 3;
-     *
-     * // Default the status to success. This can be overridden if the response
-     * // provides a status
-     * emberStatus = EmberStatus.EMBER_SUCCESS;
-     *
-     * return true;
-     * }
-     */
-    /*
-     * protected boolean initialEzspResponse(EzspFrame response) {
-     * // Make sure this is a response
-     * if (!response.isResponse()) {
-     * return false;
-     * }
-     * 
-     * // Check the sequence number
-     * if (response.getSequenceNumber() != sequenceNumber) {
-     * return false;
-     * }
-     * 
-     * // Default the status to success. This can be overridden if the response
-     * // provides a status
-     * emberStatus = EmberStatus.EMBER_SUCCESS;
-     * 
-     * return true;
-     * }
-     */
 
 }

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzspTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzspTest.java
@@ -8,11 +8,13 @@
 package com.zsmartsystems.zigbee.dongle.ember;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
 import com.zsmartsystems.zigbee.ExtendedPanId;
-import com.zsmartsystems.zigbee.dongle.ember.ZigBeeDongleEzsp;
+import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.EzspFrame;
 
 /**
  *
@@ -34,5 +36,22 @@ public class ZigBeeDongleEzspTest {
 
         dongle.setZigBeePanId(0x1234);
         assertEquals(0x1234, dongle.getZigBeePanId());
+    }
+
+    @Test
+    public void testEzspVersions() {
+        EzspFrame.setEzspVersion(4);
+        assertEquals(4, EzspFrame.getEzspVersion());
+        assertFalse(EzspFrame.setEzspVersion(3));
+        assertEquals(4, EzspFrame.getEzspVersion());
+        assertTrue(EzspFrame.setEzspVersion(4));
+        assertEquals(4, EzspFrame.getEzspVersion());
+        assertTrue(EzspFrame.setEzspVersion(5));
+        assertEquals(5, EzspFrame.getEzspVersion());
+        assertTrue(EzspFrame.setEzspVersion(6));
+        assertEquals(6, EzspFrame.getEzspVersion());
+        assertFalse(EzspFrame.setEzspVersion(7));
+        assertEquals(6, EzspFrame.getEzspVersion());
+        EzspFrame.setEzspVersion(4);
     }
 }

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/ezsp/EzspFrameResponseTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/ezsp/EzspFrameResponseTest.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2016-2017 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.dongle.ember.internal.ezsp;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.command.EzspVersionResponse;
+
+/**
+ *
+ * @author Chris Jackson
+ *
+ */
+public class EzspFrameResponseTest {
+
+    @Test
+    public void testResponseV4() {
+        EzspVersionResponse response = new EzspVersionResponse(new int[] { 0x01, 0x80, 0x00, 0x04, 0x02, 0x00, 0x59 });
+        System.out.println(response);
+
+        assertEquals(4, response.getProtocolVersion());
+        assertEquals(0x5900, response.getStackVersion());
+    }
+
+    @Test
+    public void testResponseV5() {
+        EzspVersionResponse response = new EzspVersionResponse(
+                new int[] { 0x01, 0x80, 0xFF, 0x00, 0x00, 0x05, 0x02, 0x10, 0x5A });
+        System.out.println(response);
+
+        assertEquals(5, response.getProtocolVersion());
+        assertEquals(0x5A10, response.getStackVersion());
+    }
+}

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/ezsp/command/EzspAddEndpointRequestTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/ezsp/command/EzspAddEndpointRequestTest.java
@@ -13,8 +13,8 @@ import java.util.Arrays;
 
 import org.junit.Test;
 
+import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.EzspFrame;
 import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.EzspFrameTest;
-import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.command.EzspAddEndpointRequest;
 
 /**
  *
@@ -24,6 +24,7 @@ import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.command.EzspAddEndpoi
 public class EzspAddEndpointRequestTest extends EzspFrameTest {
     @Test
     public void testAddEndpointRequest() {
+        EzspFrame.setEzspVersion(4);
         int[] clusters = new int[] { 0, 1, 6 };
         EzspAddEndpointRequest request = new EzspAddEndpointRequest();
         request.setAppFlags(0);
@@ -42,6 +43,7 @@ public class EzspAddEndpointRequestTest extends EzspFrameTest {
 
     @Test
     public void testAddEndpointRequestNoClusters() {
+        EzspFrame.setEzspVersion(4);
         int[] clusters = new int[] {};
         EzspAddEndpointRequest request = new EzspAddEndpointRequest();
         request.setDeviceId(0);
@@ -56,4 +58,3 @@ public class EzspAddEndpointRequestTest extends EzspFrameTest {
         assertTrue(Arrays.equals(getPacketData("AA 00 02 01 04 01 00 00 00 00 00"), request.serialize()));
     }
 }
-// [2, 0, 2, 1, 4, 1, 0, 0, 0, 0, 0]

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/ezsp/command/EzspAddEndpointResponseTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/ezsp/command/EzspAddEndpointResponseTest.java
@@ -11,8 +11,8 @@ import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 
+import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.EzspFrame;
 import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.EzspFrameTest;
-import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.command.EzspAddEndpointResponse;
 import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.structure.EzspStatus;
 
 /**
@@ -23,6 +23,7 @@ import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.structure.EzspStatus;
 public class EzspAddEndpointResponseTest extends EzspFrameTest {
     @Test
     public void testVersionError() {
+        EzspFrame.setEzspVersion(4);
         EzspAddEndpointResponse response = new EzspAddEndpointResponse(getPacketData("02 80 02 36"));
 
         assertEquals(2, response.getSequenceNumber());

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/ezsp/command/EzspChildJoinHandlerTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/ezsp/command/EzspChildJoinHandlerTest.java
@@ -13,8 +13,8 @@ import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 
 import com.zsmartsystems.zigbee.IeeeAddress;
+import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.EzspFrame;
 import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.EzspFrameTest;
-import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.command.EzspChildJoinHandler;
 import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.structure.EmberNodeType;
 
 /**
@@ -24,6 +24,7 @@ public class EzspChildJoinHandlerTest extends EzspFrameTest {
 
     @Test
     public void testReceive1() {
+        EzspFrame.setEzspVersion(4);
         EzspChildJoinHandler handler = new EzspChildJoinHandler(
                 getPacketData("0B 90 23 00 00 95 87 F9 41 F6 02 00 4B 12 00 04"));
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/ezsp/command/EzspGetNeighborResponseTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/ezsp/command/EzspGetNeighborResponseTest.java
@@ -13,8 +13,8 @@ import static org.junit.Assert.assertNotNull;
 import org.junit.Test;
 
 import com.zsmartsystems.zigbee.IeeeAddress;
+import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.EzspFrame;
 import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.EzspFrameTest;
-import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.command.EzspGetNeighborResponse;
 import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.structure.EmberNeighborTableEntry;
 import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.structure.EmberStatus;
 
@@ -26,6 +26,7 @@ import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.structure.EmberStatus
 public class EzspGetNeighborResponseTest extends EzspFrameTest {
     @Test
     public void testVersion() {
+        EzspFrame.setEzspVersion(4);
         EzspGetNeighborResponse response = new EzspGetNeighborResponse(
                 getPacketData("29 80 79 00 9E 72 FF 01 01 03 CC 43 6B 05 00 6F 0D 00"));
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/ezsp/command/EzspGetNetworkParametersResponseTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/ezsp/command/EzspGetNetworkParametersResponseTest.java
@@ -11,8 +11,8 @@ import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 
+import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.EzspFrame;
 import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.EzspFrameTest;
-import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.command.EzspGetNetworkParametersResponse;
 import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.structure.EmberJoinMethod;
 import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.structure.EmberNetworkParameters;
 import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.structure.EmberNodeType;
@@ -26,6 +26,7 @@ import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.structure.EmberStatus
 public class EzspGetNetworkParametersResponseTest extends EzspFrameTest {
     @Test
     public void testVersionError() {
+        EzspFrame.setEzspVersion(4);
         EzspGetNetworkParametersResponse response = new EzspGetNetworkParametersResponse(
                 getPacketData("05 80 28 00 01 EF CB B1 57 A8 CC C6 D7 05 C8 00 0B 00 00 00 00 00 F8 FF 07"));
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/ezsp/command/EzspGetRouteTableEntryResponseTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/ezsp/command/EzspGetRouteTableEntryResponseTest.java
@@ -12,8 +12,8 @@ import static org.junit.Assert.assertNotNull;
 
 import org.junit.Test;
 
+import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.EzspFrame;
 import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.EzspFrameTest;
-import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.command.EzspGetRouteTableEntryResponse;
 import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.structure.EmberRouteTableEntry;
 import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.structure.EmberStatus;
 
@@ -25,6 +25,7 @@ import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.structure.EmberStatus
 public class EzspGetRouteTableEntryResponseTest extends EzspFrameTest {
     @Test
     public void testVersion() {
+        EzspFrame.setEzspVersion(4);
         EzspGetRouteTableEntryResponse response = new EzspGetRouteTableEntryResponse(
                 getPacketData("28 80 7B 00 FF FF 00 00 03 00 00 00"));
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/ezsp/command/EzspIncomingMessageHandlerTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/ezsp/command/EzspIncomingMessageHandlerTest.java
@@ -18,8 +18,8 @@ import org.mockito.Mockito;
 
 import com.zsmartsystems.zigbee.ZigBeeApsFrame;
 import com.zsmartsystems.zigbee.dongle.ember.ZigBeeDongleEzsp;
+import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.EzspFrame;
 import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.EzspFrameTest;
-import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.command.EzspIncomingMessageHandler;
 import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.structure.EmberIncomingMessageType;
 import com.zsmartsystems.zigbee.transport.ZigBeeTransportReceive;
 
@@ -30,6 +30,7 @@ public class EzspIncomingMessageHandlerTest extends EzspFrameTest {
 
     @Test
     public void testReceive1() {
+        EzspFrame.setEzspVersion(4);
         EzspIncomingMessageHandler incomingMessageHandler = new EzspIncomingMessageHandler(
                 getPacketData("00 94 45 00 00 01 00 00 00 00 00 00 00 00 58 FF 00 00 00 FF FF 01 00"));
 
@@ -40,6 +41,7 @@ public class EzspIncomingMessageHandlerTest extends EzspFrameTest {
 
     @Test
     public void testReceive2() {
+        EzspFrame.setEzspVersion(4);
         // This tests a number of stages - not just this class
         // We process the received frame, make sure the dongle sends it to the networkManager
         EzspIncomingMessageHandler incomingMessageHandler = new EzspIncomingMessageHandler(getPacketData(
@@ -76,6 +78,8 @@ public class EzspIncomingMessageHandlerTest extends EzspFrameTest {
 
     @Test
     public void testReceive3() {
+        EzspFrame.setEzspVersion(4);
+
         EzspIncomingMessageHandler incomingMessageHandler = new EzspIncomingMessageHandler(getPacketData(
                 "01 90 45 00 00 00 02 80 00 00 40 00 00 00 44 FF 00 00 00 FF FF 11 00 00 00 00 00 40 8F CD AB 52 80 00 41 2A 80 00 00"));
         assertEquals(0x45, incomingMessageHandler.getFrameId());

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/ezsp/command/EzspLookupEui64ByNodeIdRequestTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/ezsp/command/EzspLookupEui64ByNodeIdRequestTest.java
@@ -13,8 +13,8 @@ import java.util.Arrays;
 
 import org.junit.Test;
 
+import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.EzspFrame;
 import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.EzspFrameTest;
-import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.command.EzspLookupEui64ByNodeIdRequest;
 
 /**
  *
@@ -24,6 +24,7 @@ import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.command.EzspLookupEui
 public class EzspLookupEui64ByNodeIdRequestTest extends EzspFrameTest {
     @Test
     public void testLookupAddress() {
+        EzspFrame.setEzspVersion(4);
         EzspLookupEui64ByNodeIdRequest request = new EzspLookupEui64ByNodeIdRequest();
         request.setNodeId(0);
         request.setSequenceNumber(5);

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/ezsp/command/EzspLookupEui64ByNodeIdResponseTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/ezsp/command/EzspLookupEui64ByNodeIdResponseTest.java
@@ -12,8 +12,8 @@ import static org.junit.Assert.assertEquals;
 import org.junit.Test;
 
 import com.zsmartsystems.zigbee.IeeeAddress;
+import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.EzspFrame;
 import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.EzspFrameTest;
-import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.command.EzspLookupEui64ByNodeIdResponse;
 import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.structure.EmberStatus;
 
 /**
@@ -24,6 +24,7 @@ import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.structure.EmberStatus
 public class EzspLookupEui64ByNodeIdResponseTest extends EzspFrameTest {
     @Test
     public void testVersionError() {
+        EzspFrame.setEzspVersion(4);
         EzspLookupEui64ByNodeIdResponse response = new EzspLookupEui64ByNodeIdResponse(
                 getPacketData("05 80 61 00 BF 32 17 00 00 A3 22 00"));
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/ezsp/command/EzspMacFilterMatchMessageHandlerTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/ezsp/command/EzspMacFilterMatchMessageHandlerTest.java
@@ -14,8 +14,8 @@ import java.util.Arrays;
 
 import org.junit.Test;
 
+import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.EzspFrame;
 import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.EzspFrameTest;
-import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.command.EzspMacFilterMatchMessageHandler;
 
 /**
  *
@@ -25,6 +25,8 @@ import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.command.EzspMacFilter
 public class EzspMacFilterMatchMessageHandlerTest extends EzspFrameTest {
     @Test
     public void testReceive() {
+        EzspFrame.setEzspVersion(4);
+
         EzspMacFilterMatchMessageHandler response = new EzspMacFilterMatchMessageHandler(getPacketData(
                 "0F 90 46 01 80 C1 B8 21 01 C8 4A FF FF FF FF 9C 05 23 3F FF E7 0F 00 FF FF 0B 00 0B 00 10 5E C0 11 00 00 20 02 5C 37 02 12"));
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/ezsp/command/EzspMessageSentHandlerTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/ezsp/command/EzspMessageSentHandlerTest.java
@@ -13,8 +13,8 @@ import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
+import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.EzspFrame;
 import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.EzspFrameTest;
-import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.command.EzspMessageSentHandler;
 import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.structure.EmberApsFrame;
 import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.structure.EmberApsOption;
 import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.structure.EmberOutgoingMessageType;
@@ -27,6 +27,7 @@ public class EzspMessageSentHandlerTest extends EzspFrameTest {
 
     @Test
     public void testReceive1() {
+        EzspFrame.setEzspVersion(4);
         EzspMessageSentHandler messageSentHandler = new EzspMessageSentHandler(
                 getPacketData("01 90 3F 00 00 00 00 01 00 00 00 00 00 01 00 00 45 00 00 00"));
 
@@ -37,6 +38,7 @@ public class EzspMessageSentHandlerTest extends EzspFrameTest {
 
     @Test
     public void testReceive2() {
+        EzspFrame.setEzspVersion(4);
         EzspMessageSentHandler messageSentHandler = new EzspMessageSentHandler(
                 getPacketData("04 90 3F 00 00 00 00 00 04 00 00 00 40 11 00 00 78 04 00 00"));
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/ezsp/command/EzspNeighborCountResponseTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/ezsp/command/EzspNeighborCountResponseTest.java
@@ -11,8 +11,8 @@ import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 
+import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.EzspFrame;
 import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.EzspFrameTest;
-import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.command.EzspNeighborCountResponse;
 
 /**
  *
@@ -22,6 +22,7 @@ import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.command.EzspNeighborC
 public class EzspNeighborCountResponseTest extends EzspFrameTest {
     @Test
     public void testVersion() {
+        EzspFrame.setEzspVersion(4);
         EzspNeighborCountResponse response = new EzspNeighborCountResponse(getPacketData("28 80 7A 01"));
 
         assertEquals(true, response.isResponse());

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/ezsp/command/EzspSendUnicastTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/ezsp/command/EzspSendUnicastTest.java
@@ -15,9 +15,8 @@ import java.util.Arrays;
 import org.junit.Test;
 
 import com.zsmartsystems.zigbee.ZigBeeEndpointAddress;
+import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.EzspFrame;
 import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.EzspFrameTest;
-import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.command.EzspSendUnicastRequest;
-import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.command.EzspSendUnicastResponse;
 import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.structure.EmberApsFrame;
 import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.structure.EmberApsOption;
 import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.structure.EmberOutgoingMessageType;
@@ -33,6 +32,7 @@ public class EzspSendUnicastTest extends EzspFrameTest {
 
     @Test
     public void testReceive1() {
+        EzspFrame.setEzspVersion(4);
         EzspSendUnicastResponse unicastResponse = new EzspSendUnicastResponse(getPacketData("02 80 34 00 9E"));
 
         assertEquals(0x34, unicastResponse.getFrameId());
@@ -42,6 +42,7 @@ public class EzspSendUnicastTest extends EzspFrameTest {
 
     @Test
     public void testSendPermitJoining() {
+        EzspFrame.setEzspVersion(4);
         ManagementPermitJoiningRequest permitJoining = new ManagementPermitJoiningRequest();
 
         permitJoining.setDestinationAddress(new ZigBeeEndpointAddress(0x401C));
@@ -83,9 +84,5 @@ public class EzspSendUnicastTest extends EzspFrameTest {
             out += String.format("%02X ", c);
         }
         System.out.println(out);
-
-        // assertTrue(Arrays.equals(getPacketData("02 00 02 01 04 01 00 00 00 03 03 00 00 01 00 06 00 00 00 01 00 06
-        // 00"),
-        // messageToSend));
     }
 }

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/ezsp/command/EzspSetConcentratorRequestTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/ezsp/command/EzspSetConcentratorRequestTest.java
@@ -13,6 +13,7 @@ import java.util.Arrays;
 
 import org.junit.Test;
 
+import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.EzspFrame;
 import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.EzspFrameTest;
 import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.structure.EmberConcentratorType;
 
@@ -24,6 +25,7 @@ import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.structure.EmberConcen
 public class EzspSetConcentratorRequestTest extends EzspFrameTest {
     @Test
     public void testEnabled() {
+        EzspFrame.setEzspVersion(4);
         EzspSetConcentratorRequest request = new EzspSetConcentratorRequest();
         request.setSequenceNumber(52);
         request.setConcentratorType(EmberConcentratorType.EMBER_HIGH_RAM_CONCENTRATOR);
@@ -39,6 +41,7 @@ public class EzspSetConcentratorRequestTest extends EzspFrameTest {
 
     @Test
     public void testDisabled() {
+        EzspFrame.setEzspVersion(4);
         EzspSetConcentratorRequest request = new EzspSetConcentratorRequest();
         request.setSequenceNumber(52);
         request.setConcentratorType(EmberConcentratorType.EMBER_LOW_RAM_CONCENTRATOR);

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/ezsp/command/EzspSetConfigurationValueRequestTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/ezsp/command/EzspSetConfigurationValueRequestTest.java
@@ -13,8 +13,8 @@ import java.util.Arrays;
 
 import org.junit.Test;
 
+import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.EzspFrame;
 import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.EzspFrameTest;
-import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.command.EzspSetConfigurationValueRequest;
 import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.structure.EmberZdoConfigurationFlags;
 import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.structure.EzspConfigId;
 
@@ -26,6 +26,7 @@ import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.structure.EzspConfigI
 public class EzspSetConfigurationValueRequestTest extends EzspFrameTest {
     @Test
     public void testVersion() {
+        EzspFrame.setEzspVersion(4);
         EzspSetConfigurationValueRequest request = new EzspSetConfigurationValueRequest();
         request.setSequenceNumber(2);
         request.setConfigId(EzspConfigId.EZSP_CONFIG_APPLICATION_ZDO_FLAGS);

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/ezsp/command/EzspSetConfigurationValueResponseTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/ezsp/command/EzspSetConfigurationValueResponseTest.java
@@ -11,8 +11,8 @@ import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 
+import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.EzspFrame;
 import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.EzspFrameTest;
-import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.command.EzspSetConfigurationValueResponse;
 import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.structure.EzspStatus;
 
 /**
@@ -23,6 +23,8 @@ import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.structure.EzspStatus;
 public class EzspSetConfigurationValueResponseTest extends EzspFrameTest {
     @Test
     public void testVersion() {
+        EzspFrame.setEzspVersion(4);
+
         EzspSetConfigurationValueResponse response = new EzspSetConfigurationValueResponse(
                 getPacketData("02 80 53 00"));
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/ezsp/command/EzspSetInitialSecurityStateRequestTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/ezsp/command/EzspSetInitialSecurityStateRequestTest.java
@@ -14,8 +14,8 @@ import java.util.Arrays;
 import org.junit.Test;
 
 import com.zsmartsystems.zigbee.IeeeAddress;
+import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.EzspFrame;
 import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.EzspFrameTest;
-import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.command.EzspSetInitialSecurityStateRequest;
 import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.structure.EmberInitialSecurityBitmask;
 import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.structure.EmberInitialSecurityState;
 import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.structure.EmberKeyData;
@@ -28,6 +28,8 @@ import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.structure.EmberKeyDat
 public class EzspSetInitialSecurityStateRequestTest extends EzspFrameTest {
     @Test
     public void testSecurityStateRequest() {
+        EzspFrame.setEzspVersion(4);
+
         EmberKeyData keyData;
         EzspSetInitialSecurityStateRequest request = new EzspSetInitialSecurityStateRequest();
         EmberInitialSecurityState state = new EmberInitialSecurityState();
@@ -42,9 +44,8 @@ public class EzspSetInitialSecurityStateRequestTest extends EzspFrameTest {
         state.addBitmask(EmberInitialSecurityBitmask.EMBER_STANDARD_SECURITY_MODE);
         request.setState(state);
         request.setSequenceNumber(7);
-        assertTrue(Arrays.equals(
-                getPacketData(
-                        "07 00 68 00 00 BB 00 00 00 00 00 00 00 00 00 00 00 00 00 00 BB AA 00 00 00 00 00 00 00 00 00 00 00 00 00 00 AA 00 EF CD AB 90 78 56 34 12"),
+        assertTrue(Arrays.equals(getPacketData(
+                "07 00 68 00 00 BB 00 00 00 00 00 00 00 00 00 00 00 00 00 00 BB AA 00 00 00 00 00 00 00 00 00 00 00 00 00 00 AA 00 EF CD AB 90 78 56 34 12"),
                 request.serialize()));
     }
 }

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/ezsp/command/EzspStackStatusHandlerResponseTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/ezsp/command/EzspStackStatusHandlerResponseTest.java
@@ -11,8 +11,8 @@ import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 
+import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.EzspFrame;
 import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.EzspFrameTest;
-import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.command.EzspStackStatusHandler;
 import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.structure.EmberStatus;
 
 /**
@@ -23,6 +23,8 @@ import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.structure.EmberStatus
 public class EzspStackStatusHandlerResponseTest extends EzspFrameTest {
     @Test
     public void testStackHandler() {
+        EzspFrame.setEzspVersion(4);
+
         EzspStackStatusHandler response = new EzspStackStatusHandler(getPacketData("03 90 19 90"));
         assertEquals(EzspStackStatusHandler.FRAME_ID, response.getFrameId());
         assertEquals(EmberStatus.EMBER_NETWORK_UP, response.getStatus());

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/ezsp/command/EzspStartScanRequestTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/ezsp/command/EzspStartScanRequestTest.java
@@ -14,8 +14,8 @@ import java.util.Arrays;
 import org.junit.Test;
 
 import com.zsmartsystems.zigbee.ZigBeeChannelMask;
+import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.EzspFrame;
 import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.EzspFrameTest;
-import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.command.EzspStartScanRequest;
 import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.structure.EzspNetworkScanType;
 
 /**
@@ -26,6 +26,7 @@ import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.structure.EzspNetwork
 public class EzspStartScanRequestTest extends EzspFrameTest {
     @Test
     public void testVersion() {
+        EzspFrame.setEzspVersion(4);
         EzspStartScanRequest request = new EzspStartScanRequest();
         request.setSequenceNumber(3);
         request.setScanType(EzspNetworkScanType.EZSP_ENERGY_SCAN);

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/ezsp/command/EzspStartScanResponseTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/ezsp/command/EzspStartScanResponseTest.java
@@ -11,9 +11,8 @@ import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 
+import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.EzspFrame;
 import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.EzspFrameTest;
-import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.command.EzspStartScanResponse;
-import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.command.EzspVersionResponse;
 import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.structure.EmberStatus;
 
 /**
@@ -24,6 +23,7 @@ import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.structure.EmberStatus
 public class EzspStartScanResponseTest extends EzspFrameTest {
     @Test
     public void testVersion() {
+        EzspFrame.setEzspVersion(4);
         EzspVersionResponse version = new EzspVersionResponse(getPacketData("03 80 00 04 02 00 58"));
 
         assertEquals(3, version.getSequenceNumber());

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/ezsp/command/EzspVersionRequestTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/ezsp/command/EzspVersionRequestTest.java
@@ -13,8 +13,8 @@ import java.util.Arrays;
 
 import org.junit.Test;
 
+import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.EzspFrame;
 import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.EzspFrameTest;
-import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.command.EzspVersionRequest;
 
 /**
  *
@@ -23,11 +23,32 @@ import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.command.EzspVersionRe
  */
 public class EzspVersionRequestTest extends EzspFrameTest {
     @Test
-    public void testVersion() {
+    public void testVersion4() {
+        EzspFrame.setEzspVersion(4);
         EzspVersionRequest version = new EzspVersionRequest();
         version.setDesiredProtocolVersion(4);
         version.setSequenceNumber(0);
 
         assertTrue(Arrays.equals(getPacketData("00 00 00 04"), version.serialize()));
+    }
+
+    @Test
+    public void testVersion5() {
+        EzspFrame.setEzspVersion(5);
+        EzspVersionRequest version = new EzspVersionRequest();
+        version.setDesiredProtocolVersion(5);
+        version.setSequenceNumber(0);
+
+        assertTrue(Arrays.equals(getPacketData("00 00 FF 00 00 05"), version.serialize()));
+    }
+
+    @Test
+    public void testVersion6() {
+        EzspFrame.setEzspVersion(6);
+        EzspVersionRequest version = new EzspVersionRequest();
+        version.setDesiredProtocolVersion(6);
+        version.setSequenceNumber(0);
+
+        assertTrue(Arrays.equals(getPacketData("00 00 FF 00 00 06"), version.serialize()));
     }
 }

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/ezsp/command/EzspVersionResponseTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/ezsp/command/EzspVersionResponseTest.java
@@ -11,8 +11,8 @@ import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 
+import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.EzspFrame;
 import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.EzspFrameTest;
-import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.command.EzspVersionResponse;
 
 /**
  *
@@ -21,14 +21,58 @@ import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.command.EzspVersionRe
  */
 public class EzspVersionResponseTest extends EzspFrameTest {
     @Test
-    public void testVersion() {
+    public void testVersion58() {
+        EzspFrame.setEzspVersion(4);
         EzspVersionResponse version = new EzspVersionResponse(getPacketData("03 80 00 04 02 00 58"));
 
+        // Version 5.8.0 - EZSP 4
         assertEquals(3, version.getSequenceNumber());
         assertEquals(true, version.isResponse());
         assertEquals(0, version.getFrameId());
         assertEquals(4, version.getProtocolVersion());
         assertEquals(2, version.getStackType());
-        assertEquals(22528, version.getStackVersion());
+        assertEquals(0x5800, version.getStackVersion());
+    }
+
+    @Test
+    public void testVersion581() {
+        EzspFrame.setEzspVersion(4);
+        EzspVersionResponse version = new EzspVersionResponse(getPacketData("01 80 00 04 02 10 58"));
+
+        // Version 5.8.1 - EZSP 4
+        assertEquals(1, version.getSequenceNumber());
+        assertEquals(true, version.isResponse());
+        assertEquals(0, version.getFrameId());
+        assertEquals(4, version.getProtocolVersion());
+        assertEquals(2, version.getStackType());
+        assertEquals(0x5810, version.getStackVersion());
+    }
+
+    @Test
+    public void testVersion5A1() {
+        EzspFrame.setEzspVersion(4);
+        EzspVersionResponse version = new EzspVersionResponse(getPacketData("01 80 FF 00 00 05 02 10 5A"));
+
+        // Version 5.10.1 - EZSP 5
+        assertEquals(1, version.getSequenceNumber());
+        assertEquals(true, version.isResponse());
+        assertEquals(0, version.getFrameId());
+        assertEquals(5, version.getProtocolVersion());
+        assertEquals(2, version.getStackType());
+        assertEquals(0x5A10, version.getStackVersion());
+    }
+
+    @Test
+    public void testVersion600() {
+        EzspFrame.setEzspVersion(4);
+        EzspVersionResponse version = new EzspVersionResponse(getPacketData("01 80 FF 00 00 06 02 00 60"));
+
+        // Version 6.0.0 - EZSP 6
+        assertEquals(1, version.getSequenceNumber());
+        assertEquals(true, version.isResponse());
+        assertEquals(0, version.getFrameId());
+        assertEquals(6, version.getProtocolVersion());
+        assertEquals(2, version.getStackType());
+        assertEquals(0x6000, version.getStackVersion());
     }
 }

--- a/com.zsmartsystems.zigbee.serial/src/main/java/com/zsmartsystems/zigbee/serial/ZigBeeSerialPort.java
+++ b/com.zsmartsystems.zigbee.serial/src/main/java/com/zsmartsystems/zigbee/serial/ZigBeeSerialPort.java
@@ -126,7 +126,7 @@ public class ZigBeeSerialPort implements ZigBeePort, SerialPortEventListener {
             throw new RuntimeException("Serial port already open.");
         }
 
-        logger.debug("Opening port {} at {} baud with {}.", baudRate, baudRate, flowControl);
+        logger.debug("Opening port {} at {} baud with {}.", portName, baudRate, flowControl);
 
         serialPort = new jssc.SerialPort(portName);
         try {


### PR DESCRIPTION
Refactor #122 to only use ASH2 and add tests.

Closes #109 
Closes #122 
Closes #200 

Signed-off-by: Chris Jackson <chris@cd-jackson.com>