### PR TITLE
Update attribute to add isLastValueCurrent method and remove comparison from clusters

### DIFF
--- a/com.zsmartsystems.zigbee.autocode/src/main/java/com/zsmartsystems/zigbee/autocode/ZclProtocolCodeGenerator.java
+++ b/com.zsmartsystems.zigbee.autocode/src/main/java/com/zsmartsystems/zigbee/autocode/ZclProtocolCodeGenerator.java
@@ -1629,15 +1629,10 @@ public class ZclProtocolCodeGenerator {
                         outputAttributeJavaDoc(out, "Synchronously get", attribute, zclDataType);
                         out.println("    public " + attribute.dataTypeClass + " get"
                                 + attribute.nameUpperCamelCase.replace("_", "") + "(final long refreshPeriod) {");
-                        out.println("        if(refreshPeriod > 0 && attributes.get(" + attribute.enumName
-                                + ").getLastReportTime() != null) {");
-                        out.println(
-                                "            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;");
-                        out.println("            if(attributes.get(" + attribute.enumName
-                                + ").getLastReportTime().getTimeInMillis() < refreshTime) {");
-                        out.println("                return (" + attribute.dataTypeClass + ") attributes.get("
+                        out.println("        if (attributes.get(" + attribute.enumName
+                                + ").isLastValueCurrent(refreshPeriod)) {");
+                        out.println("            return (" + attribute.dataTypeClass + ") attributes.get("
                                 + attribute.enumName + ").getLastValue();");
-                        out.println("            }");
                         out.println("        }");
                         out.println();
                         out.println("        return (" + attribute.dataTypeClass + ") readSync(attributes.get("

--- a/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsole.java
+++ b/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsole.java
@@ -2337,7 +2337,7 @@ public final class ZigBeeConsole {
          */
         @Override
         public String getSyntax() {
-            return "info node [MANUFACTURER|APPVERSION|MODEL|APPVERSION|STKVERSION|HWVERSION|ZCLVERSION|DATE]";
+            return "info node [MANUFACTURER|APPVERSION|MODEL|APPVERSION|STKVERSION|HWVERSION|ZCLVERSION|DATE] [REFRESH]";
         }
 
         /**
@@ -2345,11 +2345,20 @@ public final class ZigBeeConsole {
          */
         @Override
         public boolean process(final ZigBeeApi zigbeeApi, final String[] args, PrintStream out) throws Exception {
-            if (args.length != 3) {
+            if (args.length < 3) {
                 return false;
             }
 
+            long refresh = Long.MAX_VALUE;
+            if (args.length == 4) {
+                refresh = 0;
+            }
+
             final ZigBeeEndpoint device = getDevice(zigbeeApi, args[1]);
+            if (device == null) {
+                print("Can't find endpoint " + args[1], out);
+                return false;
+            }
             final String command = args[2].toUpperCase();
 
             ZclBasicCluster basicCluster = (ZclBasicCluster) device.getCluster(0);
@@ -2361,25 +2370,25 @@ public final class ZigBeeConsole {
             String response = null;
             switch (command) {
                 case "MANUFACTURER":
-                    response = basicCluster.getManufacturerName(Long.MAX_VALUE);
+                    response = basicCluster.getManufacturerName(refresh);
                     break;
                 case "MODEL":
-                    response = basicCluster.getModelIdentifier(Long.MAX_VALUE);
+                    response = basicCluster.getModelIdentifier(refresh);
                     break;
                 case "APPVERSION":
-                    response = basicCluster.getApplicationVersion(Long.MAX_VALUE).toString();
+                    response = basicCluster.getApplicationVersion(refresh).toString();
                     break;
                 case "STKVERSION":
-                    response = basicCluster.getStackVersion(Long.MAX_VALUE).toString();
+                    response = basicCluster.getStackVersion(refresh).toString();
                     break;
                 case "ZCLVERSION":
-                    response = basicCluster.getZclVersion(Long.MAX_VALUE).toString();
+                    response = basicCluster.getZclVersion(refresh).toString();
                     break;
                 case "HWVERSION":
-                    response = basicCluster.getHwVersion(Long.MAX_VALUE).toString();
+                    response = basicCluster.getHwVersion(refresh).toString();
                     break;
                 case "DATE":
-                    response = basicCluster.getDateCode(Long.MAX_VALUE).toString();
+                    response = basicCluster.getDateCode(refresh).toString();
                     break;
                 default:
                     print("Unknown info type: " + command, out);

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/ZclAttribute.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/ZclAttribute.java
@@ -286,6 +286,26 @@ public class ZclAttribute {
     }
 
     /**
+     * Checks if the last value received for the attribute is still current.
+     * If the last update time is more recent than the allowedAge then this will return true. allowedAge is defined in
+     * milliseconds.
+     *
+     * @param allowedAge the number of milliseconds to consider the value current
+     * @return true if the last value can be considered current
+     */
+    public boolean isLastValueCurrent(long allowedAge) {
+        if (lastReportTime == null) {
+            return false;
+        }
+
+        long refreshTime = Calendar.getInstance().getTimeInMillis() - allowedAge;
+        if (refreshTime < 0) {
+            return true;
+        }
+        return getLastReportTime().getTimeInMillis() > refreshTime;
+    }
+
+    /**
      * Gets the name of this attribute
      *
      * @return the name as {@link String}
@@ -319,6 +339,10 @@ public class ZclAttribute {
         builder.append(dataType);
         builder.append(", lastValue=");
         builder.append(lastValue);
+        if (lastReportTime != null) {
+            builder.append(", lastReportTime=");
+            builder.append(lastReportTime.getTime());
+        }
         builder.append(']');
 
         return builder.toString();

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclAlarmsCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclAlarmsCluster.java
@@ -132,11 +132,8 @@ public class ZclAlarmsCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getAlarmCount(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_ALARMCOUNT).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_ALARMCOUNT).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_ALARMCOUNT).getLastValue();
-            }
+        if (attributes.get(ATTR_ALARMCOUNT).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_ALARMCOUNT).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_ALARMCOUNT));

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclBasicCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclBasicCluster.java
@@ -7,6 +7,10 @@
  */
 package com.zsmartsystems.zigbee.zcl.clusters;
 
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Future;
+
 import com.zsmartsystems.zigbee.CommandResult;
 import com.zsmartsystems.zigbee.ZigBeeEndpoint;
 import com.zsmartsystems.zigbee.ZigBeeNetworkManager;
@@ -16,10 +20,6 @@ import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.clusters.basic.ResetToFactoryDefaultsCommand;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclClusterType;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
-import java.util.Calendar;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.Future;
 
 /**
  * <b>Basic</b> cluster implementation (<i>Cluster ID 0x0000</i>).
@@ -114,22 +114,36 @@ public class ZclBasicCluster extends ZclCluster {
     public static final int ATTR_DISABLELOCALCONFIG = 0x0014;
 
     // Attribute initialisation
+    @Override
     protected Map<Integer, ZclAttribute> initializeAttributes() {
         Map<Integer, ZclAttribute> attributeMap = new ConcurrentHashMap<Integer, ZclAttribute>(13);
 
-        attributeMap.put(ATTR_ZCLVERSION, new ZclAttribute(ZclClusterType.BASIC, ATTR_ZCLVERSION, "ZCLVersion", ZclDataType.UNSIGNED_8_BIT_INTEGER, true, true, false, false));
-        attributeMap.put(ATTR_APPLICATIONVERSION, new ZclAttribute(ZclClusterType.BASIC, ATTR_APPLICATIONVERSION, "ApplicationVersion", ZclDataType.UNSIGNED_8_BIT_INTEGER, true, true, false, false));
-        attributeMap.put(ATTR_STACKVERSION, new ZclAttribute(ZclClusterType.BASIC, ATTR_STACKVERSION, "StackVersion", ZclDataType.UNSIGNED_8_BIT_INTEGER, true, true, false, false));
-        attributeMap.put(ATTR_HWVERSION, new ZclAttribute(ZclClusterType.BASIC, ATTR_HWVERSION, "HWVersion", ZclDataType.UNSIGNED_8_BIT_INTEGER, true, true, false, false));
-        attributeMap.put(ATTR_MANUFACTURERNAME, new ZclAttribute(ZclClusterType.BASIC, ATTR_MANUFACTURERNAME, "ManufacturerName", ZclDataType.CHARACTER_STRING, true, true, false, false));
-        attributeMap.put(ATTR_MODELIDENTIFIER, new ZclAttribute(ZclClusterType.BASIC, ATTR_MODELIDENTIFIER, "ModelIdentifier", ZclDataType.CHARACTER_STRING, true, true, false, false));
-        attributeMap.put(ATTR_DATECODE, new ZclAttribute(ZclClusterType.BASIC, ATTR_DATECODE, "DateCode", ZclDataType.CHARACTER_STRING, true, true, false, false));
-        attributeMap.put(ATTR_POWERSOURCE, new ZclAttribute(ZclClusterType.BASIC, ATTR_POWERSOURCE, "PowerSource", ZclDataType.ENUMERATION_8_BIT, true, true, false, false));
-        attributeMap.put(ATTR_LOCATIONDESCRIPTION, new ZclAttribute(ZclClusterType.BASIC, ATTR_LOCATIONDESCRIPTION, "LocationDescription", ZclDataType.CHARACTER_STRING, true, true, true, false));
-        attributeMap.put(ATTR_PHYSICALENVIRONMENT, new ZclAttribute(ZclClusterType.BASIC, ATTR_PHYSICALENVIRONMENT, "PhysicalEnvironment", ZclDataType.ENUMERATION_8_BIT, true, true, true, false));
-        attributeMap.put(ATTR_DEVICEENABLED, new ZclAttribute(ZclClusterType.BASIC, ATTR_DEVICEENABLED, "DeviceEnabled", ZclDataType.BOOLEAN, true, true, true, false));
-        attributeMap.put(ATTR_ALARMMASK, new ZclAttribute(ZclClusterType.BASIC, ATTR_ALARMMASK, "AlarmMask", ZclDataType.BITMAP_8_BIT, true, true, true, false));
-        attributeMap.put(ATTR_DISABLELOCALCONFIG, new ZclAttribute(ZclClusterType.BASIC, ATTR_DISABLELOCALCONFIG, "DisableLocalConfig", ZclDataType.BITMAP_8_BIT, true, true, true, false));
+        attributeMap.put(ATTR_ZCLVERSION, new ZclAttribute(ZclClusterType.BASIC, ATTR_ZCLVERSION, "ZCLVersion",
+                ZclDataType.UNSIGNED_8_BIT_INTEGER, true, true, false, false));
+        attributeMap.put(ATTR_APPLICATIONVERSION, new ZclAttribute(ZclClusterType.BASIC, ATTR_APPLICATIONVERSION,
+                "ApplicationVersion", ZclDataType.UNSIGNED_8_BIT_INTEGER, true, true, false, false));
+        attributeMap.put(ATTR_STACKVERSION, new ZclAttribute(ZclClusterType.BASIC, ATTR_STACKVERSION, "StackVersion",
+                ZclDataType.UNSIGNED_8_BIT_INTEGER, true, true, false, false));
+        attributeMap.put(ATTR_HWVERSION, new ZclAttribute(ZclClusterType.BASIC, ATTR_HWVERSION, "HWVersion",
+                ZclDataType.UNSIGNED_8_BIT_INTEGER, true, true, false, false));
+        attributeMap.put(ATTR_MANUFACTURERNAME, new ZclAttribute(ZclClusterType.BASIC, ATTR_MANUFACTURERNAME,
+                "ManufacturerName", ZclDataType.CHARACTER_STRING, true, true, false, false));
+        attributeMap.put(ATTR_MODELIDENTIFIER, new ZclAttribute(ZclClusterType.BASIC, ATTR_MODELIDENTIFIER,
+                "ModelIdentifier", ZclDataType.CHARACTER_STRING, true, true, false, false));
+        attributeMap.put(ATTR_DATECODE, new ZclAttribute(ZclClusterType.BASIC, ATTR_DATECODE, "DateCode",
+                ZclDataType.CHARACTER_STRING, true, true, false, false));
+        attributeMap.put(ATTR_POWERSOURCE, new ZclAttribute(ZclClusterType.BASIC, ATTR_POWERSOURCE, "PowerSource",
+                ZclDataType.ENUMERATION_8_BIT, true, true, false, false));
+        attributeMap.put(ATTR_LOCATIONDESCRIPTION, new ZclAttribute(ZclClusterType.BASIC, ATTR_LOCATIONDESCRIPTION,
+                "LocationDescription", ZclDataType.CHARACTER_STRING, true, true, true, false));
+        attributeMap.put(ATTR_PHYSICALENVIRONMENT, new ZclAttribute(ZclClusterType.BASIC, ATTR_PHYSICALENVIRONMENT,
+                "PhysicalEnvironment", ZclDataType.ENUMERATION_8_BIT, true, true, true, false));
+        attributeMap.put(ATTR_DEVICEENABLED, new ZclAttribute(ZclClusterType.BASIC, ATTR_DEVICEENABLED, "DeviceEnabled",
+                ZclDataType.BOOLEAN, true, true, true, false));
+        attributeMap.put(ATTR_ALARMMASK, new ZclAttribute(ZclClusterType.BASIC, ATTR_ALARMMASK, "AlarmMask",
+                ZclDataType.BITMAP_8_BIT, true, true, true, false));
+        attributeMap.put(ATTR_DISABLELOCALCONFIG, new ZclAttribute(ZclClusterType.BASIC, ATTR_DISABLELOCALCONFIG,
+                "DisableLocalConfig", ZclDataType.BITMAP_8_BIT, true, true, true, false));
 
         return attributeMap;
     }
@@ -143,7 +157,6 @@ public class ZclBasicCluster extends ZclCluster {
     public ZclBasicCluster(final ZigBeeNetworkManager zigbeeManager, final ZigBeeEndpoint zigbeeEndpoint) {
         super(zigbeeManager, zigbeeEndpoint, CLUSTER_ID, CLUSTER_NAME);
     }
-
 
     /**
      * Get the <i>ZCLVersion</i> attribute [attribute ID <b>0</b>].
@@ -160,7 +173,6 @@ public class ZclBasicCluster extends ZclCluster {
     public Future<CommandResult> getZclVersionAsync() {
         return read(attributes.get(ATTR_ZCLVERSION));
     }
-
 
     /**
      * Synchronously get the <i>ZCLVersion</i> attribute [attribute ID <b>0</b>].
@@ -183,11 +195,8 @@ public class ZclBasicCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getZclVersion(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_ZCLVERSION).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_ZCLVERSION).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_ZCLVERSION).getLastValue();
-            }
+        if (attributes.get(ATTR_ZCLVERSION).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_ZCLVERSION).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_ZCLVERSION));
@@ -209,7 +218,6 @@ public class ZclBasicCluster extends ZclCluster {
     public Future<CommandResult> getApplicationVersionAsync() {
         return read(attributes.get(ATTR_APPLICATIONVERSION));
     }
-
 
     /**
      * Synchronously get the <i>ApplicationVersion</i> attribute [attribute ID <b>1</b>].
@@ -233,11 +241,8 @@ public class ZclBasicCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getApplicationVersion(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_APPLICATIONVERSION).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_APPLICATIONVERSION).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_APPLICATIONVERSION).getLastValue();
-            }
+        if (attributes.get(ATTR_APPLICATIONVERSION).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_APPLICATIONVERSION).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_APPLICATIONVERSION));
@@ -259,7 +264,6 @@ public class ZclBasicCluster extends ZclCluster {
     public Future<CommandResult> getStackVersionAsync() {
         return read(attributes.get(ATTR_STACKVERSION));
     }
-
 
     /**
      * Synchronously get the <i>StackVersion</i> attribute [attribute ID <b>2</b>].
@@ -283,11 +287,8 @@ public class ZclBasicCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getStackVersion(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_STACKVERSION).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_STACKVERSION).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_STACKVERSION).getLastValue();
-            }
+        if (attributes.get(ATTR_STACKVERSION).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_STACKVERSION).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_STACKVERSION));
@@ -308,7 +309,6 @@ public class ZclBasicCluster extends ZclCluster {
     public Future<CommandResult> getHwVersionAsync() {
         return read(attributes.get(ATTR_HWVERSION));
     }
-
 
     /**
      * Synchronously get the <i>HWVersion</i> attribute [attribute ID <b>3</b>].
@@ -331,11 +331,8 @@ public class ZclBasicCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getHwVersion(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_HWVERSION).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_HWVERSION).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_HWVERSION).getLastValue();
-            }
+        if (attributes.get(ATTR_HWVERSION).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_HWVERSION).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_HWVERSION));
@@ -356,7 +353,6 @@ public class ZclBasicCluster extends ZclCluster {
     public Future<CommandResult> getManufacturerNameAsync() {
         return read(attributes.get(ATTR_MANUFACTURERNAME));
     }
-
 
     /**
      * Synchronously get the <i>ManufacturerName</i> attribute [attribute ID <b>4</b>].
@@ -379,11 +375,8 @@ public class ZclBasicCluster extends ZclCluster {
      * @return the {@link String} attribute value, or null on error
      */
     public String getManufacturerName(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_MANUFACTURERNAME).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_MANUFACTURERNAME).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (String) attributes.get(ATTR_MANUFACTURERNAME).getLastValue();
-            }
+        if (attributes.get(ATTR_MANUFACTURERNAME).isLastValueCurrent(refreshPeriod)) {
+            return (String) attributes.get(ATTR_MANUFACTURERNAME).getLastValue();
         }
 
         return (String) readSync(attributes.get(ATTR_MANUFACTURERNAME));
@@ -404,7 +397,6 @@ public class ZclBasicCluster extends ZclCluster {
     public Future<CommandResult> getModelIdentifierAsync() {
         return read(attributes.get(ATTR_MODELIDENTIFIER));
     }
-
 
     /**
      * Synchronously get the <i>ModelIdentifier</i> attribute [attribute ID <b>5</b>].
@@ -427,11 +419,8 @@ public class ZclBasicCluster extends ZclCluster {
      * @return the {@link String} attribute value, or null on error
      */
     public String getModelIdentifier(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_MODELIDENTIFIER).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_MODELIDENTIFIER).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (String) attributes.get(ATTR_MODELIDENTIFIER).getLastValue();
-            }
+        if (attributes.get(ATTR_MODELIDENTIFIER).isLastValueCurrent(refreshPeriod)) {
+            return (String) attributes.get(ATTR_MODELIDENTIFIER).getLastValue();
         }
 
         return (String) readSync(attributes.get(ATTR_MODELIDENTIFIER));
@@ -453,7 +442,6 @@ public class ZclBasicCluster extends ZclCluster {
     public Future<CommandResult> getDateCodeAsync() {
         return read(attributes.get(ATTR_DATECODE));
     }
-
 
     /**
      * Synchronously get the <i>DateCode</i> attribute [attribute ID <b>6</b>].
@@ -477,11 +465,8 @@ public class ZclBasicCluster extends ZclCluster {
      * @return the {@link String} attribute value, or null on error
      */
     public String getDateCode(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_DATECODE).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_DATECODE).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (String) attributes.get(ATTR_DATECODE).getLastValue();
-            }
+        if (attributes.get(ATTR_DATECODE).isLastValueCurrent(refreshPeriod)) {
+            return (String) attributes.get(ATTR_DATECODE).getLastValue();
         }
 
         return (String) readSync(attributes.get(ATTR_DATECODE));
@@ -504,7 +489,6 @@ public class ZclBasicCluster extends ZclCluster {
     public Future<CommandResult> getPowerSourceAsync() {
         return read(attributes.get(ATTR_POWERSOURCE));
     }
-
 
     /**
      * Synchronously get the <i>PowerSource</i> attribute [attribute ID <b>7</b>].
@@ -529,16 +513,12 @@ public class ZclBasicCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getPowerSource(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_POWERSOURCE).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_POWERSOURCE).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_POWERSOURCE).getLastValue();
-            }
+        if (attributes.get(ATTR_POWERSOURCE).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_POWERSOURCE).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_POWERSOURCE));
     }
-
 
     /**
      * Set the <i>LocationDescription</i> attribute [attribute ID <b>16</b>].
@@ -573,7 +553,6 @@ public class ZclBasicCluster extends ZclCluster {
         return read(attributes.get(ATTR_LOCATIONDESCRIPTION));
     }
 
-
     /**
      * Synchronously get the <i>LocationDescription</i> attribute [attribute ID <b>16</b>].
      * <p>
@@ -595,16 +574,12 @@ public class ZclBasicCluster extends ZclCluster {
      * @return the {@link String} attribute value, or null on error
      */
     public String getLocationDescription(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_LOCATIONDESCRIPTION).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_LOCATIONDESCRIPTION).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (String) attributes.get(ATTR_LOCATIONDESCRIPTION).getLastValue();
-            }
+        if (attributes.get(ATTR_LOCATIONDESCRIPTION).isLastValueCurrent(refreshPeriod)) {
+            return (String) attributes.get(ATTR_LOCATIONDESCRIPTION).getLastValue();
         }
 
         return (String) readSync(attributes.get(ATTR_LOCATIONDESCRIPTION));
     }
-
 
     /**
      * Set the <i>PhysicalEnvironment</i> attribute [attribute ID <b>17</b>].
@@ -639,7 +614,6 @@ public class ZclBasicCluster extends ZclCluster {
         return read(attributes.get(ATTR_PHYSICALENVIRONMENT));
     }
 
-
     /**
      * Synchronously get the <i>PhysicalEnvironment</i> attribute [attribute ID <b>17</b>].
      * <p>
@@ -661,16 +635,12 @@ public class ZclBasicCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getPhysicalEnvironment(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_PHYSICALENVIRONMENT).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_PHYSICALENVIRONMENT).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_PHYSICALENVIRONMENT).getLastValue();
-            }
+        if (attributes.get(ATTR_PHYSICALENVIRONMENT).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_PHYSICALENVIRONMENT).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_PHYSICALENVIRONMENT));
     }
-
 
     /**
      * Set the <i>DeviceEnabled</i> attribute [attribute ID <b>18</b>].
@@ -705,7 +675,6 @@ public class ZclBasicCluster extends ZclCluster {
         return read(attributes.get(ATTR_DEVICEENABLED));
     }
 
-
     /**
      * Synchronously get the <i>DeviceEnabled</i> attribute [attribute ID <b>18</b>].
      * <p>
@@ -727,16 +696,12 @@ public class ZclBasicCluster extends ZclCluster {
      * @return the {@link Boolean} attribute value, or null on error
      */
     public Boolean getDeviceEnabled(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_DEVICEENABLED).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_DEVICEENABLED).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Boolean) attributes.get(ATTR_DEVICEENABLED).getLastValue();
