### PR TITLE
Add IEEE address to APS structure for dongles that require long address

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeApsFrame.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeApsFrame.java
@@ -37,6 +37,11 @@ public class ZigBeeApsFrame {
     private int destinationAddress;
 
     /**
+     * Destination address.
+     */
+    private IeeeAddress destinationIeeeAddress;
+
+    /**
      * Source address
      */
     private int sourceAddress;
@@ -137,6 +142,14 @@ public class ZigBeeApsFrame {
 
     public void setDestinationAddress(int destinationAddress) {
         this.destinationAddress = destinationAddress;
+    }
+
+    public IeeeAddress getDestinationIeeeAddress() {
+        return destinationIeeeAddress;
+    }
+
+    public void setDestinationIeeeAddress(IeeeAddress destinationIeeeAddress) {
+        this.destinationIeeeAddress = destinationIeeeAddress;
     }
 
     public int getSourceAddress() {
@@ -289,4 +302,5 @@ public class ZigBeeApsFrame {
         builder.append("]");
         return builder.toString();
     }
+
 }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
@@ -504,6 +504,11 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
             apsFrame.setAddressMode(ZigBeeNwkAddressMode.DEVICE);
             apsFrame.setDestinationAddress(((ZigBeeEndpointAddress) command.getDestinationAddress()).getAddress());
             apsFrame.setDestinationEndpoint(((ZigBeeEndpointAddress) command.getDestinationAddress()).getEndpoint());
+
+            ZigBeeNode node = getNode(command.getDestinationAddress().getAddress());
+            if (node != null) {
+                apsFrame.setDestinationIeeeAddress(node.getIeeeAddress());
+            }
         } else {
             apsFrame.setAddressMode(ZigBeeNwkAddressMode.GROUP);
             // TODO: Handle multicast


### PR DESCRIPTION
Add the IEEE Address into transmit frames as this is needed by some dongles (ConBee / XBee).
Signed-off-by: Chris Jackson <chris@cd-jackson.com>