### PR TITLE
Only upload coverage results to Codacy during deployment

### DIFF
--- a/com.zsmartsystems.zigbee.test/pom.xml
+++ b/com.zsmartsystems.zigbee.test/pom.xml
@@ -72,7 +72,7 @@
                 <executions>
                     <execution>
                         <id>codacy-upload-coverage</id>
-                        <phase>verify</phase>
+                        <phase>deploy</phase>
                         <goals>
                             <goal>coverage</goal>
                         </goals>


### PR DESCRIPTION
This will now only upload the coverage results to Codacy during the deployment phase to prevent failure during a normal build.
Fixes #272 
Signed-off-by: Chris Jackson <chris@cd-jackson.com>