-            }
+        if (attributes.get(ATTR_DEVICEENABLED).isLastValueCurrent(refreshPeriod)) {
+            return (Boolean) attributes.get(ATTR_DEVICEENABLED).getLastValue();
         }
 
         return (Boolean) readSync(attributes.get(ATTR_DEVICEENABLED));
     }
-
 
     /**
      * Set the <i>AlarmMask</i> attribute [attribute ID <b>19</b>].
@@ -771,7 +736,6 @@ public class ZclBasicCluster extends ZclCluster {
         return read(attributes.get(ATTR_ALARMMASK));
     }
 
-
     /**
      * Synchronously get the <i>AlarmMask</i> attribute [attribute ID <b>19</b>].
      * <p>
@@ -793,16 +757,12 @@ public class ZclBasicCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getAlarmMask(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_ALARMMASK).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_ALARMMASK).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_ALARMMASK).getLastValue();
-            }
+        if (attributes.get(ATTR_ALARMMASK).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_ALARMMASK).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_ALARMMASK));
     }
-
 
     /**
      * Set the <i>DisableLocalConfig</i> attribute [attribute ID <b>20</b>].
@@ -845,7 +805,6 @@ public class ZclBasicCluster extends ZclCluster {
         return read(attributes.get(ATTR_DISABLELOCALCONFIG));
     }
 
-
     /**
      * Synchronously get the <i>DisableLocalConfig</i> attribute [attribute ID <b>20</b>].
      * <p>
@@ -871,11 +830,8 @@ public class ZclBasicCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getDisableLocalConfig(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_DISABLELOCALCONFIG).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_DISABLELOCALCONFIG).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_DISABLELOCALCONFIG).getLastValue();
-            }
+        if (attributes.get(ATTR_DISABLELOCALCONFIG).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_DISABLELOCALCONFIG).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_DISABLELOCALCONFIG));
@@ -885,7 +841,7 @@ public class ZclBasicCluster extends ZclCluster {
      * The Reset to Factory Defaults Command
      * <p>
      * On receipt of this command, the device resets all the attributes of all its clusters
-     * to their factory defaults.Note that ZigBee networking functionality,bindings, groups
+     * to their factory defaults. Note that ZigBee networking functionality,bindings, groups
      * or other persistent data are not affected by this command
      *
      * @return the {@link Future<CommandResult>} command result future

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclColorControlCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclColorControlCluster.java
@@ -289,11 +289,8 @@ public class ZclColorControlCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getCurrentHue(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_CURRENTHUE).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_CURRENTHUE).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_CURRENTHUE).getLastValue();
-            }
+        if (attributes.get(ATTR_CURRENTHUE).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_CURRENTHUE).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_CURRENTHUE));
@@ -373,11 +370,8 @@ public class ZclColorControlCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getCurrentSaturation(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_CURRENTSATURATION).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_CURRENTSATURATION).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_CURRENTSATURATION).getLastValue();
-            }
+        if (attributes.get(ATTR_CURRENTSATURATION).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_CURRENTSATURATION).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_CURRENTSATURATION));
@@ -446,11 +440,8 @@ public class ZclColorControlCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getRemainingTime(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_REMAININGTIME).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_REMAININGTIME).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_REMAININGTIME).getLastValue();
-            }
+        if (attributes.get(ATTR_REMAININGTIME).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_REMAININGTIME).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_REMAININGTIME));
@@ -504,11 +495,8 @@ public class ZclColorControlCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getCurrentX(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_CURRENTX).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_CURRENTX).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_CURRENTX).getLastValue();
-            }
+        if (attributes.get(ATTR_CURRENTX).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_CURRENTX).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_CURRENTX));
@@ -587,11 +575,8 @@ public class ZclColorControlCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getCurrentY(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_CURRENTY).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_CURRENTY).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_CURRENTY).getLastValue();
-            }
+        if (attributes.get(ATTR_CURRENTY).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_CURRENTY).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_CURRENTY));
@@ -660,11 +645,8 @@ public class ZclColorControlCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getDriftCompensation(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_DRIFTCOMPENSATION).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_DRIFTCOMPENSATION).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_DRIFTCOMPENSATION).getLastValue();
-            }
+        if (attributes.get(ATTR_DRIFTCOMPENSATION).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_DRIFTCOMPENSATION).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_DRIFTCOMPENSATION));
@@ -708,11 +690,8 @@ public class ZclColorControlCluster extends ZclCluster {
      * @return the {@link String} attribute value, or null on error
      */
     public String getCompensationText(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_COMPENSATIONTEXT).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_COMPENSATIONTEXT).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (String) attributes.get(ATTR_COMPENSATIONTEXT).getLastValue();
-            }
+        if (attributes.get(ATTR_COMPENSATIONTEXT).isLastValueCurrent(refreshPeriod)) {
+            return (String) attributes.get(ATTR_COMPENSATIONTEXT).getLastValue();
         }
 
         return (String) readSync(attributes.get(ATTR_COMPENSATIONTEXT));
