### PR TITLE
Improve robustness of XBee handler

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.xbee/src/main/java/com/zsmartsystems/zigbee/dongle/xbee/ZigBeeDongleXBee.java
+++ b/com.zsmartsystems.zigbee.dongle.xbee/src/main/java/com/zsmartsystems/zigbee/dongle/xbee/ZigBeeDongleXBee.java
@@ -189,6 +189,11 @@ public class ZigBeeDongleXBee implements ZigBeeTransportTransmit, XBeeEventListe
         XBeeIeeeAddressLowResponse ieeeLowResponse = (XBeeIeeeAddressLowResponse) frameHandler
                 .sendRequest(ieeeLowCommand);
 
+        if (ieeeHighResponse == null || ieeeLowCommand == null) {
+            logger.error("Unable to get XBee IEEE address");
+            return ZigBeeInitializeResponse.FAILED;
+        }
+
         int[] tmpAddress = new int[8];
         tmpAddress[0] = ieeeLowResponse.getIeeeAddress()[3];
         tmpAddress[1] = ieeeLowResponse.getIeeeAddress()[2];


### PR DESCRIPTION
Increases max length of received command since the detailed version command appears to be quite long on some devices. If a receive error occurs, then the next command is sent.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>