### PR TITLE
Minor fixes in Ember driver (retry timer and not-connected holdout)

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/ash/AshFrame.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/ash/AshFrame.java
@@ -291,7 +291,7 @@ public class AshFrame {
     }
 
     public static String frameToString(int[] inputBuffer) {
-        if (inputBuffer == null || inputBuffer.length == 4) {
+        if (inputBuffer == null || inputBuffer.length == 0) {
             return "";
         }
         StringBuilder result = new StringBuilder();
@@ -303,13 +303,5 @@ public class AshFrame {
 
     public FrameType getFrameType() {
         return frameType;
-    }
-
-    public static String frameToString(int[] inputBuffer, int length) {
-        StringBuilder result = new StringBuilder();
-        for (int i = 0; i < length; i++) {
-            result.append(String.format("%02X ", inputBuffer[i]));
-        }
-        return result.toString();
     }
 }


### PR DESCRIPTION
This fixes two small issues in the Ember ASH driver -:

* It doesn't respond to any ASH frames received until the RSTACK frame is received. The doc states -:

>Due to possible I/O buffering, it is important to note that the Host could receive several valid or invalid frames after triggering a reset of the NCP. The Host must discard all frames and errors until a valid RSTACK frame is received."

* It doubles the retry timer each time a retry is sent, up to the T_RX_MAX value

Signed-off-by: Chris Jackson <chris@cd-jackson.com>