@@ -778,11 +757,8 @@ public class ZclColorControlCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getColorTemperature(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_COLORTEMPERATURE).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_COLORTEMPERATURE).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_COLORTEMPERATURE).getLastValue();
-            }
+        if (attributes.get(ATTR_COLORTEMPERATURE).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_COLORTEMPERATURE).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_COLORTEMPERATURE));
@@ -861,11 +837,8 @@ public class ZclColorControlCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getColorMode(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_COLORMODE).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_COLORMODE).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_COLORMODE).getLastValue();
-            }
+        if (attributes.get(ATTR_COLORMODE).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_COLORMODE).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_COLORMODE));
@@ -915,11 +888,8 @@ public class ZclColorControlCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getEnhancedCurrentHue(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_ENHANCEDCURRENTHUE).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_ENHANCEDCURRENTHUE).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_ENHANCEDCURRENTHUE).getLastValue();
-            }
+        if (attributes.get(ATTR_ENHANCEDCURRENTHUE).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_ENHANCEDCURRENTHUE).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_ENHANCEDCURRENTHUE));
@@ -988,11 +958,8 @@ public class ZclColorControlCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getEnhancedColorMode(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_ENHANCEDCOLORMODE).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_ENHANCEDCOLORMODE).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_ENHANCEDCOLORMODE).getLastValue();
-            }
+        if (attributes.get(ATTR_ENHANCEDCOLORMODE).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_ENHANCEDCOLORMODE).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_ENHANCEDCOLORMODE));
@@ -1038,11 +1005,8 @@ public class ZclColorControlCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getColorLoopActive(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_COLORLOOPACTIVE).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_COLORLOOPACTIVE).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_COLORLOOPACTIVE).getLastValue();
-            }
+        if (attributes.get(ATTR_COLORLOOPACTIVE).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_COLORLOOPACTIVE).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_COLORLOOPACTIVE));
@@ -1090,11 +1054,8 @@ public class ZclColorControlCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getColorLoopDirection(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_COLORLOOPDIRECTION).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_COLORLOOPDIRECTION).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_COLORLOOPDIRECTION).getLastValue();
-            }
+        if (attributes.get(ATTR_COLORLOOPDIRECTION).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_COLORLOOPDIRECTION).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_COLORLOOPDIRECTION));
@@ -1138,11 +1099,8 @@ public class ZclColorControlCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getColorLoopTime(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_COLORLOOPTIME).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_COLORLOOPTIME).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_COLORLOOPTIME).getLastValue();
-            }
+        if (attributes.get(ATTR_COLORLOOPTIME).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_COLORLOOPTIME).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_COLORLOOPTIME));
@@ -1186,11 +1144,8 @@ public class ZclColorControlCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getColorLoopStartHue(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_COLORLOOPSTARTHUE).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_COLORLOOPSTARTHUE).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_COLORLOOPSTARTHUE).getLastValue();
-            }
+        if (attributes.get(ATTR_COLORLOOPSTARTHUE).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_COLORLOOPSTARTHUE).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_COLORLOOPSTARTHUE));
@@ -1236,11 +1191,8 @@ public class ZclColorControlCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getColorLoopStoredHue(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_COLORLOOPSTOREDHUE).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_COLORLOOPSTOREDHUE).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_COLORLOOPSTOREDHUE).getLastValue();
-            }
+        if (attributes.get(ATTR_COLORLOOPSTOREDHUE).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_COLORLOOPSTOREDHUE).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_COLORLOOPSTOREDHUE));
@@ -1288,11 +1240,8 @@ public class ZclColorControlCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getColorCapabilities(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_COLORCAPABILITIES).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_COLORCAPABILITIES).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_COLORCAPABILITIES).getLastValue();
-            }
+        if (attributes.get(ATTR_COLORCAPABILITIES).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_COLORCAPABILITIES).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_COLORCAPABILITIES));
@@ -1340,11 +1289,8 @@ public class ZclColorControlCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getColorTemperatureMin(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_COLORTEMPERATUREMIN).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_COLORTEMPERATUREMIN).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_COLORTEMPERATUREMIN).getLastValue();
-            }
+        if (attributes.get(ATTR_COLORTEMPERATUREMIN).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_COLORTEMPERATUREMIN).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_COLORTEMPERATUREMIN));
@@ -1392,11 +1338,8 @@ public class ZclColorControlCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getColorTemperatureMax(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_COLORTEMPERATUREMAX).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_COLORTEMPERATUREMAX).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_COLORTEMPERATUREMAX).getLastValue();
-            }
+        if (attributes.get(ATTR_COLORTEMPERATUREMAX).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_COLORTEMPERATUREMAX).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_COLORTEMPERATUREMAX));

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclDiagnosticsCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclDiagnosticsCluster.java
@@ -208,11 +208,8 @@ public class ZclDiagnosticsCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getMacRxBcast(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_MACRXBCAST).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_MACRXBCAST).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_MACRXBCAST).getLastValue();
-            }
+        if (attributes.get(ATTR_MACRXBCAST).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_MACRXBCAST).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_MACRXBCAST));
@@ -250,11 +247,8 @@ public class ZclDiagnosticsCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getMacTxBcast(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_MACTXBCAST).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_MACTXBCAST).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_MACTXBCAST).getLastValue();
-            }
+        if (attributes.get(ATTR_MACTXBCAST).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_MACTXBCAST).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_MACTXBCAST));
@@ -292,11 +286,8 @@ public class ZclDiagnosticsCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getMacRxUcast(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_MACRXUCAST).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_MACRXUCAST).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_MACRXUCAST).getLastValue();
-            }
+        if (attributes.get(ATTR_MACRXUCAST).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_MACRXUCAST).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_MACRXUCAST));
@@ -334,11 +325,8 @@ public class ZclDiagnosticsCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getMacTxUcast(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_MACTXUCAST).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_MACTXUCAST).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_MACTXUCAST).getLastValue();
-            }
+        if (attributes.get(ATTR_MACTXUCAST).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_MACTXUCAST).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_MACTXUCAST));
@@ -376,11 +364,8 @@ public class ZclDiagnosticsCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getMacTxUcastRetry(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_MACTXUCASTRETRY).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_MACTXUCASTRETRY).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_MACTXUCASTRETRY).getLastValue();
-            }
+        if (attributes.get(ATTR_MACTXUCASTRETRY).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_MACTXUCASTRETRY).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_MACTXUCASTRETRY));
@@ -418,11 +403,8 @@ public class ZclDiagnosticsCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getMacTxUcastFail(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_MACTXUCASTFAIL).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_MACTXUCASTFAIL).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_MACTXUCASTFAIL).getLastValue();
-            }
+        if (attributes.get(ATTR_MACTXUCASTFAIL).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_MACTXUCASTFAIL).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_MACTXUCASTFAIL));
@@ -460,11 +442,8 @@ public class ZclDiagnosticsCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getApsRxBcast(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_APSRXBCAST).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_APSRXBCAST).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_APSRXBCAST).getLastValue();
-            }
+        if (attributes.get(ATTR_APSRXBCAST).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_APSRXBCAST).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_APSRXBCAST));
@@ -502,11 +481,8 @@ public class ZclDiagnosticsCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getApsTxBcast(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_APSTXBCAST).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_APSTXBCAST).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_APSTXBCAST).getLastValue();
-            }
+        if (attributes.get(ATTR_APSTXBCAST).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_APSTXBCAST).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_APSTXBCAST));
@@ -544,11 +520,8 @@ public class ZclDiagnosticsCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getApsRxUcast(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_APSRXUCAST).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_APSRXUCAST).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_APSRXUCAST).getLastValue();
-            }
+        if (attributes.get(ATTR_APSRXUCAST).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_APSRXUCAST).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_APSRXUCAST));
@@ -586,11 +559,8 @@ public class ZclDiagnosticsCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getApsTxUcastSuccess(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_APSTXUCASTSUCCESS).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_APSTXUCASTSUCCESS).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_APSTXUCASTSUCCESS).getLastValue();
-            }
+        if (attributes.get(ATTR_APSTXUCASTSUCCESS).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_APSTXUCASTSUCCESS).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_APSTXUCASTSUCCESS));
@@ -628,11 +598,8 @@ public class ZclDiagnosticsCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getApsTxUcastRetry(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_APSTXUCASTRETRY).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_APSTXUCASTRETRY).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_APSTXUCASTRETRY).getLastValue();
-            }
+        if (attributes.get(ATTR_APSTXUCASTRETRY).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_APSTXUCASTRETRY).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_APSTXUCASTRETRY));
@@ -670,11 +637,8 @@ public class ZclDiagnosticsCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getApsTxUcastFail(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_APSTXUCASTFAIL).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_APSTXUCASTFAIL).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_APSTXUCASTFAIL).getLastValue();
-            }
+        if (attributes.get(ATTR_APSTXUCASTFAIL).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_APSTXUCASTFAIL).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_APSTXUCASTFAIL));
@@ -712,11 +676,8 @@ public class ZclDiagnosticsCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getRouteDiscInitiated(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_ROUTEDISCINITIATED).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_ROUTEDISCINITIATED).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_ROUTEDISCINITIATED).getLastValue();
-            }
+        if (attributes.get(ATTR_ROUTEDISCINITIATED).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_ROUTEDISCINITIATED).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_ROUTEDISCINITIATED));
@@ -754,11 +715,8 @@ public class ZclDiagnosticsCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getNeighborAdded(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_NEIGHBORADDED).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_NEIGHBORADDED).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_NEIGHBORADDED).getLastValue();
-            }
+        if (attributes.get(ATTR_NEIGHBORADDED).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_NEIGHBORADDED).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_NEIGHBORADDED));
@@ -796,11 +754,8 @@ public class ZclDiagnosticsCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getNeighborRemoved(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_NEIGHBORREMOVED).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_NEIGHBORREMOVED).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_NEIGHBORREMOVED).getLastValue();
-            }
+        if (attributes.get(ATTR_NEIGHBORREMOVED).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_NEIGHBORREMOVED).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_NEIGHBORREMOVED));
@@ -838,11 +793,8 @@ public class ZclDiagnosticsCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getNeighborStale(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_NEIGHBORSTALE).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_NEIGHBORSTALE).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_NEIGHBORSTALE).getLastValue();
-            }
+        if (attributes.get(ATTR_NEIGHBORSTALE).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_NEIGHBORSTALE).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_NEIGHBORSTALE));
@@ -880,11 +832,8 @@ public class ZclDiagnosticsCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getJoinIndication(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_JOININDICATION).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_JOININDICATION).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_JOININDICATION).getLastValue();
-            }
+        if (attributes.get(ATTR_JOININDICATION).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_JOININDICATION).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_JOININDICATION));
@@ -922,11 +871,8 @@ public class ZclDiagnosticsCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getChildMoved(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_CHILDMOVED).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_CHILDMOVED).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_CHILDMOVED).getLastValue();
-            }
+        if (attributes.get(ATTR_CHILDMOVED).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_CHILDMOVED).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_CHILDMOVED));
@@ -964,11 +910,8 @@ public class ZclDiagnosticsCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getNwkfcFailure(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_NWKFCFAILURE).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_NWKFCFAILURE).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_NWKFCFAILURE).getLastValue();
-            }
+        if (attributes.get(ATTR_NWKFCFAILURE).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_NWKFCFAILURE).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_NWKFCFAILURE));
@@ -1006,11 +949,8 @@ public class ZclDiagnosticsCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getApsfcFailure(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_APSFCFAILURE).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_APSFCFAILURE).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_APSFCFAILURE).getLastValue();
-            }
+        if (attributes.get(ATTR_APSFCFAILURE).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_APSFCFAILURE).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_APSFCFAILURE));
@@ -1048,11 +988,8 @@ public class ZclDiagnosticsCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getApsUnauthorizedKey(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_APSUNAUTHORIZEDKEY).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_APSUNAUTHORIZEDKEY).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_APSUNAUTHORIZEDKEY).getLastValue();
-            }
+        if (attributes.get(ATTR_APSUNAUTHORIZEDKEY).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_APSUNAUTHORIZEDKEY).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_APSUNAUTHORIZEDKEY));
@@ -1090,11 +1027,8 @@ public class ZclDiagnosticsCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getNwkDecryptFailures(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_NWKDECRYPTFAILURES).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_NWKDECRYPTFAILURES).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_NWKDECRYPTFAILURES).getLastValue();
-            }
+        if (attributes.get(ATTR_NWKDECRYPTFAILURES).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_NWKDECRYPTFAILURES).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_NWKDECRYPTFAILURES));
@@ -1132,11 +1066,8 @@ public class ZclDiagnosticsCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getApsDecryptFailures(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_APSDECRYPTFAILURES).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_APSDECRYPTFAILURES).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_APSDECRYPTFAILURES).getLastValue();
-            }
+        if (attributes.get(ATTR_APSDECRYPTFAILURES).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_APSDECRYPTFAILURES).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_APSDECRYPTFAILURES));
@@ -1174,11 +1105,8 @@ public class ZclDiagnosticsCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getPacketBufferAllocateFailures(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_PACKETBUFFERALLOCATEFAILURES).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_PACKETBUFFERALLOCATEFAILURES).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_PACKETBUFFERALLOCATEFAILURES).getLastValue();
-            }
+        if (attributes.get(ATTR_PACKETBUFFERALLOCATEFAILURES).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_PACKETBUFFERALLOCATEFAILURES).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_PACKETBUFFERALLOCATEFAILURES));
@@ -1216,11 +1144,8 @@ public class ZclDiagnosticsCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getRelayedUcast(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_RELAYEDUCAST).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_RELAYEDUCAST).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_RELAYEDUCAST).getLastValue();
-            }
+        if (attributes.get(ATTR_RELAYEDUCAST).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_RELAYEDUCAST).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_RELAYEDUCAST));
@@ -1258,11 +1183,8 @@ public class ZclDiagnosticsCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getPhytoMaCqueuelimitreached(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_PHYTOMACQUEUELIMITREACHED).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_PHYTOMACQUEUELIMITREACHED).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_PHYTOMACQUEUELIMITREACHED).getLastValue();
-            }
+        if (attributes.get(ATTR_PHYTOMACQUEUELIMITREACHED).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_PHYTOMACQUEUELIMITREACHED).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_PHYTOMACQUEUELIMITREACHED));
@@ -1300,11 +1222,8 @@ public class ZclDiagnosticsCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getPacketValidatedropcount(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_PACKETVALIDATEDROPCOUNT).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_PACKETVALIDATEDROPCOUNT).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_PACKETVALIDATEDROPCOUNT).getLastValue();
-            }
+        if (attributes.get(ATTR_PACKETVALIDATEDROPCOUNT).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_PACKETVALIDATEDROPCOUNT).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_PACKETVALIDATEDROPCOUNT));
@@ -1342,11 +1261,8 @@ public class ZclDiagnosticsCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getAverageMacRetryPerApsMessageSent(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_AVERAGEMACRETRYPERAPSMESSAGESENT).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_AVERAGEMACRETRYPERAPSMESSAGESENT).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_AVERAGEMACRETRYPERAPSMESSAGESENT).getLastValue();
-            }
+        if (attributes.get(ATTR_AVERAGEMACRETRYPERAPSMESSAGESENT).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_AVERAGEMACRETRYPERAPSMESSAGESENT).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_AVERAGEMACRETRYPERAPSMESSAGESENT));
@@ -1384,11 +1300,8 @@ public class ZclDiagnosticsCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getLastMessageLqi(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_LASTMESSAGELQI).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_LASTMESSAGELQI).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_LASTMESSAGELQI).getLastValue();
-            }
+        if (attributes.get(ATTR_LASTMESSAGELQI).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_LASTMESSAGELQI).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_LASTMESSAGELQI));
@@ -1426,11 +1339,8 @@ public class ZclDiagnosticsCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getLastMessageRssi(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_LASTMESSAGERSSI).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_LASTMESSAGERSSI).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_LASTMESSAGERSSI).getLastValue();
-            }
+        if (attributes.get(ATTR_LASTMESSAGERSSI).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_LASTMESSAGERSSI).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_LASTMESSAGERSSI));

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclElectricalMeasurementCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclElectricalMeasurementCluster.java
@@ -186,11 +186,8 @@ public class ZclElectricalMeasurementCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getMeasurementType(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_MEASUREMENTTYPE).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_MEASUREMENTTYPE).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_MEASUREMENTTYPE).getLastValue();
-            }
+        if (attributes.get(ATTR_MEASUREMENTTYPE).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_MEASUREMENTTYPE).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_MEASUREMENTTYPE));
@@ -234,11 +231,8 @@ public class ZclElectricalMeasurementCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getAcFrequency(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_ACFREQUENCY).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_ACFREQUENCY).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_ACFREQUENCY).getLastValue();
-            }
+        if (attributes.get(ATTR_ACFREQUENCY).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_ACFREQUENCY).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_ACFREQUENCY));
@@ -286,11 +280,8 @@ public class ZclElectricalMeasurementCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getTotalActivePower(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_TOTALACTIVEPOWER).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_TOTALACTIVEPOWER).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_TOTALACTIVEPOWER).getLastValue();
-            }
+        if (attributes.get(ATTR_TOTALACTIVEPOWER).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_TOTALACTIVEPOWER).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_TOTALACTIVEPOWER));
@@ -340,11 +331,8 @@ public class ZclElectricalMeasurementCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getTotalReactivePower(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_TOTALREACTIVEPOWER).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_TOTALREACTIVEPOWER).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_TOTALREACTIVEPOWER).getLastValue();
-            }
+        if (attributes.get(ATTR_TOTALREACTIVEPOWER).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_TOTALREACTIVEPOWER).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_TOTALREACTIVEPOWER));
@@ -388,11 +376,8 @@ public class ZclElectricalMeasurementCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getTotalApparentPower(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_TOTALAPPARENTPOWER).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_TOTALAPPARENTPOWER).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_TOTALAPPARENTPOWER).getLastValue();
-            }
+        if (attributes.get(ATTR_TOTALAPPARENTPOWER).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_TOTALAPPARENTPOWER).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_TOTALAPPARENTPOWER));
@@ -436,11 +421,8 @@ public class ZclElectricalMeasurementCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getRmsVoltage(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_RMSVOLTAGE).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_RMSVOLTAGE).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_RMSVOLTAGE).getLastValue();
-            }
+        if (attributes.get(ATTR_RMSVOLTAGE).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_RMSVOLTAGE).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_RMSVOLTAGE));
@@ -484,11 +466,8 @@ public class ZclElectricalMeasurementCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getRmsCurrent(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_RMSCURRENT).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_RMSCURRENT).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_RMSCURRENT).getLastValue();
-            }
+        if (attributes.get(ATTR_RMSCURRENT).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_RMSCURRENT).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_RMSCURRENT));
@@ -534,11 +513,8 @@ public class ZclElectricalMeasurementCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getActivePower(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_ACTIVEPOWER).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_ACTIVEPOWER).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_ACTIVEPOWER).getLastValue();
-            }
+        if (attributes.get(ATTR_ACTIVEPOWER).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_ACTIVEPOWER).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_ACTIVEPOWER));
@@ -582,11 +558,8 @@ public class ZclElectricalMeasurementCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getAcCurrentMultiplier(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_ACCURRENTMULTIPLIER).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_ACCURRENTMULTIPLIER).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_ACCURRENTMULTIPLIER).getLastValue();
-            }
+        if (attributes.get(ATTR_ACCURRENTMULTIPLIER).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_ACCURRENTMULTIPLIER).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_ACCURRENTMULTIPLIER));
@@ -632,11 +605,8 @@ public class ZclElectricalMeasurementCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getAcCurrentDivisor(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_ACCURRENTDIVISOR).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_ACCURRENTDIVISOR).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_ACCURRENTDIVISOR).getLastValue();
-            }
+        if (attributes.get(ATTR_ACCURRENTDIVISOR).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_ACCURRENTDIVISOR).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_ACCURRENTDIVISOR));
@@ -682,11 +652,8 @@ public class ZclElectricalMeasurementCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getAcPowerMultiplier(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_ACPOWERMULTIPLIER).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_ACPOWERMULTIPLIER).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_ACPOWERMULTIPLIER).getLastValue();
-            }
+        if (attributes.get(ATTR_ACPOWERMULTIPLIER).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_ACPOWERMULTIPLIER).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_ACPOWERMULTIPLIER));
@@ -732,11 +699,8 @@ public class ZclElectricalMeasurementCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getAcPowerDivisor(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_ACPOWERDIVISOR).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_ACPOWERDIVISOR).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_ACPOWERDIVISOR).getLastValue();
-            }
+        if (attributes.get(ATTR_ACPOWERDIVISOR).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_ACPOWERDIVISOR).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_ACPOWERDIVISOR));

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclFlowMeasurementCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclFlowMeasurementCluster.java
@@ -162,11 +162,8 @@ public class ZclFlowMeasurementCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getMeasuredValue(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_MEASUREDVALUE).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_MEASUREDVALUE).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_MEASUREDVALUE).getLastValue();
-            }
+        if (attributes.get(ATTR_MEASUREDVALUE).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_MEASUREDVALUE).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_MEASUREDVALUE));
@@ -242,11 +239,8 @@ public class ZclFlowMeasurementCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getMinMeasuredValue(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_MINMEASUREDVALUE).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_MINMEASUREDVALUE).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_MINMEASUREDVALUE).getLastValue();
-            }
+        if (attributes.get(ATTR_MINMEASUREDVALUE).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_MINMEASUREDVALUE).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_MINMEASUREDVALUE));
@@ -298,11 +292,8 @@ public class ZclFlowMeasurementCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getMaxMeasuredValue(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_MAXMEASUREDVALUE).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_MAXMEASUREDVALUE).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_MAXMEASUREDVALUE).getLastValue();
-            }
+        if (attributes.get(ATTR_MAXMEASUREDVALUE).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_MAXMEASUREDVALUE).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_MAXMEASUREDVALUE));
@@ -348,11 +339,8 @@ public class ZclFlowMeasurementCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getTolerance(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_TOLERANCE).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_TOLERANCE).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_TOLERANCE).getLastValue();
-            }
+        if (attributes.get(ATTR_TOLERANCE).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_TOLERANCE).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_TOLERANCE));

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclIasWdCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclIasWdCluster.java
@@ -139,11 +139,8 @@ public class ZclIasWdCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getMaxDuration(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_MAXDURATION).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_MAXDURATION).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_MAXDURATION).getLastValue();
-            }
+        if (attributes.get(ATTR_MAXDURATION).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_MAXDURATION).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_MAXDURATION));
@@ -181,11 +178,8 @@ public class ZclIasWdCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getZoneType(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_ZONETYPE).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_ZONETYPE).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_ZONETYPE).getLastValue();
-            }
+        if (attributes.get(ATTR_ZONETYPE).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_ZONETYPE).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_ZONETYPE));
@@ -223,11 +217,8 @@ public class ZclIasWdCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getZoneStatus(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_ZONESTATUS).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_ZONESTATUS).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_ZONESTATUS).getLastValue();
-            }
+        if (attributes.get(ATTR_ZONESTATUS).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_ZONESTATUS).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_ZONESTATUS));
@@ -280,11 +271,8 @@ public class ZclIasWdCluster extends ZclCluster {
      * @return the {@link IeeeAddress} attribute value, or null on error
      */
     public IeeeAddress getIasCieAddress(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_IAS_CIE_ADDRESS).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_IAS_CIE_ADDRESS).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (IeeeAddress) attributes.get(ATTR_IAS_CIE_ADDRESS).getLastValue();
