### PR TITLE
Improve logging and add statistics in Ember driver. Add XON/XOFF option.

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
@@ -764,4 +764,19 @@ public class ZigBeeDongleEzsp implements ZigBeeTransportTransmit, ZigBeeTranspor
         }
         return TransportConfigResult.FAILURE;
     }
+
+    /**
+     * Get a map of statistics counters from the dongle
+     *
+     * @return map of counters
+     */
+    public Map<String, Long> getCounters() {
+        Map<String, Long> counters = new HashMap<String, Long>();
+
+        if (ashHandler != null) {
+            counters.putAll(ashHandler.getCounters());
+        }
+
+        return counters;
+    }
 }

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/ash/AshFrameAck.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/ash/AshFrameAck.java
@@ -9,14 +9,14 @@ package com.zsmartsystems.zigbee.dongle.ember.internal.ash;
 
 /**
  * ASH Frame Error
- * 
+ *
  * @author Chris Jackson
  *
  */
 public class AshFrameAck extends AshFrame {
     /**
      * Constructor to create an ASH ACK frame.
-     * 
+     *
      * @param buffer
      */
     public AshFrameAck(int ackNum) {
@@ -31,6 +31,6 @@ public class AshFrameAck extends AshFrame {
 
     @Override
     public String toString() {
-        return "AshFrameAck [ackNum=" + ackNum + "]";
+        return "AshFrameAck [ackNum=" + ackNum + ", notRdy=" + nRdy + "]";
     }
 }

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/ash/AshFrameNak.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/ash/AshFrameNak.java
@@ -31,6 +31,6 @@ public class AshFrameNak extends AshFrame {
 
     @Override
     public String toString() {
-        return "AshFrameNak [ackNum=" + ackNum + "]";
+        return "AshFrameNak [ackNum=" + ackNum + ", notRdy=" + nRdy + "]";
     }
 }

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/ash/AshFrameHandlerTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/ash/AshFrameHandlerTest.java
@@ -20,15 +20,10 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Arrays;
+import java.util.Map;
 
 import org.junit.Test;
 
-import com.zsmartsystems.zigbee.dongle.ember.internal.ash.AshFrame;
-import com.zsmartsystems.zigbee.dongle.ember.internal.ash.AshFrameAck;
-import com.zsmartsystems.zigbee.dongle.ember.internal.ash.AshFrameData;
-import com.zsmartsystems.zigbee.dongle.ember.internal.ash.AshFrameHandler;
-import com.zsmartsystems.zigbee.dongle.ember.internal.ash.AshFrameNak;
-import com.zsmartsystems.zigbee.dongle.ember.internal.ash.AshFrameRst;
 import com.zsmartsystems.zigbee.dongle.ember.internal.ash.AshFrame.FrameType;
 import com.zsmartsystems.zigbee.dongle.ember.internal.ezsp.command.EzspVersionRequest;
 import com.zsmartsystems.zigbee.transport.ZigBeePort;
@@ -244,5 +239,22 @@ public class AshFrameHandlerTest {
         assertEquals(6, inFrame.getAckNum());
         assertEquals(2, inFrame.getFrmNum());
         assertEquals(FrameType.DATA, inFrame.getFrameType());
+    }
+
+    @Test
+    public void testGetCounters() {
+        AshFrameHandler frameHandler = new AshFrameHandler(null);
+
+        assertNotNull(frameHandler.getCounters());
+
+        Map<String, Long> counters = frameHandler.getCounters();
+
+        assertEquals(Long.valueOf(0), counters.get("ASH_RX_DAT"));
+        assertEquals(Long.valueOf(0), counters.get("ASH_TX_DAT"));
+        assertEquals(Long.valueOf(0), counters.get("ASH_RX_ACK"));
+        assertEquals(Long.valueOf(0), counters.get("ASH_TX_ACK"));
+        assertEquals(Long.valueOf(0), counters.get("ASH_RX_NAK"));
+        assertEquals(Long.valueOf(0), counters.get("ASH_TX_NAK"));
+        assertEquals(Long.valueOf(0), counters.get("ASH_RX_ERR"));
     }
 }

--- a/com.zsmartsystems.zigbee.serial/src/main/java/com/zsmartsystems/zigbee/serial/ZigBeeSerialPort.java
+++ b/com.zsmartsystems.zigbee.serial/src/main/java/com/zsmartsystems/zigbee/serial/ZigBeeSerialPort.java
@@ -137,7 +137,8 @@ public class ZigBeeSerialPort implements ZigBeePort, SerialPortEventListener {
                     serialPort.setFlowControlMode(jssc.SerialPort.FLOWCONTROL_NONE);
                     break;
                 case FLOWCONTROL_OUT_RTSCTS:
-                    serialPort.setFlowControlMode(jssc.SerialPort.FLOWCONTROL_RTSCTS_OUT);
+                    serialPort.setFlowControlMode(
+                            jssc.SerialPort.FLOWCONTROL_RTSCTS_IN | jssc.SerialPort.FLOWCONTROL_RTSCTS_OUT);
                     break;
                 case FLOWCONTROL_OUT_XONOFF:
                     serialPort.setFlowControlMode(jssc.SerialPort.FLOWCONTROL_XONXOFF_OUT);


### PR DESCRIPTION
This docs (AN706) indicate that dongles using 57k6 probably use XON/OFF flow control instead of RTS/CTS flow control, so add this as an option.

> RTS/CTS flow control is required for operation at 115,200 bps. (Other baud rates may be selected by a configuration value programmed into flash during manufacturing.) If RTS/CTS flow control cannot be supported by the host hardware, XON/XOFF may be used at 57,600 bps.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>