-            }
+        if (attributes.get(ATTR_IAS_CIE_ADDRESS).isLastValueCurrent(refreshPeriod)) {
+            return (IeeeAddress) attributes.get(ATTR_IAS_CIE_ADDRESS).getLastValue();
         }
 
         return (IeeeAddress) readSync(attributes.get(ATTR_IAS_CIE_ADDRESS));

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclIasZoneCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclIasZoneCluster.java
@@ -141,11 +141,8 @@ public class ZclIasZoneCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getZoneState(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_ZONESTATE).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_ZONESTATE).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_ZONESTATE).getLastValue();
-            }
+        if (attributes.get(ATTR_ZONESTATE).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_ZONESTATE).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_ZONESTATE));
@@ -187,11 +184,8 @@ public class ZclIasZoneCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getZoneType(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_ZONETYPE).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_ZONETYPE).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_ZONETYPE).getLastValue();
-            }
+        if (attributes.get(ATTR_ZONETYPE).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_ZONETYPE).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_ZONETYPE));
@@ -233,11 +227,8 @@ public class ZclIasZoneCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getZoneStatus(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_ZONESTATUS).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_ZONESTATUS).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_ZONESTATUS).getLastValue();
-            }
+        if (attributes.get(ATTR_ZONESTATUS).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_ZONESTATUS).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_ZONESTATUS));
@@ -320,11 +311,8 @@ public class ZclIasZoneCluster extends ZclCluster {
      * @return the {@link IeeeAddress} attribute value, or null on error
      */
     public IeeeAddress getIascieAddress(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_IASCIEADDRESS).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_IASCIEADDRESS).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (IeeeAddress) attributes.get(ATTR_IASCIEADDRESS).getLastValue();
-            }
+        if (attributes.get(ATTR_IASCIEADDRESS).isLastValueCurrent(refreshPeriod)) {
+            return (IeeeAddress) attributes.get(ATTR_IASCIEADDRESS).getLastValue();
         }
 
         return (IeeeAddress) readSync(attributes.get(ATTR_IASCIEADDRESS));
@@ -362,11 +350,8 @@ public class ZclIasZoneCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getZoneId(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_ZONEID).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_ZONEID).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_ZONEID).getLastValue();
-            }
+        if (attributes.get(ATTR_ZONEID).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_ZONEID).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_ZONEID));
@@ -404,11 +389,8 @@ public class ZclIasZoneCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getNumberOfZoneSensitivityLevelsSupported(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_NUMBEROFZONESENSITIVITYLEVELSSUPPORTED).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_NUMBEROFZONESENSITIVITYLEVELSSUPPORTED).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_NUMBEROFZONESENSITIVITYLEVELSSUPPORTED).getLastValue();
-            }
+        if (attributes.get(ATTR_NUMBEROFZONESENSITIVITYLEVELSSUPPORTED).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_NUMBEROFZONESENSITIVITYLEVELSSUPPORTED).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_NUMBEROFZONESENSITIVITYLEVELSSUPPORTED));
@@ -461,11 +443,8 @@ public class ZclIasZoneCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getCurrentZoneSensitivityLevel(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_CURRENTZONESENSITIVITYLEVEL).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_CURRENTZONESENSITIVITYLEVEL).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_CURRENTZONESENSITIVITYLEVEL).getLastValue();
-            }
+        if (attributes.get(ATTR_CURRENTZONESENSITIVITYLEVEL).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_CURRENTZONESENSITIVITYLEVEL).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_CURRENTZONESENSITIVITYLEVEL));

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclIdentifyCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclIdentifyCluster.java
@@ -165,11 +165,8 @@ public class ZclIdentifyCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getIdentifyTime(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_IDENTIFYTIME).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_IDENTIFYTIME).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_IDENTIFYTIME).getLastValue();
-            }
+        if (attributes.get(ATTR_IDENTIFYTIME).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_IDENTIFYTIME).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_IDENTIFYTIME));

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclIlluminanceLevelSensingCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclIlluminanceLevelSensingCluster.java
@@ -109,11 +109,8 @@ public class ZclIlluminanceLevelSensingCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getLevelStatus(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_LEVELSTATUS).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_LEVELSTATUS).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_LEVELSTATUS).getLastValue();
-            }
+        if (attributes.get(ATTR_LEVELSTATUS).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_LEVELSTATUS).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_LEVELSTATUS));
@@ -174,11 +171,8 @@ public class ZclIlluminanceLevelSensingCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getLightSensorType(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_LIGHTSENSORTYPE).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_LIGHTSENSORTYPE).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_LIGHTSENSORTYPE).getLastValue();
-            }
+        if (attributes.get(ATTR_LIGHTSENSORTYPE).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_LIGHTSENSORTYPE).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_LIGHTSENSORTYPE));

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclIlluminanceMeasurementCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclIlluminanceMeasurementCluster.java
@@ -156,11 +156,8 @@ public class ZclIlluminanceMeasurementCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getMeasuredValue(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_MEASUREDVALUE).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_MEASUREDVALUE).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_MEASUREDVALUE).getLastValue();
-            }
+        if (attributes.get(ATTR_MEASUREDVALUE).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_MEASUREDVALUE).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_MEASUREDVALUE));
@@ -232,11 +229,8 @@ public class ZclIlluminanceMeasurementCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getMinMeasuredValue(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_MINMEASUREDVALUE).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_MINMEASUREDVALUE).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_MINMEASUREDVALUE).getLastValue();
-            }
+        if (attributes.get(ATTR_MINMEASUREDVALUE).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_MINMEASUREDVALUE).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_MINMEASUREDVALUE));
@@ -288,11 +282,8 @@ public class ZclIlluminanceMeasurementCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getMaxMeasuredValue(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_MAXMEASUREDVALUE).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_MAXMEASUREDVALUE).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_MAXMEASUREDVALUE).getLastValue();
-            }
+        if (attributes.get(ATTR_MAXMEASUREDVALUE).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_MAXMEASUREDVALUE).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_MAXMEASUREDVALUE));
@@ -338,11 +329,8 @@ public class ZclIlluminanceMeasurementCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getTolerance(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_TOLERANCE).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_TOLERANCE).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_TOLERANCE).getLastValue();
-            }
+        if (attributes.get(ATTR_TOLERANCE).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_TOLERANCE).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_TOLERANCE));
@@ -405,11 +393,8 @@ public class ZclIlluminanceMeasurementCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getLightSensorType(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_LIGHTSENSORTYPE).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_LIGHTSENSORTYPE).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_LIGHTSENSORTYPE).getLastValue();
-            }
+        if (attributes.get(ATTR_LIGHTSENSORTYPE).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_LIGHTSENSORTYPE).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_LIGHTSENSORTYPE));

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclLevelControlCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclLevelControlCluster.java
@@ -159,11 +159,8 @@ public class ZclLevelControlCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getCurrentLevel(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_CURRENTLEVEL).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_CURRENTLEVEL).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_CURRENTLEVEL).getLastValue();
-            }
+        if (attributes.get(ATTR_CURRENTLEVEL).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_CURRENTLEVEL).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_CURRENTLEVEL));
@@ -227,11 +224,8 @@ public class ZclLevelControlCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getRemainingTime(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_REMAININGTIME).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_REMAININGTIME).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_REMAININGTIME).getLastValue();
-            }
+        if (attributes.get(ATTR_REMAININGTIME).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_REMAININGTIME).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_REMAININGTIME));
@@ -308,11 +302,8 @@ public class ZclLevelControlCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getOnOffTransitionTime(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_ONOFFTRANSITIONTIME).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_ONOFFTRANSITIONTIME).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_ONOFFTRANSITIONTIME).getLastValue();
-            }
+        if (attributes.get(ATTR_ONOFFTRANSITIONTIME).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_ONOFFTRANSITIONTIME).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_ONOFFTRANSITIONTIME));
@@ -377,11 +368,8 @@ public class ZclLevelControlCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getOnLevel(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_ONLEVEL).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_ONLEVEL).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_ONLEVEL).getLastValue();
-            }
+        if (attributes.get(ATTR_ONLEVEL).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_ONLEVEL).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_ONLEVEL));
@@ -449,11 +437,8 @@ public class ZclLevelControlCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getOnTransitionTime(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_ONTRANSITIONTIME).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_ONTRANSITIONTIME).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_ONTRANSITIONTIME).getLastValue();
-            }
+        if (attributes.get(ATTR_ONTRANSITIONTIME).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_ONTRANSITIONTIME).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_ONTRANSITIONTIME));
@@ -521,11 +506,8 @@ public class ZclLevelControlCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getOffTransitionTime(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_OFFTRANSITIONTIME).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_OFFTRANSITIONTIME).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_OFFTRANSITIONTIME).getLastValue();
-            }
+        if (attributes.get(ATTR_OFFTRANSITIONTIME).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_OFFTRANSITIONTIME).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_OFFTRANSITIONTIME));
@@ -587,11 +569,8 @@ public class ZclLevelControlCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getDefaultMoveRate(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_DEFAULTMOVERATE).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_DEFAULTMOVERATE).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_DEFAULTMOVERATE).getLastValue();
-            }
+        if (attributes.get(ATTR_DEFAULTMOVERATE).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_DEFAULTMOVERATE).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_DEFAULTMOVERATE));

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclOccupancySensingCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclOccupancySensingCluster.java
@@ -142,11 +142,8 @@ public class ZclOccupancySensingCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getOccupancy(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_OCCUPANCY).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_OCCUPANCY).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_OCCUPANCY).getLastValue();
-            }
+        if (attributes.get(ATTR_OCCUPANCY).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_OCCUPANCY).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_OCCUPANCY));
@@ -209,11 +206,8 @@ public class ZclOccupancySensingCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getOccupancySensorType(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_OCCUPANCYSENSORTYPE).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_OCCUPANCYSENSORTYPE).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_OCCUPANCYSENSORTYPE).getLastValue();
-            }
+        if (attributes.get(ATTR_OCCUPANCYSENSORTYPE).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_OCCUPANCYSENSORTYPE).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_OCCUPANCYSENSORTYPE));
@@ -266,11 +260,8 @@ public class ZclOccupancySensingCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getPirOccupiedToUnoccupiedDelay(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_PIROCCUPIEDTOUNOCCUPIEDDELAY).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_PIROCCUPIEDTOUNOCCUPIEDDELAY).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_PIROCCUPIEDTOUNOCCUPIEDDELAY).getLastValue();
-            }
+        if (attributes.get(ATTR_PIROCCUPIEDTOUNOCCUPIEDDELAY).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_PIROCCUPIEDTOUNOCCUPIEDDELAY).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_PIROCCUPIEDTOUNOCCUPIEDDELAY));
@@ -323,11 +314,8 @@ public class ZclOccupancySensingCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getPirUnoccupiedToOccupiedDelay(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_PIRUNOCCUPIEDTOOCCUPIEDDELAY).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_PIRUNOCCUPIEDTOOCCUPIEDDELAY).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_PIRUNOCCUPIEDTOOCCUPIEDDELAY).getLastValue();
-            }
+        if (attributes.get(ATTR_PIRUNOCCUPIEDTOOCCUPIEDDELAY).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_PIRUNOCCUPIEDTOOCCUPIEDDELAY).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_PIRUNOCCUPIEDTOOCCUPIEDDELAY));
@@ -398,11 +386,8 @@ public class ZclOccupancySensingCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getUltraSonicOccupiedToUnoccupiedDelay(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_ULTRASONICOCCUPIEDTOUNOCCUPIEDDELAY).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_ULTRASONICOCCUPIEDTOUNOCCUPIEDDELAY).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_ULTRASONICOCCUPIEDTOUNOCCUPIEDDELAY).getLastValue();
-            }
+        if (attributes.get(ATTR_ULTRASONICOCCUPIEDTOUNOCCUPIEDDELAY).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_ULTRASONICOCCUPIEDTOUNOCCUPIEDDELAY).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_ULTRASONICOCCUPIEDTOUNOCCUPIEDDELAY));
@@ -467,11 +452,8 @@ public class ZclOccupancySensingCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getUltraSonicUnoccupiedToOccupiedDelay(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_ULTRASONICUNOCCUPIEDTOOCCUPIEDDELAY).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_ULTRASONICUNOCCUPIEDTOOCCUPIEDDELAY).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_ULTRASONICUNOCCUPIEDTOOCCUPIEDDELAY).getLastValue();
-            }
+        if (attributes.get(ATTR_ULTRASONICUNOCCUPIEDTOOCCUPIEDDELAY).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_ULTRASONICUNOCCUPIEDTOOCCUPIEDDELAY).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_ULTRASONICUNOCCUPIEDTOOCCUPIEDDELAY));
@@ -524,11 +506,8 @@ public class ZclOccupancySensingCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getUltrasonicUnoccupiedToOccupiedThreshold(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_ULTRASONICUNOCCUPIEDTOOCCUPIEDTHRESHOLD).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_ULTRASONICUNOCCUPIEDTOOCCUPIEDTHRESHOLD).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_ULTRASONICUNOCCUPIEDTOOCCUPIEDTHRESHOLD).getLastValue();
-            }
+        if (attributes.get(ATTR_ULTRASONICUNOCCUPIEDTOOCCUPIEDTHRESHOLD).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_ULTRASONICUNOCCUPIEDTOOCCUPIEDTHRESHOLD).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_ULTRASONICUNOCCUPIEDTOOCCUPIEDTHRESHOLD));

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclOnOffCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclOnOffCluster.java
@@ -115,11 +115,8 @@ public class ZclOnOffCluster extends ZclCluster {
      * @return the {@link Boolean} attribute value, or null on error
      */
     public Boolean getOnOff(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_ONOFF).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_ONOFF).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Boolean) attributes.get(ATTR_ONOFF).getLastValue();
-            }
+        if (attributes.get(ATTR_ONOFF).isLastValueCurrent(refreshPeriod)) {
+            return (Boolean) attributes.get(ATTR_ONOFF).getLastValue();
         }
 
         return (Boolean) readSync(attributes.get(ATTR_ONOFF));
@@ -190,11 +187,8 @@ public class ZclOnOffCluster extends ZclCluster {
      * @return the {@link Boolean} attribute value, or null on error
      */
     public Boolean getGlobalSceneControl(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_GLOBALSCENECONTROL).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_GLOBALSCENECONTROL).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Boolean) attributes.get(ATTR_GLOBALSCENECONTROL).getLastValue();
-            }
+        if (attributes.get(ATTR_GLOBALSCENECONTROL).isLastValueCurrent(refreshPeriod)) {
+            return (Boolean) attributes.get(ATTR_GLOBALSCENECONTROL).getLastValue();
         }
 
         return (Boolean) readSync(attributes.get(ATTR_GLOBALSCENECONTROL));
@@ -263,11 +257,8 @@ public class ZclOnOffCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getOffTime(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_OFFTIME).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_OFFTIME).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_OFFTIME).getLastValue();
-            }
+        if (attributes.get(ATTR_OFFTIME).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_OFFTIME).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_OFFTIME));
@@ -337,11 +328,8 @@ public class ZclOnOffCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getOffWaitTime(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_OFFWAITTIME).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_OFFWAITTIME).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_OFFWAITTIME).getLastValue();
-            }
+        if (attributes.get(ATTR_OFFWAITTIME).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_OFFWAITTIME).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_OFFWAITTIME));

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclOnOffSwitchConfigurationCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclOnOffSwitchConfigurationCluster.java
@@ -105,11 +105,8 @@ public class ZclOnOffSwitchConfigurationCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getSwitchType(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_SWITCHTYPE).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_SWITCHTYPE).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_SWITCHTYPE).getLastValue();
-            }
+        if (attributes.get(ATTR_SWITCHTYPE).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_SWITCHTYPE).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_SWITCHTYPE));
@@ -171,11 +168,8 @@ public class ZclOnOffSwitchConfigurationCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getSwitchActions(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_SWITCHACTIONS).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_SWITCHACTIONS).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_SWITCHACTIONS).getLastValue();
-            }
+        if (attributes.get(ATTR_SWITCHACTIONS).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_SWITCHACTIONS).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_SWITCHACTIONS));

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclOtaUpgradeCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclOtaUpgradeCluster.java
@@ -189,11 +189,8 @@ public class ZclOtaUpgradeCluster extends ZclCluster {
      * @return the {@link IeeeAddress} attribute value, or null on error
      */
     public IeeeAddress getUpgradeServerId(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_UPGRADESERVERID).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_UPGRADESERVERID).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (IeeeAddress) attributes.get(ATTR_UPGRADESERVERID).getLastValue();
-            }
+        if (attributes.get(ATTR_UPGRADESERVERID).isLastValueCurrent(refreshPeriod)) {
+            return (IeeeAddress) attributes.get(ATTR_UPGRADESERVERID).getLastValue();
         }
 
         return (IeeeAddress) readSync(attributes.get(ATTR_UPGRADESERVERID));
@@ -241,11 +238,8 @@ public class ZclOtaUpgradeCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getFileOffset(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_FILEOFFSET).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_FILEOFFSET).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_FILEOFFSET).getLastValue();
-            }
+        if (attributes.get(ATTR_FILEOFFSET).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_FILEOFFSET).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_FILEOFFSET));
@@ -289,11 +283,8 @@ public class ZclOtaUpgradeCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getCurrentFileVersion(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_CURRENTFILEVERSION).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_CURRENTFILEVERSION).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_CURRENTFILEVERSION).getLastValue();
-            }
+        if (attributes.get(ATTR_CURRENTFILEVERSION).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_CURRENTFILEVERSION).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_CURRENTFILEVERSION));
@@ -337,11 +328,8 @@ public class ZclOtaUpgradeCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getCurrentZigBeeStackVersion(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_CURRENTZIGBEESTACKVERSION).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_CURRENTZIGBEESTACKVERSION).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_CURRENTZIGBEESTACKVERSION).getLastValue();
-            }
+        if (attributes.get(ATTR_CURRENTZIGBEESTACKVERSION).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_CURRENTZIGBEESTACKVERSION).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_CURRENTZIGBEESTACKVERSION));
@@ -389,11 +377,8 @@ public class ZclOtaUpgradeCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getDownloadedFileVersion(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_DOWNLOADEDFILEVERSION).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_DOWNLOADEDFILEVERSION).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_DOWNLOADEDFILEVERSION).getLastValue();
-            }
+        if (attributes.get(ATTR_DOWNLOADEDFILEVERSION).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_DOWNLOADEDFILEVERSION).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_DOWNLOADEDFILEVERSION));
@@ -441,11 +426,8 @@ public class ZclOtaUpgradeCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getDownloadedZigBeeStackVersion(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_DOWNLOADEDZIGBEESTACKVERSION).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_DOWNLOADEDZIGBEESTACKVERSION).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_DOWNLOADEDZIGBEESTACKVERSION).getLastValue();
-            }
+        if (attributes.get(ATTR_DOWNLOADEDZIGBEESTACKVERSION).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_DOWNLOADEDZIGBEESTACKVERSION).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_DOWNLOADEDZIGBEESTACKVERSION));
@@ -495,11 +477,8 @@ public class ZclOtaUpgradeCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getImageUpgradeStatus(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_IMAGEUPGRADESTATUS).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_IMAGEUPGRADESTATUS).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_IMAGEUPGRADESTATUS).getLastValue();
-            }
+        if (attributes.get(ATTR_IMAGEUPGRADESTATUS).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_IMAGEUPGRADESTATUS).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_IMAGEUPGRADESTATUS));
@@ -537,11 +516,8 @@ public class ZclOtaUpgradeCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getManufacturerId(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_MANUFACTURERID).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_MANUFACTURERID).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_MANUFACTURERID).getLastValue();
-            }
+        if (attributes.get(ATTR_MANUFACTURERID).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_MANUFACTURERID).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_MANUFACTURERID));
@@ -579,11 +555,8 @@ public class ZclOtaUpgradeCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getImageTypeId(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_IMAGETYPEID).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_IMAGETYPEID).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_IMAGETYPEID).getLastValue();
-            }
+        if (attributes.get(ATTR_IMAGETYPEID).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_IMAGETYPEID).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_IMAGETYPEID));
@@ -639,11 +612,8 @@ public class ZclOtaUpgradeCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getMinimumBlockRequestDelay(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_MINIMUMBLOCKREQUESTDELAY).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_MINIMUMBLOCKREQUESTDELAY).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_MINIMUMBLOCKREQUESTDELAY).getLastValue();
-            }
+        if (attributes.get(ATTR_MINIMUMBLOCKREQUESTDELAY).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_MINIMUMBLOCKREQUESTDELAY).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_MINIMUMBLOCKREQUESTDELAY));
@@ -681,11 +651,8 @@ public class ZclOtaUpgradeCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getImageStamp(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_IMAGESTAMP).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_IMAGESTAMP).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_IMAGESTAMP).getLastValue();
-            }
+        if (attributes.get(ATTR_IMAGESTAMP).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_IMAGESTAMP).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_IMAGESTAMP));

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclPowerConfigurationCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclPowerConfigurationCluster.java
@@ -269,11 +269,8 @@ public class ZclPowerConfigurationCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getMainsVoltage(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_MAINSVOLTAGE).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_MAINSVOLTAGE).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_MAINSVOLTAGE).getLastValue();
-            }
+        if (attributes.get(ATTR_MAINSVOLTAGE).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_MAINSVOLTAGE).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_MAINSVOLTAGE));
@@ -341,11 +338,8 @@ public class ZclPowerConfigurationCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getMainsFrequency(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_MAINSFREQUENCY).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_MAINSFREQUENCY).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_MAINSFREQUENCY).getLastValue();
-            }
+        if (attributes.get(ATTR_MAINSFREQUENCY).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_MAINSFREQUENCY).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_MAINSFREQUENCY));
@@ -407,11 +401,8 @@ public class ZclPowerConfigurationCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getMainsAlarmMask(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_MAINSALARMMASK).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_MAINSALARMMASK).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_MAINSALARMMASK).getLastValue();
-            }
+        if (attributes.get(ATTR_MAINSALARMMASK).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_MAINSALARMMASK).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_MAINSALARMMASK));
@@ -509,11 +500,8 @@ public class ZclPowerConfigurationCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getMainsVoltageMinThreshold(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_MAINSVOLTAGEMINTHRESHOLD).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_MAINSVOLTAGEMINTHRESHOLD).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_MAINSVOLTAGEMINTHRESHOLD).getLastValue();
-            }
+        if (attributes.get(ATTR_MAINSVOLTAGEMINTHRESHOLD).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_MAINSVOLTAGEMINTHRESHOLD).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_MAINSVOLTAGEMINTHRESHOLD));
@@ -611,11 +599,8 @@ public class ZclPowerConfigurationCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getMainsVoltageMaxThreshold(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_MAINSVOLTAGEMAXTHRESHOLD).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_MAINSVOLTAGEMAXTHRESHOLD).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_MAINSVOLTAGEMAXTHRESHOLD).getLastValue();
-            }
+        if (attributes.get(ATTR_MAINSVOLTAGEMAXTHRESHOLD).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_MAINSVOLTAGEMAXTHRESHOLD).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_MAINSVOLTAGEMAXTHRESHOLD));
@@ -689,11 +674,8 @@ public class ZclPowerConfigurationCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getMainsVoltageDwellTripPoint(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_MAINSVOLTAGEDWELLTRIPPOINT).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_MAINSVOLTAGEDWELLTRIPPOINT).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_MAINSVOLTAGEDWELLTRIPPOINT).getLastValue();
-            }
+        if (attributes.get(ATTR_MAINSVOLTAGEDWELLTRIPPOINT).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_MAINSVOLTAGEDWELLTRIPPOINT).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_MAINSVOLTAGEDWELLTRIPPOINT));
@@ -739,11 +721,8 @@ public class ZclPowerConfigurationCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getBatteryVoltage(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_BATTERYVOLTAGE).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_BATTERYVOLTAGE).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_BATTERYVOLTAGE).getLastValue();
-            }
+        if (attributes.get(ATTR_BATTERYVOLTAGE).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_BATTERYVOLTAGE).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_BATTERYVOLTAGE));
@@ -781,11 +760,8 @@ public class ZclPowerConfigurationCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getBatteryPercentageRemaining(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_BATTERYPERCENTAGEREMAINING).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_BATTERYPERCENTAGEREMAINING).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_BATTERYPERCENTAGEREMAINING).getLastValue();
-            }
+        if (attributes.get(ATTR_BATTERYPERCENTAGEREMAINING).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_BATTERYPERCENTAGEREMAINING).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_BATTERYPERCENTAGEREMAINING));
@@ -864,11 +840,8 @@ public class ZclPowerConfigurationCluster extends ZclCluster {
      * @return the {@link String} attribute value, or null on error
      */
     public String getBatteryManufacturer(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_BATTERYMANUFACTURER).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_BATTERYMANUFACTURER).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (String) attributes.get(ATTR_BATTERYMANUFACTURER).getLastValue();
-            }
+        if (attributes.get(ATTR_BATTERYMANUFACTURER).isLastValueCurrent(refreshPeriod)) {
+            return (String) attributes.get(ATTR_BATTERYMANUFACTURER).getLastValue();
         }
 
         return (String) readSync(attributes.get(ATTR_BATTERYMANUFACTURER));
@@ -930,11 +903,8 @@ public class ZclPowerConfigurationCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getBatterySize(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_BATTERYSIZE).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_BATTERYSIZE).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_BATTERYSIZE).getLastValue();
-            }
+        if (attributes.get(ATTR_BATTERYSIZE).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_BATTERYSIZE).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_BATTERYSIZE));
@@ -996,11 +966,8 @@ public class ZclPowerConfigurationCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getBatteryAHrRating(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_BATTERYAHRRATING).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_BATTERYAHRRATING).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_BATTERYAHRRATING).getLastValue();
-            }
+        if (attributes.get(ATTR_BATTERYAHRRATING).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_BATTERYAHRRATING).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_BATTERYAHRRATING));
@@ -1062,11 +1029,8 @@ public class ZclPowerConfigurationCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getBatteryQuantity(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_BATTERYQUANTITY).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_BATTERYQUANTITY).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_BATTERYQUANTITY).getLastValue();
-            }
+        if (attributes.get(ATTR_BATTERYQUANTITY).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_BATTERYQUANTITY).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_BATTERYQUANTITY));
@@ -1128,11 +1092,8 @@ public class ZclPowerConfigurationCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getBatteryRatedVoltage(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_BATTERYRATEDVOLTAGE).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_BATTERYRATEDVOLTAGE).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_BATTERYRATEDVOLTAGE).getLastValue();
-            }
+        if (attributes.get(ATTR_BATTERYRATEDVOLTAGE).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_BATTERYRATEDVOLTAGE).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_BATTERYRATEDVOLTAGE));
@@ -1194,11 +1155,8 @@ public class ZclPowerConfigurationCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getBatteryAlarmMask(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_BATTERYALARMMASK).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_BATTERYALARMMASK).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_BATTERYALARMMASK).getLastValue();
-            }
+        if (attributes.get(ATTR_BATTERYALARMMASK).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_BATTERYALARMMASK).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_BATTERYALARMMASK));
@@ -1284,11 +1242,8 @@ public class ZclPowerConfigurationCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getBatteryVoltageMinThreshold(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_BATTERYVOLTAGEMINTHRESHOLD).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_BATTERYVOLTAGEMINTHRESHOLD).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_BATTERYVOLTAGEMINTHRESHOLD).getLastValue();
-            }
+        if (attributes.get(ATTR_BATTERYVOLTAGEMINTHRESHOLD).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_BATTERYVOLTAGEMINTHRESHOLD).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_BATTERYVOLTAGEMINTHRESHOLD));
@@ -1341,11 +1296,8 @@ public class ZclPowerConfigurationCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getBatteryVoltageThreshold1(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_BATTERYVOLTAGETHRESHOLD1).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_BATTERYVOLTAGETHRESHOLD1).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_BATTERYVOLTAGETHRESHOLD1).getLastValue();
-            }
+        if (attributes.get(ATTR_BATTERYVOLTAGETHRESHOLD1).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_BATTERYVOLTAGETHRESHOLD1).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_BATTERYVOLTAGETHRESHOLD1));
@@ -1398,11 +1350,8 @@ public class ZclPowerConfigurationCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getBatteryVoltageThreshold2(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_BATTERYVOLTAGETHRESHOLD2).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_BATTERYVOLTAGETHRESHOLD2).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_BATTERYVOLTAGETHRESHOLD2).getLastValue();
-            }
+        if (attributes.get(ATTR_BATTERYVOLTAGETHRESHOLD2).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_BATTERYVOLTAGETHRESHOLD2).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_BATTERYVOLTAGETHRESHOLD2));
@@ -1455,11 +1404,8 @@ public class ZclPowerConfigurationCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getBatteryVoltageThreshold3(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_BATTERYVOLTAGETHRESHOLD3).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_BATTERYVOLTAGETHRESHOLD3).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_BATTERYVOLTAGETHRESHOLD3).getLastValue();
-            }
+        if (attributes.get(ATTR_BATTERYVOLTAGETHRESHOLD3).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_BATTERYVOLTAGETHRESHOLD3).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_BATTERYVOLTAGETHRESHOLD3));
@@ -1512,11 +1458,8 @@ public class ZclPowerConfigurationCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getBatteryPercentageMinThreshold(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_BATTERYPERCENTAGEMINTHRESHOLD).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_BATTERYPERCENTAGEMINTHRESHOLD).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_BATTERYPERCENTAGEMINTHRESHOLD).getLastValue();
-            }
+        if (attributes.get(ATTR_BATTERYPERCENTAGEMINTHRESHOLD).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_BATTERYPERCENTAGEMINTHRESHOLD).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_BATTERYPERCENTAGEMINTHRESHOLD));
@@ -1569,11 +1512,8 @@ public class ZclPowerConfigurationCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getBatteryPercentageThreshold1(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_BATTERYPERCENTAGETHRESHOLD1).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_BATTERYPERCENTAGETHRESHOLD1).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_BATTERYPERCENTAGETHRESHOLD1).getLastValue();
-            }
+        if (attributes.get(ATTR_BATTERYPERCENTAGETHRESHOLD1).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_BATTERYPERCENTAGETHRESHOLD1).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_BATTERYPERCENTAGETHRESHOLD1));
@@ -1626,11 +1566,8 @@ public class ZclPowerConfigurationCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getBatteryPercentageThreshold2(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_BATTERYPERCENTAGETHRESHOLD2).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_BATTERYPERCENTAGETHRESHOLD2).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_BATTERYPERCENTAGETHRESHOLD2).getLastValue();
-            }
+        if (attributes.get(ATTR_BATTERYPERCENTAGETHRESHOLD2).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_BATTERYPERCENTAGETHRESHOLD2).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_BATTERYPERCENTAGETHRESHOLD2));
@@ -1683,11 +1620,8 @@ public class ZclPowerConfigurationCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getBatteryPercentageThreshold3(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_BATTERYPERCENTAGETHRESHOLD3).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_BATTERYPERCENTAGETHRESHOLD3).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_BATTERYPERCENTAGETHRESHOLD3).getLastValue();
-            }
+        if (attributes.get(ATTR_BATTERYPERCENTAGETHRESHOLD3).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_BATTERYPERCENTAGETHRESHOLD3).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_BATTERYPERCENTAGETHRESHOLD3));
@@ -1725,11 +1659,8 @@ public class ZclPowerConfigurationCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getBatteryAlarmState(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_BATTERYALARMSTATE).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_BATTERYALARMSTATE).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_BATTERYALARMSTATE).getLastValue();
-            }
+        if (attributes.get(ATTR_BATTERYALARMSTATE).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_BATTERYALARMSTATE).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_BATTERYALARMSTATE));

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclPressureMeasurementCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclPressureMeasurementCluster.java
@@ -173,11 +173,8 @@ public class ZclPressureMeasurementCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getMeasuredValue(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_MEASUREDVALUE).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_MEASUREDVALUE).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_MEASUREDVALUE).getLastValue();
-            }
+        if (attributes.get(ATTR_MEASUREDVALUE).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_MEASUREDVALUE).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_MEASUREDVALUE));
@@ -250,11 +247,8 @@ public class ZclPressureMeasurementCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getMinMeasuredValue(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_MINMEASUREDVALUE).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_MINMEASUREDVALUE).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_MINMEASUREDVALUE).getLastValue();
-            }
+        if (attributes.get(ATTR_MINMEASUREDVALUE).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_MINMEASUREDVALUE).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_MINMEASUREDVALUE));
@@ -306,11 +300,8 @@ public class ZclPressureMeasurementCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getMaxMeasuredValue(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_MAXMEASUREDVALUE).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_MAXMEASUREDVALUE).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_MAXMEASUREDVALUE).getLastValue();
-            }
+        if (attributes.get(ATTR_MAXMEASUREDVALUE).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_MAXMEASUREDVALUE).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_MAXMEASUREDVALUE));
@@ -380,11 +371,8 @@ public class ZclPressureMeasurementCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getTolerance(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_TOLERANCE).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_TOLERANCE).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_TOLERANCE).getLastValue();
-            }
+        if (attributes.get(ATTR_TOLERANCE).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_TOLERANCE).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_TOLERANCE));
@@ -422,11 +410,8 @@ public class ZclPressureMeasurementCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getScaledValue(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_SCALEDVALUE).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_SCALEDVALUE).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_SCALEDVALUE).getLastValue();
-            }
+        if (attributes.get(ATTR_SCALEDVALUE).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_SCALEDVALUE).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_SCALEDVALUE));
@@ -481,11 +466,8 @@ public class ZclPressureMeasurementCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getMinScaledValue(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_MINSCALEDVALUE).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_MINSCALEDVALUE).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_MINSCALEDVALUE).getLastValue();
-            }
+        if (attributes.get(ATTR_MINSCALEDVALUE).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_MINSCALEDVALUE).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_MINSCALEDVALUE));
@@ -523,11 +505,8 @@ public class ZclPressureMeasurementCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getMaxScaledValue(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_MAXSCALEDVALUE).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_MAXSCALEDVALUE).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_MAXSCALEDVALUE).getLastValue();
-            }
+        if (attributes.get(ATTR_MAXSCALEDVALUE).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_MAXSCALEDVALUE).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_MAXSCALEDVALUE));
@@ -565,11 +544,8 @@ public class ZclPressureMeasurementCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getScaledTolerance(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_SCALEDTOLERANCE).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_SCALEDTOLERANCE).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_SCALEDTOLERANCE).getLastValue();
-            }
+        if (attributes.get(ATTR_SCALEDTOLERANCE).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_SCALEDTOLERANCE).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_SCALEDTOLERANCE));
@@ -624,11 +600,8 @@ public class ZclPressureMeasurementCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getScale(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_SCALE).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_SCALE).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_SCALE).getLastValue();
-            }
+        if (attributes.get(ATTR_SCALE).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_SCALE).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_SCALE));

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclRelativeHumidityMeasurementCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclRelativeHumidityMeasurementCluster.java
@@ -157,11 +157,8 @@ public class ZclRelativeHumidityMeasurementCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getMeasuredValue(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_MEASUREDVALUE).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_MEASUREDVALUE).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_MEASUREDVALUE).getLastValue();
-            }
+        if (attributes.get(ATTR_MEASUREDVALUE).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_MEASUREDVALUE).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_MEASUREDVALUE));
@@ -235,11 +232,8 @@ public class ZclRelativeHumidityMeasurementCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getMinMeasuredValue(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_MINMEASUREDVALUE).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_MINMEASUREDVALUE).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_MINMEASUREDVALUE).getLastValue();
-            }
+        if (attributes.get(ATTR_MINMEASUREDVALUE).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_MINMEASUREDVALUE).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_MINMEASUREDVALUE));
@@ -291,11 +285,8 @@ public class ZclRelativeHumidityMeasurementCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getMaxMeasuredValue(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_MAXMEASUREDVALUE).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_MAXMEASUREDVALUE).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_MAXMEASUREDVALUE).getLastValue();
-            }
+        if (attributes.get(ATTR_MAXMEASUREDVALUE).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_MAXMEASUREDVALUE).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_MAXMEASUREDVALUE));
@@ -341,11 +332,8 @@ public class ZclRelativeHumidityMeasurementCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getTolerance(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_TOLERANCE).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_TOLERANCE).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_TOLERANCE).getLastValue();
-            }
+        if (attributes.get(ATTR_TOLERANCE).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_TOLERANCE).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_TOLERANCE));

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclRssiLocationCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclRssiLocationCluster.java
@@ -228,11 +228,8 @@ public class ZclRssiLocationCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getLocationType(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_LOCATIONTYPE).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_LOCATIONTYPE).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_LOCATIONTYPE).getLastValue();
-            }
+        if (attributes.get(ATTR_LOCATIONTYPE).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_LOCATIONTYPE).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_LOCATIONTYPE));
@@ -270,11 +267,8 @@ public class ZclRssiLocationCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getLocationMethod(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_LOCATIONMETHOD).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_LOCATIONMETHOD).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_LOCATIONMETHOD).getLastValue();
-            }
+        if (attributes.get(ATTR_LOCATIONMETHOD).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_LOCATIONMETHOD).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_LOCATIONMETHOD));
@@ -320,11 +314,8 @@ public class ZclRssiLocationCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getLocationAge(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_LOCATIONAGE).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_LOCATIONAGE).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_LOCATIONAGE).getLastValue();
-            }
+        if (attributes.get(ATTR_LOCATIONAGE).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_LOCATIONAGE).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_LOCATIONAGE));
@@ -380,11 +371,8 @@ public class ZclRssiLocationCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getQualityMeasure(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_QUALITYMEASURE).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_QUALITYMEASURE).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_QUALITYMEASURE).getLastValue();
-            }
+        if (attributes.get(ATTR_QUALITYMEASURE).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_QUALITYMEASURE).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_QUALITYMEASURE));
@@ -430,11 +418,8 @@ public class ZclRssiLocationCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getNumberOfDevices(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_NUMBEROFDEVICES).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_NUMBEROFDEVICES).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_NUMBEROFDEVICES).getLastValue();
-            }
+        if (attributes.get(ATTR_NUMBEROFDEVICES).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_NUMBEROFDEVICES).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_NUMBEROFDEVICES));
@@ -514,11 +499,8 @@ public class ZclRssiLocationCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getCoordinate1(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_COORDINATE1).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_COORDINATE1).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_COORDINATE1).getLastValue();
-            }
+        if (attributes.get(ATTR_COORDINATE1).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_COORDINATE1).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_COORDINATE1));
@@ -598,11 +580,8 @@ public class ZclRssiLocationCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getCoordinate2(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_COORDINATE2).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_COORDINATE2).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_COORDINATE2).getLastValue();
-            }
+        if (attributes.get(ATTR_COORDINATE2).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_COORDINATE2).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_COORDINATE2));
@@ -682,11 +661,8 @@ public class ZclRssiLocationCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getCoordinate3(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_COORDINATE3).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_COORDINATE3).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_COORDINATE3).getLastValue();
-            }
+        if (attributes.get(ATTR_COORDINATE3).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_COORDINATE3).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_COORDINATE3));
@@ -760,11 +736,8 @@ public class ZclRssiLocationCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getPower(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_POWER).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_POWER).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_POWER).getLastValue();
-            }
+        if (attributes.get(ATTR_POWER).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_POWER).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_POWER));
@@ -841,11 +814,8 @@ public class ZclRssiLocationCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getPathLossExponent(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_PATHLOSSEXPONENT).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_PATHLOSSEXPONENT).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_PATHLOSSEXPONENT).getLastValue();
-            }
+        if (attributes.get(ATTR_PATHLOSSEXPONENT).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_PATHLOSSEXPONENT).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_PATHLOSSEXPONENT));
@@ -916,11 +886,8 @@ public class ZclRssiLocationCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getReportingPeriod(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_REPORTINGPERIOD).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_REPORTINGPERIOD).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_REPORTINGPERIOD).getLastValue();
-            }
+        if (attributes.get(ATTR_REPORTINGPERIOD).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_REPORTINGPERIOD).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_REPORTINGPERIOD));
@@ -988,11 +955,8 @@ public class ZclRssiLocationCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getCalculationPeriod(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_CALCULATIONPERIOD).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_CALCULATIONPERIOD).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_CALCULATIONPERIOD).getLastValue();
-            }
+        if (attributes.get(ATTR_CALCULATIONPERIOD).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_CALCULATIONPERIOD).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_CALCULATIONPERIOD));
@@ -1060,11 +1024,8 @@ public class ZclRssiLocationCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getNumberRssiMeasurements(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_NUMBERRSSIMEASUREMENTS).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_NUMBERRSSIMEASUREMENTS).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_NUMBERRSSIMEASUREMENTS).getLastValue();
-            }
+        if (attributes.get(ATTR_NUMBERRSSIMEASUREMENTS).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_NUMBERRSSIMEASUREMENTS).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_NUMBERRSSIMEASUREMENTS));

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclScenesCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclScenesCluster.java
@@ -166,11 +166,8 @@ public class ZclScenesCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getSceneCount(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_SCENECOUNT).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_SCENECOUNT).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_SCENECOUNT).getLastValue();
-            }
+        if (attributes.get(ATTR_SCENECOUNT).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_SCENECOUNT).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_SCENECOUNT));
@@ -212,11 +209,8 @@ public class ZclScenesCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getCurrentScene(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_CURRENTSCENE).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_CURRENTSCENE).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_CURRENTSCENE).getLastValue();
-            }
+        if (attributes.get(ATTR_CURRENTSCENE).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_CURRENTSCENE).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_CURRENTSCENE));
@@ -260,11 +254,8 @@ public class ZclScenesCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getCurrentGroup(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_CURRENTGROUP).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_CURRENTGROUP).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_CURRENTGROUP).getLastValue();
-            }
+        if (attributes.get(ATTR_CURRENTGROUP).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_CURRENTGROUP).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_CURRENTGROUP));
@@ -320,11 +311,8 @@ public class ZclScenesCluster extends ZclCluster {
      * @return the {@link Boolean} attribute value, or null on error
      */
     public Boolean getSceneValid(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_SCENEVALID).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_SCENEVALID).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Boolean) attributes.get(ATTR_SCENEVALID).getLastValue();
-            }
+        if (attributes.get(ATTR_SCENEVALID).isLastValueCurrent(refreshPeriod)) {
+            return (Boolean) attributes.get(ATTR_SCENEVALID).getLastValue();
         }
 
         return (Boolean) readSync(attributes.get(ATTR_SCENEVALID));
@@ -370,11 +358,8 @@ public class ZclScenesCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getNameSupport(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_NAMESUPPORT).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_NAMESUPPORT).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_NAMESUPPORT).getLastValue();
-            }
+        if (attributes.get(ATTR_NAMESUPPORT).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_NAMESUPPORT).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_NAMESUPPORT));
@@ -424,11 +409,8 @@ public class ZclScenesCluster extends ZclCluster {
      * @return the {@link IeeeAddress} attribute value, or null on error
      */
     public IeeeAddress getLastConfiguredBy(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_LASTCONFIGUREDBY).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_LASTCONFIGUREDBY).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (IeeeAddress) attributes.get(ATTR_LASTCONFIGUREDBY).getLastValue();
-            }
+        if (attributes.get(ATTR_LASTCONFIGUREDBY).isLastValueCurrent(refreshPeriod)) {
+            return (IeeeAddress) attributes.get(ATTR_LASTCONFIGUREDBY).getLastValue();
         }
 
         return (IeeeAddress) readSync(attributes.get(ATTR_LASTCONFIGUREDBY));

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclTemperatureMeasurementCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclTemperatureMeasurementCluster.java
@@ -156,11 +156,8 @@ public class ZclTemperatureMeasurementCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getMeasuredValue(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_MEASUREDVALUE).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_MEASUREDVALUE).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_MEASUREDVALUE).getLastValue();
-            }
+        if (attributes.get(ATTR_MEASUREDVALUE).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_MEASUREDVALUE).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_MEASUREDVALUE));
@@ -236,11 +233,8 @@ public class ZclTemperatureMeasurementCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getMinMeasuredValue(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_MINMEASUREDVALUE).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_MINMEASUREDVALUE).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_MINMEASUREDVALUE).getLastValue();
-            }
+        if (attributes.get(ATTR_MINMEASUREDVALUE).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_MINMEASUREDVALUE).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_MINMEASUREDVALUE));
@@ -296,11 +290,8 @@ public class ZclTemperatureMeasurementCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getMaxMeasuredValue(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_MAXMEASUREDVALUE).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_MAXMEASUREDVALUE).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_MAXMEASUREDVALUE).getLastValue();
-            }
+        if (attributes.get(ATTR_MAXMEASUREDVALUE).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_MAXMEASUREDVALUE).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_MAXMEASUREDVALUE));
@@ -346,11 +337,8 @@ public class ZclTemperatureMeasurementCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getTolerance(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_TOLERANCE).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_TOLERANCE).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_TOLERANCE).getLastValue();
-            }
+        if (attributes.get(ATTR_TOLERANCE).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_TOLERANCE).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_TOLERANCE));

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclThermostatCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclThermostatCluster.java
@@ -217,11 +217,8 @@ public class ZclThermostatCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getLocalTemperature(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_LOCALTEMPERATURE).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_LOCALTEMPERATURE).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_LOCALTEMPERATURE).getLastValue();
-            }
+        if (attributes.get(ATTR_LOCALTEMPERATURE).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_LOCALTEMPERATURE).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_LOCALTEMPERATURE));
@@ -282,11 +279,8 @@ public class ZclThermostatCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getOutdoorTemperature(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_OUTDOORTEMPERATURE).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_OUTDOORTEMPERATURE).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_OUTDOORTEMPERATURE).getLastValue();
-            }
+        if (attributes.get(ATTR_OUTDOORTEMPERATURE).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_OUTDOORTEMPERATURE).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_OUTDOORTEMPERATURE));
@@ -328,11 +322,8 @@ public class ZclThermostatCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getOccupancy(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_OCCUPANCY).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_OCCUPANCY).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_OCCUPANCY).getLastValue();
-            }
+        if (attributes.get(ATTR_OCCUPANCY).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_OCCUPANCY).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_OCCUPANCY));
@@ -376,11 +367,8 @@ public class ZclThermostatCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getAbsMinHeatSetpointLimit(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_ABSMINHEATSETPOINTLIMIT).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_ABSMINHEATSETPOINTLIMIT).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_ABSMINHEATSETPOINTLIMIT).getLastValue();
-            }
+        if (attributes.get(ATTR_ABSMINHEATSETPOINTLIMIT).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_ABSMINHEATSETPOINTLIMIT).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_ABSMINHEATSETPOINTLIMIT));
@@ -424,11 +412,8 @@ public class ZclThermostatCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getAbsMaxHeatSetpointLimit(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_ABSMAXHEATSETPOINTLIMIT).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_ABSMAXHEATSETPOINTLIMIT).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_ABSMAXHEATSETPOINTLIMIT).getLastValue();
-            }
+        if (attributes.get(ATTR_ABSMAXHEATSETPOINTLIMIT).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_ABSMAXHEATSETPOINTLIMIT).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_ABSMAXHEATSETPOINTLIMIT));
@@ -472,11 +457,8 @@ public class ZclThermostatCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getAbsMinCoolSetpointLimit(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_ABSMINCOOLSETPOINTLIMIT).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_ABSMINCOOLSETPOINTLIMIT).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_ABSMINCOOLSETPOINTLIMIT).getLastValue();
-            }
+        if (attributes.get(ATTR_ABSMINCOOLSETPOINTLIMIT).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_ABSMINCOOLSETPOINTLIMIT).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_ABSMINCOOLSETPOINTLIMIT));
@@ -520,11 +502,8 @@ public class ZclThermostatCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getAbsMaxCoolSetpointLimit(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_ABSMAXCOOLSETPOINTLIMIT).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_ABSMAXCOOLSETPOINTLIMIT).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_ABSMAXCOOLSETPOINTLIMIT).getLastValue();
-            }
+        if (attributes.get(ATTR_ABSMAXCOOLSETPOINTLIMIT).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_ABSMAXCOOLSETPOINTLIMIT).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_ABSMAXCOOLSETPOINTLIMIT));
@@ -570,11 +549,8 @@ public class ZclThermostatCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getPiCoolingDemand(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_PICOOLINGDEMAND).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_PICOOLINGDEMAND).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_PICOOLINGDEMAND).getLastValue();
-            }
+        if (attributes.get(ATTR_PICOOLINGDEMAND).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_PICOOLINGDEMAND).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_PICOOLINGDEMAND));
@@ -641,11 +617,8 @@ public class ZclThermostatCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getPiHeatingDemand(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_PIHEATINGDEMAND).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_PIHEATINGDEMAND).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_PIHEATINGDEMAND).getLastValue();
-            }
+        if (attributes.get(ATTR_PIHEATINGDEMAND).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_PIHEATINGDEMAND).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_PIHEATINGDEMAND));
@@ -704,11 +677,8 @@ public class ZclThermostatCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getHvacSystemTypeConfiguration(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_HVACSYSTEMTYPECONFIGURATION).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_HVACSYSTEMTYPECONFIGURATION).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_HVACSYSTEMTYPECONFIGURATION).getLastValue();
-            }
+        if (attributes.get(ATTR_HVACSYSTEMTYPECONFIGURATION).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_HVACSYSTEMTYPECONFIGURATION).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_HVACSYSTEMTYPECONFIGURATION));
@@ -746,11 +716,8 @@ public class ZclThermostatCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getLocalTemperatureCalibration(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_LOCALTEMPERATURECALIBRATION).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_LOCALTEMPERATURECALIBRATION).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_LOCALTEMPERATURECALIBRATION).getLastValue();
-            }
+        if (attributes.get(ATTR_LOCALTEMPERATURECALIBRATION).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_LOCALTEMPERATURECALIBRATION).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_LOCALTEMPERATURECALIBRATION));
@@ -788,11 +755,8 @@ public class ZclThermostatCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getOccupiedCoolingSetpoint(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_OCCUPIEDCOOLINGSETPOINT).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_OCCUPIEDCOOLINGSETPOINT).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_OCCUPIEDCOOLINGSETPOINT).getLastValue();
-            }
+        if (attributes.get(ATTR_OCCUPIEDCOOLINGSETPOINT).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_OCCUPIEDCOOLINGSETPOINT).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_OCCUPIEDCOOLINGSETPOINT));
@@ -830,11 +794,8 @@ public class ZclThermostatCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getOccupiedHeatingSetpoint(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_OCCUPIEDHEATINGSETPOINT).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_OCCUPIEDHEATINGSETPOINT).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_OCCUPIEDHEATINGSETPOINT).getLastValue();
-            }
+        if (attributes.get(ATTR_OCCUPIEDHEATINGSETPOINT).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_OCCUPIEDHEATINGSETPOINT).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_OCCUPIEDHEATINGSETPOINT));
@@ -872,11 +833,8 @@ public class ZclThermostatCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getUnoccupiedCoolingSetpoint(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_UNOCCUPIEDCOOLINGSETPOINT).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_UNOCCUPIEDCOOLINGSETPOINT).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_UNOCCUPIEDCOOLINGSETPOINT).getLastValue();
-            }
+        if (attributes.get(ATTR_UNOCCUPIEDCOOLINGSETPOINT).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_UNOCCUPIEDCOOLINGSETPOINT).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_UNOCCUPIEDCOOLINGSETPOINT));
@@ -914,11 +872,8 @@ public class ZclThermostatCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getUnoccupiedHeatingSetpoint(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_UNOCCUPIEDHEATINGSETPOINT).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_UNOCCUPIEDHEATINGSETPOINT).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_UNOCCUPIEDHEATINGSETPOINT).getLastValue();
-            }
+        if (attributes.get(ATTR_UNOCCUPIEDHEATINGSETPOINT).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_UNOCCUPIEDHEATINGSETPOINT).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_UNOCCUPIEDHEATINGSETPOINT));
@@ -956,11 +911,8 @@ public class ZclThermostatCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getMinHeatSetpointLimit(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_MINHEATSETPOINTLIMIT).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_MINHEATSETPOINTLIMIT).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_MINHEATSETPOINTLIMIT).getLastValue();
-            }
+        if (attributes.get(ATTR_MINHEATSETPOINTLIMIT).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_MINHEATSETPOINTLIMIT).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_MINHEATSETPOINTLIMIT));
@@ -998,11 +950,8 @@ public class ZclThermostatCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getMaxHeatSetpointLimit(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_MAXHEATSETPOINTLIMIT).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_MAXHEATSETPOINTLIMIT).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_MAXHEATSETPOINTLIMIT).getLastValue();
-            }
+        if (attributes.get(ATTR_MAXHEATSETPOINTLIMIT).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_MAXHEATSETPOINTLIMIT).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_MAXHEATSETPOINTLIMIT));
@@ -1040,11 +989,8 @@ public class ZclThermostatCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getMinCoolSetpointLimit(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_MINCOOLSETPOINTLIMIT).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_MINCOOLSETPOINTLIMIT).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_MINCOOLSETPOINTLIMIT).getLastValue();
-            }
+        if (attributes.get(ATTR_MINCOOLSETPOINTLIMIT).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_MINCOOLSETPOINTLIMIT).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_MINCOOLSETPOINTLIMIT));
@@ -1082,11 +1028,8 @@ public class ZclThermostatCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getMaxCoolSetpointLimit(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_MAXCOOLSETPOINTLIMIT).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_MAXCOOLSETPOINTLIMIT).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_MAXCOOLSETPOINTLIMIT).getLastValue();
-            }
+        if (attributes.get(ATTR_MAXCOOLSETPOINTLIMIT).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_MAXCOOLSETPOINTLIMIT).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_MAXCOOLSETPOINTLIMIT));
@@ -1124,11 +1067,8 @@ public class ZclThermostatCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getMinSetpointDeadBand(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_MINSETPOINTDEADBAND).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_MINSETPOINTDEADBAND).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_MINSETPOINTDEADBAND).getLastValue();
-            }
+        if (attributes.get(ATTR_MINSETPOINTDEADBAND).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_MINSETPOINTDEADBAND).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_MINSETPOINTDEADBAND));
@@ -1166,11 +1106,8 @@ public class ZclThermostatCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getRemoteSensing(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_REMOTESENSING).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_REMOTESENSING).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_REMOTESENSING).getLastValue();
-            }
+        if (attributes.get(ATTR_REMOTESENSING).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_REMOTESENSING).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_REMOTESENSING));
@@ -1208,11 +1145,8 @@ public class ZclThermostatCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getControlSequenceOfOperation(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_CONTROLSEQUENCEOFOPERATION).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_CONTROLSEQUENCEOFOPERATION).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_CONTROLSEQUENCEOFOPERATION).getLastValue();
-            }
+        if (attributes.get(ATTR_CONTROLSEQUENCEOFOPERATION).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_CONTROLSEQUENCEOFOPERATION).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_CONTROLSEQUENCEOFOPERATION));
@@ -1250,11 +1184,8 @@ public class ZclThermostatCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getSystemMode(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_SYSTEMMODE).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_SYSTEMMODE).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_SYSTEMMODE).getLastValue();
-            }
+        if (attributes.get(ATTR_SYSTEMMODE).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_SYSTEMMODE).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_SYSTEMMODE));
@@ -1292,11 +1223,8 @@ public class ZclThermostatCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getAlarmMask(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_ALARMMASK).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_ALARMMASK).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_ALARMMASK).getLastValue();
-            }
+        if (attributes.get(ATTR_ALARMMASK).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_ALARMMASK).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_ALARMMASK));
@@ -1334,11 +1262,8 @@ public class ZclThermostatCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getThermostatRunningMode(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_THERMOSTATRUNNINGMODE).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_THERMOSTATRUNNINGMODE).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_THERMOSTATRUNNINGMODE).getLastValue();
-            }
+        if (attributes.get(ATTR_THERMOSTATRUNNINGMODE).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_THERMOSTATRUNNINGMODE).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_THERMOSTATRUNNINGMODE));

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclTimeCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclTimeCluster.java
@@ -200,11 +200,8 @@ public class ZclTimeCluster extends ZclCluster {
      * @return the {@link Calendar} attribute value, or null on error
      */
     public Calendar getTime(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_TIME).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_TIME).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Calendar) attributes.get(ATTR_TIME).getLastValue();
-            }
+        if (attributes.get(ATTR_TIME).isLastValueCurrent(refreshPeriod)) {
+            return (Calendar) attributes.get(ATTR_TIME).getLastValue();
         }
 
         return (Calendar) readSync(attributes.get(ATTR_TIME));
@@ -263,11 +260,8 @@ public class ZclTimeCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getTimeStatus(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_TIMESTATUS).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_TIMESTATUS).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_TIMESTATUS).getLastValue();
-            }
+        if (attributes.get(ATTR_TIMESTATUS).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_TIMESTATUS).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_TIMESTATUS));
@@ -329,11 +323,8 @@ public class ZclTimeCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getTimeZone(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_TIMEZONE).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_TIMEZONE).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_TIMEZONE).getLastValue();
-            }
+        if (attributes.get(ATTR_TIMEZONE).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_TIMEZONE).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_TIMEZONE));
@@ -395,11 +386,8 @@ public class ZclTimeCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getDstStart(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_DSTSTART).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_DSTSTART).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_DSTSTART).getLastValue();
-            }
+        if (attributes.get(ATTR_DSTSTART).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_DSTSTART).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_DSTSTART));
@@ -497,11 +485,8 @@ public class ZclTimeCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getDstEnd(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_DSTEND).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_DSTEND).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_DSTEND).getLastValue();
-            }
+        if (attributes.get(ATTR_DSTEND).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_DSTEND).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_DSTEND));
@@ -578,11 +563,8 @@ public class ZclTimeCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getDstShift(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_DSTSHIFT).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_DSTSHIFT).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_DSTSHIFT).getLastValue();
-            }
+        if (attributes.get(ATTR_DSTSHIFT).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_DSTSHIFT).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_DSTSHIFT));
@@ -630,11 +612,8 @@ public class ZclTimeCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getStandardTime(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_STANDARDTIME).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_STANDARDTIME).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_STANDARDTIME).getLastValue();
-            }
+        if (attributes.get(ATTR_STANDARDTIME).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_STANDARDTIME).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_STANDARDTIME));
@@ -682,11 +661,8 @@ public class ZclTimeCluster extends ZclCluster {
      * @return the {@link Integer} attribute value, or null on error
      */
     public Integer getLocalTime(final long refreshPeriod) {
-        if(refreshPeriod > 0 && attributes.get(ATTR_LOCALTIME).getLastReportTime() != null) {
-            long refreshTime = Calendar.getInstance().getTimeInMillis() - refreshPeriod;
-            if(attributes.get(ATTR_LOCALTIME).getLastReportTime().getTimeInMillis() < refreshTime) {
-                return (Integer) attributes.get(ATTR_LOCALTIME).getLastValue();
-            }
+        if (attributes.get(ATTR_LOCALTIME).isLastValueCurrent(refreshPeriod)) {
+            return (Integer) attributes.get(ATTR_LOCALTIME).getLastValue();
         }
 
         return (Integer) readSync(attributes.get(ATTR_LOCALTIME));

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/basic/ResetToFactoryDefaultsCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/basic/ResetToFactoryDefaultsCommand.java
@@ -14,7 +14,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * Reset to Factory Defaults Command value object class.
  * <p>
  * On receipt of this command, the device resets all the attributes of all its clusters
- * to their factory defaults.Note that ZigBee networking functionality,bindings, groups
+ * to their factory defaults. Note that ZigBee networking functionality,bindings, groups
  * or other persistent data are not affected by this command
  * <p>
  * Cluster: <b>Basic</b>. Command is sent <b>TO</b> the server.

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zcl/ZclAttributeTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zcl/ZclAttributeTest.java
@@ -8,6 +8,7 @@
 package com.zsmartsystems.zigbee.zcl;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Calendar;
@@ -53,6 +54,9 @@ public class ZclAttributeTest {
         ZclAttribute attribute = new ZclAttribute(ZclClusterType.ON_OFF, 0, "Test Name",
                 ZclDataType.UNSIGNED_8_BIT_INTEGER, false, false, false, false);
 
+        // No value has been set, so should always be false
+        assertFalse(attribute.isLastValueCurrent(Long.MAX_VALUE));
+
         Calendar start = Calendar.getInstance();
         attribute.updateValue(0);
         Calendar stop = Calendar.getInstance();
@@ -60,5 +64,14 @@ public class ZclAttributeTest {
         assertEquals(0, attribute.getLastValue());
         assertTrue(attribute.getLastReportTime().compareTo(start) >= 0);
         assertTrue(attribute.getLastReportTime().compareTo(stop) <= 0);
+
+        try {
+            Thread.sleep(100);
+        } catch (InterruptedException e) {
+            // TODO Auto-generated catch block
+            e.printStackTrace();
+        }
+        assertFalse(attribute.isLastValueCurrent(50));
+        assertTrue(attribute.isLastValueCurrent(Long.MAX_VALUE));
     }
 }


### PR DESCRIPTION
This fixes a bug with checking if an attribute needed to be updated. Also moves the check into a single place in the attribute rather than having it duplicated multiple times in the clusters.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>