### PR TITLE
Fix the javadoc in ZCL commands

### DIFF
--- a/com.zsmartsystems.zigbee.autocode/src/main/java/com/zsmartsystems/zigbee/autocode/ZclProtocolCodeGenerator.java
+++ b/com.zsmartsystems.zigbee.autocode/src/main/java/com/zsmartsystems/zigbee/autocode/ZclProtocolCodeGenerator.java
@@ -1021,9 +1021,9 @@ public class ZclProtocolCodeGenerator {
                             ? "a <b>generic</b> command used across the profile."
                             : "a <b>specific</b> command used for the " + cluster.clusterName + " cluster."));
 
-                    if (cluster.clusterDescription.size() > 0) {
+                    if (command.commandDescription.size() > 0) {
                         out.println(" * <p>");
-                        outputWithLinebreak(out, "", cluster.clusterDescription);
+                        outputWithLinebreak(out, "", command.commandDescription);
                     }
 
                     out.println(" * <p>");

--- a/com.zsmartsystems.zigbee.autocode/src/main/resources/ota_definition.md
+++ b/com.zsmartsystems.zigbee.autocode/src/main/resources/ota_definition.md
@@ -2,6 +2,12 @@
 
 ## OTA Upgrade [0x0019]
 
+The cluster provides a standard way to upgrade devices in the network via OTA messages. Thus the upgrade process MAY be performed between two devices from different manufacturers. Devices are required to have application bootloader and additional memory space in order to successfully implement the cluster.
+
+It is the responsibility of the server to indicate to the clients when update images are available. The client MAY be upgraded or downgraded64. The upgrade server knows which client devices to upgrade and to what file version. The upgrade server MAY be notified of such information via the backend system. For ZR clients, the server MAY send a message to notify the device when an updated image is available. It is assumed that ZED clients will not be awake to receive an unsolicited notification of an available image. All clients (ZR and ZED) SHALL query (poll) the server periodically to determine whether the server has an image update for them. Image Notify is optional.
+
+The cluster is implemented in such a way that the client service works on both ZED and ZR devices. Being able to handle polling is mandatory for all server devices while being able to send a notify is optional. Hence, all client devices must be able to use a ‘poll’ mechanism to send query message to the server in order to see if the server has any new file for it. The polling mechanism also puts fewer resources on the upgrade server. It is ideal to have the server maintain as little state as possible since this will scale when there are hundreds of clients in the network. The upgrade server is not required to keep track of what pieces of an image that a particular client has received; instead the client SHALL do that. Lastly poll makes more sense for devices that MAY need to perform special setup to get ready to receive an image, such as unlocking flash or allocating space for the new image.
+
 ### Attributes
 
 |Id     |Name                         |Type                       |Access     |Implement |Reporting |

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclOtaUpgradeCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclOtaUpgradeCluster.java
@@ -36,9 +36,27 @@ import javax.annotation.Generated;
 /**
  * <b>OTA Upgrade</b> cluster implementation (<i>Cluster ID 0x0019</i>).
  * <p>
+ * The cluster provides a standard way to upgrade devices in the network via OTA messages. Thus the upgrade process MAY be performed between two
+ * devices from different manufacturers. Devices are required to have application bootloader and additional memory space in order to
+ * successfully implement the cluster.
+ * <p>
+ * It is the responsibility of the server to indicate to the clients when update images are available. The client MAY be upgraded or
+ * downgraded64. The upgrade server knows which client devices to upgrade and to what file version. The upgrade server MAY be notified of such
+ * information via the backend system. For ZR clients, the server MAY send a message to notify the device when an updated image is available. It
+ * is assumed that ZED clients will not be awake to receive an unsolicited notification of an available image. All clients (ZR and ZED) SHALL
+ * query (poll) the server periodically to determine whether the server has an image update for them. Image Notify is optional.
+ * <p>
+ * The cluster is implemented in such a way that the client service works on both ZED and ZR devices. Being able to handle polling is mandatory for
+ * all server devices while being able to send a notify is optional. Hence, all client devices must be able to use a ‘poll’ mechanism to send query
+ * message to the server in order to see if the server has any new file for it. The polling mechanism also puts fewer resources on the upgrade
+ * server. It is ideal to have the server maintain as little state as possible since this will scale when there are hundreds of clients in the
+ * network. The upgrade server is not required to keep track of what pieces of an image that a particular client has received; instead the client
+ * SHALL do that. Lastly poll makes more sense for devices that MAY need to perform special setup to get ready to receive an image, such as
+ * unlocking flash or allocating space for the new image.
+ * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:08:22Z")
 public class ZclOtaUpgradeCluster extends ZclCluster {
     /**
      * The ZigBee Cluster Library Cluster ID

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/alarms/AlarmCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/alarms/AlarmCommand.java
@@ -27,22 +27,15 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * Cluster: <b>Alarms</b>. Command is sent <b>FROM</b> the server.
  * This command is a <b>specific</b> command used for the Alarms cluster.
  * <p>
- * Attributes and commands for sending alarm notifications and configuring alarm
- * functionality.
- * <p>
- * Alarm conditions and their respective alarm codes are described in individual
- * clusters, along with an alarm mask field. Where not masked, alarm notifications
- * are reported to subscribed targets using binding.
- * <p>
- * Where an alarm table is implemented, all alarms, masked or otherwise, are
- * recorded and may be retrieved on demand.
- * <p>
- * Alarms may either reset automatically when the conditions that cause are no
- * longer active, or may need to be explicitly reset.
+ * The alarm command signals an alarm situation on the sending device.
+ * <br>
+ * An alarm command is generated when a  cluster  which has alarm functionality detects an alarm
+ * condition, e.g., an attribute has taken on a value that is outside a ‘safe’ range. The details
+ * are given by individual cluster specifications.
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:17Z")
 public class AlarmCommand extends ZclCommand {
     /**
      * Alarm code command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/alarms/GetAlarmCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/alarms/GetAlarmCommand.java
@@ -18,22 +18,9 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * Cluster: <b>Alarms</b>. Command is sent <b>TO</b> the server.
  * This command is a <b>specific</b> command used for the Alarms cluster.
  * <p>
- * Attributes and commands for sending alarm notifications and configuring alarm
- * functionality.
- * <p>
- * Alarm conditions and their respective alarm codes are described in individual
- * clusters, along with an alarm mask field. Where not masked, alarm notifications
- * are reported to subscribed targets using binding.
- * <p>
- * Where an alarm table is implemented, all alarms, masked or otherwise, are
- * recorded and may be retrieved on demand.
- * <p>
- * Alarms may either reset automatically when the conditions that cause are no
- * longer active, or may need to be explicitly reset.
- * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:42Z")
 public class GetAlarmCommand extends ZclCommand {
     /**
      * Default constructor.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/alarms/GetAlarmResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/alarms/GetAlarmResponse.java
@@ -27,22 +27,15 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * Cluster: <b>Alarms</b>. Command is sent <b>FROM</b> the server.
  * This command is a <b>specific</b> command used for the Alarms cluster.
  * <p>
- * Attributes and commands for sending alarm notifications and configuring alarm
- * functionality.
- * <p>
- * Alarm conditions and their respective alarm codes are described in individual
- * clusters, along with an alarm mask field. Where not masked, alarm notifications
- * are reported to subscribed targets using binding.
- * <p>
- * Where an alarm table is implemented, all alarms, masked or otherwise, are
- * recorded and may be retrieved on demand.
- * <p>
- * Alarms may either reset automatically when the conditions that cause are no
- * longer active, or may need to be explicitly reset.
+ * If there is at least one alarm record in the alarm table then the status field is set to SUCCESS.
+ * The alarm code, cluster identifier and time stamp fields SHALL all be present and SHALL take their
+ * values from the item in the alarm table that they are reporting.If there  are  no more  alarms logged
+ * in the  alarm table  then the  status field is set  to NOT_FOUND  and the alarm code, cluster
+ * identifier and time stamp fields SHALL be omitted.
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:17Z")
 public class GetAlarmResponse extends ZclCommand {
     /**
      * Status command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/alarms/ResetAlarmCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/alarms/ResetAlarmCommand.java
@@ -21,22 +21,9 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * Cluster: <b>Alarms</b>. Command is sent <b>TO</b> the server.
  * This command is a <b>specific</b> command used for the Alarms cluster.
  * <p>
- * Attributes and commands for sending alarm notifications and configuring alarm
- * functionality.
- * <p>
- * Alarm conditions and their respective alarm codes are described in individual
- * clusters, along with an alarm mask field. Where not masked, alarm notifications
- * are reported to subscribed targets using binding.
- * <p>
- * Where an alarm table is implemented, all alarms, masked or otherwise, are
- * recorded and may be retrieved on demand.
- * <p>
- * Alarms may either reset automatically when the conditions that cause are no
- * longer active, or may need to be explicitly reset.
- * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:42Z")
 public class ResetAlarmCommand extends ZclCommand {
     /**
      * Alarm code command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/alarms/ResetAlarmLogCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/alarms/ResetAlarmLogCommand.java
@@ -18,22 +18,9 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * Cluster: <b>Alarms</b>. Command is sent <b>TO</b> the server.
  * This command is a <b>specific</b> command used for the Alarms cluster.
  * <p>
- * Attributes and commands for sending alarm notifications and configuring alarm
- * functionality.
- * <p>
- * Alarm conditions and their respective alarm codes are described in individual
- * clusters, along with an alarm mask field. Where not masked, alarm notifications
- * are reported to subscribed targets using binding.
- * <p>
- * Where an alarm table is implemented, all alarms, masked or otherwise, are
- * recorded and may be retrieved on demand.
- * <p>
- * Alarms may either reset automatically when the conditions that cause are no
- * longer active, or may need to be explicitly reset.
- * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:42Z")
 public class ResetAlarmLogCommand extends ZclCommand {
     /**
      * Default constructor.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/alarms/ResetAllAlarmsCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/alarms/ResetAllAlarmsCommand.java
@@ -18,22 +18,9 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * Cluster: <b>Alarms</b>. Command is sent <b>TO</b> the server.
  * This command is a <b>specific</b> command used for the Alarms cluster.
  * <p>
- * Attributes and commands for sending alarm notifications and configuring alarm
- * functionality.
- * <p>
- * Alarm conditions and their respective alarm codes are described in individual
- * clusters, along with an alarm mask field. Where not masked, alarm notifications
- * are reported to subscribed targets using binding.
- * <p>
- * Where an alarm table is implemented, all alarms, masked or otherwise, are
- * recorded and may be retrieved on demand.
- * <p>
- * Alarms may either reset automatically when the conditions that cause are no
- * longer active, or may need to be explicitly reset.
- * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:42Z")
 public class ResetAllAlarmsCommand extends ZclCommand {
     /**
      * Default constructor.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/basic/ResetToFactoryDefaultsCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/basic/ResetToFactoryDefaultsCommand.java
@@ -22,9 +22,13 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * Cluster: <b>Basic</b>. Command is sent <b>TO</b> the server.
  * This command is a <b>specific</b> command used for the Basic cluster.
  * <p>
+ * On receipt of this command, the device resets all the attributes of all its clusters
+ * to their factory defaults. Note that ZigBee networking functionality,bindings, groups
+ * or other persistent data are not affected by this command
+ * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:42Z")
 public class ResetToFactoryDefaultsCommand extends ZclCommand {
     /**
      * Default constructor.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/ColorLoopSetCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/ColorLoopSetCommand.java
@@ -18,17 +18,12 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 /**
  * Color Loop Set Command value object class.
  * <p>
- * Cluster: <b>Color control</b>. Command is sent <b>TO</b> the server.
- * This command is a <b>specific</b> command used for the Color control cluster.
- * <p>
- * This cluster provides an interface for changing the color of a light. Color is
- * specified according to the Commission Internationale de l'Éclairage (CIE)
- * specification CIE 1931 Color Space, [B4]. Color control is carried out in terms of
- * x,y values, as defined by this specification.
+ * Cluster: <b>Color Control</b>. Command is sent <b>TO</b> the server.
+ * This command is a <b>specific</b> command used for the Color Control cluster.
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:42Z")
 public class ColorLoopSetCommand extends ZclCommand {
     /**
      * Update Flags command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/EnhancedMoveToHueAndSaturationCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/EnhancedMoveToHueAndSaturationCommand.java
@@ -18,17 +18,12 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 /**
  * Enhanced Move To Hue and Saturation Command value object class.
  * <p>
- * Cluster: <b>Color control</b>. Command is sent <b>TO</b> the server.
- * This command is a <b>specific</b> command used for the Color control cluster.
- * <p>
- * This cluster provides an interface for changing the color of a light. Color is
- * specified according to the Commission Internationale de l'Éclairage (CIE)
- * specification CIE 1931 Color Space, [B4]. Color control is carried out in terms of
- * x,y values, as defined by this specification.
+ * Cluster: <b>Color Control</b>. Command is sent <b>TO</b> the server.
+ * This command is a <b>specific</b> command used for the Color Control cluster.
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:42Z")
 public class EnhancedMoveToHueAndSaturationCommand extends ZclCommand {
     /**
      * Hue command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/EnhancedMoveToHueCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/EnhancedMoveToHueCommand.java
@@ -18,17 +18,12 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 /**
  * Enhanced Move To Hue Command value object class.
  * <p>
- * Cluster: <b>Color control</b>. Command is sent <b>TO</b> the server.
- * This command is a <b>specific</b> command used for the Color control cluster.
- * <p>
- * This cluster provides an interface for changing the color of a light. Color is
- * specified according to the Commission Internationale de l'Éclairage (CIE)
- * specification CIE 1931 Color Space, [B4]. Color control is carried out in terms of
- * x,y values, as defined by this specification.
+ * Cluster: <b>Color Control</b>. Command is sent <b>TO</b> the server.
+ * This command is a <b>specific</b> command used for the Color Control cluster.
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:42Z")
 public class EnhancedMoveToHueCommand extends ZclCommand {
     /**
      * Hue command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/EnhancedStepHueCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/EnhancedStepHueCommand.java
@@ -18,17 +18,12 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 /**
  * Enhanced Step Hue Command value object class.
  * <p>
- * Cluster: <b>Color control</b>. Command is sent <b>TO</b> the server.
- * This command is a <b>specific</b> command used for the Color control cluster.
- * <p>
- * This cluster provides an interface for changing the color of a light. Color is
- * specified according to the Commission Internationale de l'Éclairage (CIE)
- * specification CIE 1931 Color Space, [B4]. Color control is carried out in terms of
- * x,y values, as defined by this specification.
+ * Cluster: <b>Color Control</b>. Command is sent <b>TO</b> the server.
+ * This command is a <b>specific</b> command used for the Color Control cluster.
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:42Z")
 public class EnhancedStepHueCommand extends ZclCommand {
     /**
      * Step Mode command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/MoveColorCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/MoveColorCommand.java
@@ -18,17 +18,12 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 /**
  * Move Color Command value object class.
  * <p>
- * Cluster: <b>Color control</b>. Command is sent <b>TO</b> the server.
- * This command is a <b>specific</b> command used for the Color control cluster.
- * <p>
- * This cluster provides an interface for changing the color of a light. Color is
- * specified according to the Commission Internationale de l'Éclairage (CIE)
- * specification CIE 1931 Color Space, [B4]. Color control is carried out in terms of
- * x,y values, as defined by this specification.
+ * Cluster: <b>Color Control</b>. Command is sent <b>TO</b> the server.
+ * This command is a <b>specific</b> command used for the Color Control cluster.
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:42Z")
 public class MoveColorCommand extends ZclCommand {
     /**
      * RateX command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/MoveHueCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/MoveHueCommand.java
@@ -18,17 +18,12 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 /**
  * Move Hue Command value object class.
  * <p>
- * Cluster: <b>Color control</b>. Command is sent <b>TO</b> the server.
- * This command is a <b>specific</b> command used for the Color control cluster.
- * <p>
- * This cluster provides an interface for changing the color of a light. Color is
- * specified according to the Commission Internationale de l'Éclairage (CIE)
- * specification CIE 1931 Color Space, [B4]. Color control is carried out in terms of
- * x,y values, as defined by this specification.
+ * Cluster: <b>Color Control</b>. Command is sent <b>TO</b> the server.
+ * This command is a <b>specific</b> command used for the Color Control cluster.
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:42Z")
 public class MoveHueCommand extends ZclCommand {
     /**
      * Move mode command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/MoveSaturationCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/MoveSaturationCommand.java
@@ -18,17 +18,12 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 /**
  * Move Saturation Command value object class.
  * <p>
- * Cluster: <b>Color control</b>. Command is sent <b>TO</b> the server.
- * This command is a <b>specific</b> command used for the Color control cluster.
- * <p>
- * This cluster provides an interface for changing the color of a light. Color is
- * specified according to the Commission Internationale de l'Éclairage (CIE)
- * specification CIE 1931 Color Space, [B4]. Color control is carried out in terms of
- * x,y values, as defined by this specification.
+ * Cluster: <b>Color Control</b>. Command is sent <b>TO</b> the server.
+ * This command is a <b>specific</b> command used for the Color Control cluster.
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:42Z")
 public class MoveSaturationCommand extends ZclCommand {
     /**
      * Move mode command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/MoveToColorCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/MoveToColorCommand.java
@@ -18,17 +18,12 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 /**
  * Move to Color Command value object class.
  * <p>
- * Cluster: <b>Color control</b>. Command is sent <b>TO</b> the server.
- * This command is a <b>specific</b> command used for the Color control cluster.
- * <p>
- * This cluster provides an interface for changing the color of a light. Color is
- * specified according to the Commission Internationale de l'Éclairage (CIE)
- * specification CIE 1931 Color Space, [B4]. Color control is carried out in terms of
- * x,y values, as defined by this specification.
+ * Cluster: <b>Color Control</b>. Command is sent <b>TO</b> the server.
+ * This command is a <b>specific</b> command used for the Color Control cluster.
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:42Z")
 public class MoveToColorCommand extends ZclCommand {
     /**
      * ColorX command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/MoveToColorTemperatureCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/MoveToColorTemperatureCommand.java
@@ -18,17 +18,12 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 /**
  * Move to Color Temperature Command value object class.
  * <p>
- * Cluster: <b>Color control</b>. Command is sent <b>TO</b> the server.
- * This command is a <b>specific</b> command used for the Color control cluster.
- * <p>
- * This cluster provides an interface for changing the color of a light. Color is
- * specified according to the Commission Internationale de l'Éclairage (CIE)
- * specification CIE 1931 Color Space, [B4]. Color control is carried out in terms of
- * x,y values, as defined by this specification.
+ * Cluster: <b>Color Control</b>. Command is sent <b>TO</b> the server.
+ * This command is a <b>specific</b> command used for the Color Control cluster.
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:42Z")
 public class MoveToColorTemperatureCommand extends ZclCommand {
     /**
      * Color Temperature command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/MoveToHueAndSaturationCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/MoveToHueAndSaturationCommand.java
@@ -18,17 +18,12 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 /**
  * Move to Hue and Saturation Command value object class.
  * <p>
- * Cluster: <b>Color control</b>. Command is sent <b>TO</b> the server.
- * This command is a <b>specific</b> command used for the Color control cluster.
- * <p>
- * This cluster provides an interface for changing the color of a light. Color is
- * specified according to the Commission Internationale de l'Éclairage (CIE)
- * specification CIE 1931 Color Space, [B4]. Color control is carried out in terms of
- * x,y values, as defined by this specification.
+ * Cluster: <b>Color Control</b>. Command is sent <b>TO</b> the server.
+ * This command is a <b>specific</b> command used for the Color Control cluster.
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:42Z")
 public class MoveToHueAndSaturationCommand extends ZclCommand {
     /**
      * Hue command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/MoveToHueCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/MoveToHueCommand.java
@@ -18,17 +18,12 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 /**
  * Move to Hue Command value object class.
  * <p>
- * Cluster: <b>Color control</b>. Command is sent <b>TO</b> the server.
- * This command is a <b>specific</b> command used for the Color control cluster.
- * <p>
- * This cluster provides an interface for changing the color of a light. Color is
- * specified according to the Commission Internationale de l'Éclairage (CIE)
- * specification CIE 1931 Color Space, [B4]. Color control is carried out in terms of
- * x,y values, as defined by this specification.
+ * Cluster: <b>Color Control</b>. Command is sent <b>TO</b> the server.
+ * This command is a <b>specific</b> command used for the Color Control cluster.
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:42Z")
 public class MoveToHueCommand extends ZclCommand {
     /**
      * Hue command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/MoveToSaturationCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/MoveToSaturationCommand.java
@@ -18,17 +18,12 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 /**
  * Move to Saturation Command value object class.
  * <p>
- * Cluster: <b>Color control</b>. Command is sent <b>TO</b> the server.
- * This command is a <b>specific</b> command used for the Color control cluster.
- * <p>
- * This cluster provides an interface for changing the color of a light. Color is
- * specified according to the Commission Internationale de l'Éclairage (CIE)
- * specification CIE 1931 Color Space, [B4]. Color control is carried out in terms of
- * x,y values, as defined by this specification.
+ * Cluster: <b>Color Control</b>. Command is sent <b>TO</b> the server.
+ * This command is a <b>specific</b> command used for the Color Control cluster.
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:42Z")
 public class MoveToSaturationCommand extends ZclCommand {
     /**
      * Saturation command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/StepColorCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/StepColorCommand.java
@@ -18,17 +18,12 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 /**
  * Step Color Command value object class.
  * <p>
- * Cluster: <b>Color control</b>. Command is sent <b>TO</b> the server.
- * This command is a <b>specific</b> command used for the Color control cluster.
- * <p>
- * This cluster provides an interface for changing the color of a light. Color is
- * specified according to the Commission Internationale de l'Éclairage (CIE)
- * specification CIE 1931 Color Space, [B4]. Color control is carried out in terms of
- * x,y values, as defined by this specification.
+ * Cluster: <b>Color Control</b>. Command is sent <b>TO</b> the server.
+ * This command is a <b>specific</b> command used for the Color Control cluster.
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:42Z")
 public class StepColorCommand extends ZclCommand {
     /**
      * StepX command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/StepHueCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/StepHueCommand.java
@@ -18,17 +18,12 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 /**
  * Step Hue Command value object class.
  * <p>
- * Cluster: <b>Color control</b>. Command is sent <b>TO</b> the server.
- * This command is a <b>specific</b> command used for the Color control cluster.
- * <p>
- * This cluster provides an interface for changing the color of a light. Color is
- * specified according to the Commission Internationale de l'Éclairage (CIE)
- * specification CIE 1931 Color Space, [B4]. Color control is carried out in terms of
- * x,y values, as defined by this specification.
+ * Cluster: <b>Color Control</b>. Command is sent <b>TO</b> the server.
+ * This command is a <b>specific</b> command used for the Color Control cluster.
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:42Z")
 public class StepHueCommand extends ZclCommand {
     /**
      * Step mode command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/StepSaturationCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/StepSaturationCommand.java
@@ -18,17 +18,12 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 /**
  * Step Saturation Command value object class.
  * <p>
- * Cluster: <b>Color control</b>. Command is sent <b>TO</b> the server.
- * This command is a <b>specific</b> command used for the Color control cluster.
- * <p>
- * This cluster provides an interface for changing the color of a light. Color is
- * specified according to the Commission Internationale de l'Éclairage (CIE)
- * specification CIE 1931 Color Space, [B4]. Color control is carried out in terms of
- * x,y values, as defined by this specification.
+ * Cluster: <b>Color Control</b>. Command is sent <b>TO</b> the server.
+ * This command is a <b>specific</b> command used for the Color Control cluster.
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:42Z")
 public class StepSaturationCommand extends ZclCommand {
     /**
      * Step mode command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/ConfigureReportingCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/ConfigureReportingCommand.java
@@ -31,9 +31,16 @@ import com.zsmartsystems.zigbee.zcl.field.AttributeReportingConfigurationRecord;
  * Cluster: <b>General</b>. Command is sent <b>TO</b> the server.
  * This command is a <b>generic</b> command used across the profile.
  * <p>
+ * The Configure Reporting command is used to configure the reporting mechanism
+ * for one or more of the attributes of a cluster.
+ * <br>
+ * The individual cluster definitions specify which attributes shall be available to this
+ * reporting mechanism, however specific implementations of a cluster may make
+ * additional attributes available.
+ * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:42Z")
 public class ConfigureReportingCommand extends ZclCommand {
     /**
      * Records command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/ConfigureReportingResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/ConfigureReportingResponse.java
@@ -28,9 +28,12 @@ import com.zsmartsystems.zigbee.zcl.field.AttributeStatusRecord;
  * Cluster: <b>General</b>. Command is sent <b>TO</b> the server.
  * This command is a <b>generic</b> command used across the profile.
  * <p>
+ * The Configure Reporting Response command is generated in response to a
+ * Configure Reporting command.
+ * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-23T21:55:42Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:42Z")
 public class ConfigureReportingResponse extends ZclCommand {
     /**
      * Status command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/DefaultResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/DefaultResponse.java
@@ -27,9 +27,14 @@ import com.zsmartsystems.zigbee.zcl.ZclStatus;
  * Cluster: <b>General</b>. Command is sent <b>TO</b> the server.
  * This command is a <b>generic</b> command used across the profile.
  * <p>
+ * The default response command is generated when a device receives a unicast
+ * command, there is no other relevant response specified for the command, and
+ * either an error results or the Disable default response bit of its Frame control field
+ * is set to 0.
+ * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:42Z")
 public class DefaultResponse extends ZclCommand {
     /**
      * Command identifier command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/DiscoverAttributesCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/DiscoverAttributesCommand.java
@@ -25,9 +25,13 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * Cluster: <b>General</b>. Command is sent <b>TO</b> the server.
  * This command is a <b>generic</b> command used across the profile.
  * <p>
+ * The discover attributes command is generated when a remote device wishes to
+ * discover the identifiers and types of the attributes on a device which are supported
+ * within the cluster to which this command is directed.
+ * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-23T21:55:42Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:42Z")
 public class DiscoverAttributesCommand extends ZclCommand {
     /**
      * Start attribute identifier command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/DiscoverAttributesExtended.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/DiscoverAttributesExtended.java
@@ -25,9 +25,13 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * Cluster: <b>General</b>. Command is sent <b>TO</b> the server.
  * This command is a <b>generic</b> command used across the profile.
  * <p>
+ * The Discover Attributes Extended command is generated when a remote device wishes to discover the
+ * identifiers and types of the attributes on a device which are supported within the cluster to which this
+ * command is directed, including whether the attribute is readable, writeable or reportable.
+ * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:42Z")
 public class DiscoverAttributesExtended extends ZclCommand {
     /**
      * Start attribute identifier command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/DiscoverAttributesExtendedResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/DiscoverAttributesExtendedResponse.java
@@ -27,9 +27,12 @@ import com.zsmartsystems.zigbee.zcl.field.ExtendedAttributeInformation;
  * Cluster: <b>General</b>. Command is sent <b>TO</b> the server.
  * This command is a <b>generic</b> command used across the profile.
  * <p>
+ * The Discover Attributes Extended Response command is generated in response to a Discover Attributes
+ * Extended command.
+ * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:42Z")
 public class DiscoverAttributesExtendedResponse extends ZclCommand {
     /**
      * Discovery complete command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/DiscoverAttributesResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/DiscoverAttributesResponse.java
@@ -27,9 +27,12 @@ import com.zsmartsystems.zigbee.zcl.field.AttributeInformation;
  * Cluster: <b>General</b>. Command is sent <b>TO</b> the server.
  * This command is a <b>generic</b> command used across the profile.
  * <p>
+ * The discover attributes response command is generated in response to a discover
+ * attributes command.
+ * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-23T21:55:42Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:42Z")
 public class DiscoverAttributesResponse extends ZclCommand {
     /**
      * Discovery Complete command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/DiscoverCommandsGenerated.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/DiscoverCommandsGenerated.java
@@ -24,9 +24,12 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * Cluster: <b>General</b>. Command is sent <b>TO</b> the server.
  * This command is a <b>generic</b> command used across the profile.
  * <p>
+ * The Discover Commands Generated command is generated when a remote device wishes to discover the
+ * commands that a cluster may generate on the device to which this command is directed.
+ * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:42Z")
 public class DiscoverCommandsGenerated extends ZclCommand {
     /**
      * Start command identifier command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/DiscoverCommandsGeneratedResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/DiscoverCommandsGeneratedResponse.java
@@ -26,9 +26,12 @@ import java.util.List;
  * Cluster: <b>General</b>. Command is sent <b>TO</b> the server.
  * This command is a <b>generic</b> command used across the profile.
  * <p>
+ * The Discover Commands Generated Response is generated in response to a Discover Commands Generated
+ * command.
+ * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:42Z")
 public class DiscoverCommandsGeneratedResponse extends ZclCommand {
     /**
      * Discovery complete command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/DiscoverCommandsReceived.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/DiscoverCommandsReceived.java
@@ -24,9 +24,12 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * Cluster: <b>General</b>. Command is sent <b>TO</b> the server.
  * This command is a <b>generic</b> command used across the profile.
  * <p>
+ * The Discover Commands Received command is generated when a remote device wishes to discover the
+ * optional and mandatory commands the cluster to which this command is sent can process.
+ * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:42Z")
 public class DiscoverCommandsReceived extends ZclCommand {
     /**
      * Start command identifier command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/DiscoverCommandsReceivedResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/DiscoverCommandsReceivedResponse.java
@@ -26,9 +26,12 @@ import java.util.List;
  * Cluster: <b>General</b>. Command is sent <b>TO</b> the server.
  * This command is a <b>generic</b> command used across the profile.
  * <p>
+ * The Discover Commands Received Response is generated in response to a Discover Commands Received
+ * command.
+ * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:42Z")
 public class DiscoverCommandsReceivedResponse extends ZclCommand {
     /**
      * Discovery complete command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/ReadAttributesCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/ReadAttributesCommand.java
@@ -27,9 +27,13 @@ import java.util.List;
  * Cluster: <b>General</b>. Command is sent <b>TO</b> the server.
  * This command is a <b>generic</b> command used across the profile.
  * <p>
+ * The read attributes command is generated when a device wishes to determine the
+ * values of one or more attributes located on another device. Each attribute
+ * identifier field shall contain the identifier of the attribute to be read.
+ * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:42Z")
 public class ReadAttributesCommand extends ZclCommand {
     /**
      * Identifiers command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/ReadAttributesResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/ReadAttributesResponse.java
@@ -31,9 +31,16 @@ import com.zsmartsystems.zigbee.zcl.field.ReadAttributeStatusRecord;
  * Cluster: <b>General</b>. Command is sent <b>TO</b> the server.
  * This command is a <b>generic</b> command used across the profile.
  * <p>
+ * The read attributes response command is generated in response to a read attributes
+ * or read attributes structured command. The command frame shall contain a read
+ * attribute status record for each attribute identifier specified in the original read
+ * attributes or read attributes structured command. For each read attribute status
+ * record, the attribute identifier field shall contain the identifier specified in the
+ * original read attributes or read attributes structured command.
+ * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:42Z")
 public class ReadAttributesResponse extends ZclCommand {
     /**
      * Records command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/ReadAttributesStructuredCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/ReadAttributesStructuredCommand.java
@@ -26,9 +26,14 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * Cluster: <b>General</b>. Command is sent <b>TO</b> the server.
  * This command is a <b>generic</b> command used across the profile.
  * <p>
+ * The read attributes command is generated when a device wishes to determine the
+ * values of one or more attributes, or elements of attributes, located on another
+ * device. Each attribute identifier field shall contain the identifier of the attribute to
+ * be read.
+ * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:42Z")
 public class ReadAttributesStructuredCommand extends ZclCommand {
     /**
      * Attribute selectors command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/ReadReportingConfigurationCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/ReadReportingConfigurationCommand.java
@@ -27,9 +27,12 @@ import com.zsmartsystems.zigbee.zcl.field.AttributeRecord;
  * Cluster: <b>General</b>. Command is sent <b>TO</b> the server.
  * This command is a <b>generic</b> command used across the profile.
  * <p>
+ * The Read Reporting Configuration command is used to read the configuration
+ * details of the reporting mechanism for one or more of the attributes of a cluster.
+ * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:42Z")
 public class ReadReportingConfigurationCommand extends ZclCommand {
     /**
      * Records command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/ReadReportingConfigurationResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/ReadReportingConfigurationResponse.java
@@ -27,9 +27,12 @@ import com.zsmartsystems.zigbee.zcl.field.AttributeReportingConfigurationRecord;
  * Cluster: <b>General</b>. Command is sent <b>TO</b> the server.
  * This command is a <b>generic</b> command used across the profile.
  * <p>
+ * The Read Reporting Configuration Response command is used to respond to a
+ * Read Reporting Configuration command.
+ * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:42Z")
 public class ReadReportingConfigurationResponse extends ZclCommand {
     /**
      * Records command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/ReportAttributesCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/ReportAttributesCommand.java
@@ -29,9 +29,14 @@ import com.zsmartsystems.zigbee.zcl.field.AttributeReport;
  * Cluster: <b>General</b>. Command is sent <b>TO</b> the server.
  * This command is a <b>generic</b> command used across the profile.
  * <p>
+ * The report attributes command is used by a device to report the values of one or
+ * more of its attributes to another device, bound a priori. Individual clusters, defined
+ * elsewhere in the ZCL, define which attributes are to be reported and at what
+ * interval.
+ * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:42Z")
 public class ReportAttributesCommand extends ZclCommand {
     /**
      * Reports command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/WriteAttributesCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/WriteAttributesCommand.java
@@ -29,9 +29,14 @@ import com.zsmartsystems.zigbee.zcl.field.WriteAttributeRecord;
  * Cluster: <b>General</b>. Command is sent <b>TO</b> the server.
  * This command is a <b>generic</b> command used across the profile.
  * <p>
+ * The write attributes command is generated when a device wishes to change the
+ * values of one or more attributes located on another device. Each write attribute
+ * record shall contain the identifier and the actual value of the attribute to be
+ * written.
+ * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:42Z")
 public class WriteAttributesCommand extends ZclCommand {
     /**
      * Records command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/WriteAttributesNoResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/WriteAttributesNoResponse.java
@@ -29,9 +29,14 @@ import com.zsmartsystems.zigbee.zcl.field.WriteAttributeRecord;
  * Cluster: <b>General</b>. Command is sent <b>TO</b> the server.
  * This command is a <b>generic</b> command used across the profile.
  * <p>
+ * The write attributes no response command is generated when a device wishes to
+ * change the value of one or more attributes located on another device but does not
+ * require a response. Each write attribute record shall contain the identifier and the
+ * actual value of the attribute to be written.
+ * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:42Z")
 public class WriteAttributesNoResponse extends ZclCommand {
     /**
      * Records command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/WriteAttributesResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/WriteAttributesResponse.java
@@ -27,9 +27,12 @@ import com.zsmartsystems.zigbee.zcl.field.WriteAttributeStatusRecord;
  * Cluster: <b>General</b>. Command is sent <b>TO</b> the server.
  * This command is a <b>generic</b> command used across the profile.
  * <p>
+ * The write attributes response command is generated in response to a write
+ * attributes command.
+ * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:42Z")
 public class WriteAttributesResponse extends ZclCommand {
     /**
      * Records command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/WriteAttributesStructuredCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/WriteAttributesStructuredCommand.java
@@ -27,9 +27,14 @@ import com.zsmartsystems.zigbee.zcl.ZclStatus;
  * Cluster: <b>General</b>. Command is sent <b>TO</b> the server.
  * This command is a <b>generic</b> command used across the profile.
  * <p>
+ * The write attributes structured command is generated when a device wishes to
+ * change the values of one or more attributes located on another device. Each write
+ * attribute record shall contain the identifier and the actual value of the attribute, or
+ * element thereof, to be written.
+ * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-23T21:55:42Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:42Z")
 public class WriteAttributesStructuredCommand extends ZclCommand {
     /**
      * Status command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/WriteAttributesStructuredResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/WriteAttributesStructuredResponse.java
@@ -28,9 +28,12 @@ import com.zsmartsystems.zigbee.zcl.field.WriteAttributeStatusRecord;
  * Cluster: <b>General</b>. Command is sent <b>TO</b> the server.
  * This command is a <b>generic</b> command used across the profile.
  * <p>
+ * The write attributes structured response command is generated in response to a
+ * write attributes structured command.
+ * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-23T21:55:42Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:42Z")
 public class WriteAttributesStructuredResponse extends ZclCommand {
     /**
      * Status command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/WriteAttributesUndividedCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/WriteAttributesUndividedCommand.java
@@ -35,9 +35,20 @@ import com.zsmartsystems.zigbee.zcl.field.WriteAttributeRecord;
  * Cluster: <b>General</b>. Command is sent <b>TO</b> the server.
  * This command is a <b>generic</b> command used across the profile.
  * <p>
+ * The write attributes undivided command is generated when a device wishes to
+ * change the values of one or more attributes located on another device, in such a
+ * way that if any attribute cannot be written (e.g. if an attribute is not implemented
+ * on the device, or a value to be written is outside its valid range), no attribute
+ * values are changed.
+ * <br>
+ * In all other respects, including generation of a write attributes response command,
+ * the format and operation of the command is the same as that of the write attributes
+ * command, except that the command identifier field shall be set to indicate the
+ * write attributes undivided command.
+ * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:42Z")
 public class WriteAttributesUndividedCommand extends ZclCommand {
     /**
      * Records command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/groups/AddGroupCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/groups/AddGroupCommand.java
@@ -21,27 +21,9 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * Cluster: <b>Groups</b>. Command is sent <b>TO</b> the server.
  * This command is a <b>specific</b> command used for the Groups cluster.
  * <p>
- * The ZigBee specification provides the capability for group addressing. That is,
- * any endpoint on any device may be assigned to one or more groups, each labeled
- * with a 16-bit identifier (0x0001 – 0xfff7), which acts for all intents and purposes
- * like a network address. Once a group is established, frames, sent using the
- * APSDE-DATA.request primitive and having a DstAddrMode of 0x01, denoting
- * group addressing, will be delivered to every endpoint assigned to the group
- * address named in the DstAddr parameter of the outgoing APSDE-DATA.request
- * primitive on every device in the network for which there are such endpoints.
- * <p>
- * Management of group membership on each device and endpoint is implemented
- * by the APS, but the over-the-air messages that allow for remote management and
- * commissioning of groups are defined here in the cluster library on the theory that,
- * while the basic group addressing facilities are integral to the operation of the
- * stack, not every device will need or want to implement this management cluster.
- * Furthermore, the placement of the management commands here allows developers
- * of proprietary profiles to avoid implementing the library cluster but still exploit
- * group addressing
- * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:42Z")
 public class AddGroupCommand extends ZclCommand {
     /**
      * Group ID command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/groups/AddGroupIfIdentifyingCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/groups/AddGroupIfIdentifyingCommand.java
@@ -21,27 +21,9 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * Cluster: <b>Groups</b>. Command is sent <b>TO</b> the server.
  * This command is a <b>specific</b> command used for the Groups cluster.
  * <p>
- * The ZigBee specification provides the capability for group addressing. That is,
- * any endpoint on any device may be assigned to one or more groups, each labeled
- * with a 16-bit identifier (0x0001 – 0xfff7), which acts for all intents and purposes
- * like a network address. Once a group is established, frames, sent using the
- * APSDE-DATA.request primitive and having a DstAddrMode of 0x01, denoting
- * group addressing, will be delivered to every endpoint assigned to the group
- * address named in the DstAddr parameter of the outgoing APSDE-DATA.request
- * primitive on every device in the network for which there are such endpoints.
- * <p>
- * Management of group membership on each device and endpoint is implemented
- * by the APS, but the over-the-air messages that allow for remote management and
- * commissioning of groups are defined here in the cluster library on the theory that,
- * while the basic group addressing facilities are integral to the operation of the
- * stack, not every device will need or want to implement this management cluster.
- * Furthermore, the placement of the management commands here allows developers
- * of proprietary profiles to avoid implementing the library cluster but still exploit
- * group addressing
- * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:42Z")
 public class AddGroupIfIdentifyingCommand extends ZclCommand {
     /**
      * Group ID command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/groups/AddGroupResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/groups/AddGroupResponse.java
@@ -21,27 +21,9 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * Cluster: <b>Groups</b>. Command is sent <b>FROM</b> the server.
  * This command is a <b>specific</b> command used for the Groups cluster.
  * <p>
- * The ZigBee specification provides the capability for group addressing. That is,
- * any endpoint on any device may be assigned to one or more groups, each labeled
- * with a 16-bit identifier (0x0001 – 0xfff7), which acts for all intents and purposes
- * like a network address. Once a group is established, frames, sent using the
- * APSDE-DATA.request primitive and having a DstAddrMode of 0x01, denoting
- * group addressing, will be delivered to every endpoint assigned to the group
- * address named in the DstAddr parameter of the outgoing APSDE-DATA.request
- * primitive on every device in the network for which there are such endpoints.
- * <p>
- * Management of group membership on each device and endpoint is implemented
- * by the APS, but the over-the-air messages that allow for remote management and
- * commissioning of groups are defined here in the cluster library on the theory that,
- * while the basic group addressing facilities are integral to the operation of the
- * stack, not every device will need or want to implement this management cluster.
- * Furthermore, the placement of the management commands here allows developers
- * of proprietary profiles to avoid implementing the library cluster but still exploit
- * group addressing
- * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:42Z")
 public class AddGroupResponse extends ZclCommand {
     /**
      * Status command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/groups/GetGroupMembershipCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/groups/GetGroupMembershipCommand.java
@@ -23,27 +23,9 @@ import java.util.List;
  * Cluster: <b>Groups</b>. Command is sent <b>TO</b> the server.
  * This command is a <b>specific</b> command used for the Groups cluster.
  * <p>
- * The ZigBee specification provides the capability for group addressing. That is,
- * any endpoint on any device may be assigned to one or more groups, each labeled
- * with a 16-bit identifier (0x0001 – 0xfff7), which acts for all intents and purposes
- * like a network address. Once a group is established, frames, sent using the
- * APSDE-DATA.request primitive and having a DstAddrMode of 0x01, denoting
- * group addressing, will be delivered to every endpoint assigned to the group
- * address named in the DstAddr parameter of the outgoing APSDE-DATA.request
- * primitive on every device in the network for which there are such endpoints.
- * <p>
- * Management of group membership on each device and endpoint is implemented
- * by the APS, but the over-the-air messages that allow for remote management and
- * commissioning of groups are defined here in the cluster library on the theory that,
- * while the basic group addressing facilities are integral to the operation of the
- * stack, not every device will need or want to implement this management cluster.
- * Furthermore, the placement of the management commands here allows developers
- * of proprietary profiles to avoid implementing the library cluster but still exploit
- * group addressing
- * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:42Z")
 public class GetGroupMembershipCommand extends ZclCommand {
     /**
      * Group count command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/groups/GetGroupMembershipResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/groups/GetGroupMembershipResponse.java
@@ -23,27 +23,9 @@ import java.util.List;
  * Cluster: <b>Groups</b>. Command is sent <b>FROM</b> the server.
  * This command is a <b>specific</b> command used for the Groups cluster.
  * <p>
- * The ZigBee specification provides the capability for group addressing. That is,
- * any endpoint on any device may be assigned to one or more groups, each labeled
- * with a 16-bit identifier (0x0001 – 0xfff7), which acts for all intents and purposes
- * like a network address. Once a group is established, frames, sent using the
- * APSDE-DATA.request primitive and having a DstAddrMode of 0x01, denoting
- * group addressing, will be delivered to every endpoint assigned to the group
- * address named in the DstAddr parameter of the outgoing APSDE-DATA.request
- * primitive on every device in the network for which there are such endpoints.
- * <p>
- * Management of group membership on each device and endpoint is implemented
- * by the APS, but the over-the-air messages that allow for remote management and
- * commissioning of groups are defined here in the cluster library on the theory that,
- * while the basic group addressing facilities are integral to the operation of the
- * stack, not every device will need or want to implement this management cluster.
- * Furthermore, the placement of the management commands here allows developers
- * of proprietary profiles to avoid implementing the library cluster but still exploit
- * group addressing
- * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:42Z")
 public class GetGroupMembershipResponse extends ZclCommand {
     /**
      * Capacity command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/groups/RemoveAllGroupsCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/groups/RemoveAllGroupsCommand.java
@@ -18,27 +18,9 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * Cluster: <b>Groups</b>. Command is sent <b>TO</b> the server.
  * This command is a <b>specific</b> command used for the Groups cluster.
  * <p>
- * The ZigBee specification provides the capability for group addressing. That is,
- * any endpoint on any device may be assigned to one or more groups, each labeled
- * with a 16-bit identifier (0x0001 – 0xfff7), which acts for all intents and purposes
- * like a network address. Once a group is established, frames, sent using the
- * APSDE-DATA.request primitive and having a DstAddrMode of 0x01, denoting
- * group addressing, will be delivered to every endpoint assigned to the group
- * address named in the DstAddr parameter of the outgoing APSDE-DATA.request
- * primitive on every device in the network for which there are such endpoints.
- * <p>
- * Management of group membership on each device and endpoint is implemented
- * by the APS, but the over-the-air messages that allow for remote management and
- * commissioning of groups are defined here in the cluster library on the theory that,
- * while the basic group addressing facilities are integral to the operation of the
- * stack, not every device will need or want to implement this management cluster.
- * Furthermore, the placement of the management commands here allows developers
- * of proprietary profiles to avoid implementing the library cluster but still exploit
- * group addressing
- * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:42Z")
 public class RemoveAllGroupsCommand extends ZclCommand {
     /**
      * Default constructor.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/groups/RemoveGroupCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/groups/RemoveGroupCommand.java
@@ -21,27 +21,9 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * Cluster: <b>Groups</b>. Command is sent <b>TO</b> the server.
  * This command is a <b>specific</b> command used for the Groups cluster.
  * <p>
- * The ZigBee specification provides the capability for group addressing. That is,
- * any endpoint on any device may be assigned to one or more groups, each labeled
- * with a 16-bit identifier (0x0001 – 0xfff7), which acts for all intents and purposes
- * like a network address. Once a group is established, frames, sent using the
- * APSDE-DATA.request primitive and having a DstAddrMode of 0x01, denoting
- * group addressing, will be delivered to every endpoint assigned to the group
- * address named in the DstAddr parameter of the outgoing APSDE-DATA.request
- * primitive on every device in the network for which there are such endpoints.
- * <p>
- * Management of group membership on each device and endpoint is implemented
- * by the APS, but the over-the-air messages that allow for remote management and
- * commissioning of groups are defined here in the cluster library on the theory that,
- * while the basic group addressing facilities are integral to the operation of the
- * stack, not every device will need or want to implement this management cluster.
- * Furthermore, the placement of the management commands here allows developers
- * of proprietary profiles to avoid implementing the library cluster but still exploit
- * group addressing
- * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:42Z")
 public class RemoveGroupCommand extends ZclCommand {
     /**
      * Group ID command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/groups/RemoveGroupResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/groups/RemoveGroupResponse.java
@@ -21,27 +21,9 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * Cluster: <b>Groups</b>. Command is sent <b>FROM</b> the server.
  * This command is a <b>specific</b> command used for the Groups cluster.
  * <p>
- * The ZigBee specification provides the capability for group addressing. That is,
- * any endpoint on any device may be assigned to one or more groups, each labeled
- * with a 16-bit identifier (0x0001 – 0xfff7), which acts for all intents and purposes
- * like a network address. Once a group is established, frames, sent using the
- * APSDE-DATA.request primitive and having a DstAddrMode of 0x01, denoting
- * group addressing, will be delivered to every endpoint assigned to the group
- * address named in the DstAddr parameter of the outgoing APSDE-DATA.request
- * primitive on every device in the network for which there are such endpoints.
- * <p>
- * Management of group membership on each device and endpoint is implemented
- * by the APS, but the over-the-air messages that allow for remote management and
- * commissioning of groups are defined here in the cluster library on the theory that,
- * while the basic group addressing facilities are integral to the operation of the
- * stack, not every device will need or want to implement this management cluster.
- * Furthermore, the placement of the management commands here allows developers
- * of proprietary profiles to avoid implementing the library cluster but still exploit
- * group addressing
- * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:42Z")
 public class RemoveGroupResponse extends ZclCommand {
     /**
      * Status command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/groups/ViewGroupCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/groups/ViewGroupCommand.java
@@ -21,27 +21,9 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * Cluster: <b>Groups</b>. Command is sent <b>TO</b> the server.
  * This command is a <b>specific</b> command used for the Groups cluster.
  * <p>
- * The ZigBee specification provides the capability for group addressing. That is,
- * any endpoint on any device may be assigned to one or more groups, each labeled
- * with a 16-bit identifier (0x0001 – 0xfff7), which acts for all intents and purposes
- * like a network address. Once a group is established, frames, sent using the
- * APSDE-DATA.request primitive and having a DstAddrMode of 0x01, denoting
- * group addressing, will be delivered to every endpoint assigned to the group
- * address named in the DstAddr parameter of the outgoing APSDE-DATA.request
- * primitive on every device in the network for which there are such endpoints.
- * <p>
- * Management of group membership on each device and endpoint is implemented
- * by the APS, but the over-the-air messages that allow for remote management and
- * commissioning of groups are defined here in the cluster library on the theory that,
- * while the basic group addressing facilities are integral to the operation of the
- * stack, not every device will need or want to implement this management cluster.
- * Furthermore, the placement of the management commands here allows developers
- * of proprietary profiles to avoid implementing the library cluster but still exploit
- * group addressing
- * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:42Z")
 public class ViewGroupCommand extends ZclCommand {
     /**
      * Group ID command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/groups/ViewGroupResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/groups/ViewGroupResponse.java
@@ -21,27 +21,9 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * Cluster: <b>Groups</b>. Command is sent <b>FROM</b> the server.
  * This command is a <b>specific</b> command used for the Groups cluster.
  * <p>
- * The ZigBee specification provides the capability for group addressing. That is,
- * any endpoint on any device may be assigned to one or more groups, each labeled
- * with a 16-bit identifier (0x0001 – 0xfff7), which acts for all intents and purposes
- * like a network address. Once a group is established, frames, sent using the
- * APSDE-DATA.request primitive and having a DstAddrMode of 0x01, denoting
- * group addressing, will be delivered to every endpoint assigned to the group
- * address named in the DstAddr parameter of the outgoing APSDE-DATA.request
- * primitive on every device in the network for which there are such endpoints.
- * <p>
- * Management of group membership on each device and endpoint is implemented
- * by the APS, but the over-the-air messages that allow for remote management and
- * commissioning of groups are defined here in the cluster library on the theory that,
- * while the basic group addressing facilities are integral to the operation of the
- * stack, not every device will need or want to implement this management cluster.
- * Furthermore, the placement of the management commands here allows developers
- * of proprietary profiles to avoid implementing the library cluster but still exploit
- * group addressing
- * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:42Z")
 public class ViewGroupResponse extends ZclCommand {
     /**
      * Status command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/ArmCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/ArmCommand.java
@@ -26,14 +26,14 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * Cluster: <b>IAS ACE</b>. Command is sent <b>TO</b> the server.
  * This command is a <b>specific</b> command used for the IAS ACE cluster.
  * <p>
- * The IAS ACE cluster defines an interface to the functionality of any Ancillary
- * Control Equipment of the IAS system. Using this cluster, a ZigBee enabled ACE
- * device can access a IAS CIE device and manipulate the IAS system, on behalf of a
- * level-2 user.
+ * On receipt of this command, the receiving device sets its arm mode according to the value of the Arm Mode field,
+ * as detailed in Table 8-13. It is not guaranteed that an Arm command will succeed. Based on the current state of
+ * the IAS CIE, and its related devices, the command can be rejected. The device SHALL generate an Arm Response command
+ * to indicate the resulting armed state
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-10T07:28:44Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:17Z")
 public class ArmCommand extends ZclCommand {
     /**
      * Arm Mode command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/ArmResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/ArmResponse.java
@@ -21,14 +21,9 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * Cluster: <b>IAS ACE</b>. Command is sent <b>FROM</b> the server.
  * This command is a <b>specific</b> command used for the IAS ACE cluster.
  * <p>
- * The IAS ACE cluster defines an interface to the functionality of any Ancillary
- * Control Equipment of the IAS system. Using this cluster, a ZigBee enabled ACE
- * device can access a IAS CIE device and manipulate the IAS system, on behalf of a
- * level-2 user.
- * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:42Z")
 public class ArmResponse extends ZclCommand {
     /**
      * Arm Notification command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/BypassCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/BypassCommand.java
@@ -30,14 +30,16 @@ import java.util.List;
  * Cluster: <b>IAS ACE</b>. Command is sent <b>TO</b> the server.
  * This command is a <b>specific</b> command used for the IAS ACE cluster.
  * <p>
- * The IAS ACE cluster defines an interface to the functionality of any Ancillary
- * Control Equipment of the IAS system. Using this cluster, a ZigBee enabled ACE
- * device can access a IAS CIE device and manipulate the IAS system, on behalf of a
- * level-2 user.
+ * Provides IAS ACE clients with a method to send zone bypass requests to the IAS ACE server.
+ * Bypassed zones MAYbe faulted or in alarm but will not trigger the security system to go into alarm.
+ * For example, a user MAYwish to allow certain windows in his premises protected by an IAS Zone server to
+ * be left open while the user leaves the premises. The user could bypass the IAS Zone server protecting
+ * the window on his IAS ACE client (e.g., security keypad), and if the IAS ACE server indicates that zone is
+ * successfully by-passed, arm his security system while he is away.
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-10T07:28:44Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:17Z")
 public class BypassCommand extends ZclCommand {
     /**
      * Number of Zones command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/BypassResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/BypassResponse.java
@@ -25,14 +25,11 @@ import java.util.List;
  * Cluster: <b>IAS ACE</b>. Command is sent <b>FROM</b> the server.
  * This command is a <b>specific</b> command used for the IAS ACE cluster.
  * <p>
- * The IAS ACE cluster defines an interface to the functionality of any Ancillary
- * Control Equipment of the IAS system. Using this cluster, a ZigBee enabled ACE
- * device can access a IAS CIE device and manipulate the IAS system, on behalf of a
- * level-2 user.
+ * Provides the response of the security panel to the request from the IAS ACE client to bypass zones via a Bypass command.
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-10T07:28:44Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:17Z")
 public class BypassResponse extends ZclCommand {
     /**
      * Bypass Result command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/EmergencyCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/EmergencyCommand.java
@@ -18,14 +18,9 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * Cluster: <b>IAS ACE</b>. Command is sent <b>TO</b> the server.
  * This command is a <b>specific</b> command used for the IAS ACE cluster.
  * <p>
- * The IAS ACE cluster defines an interface to the functionality of any Ancillary
- * Control Equipment of the IAS system. Using this cluster, a ZigBee enabled ACE
- * device can access a IAS CIE device and manipulate the IAS system, on behalf of a
- * level-2 user.
- * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:42Z")
 public class EmergencyCommand extends ZclCommand {
     /**
      * Default constructor.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/FireCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/FireCommand.java
@@ -18,14 +18,9 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * Cluster: <b>IAS ACE</b>. Command is sent <b>TO</b> the server.
  * This command is a <b>specific</b> command used for the IAS ACE cluster.
  * <p>
- * The IAS ACE cluster defines an interface to the functionality of any Ancillary
- * Control Equipment of the IAS system. Using this cluster, a ZigBee enabled ACE
- * device can access a IAS CIE device and manipulate the IAS system, on behalf of a
- * level-2 user.
- * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:42Z")
 public class FireCommand extends ZclCommand {
     /**
      * Default constructor.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/GetBypassedZoneListCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/GetBypassedZoneListCommand.java
@@ -22,14 +22,13 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * Cluster: <b>IAS ACE</b>. Command is sent <b>TO</b> the server.
  * This command is a <b>specific</b> command used for the IAS ACE cluster.
  * <p>
- * The IAS ACE cluster defines an interface to the functionality of any Ancillary
- * Control Equipment of the IAS system. Using this cluster, a ZigBee enabled ACE
- * device can access a IAS CIE device and manipulate the IAS system, on behalf of a
- * level-2 user.
+ * Provides IAS ACE clients with a way to retrieve the list of zones to be bypassed. This provides them with the ability
+ * to provide greater local functionality (i.e., at the IAS ACE client) for users to modify the Bypassed Zone List and reduce
+ * communications to the IAS ACE server when trying to arm the CIE security system.
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-10T07:30:44Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:17Z")
 public class GetBypassedZoneListCommand extends ZclCommand {
     /**
      * Default constructor.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/GetPanelStatusCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/GetPanelStatusCommand.java
@@ -26,14 +26,17 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * Cluster: <b>IAS ACE</b>. Command is sent <b>TO</b> the server.
  * This command is a <b>specific</b> command used for the IAS ACE cluster.
  * <p>
- * The IAS ACE cluster defines an interface to the functionality of any Ancillary
- * Control Equipment of the IAS system. Using this cluster, a ZigBee enabled ACE
- * device can access a IAS CIE device and manipulate the IAS system, on behalf of a
- * level-2 user.
+ * This command is used by ACE clients to request an update to the status (e.g., security
+ * system arm state) of the ACE server (i.e., the IAS CIE). In particular, this command is
+ * useful for battery-powered ACE clients with polling rates longer than the ZigBee standard
+ * check-in rate.
+ * <br>
+ * On receipt of this command, the ACE server responds with the status of the security system.
+ * The IAS ACE server SHALL generate a Get Panel Status Response command.
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-09T21:59:14Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:17Z")
 public class GetPanelStatusCommand extends ZclCommand {
     /**
      * Default constructor.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/GetPanelStatusResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/GetPanelStatusResponse.java
@@ -24,14 +24,12 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * Cluster: <b>IAS ACE</b>. Command is sent <b>FROM</b> the server.
  * This command is a <b>specific</b> command used for the IAS ACE cluster.
  * <p>
- * The IAS ACE cluster defines an interface to the functionality of any Ancillary
- * Control Equipment of the IAS system. Using this cluster, a ZigBee enabled ACE
- * device can access a IAS CIE device and manipulate the IAS system, on behalf of a
- * level-2 user.
+ * This command updates requesting IAS ACE clients in the system of changes to the security panel status recorded by
+ * the ACE server (e.g., IAS CIE device).
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-10T07:28:44Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:17Z")
 public class GetPanelStatusResponse extends ZclCommand {
     /**
      * Panel Status command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/GetZoneIdMapCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/GetZoneIdMapCommand.java
@@ -18,14 +18,9 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * Cluster: <b>IAS ACE</b>. Command is sent <b>TO</b> the server.
  * This command is a <b>specific</b> command used for the IAS ACE cluster.
  * <p>
- * The IAS ACE cluster defines an interface to the functionality of any Ancillary
- * Control Equipment of the IAS system. Using this cluster, a ZigBee enabled ACE
- * device can access a IAS CIE device and manipulate the IAS system, on behalf of a
- * level-2 user.
- * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:42Z")
 public class GetZoneIdMapCommand extends ZclCommand {
     /**
      * Default constructor.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/GetZoneIdMapResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/GetZoneIdMapResponse.java
@@ -24,14 +24,12 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * Cluster: <b>IAS ACE</b>. Command is sent <b>FROM</b> the server.
  * This command is a <b>specific</b> command used for the IAS ACE cluster.
  * <p>
- * The IAS ACE cluster defines an interface to the functionality of any Ancillary
- * Control Equipment of the IAS system. Using this cluster, a ZigBee enabled ACE
- * device can access a IAS CIE device and manipulate the IAS system, on behalf of a
- * level-2 user.
+ * The 16 fields of the payload indicate whether each of the Zone IDs from 0 to 0xff is allocated or not. If bit n
+ * of Zone ID Map section N is set to 1, then Zone ID (16 x N + n ) is allocated, else it is not allocated
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-26T18:46:15Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:17Z")
 public class GetZoneIdMapResponse extends ZclCommand {
     /**
      * Zone ID Map section 0 command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/GetZoneInformationCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/GetZoneInformationCommand.java
@@ -21,14 +21,9 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * Cluster: <b>IAS ACE</b>. Command is sent <b>TO</b> the server.
  * This command is a <b>specific</b> command used for the IAS ACE cluster.
  * <p>
- * The IAS ACE cluster defines an interface to the functionality of any Ancillary
- * Control Equipment of the IAS system. Using this cluster, a ZigBee enabled ACE
- * device can access a IAS CIE device and manipulate the IAS system, on behalf of a
- * level-2 user.
- * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:42Z")
 public class GetZoneInformationCommand extends ZclCommand {
     /**
      * Zone ID command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/GetZoneInformationResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/GetZoneInformationResponse.java
@@ -22,14 +22,9 @@ import com.zsmartsystems.zigbee.IeeeAddress;
  * Cluster: <b>IAS ACE</b>. Command is sent <b>FROM</b> the server.
  * This command is a <b>specific</b> command used for the IAS ACE cluster.
  * <p>
- * The IAS ACE cluster defines an interface to the functionality of any Ancillary
- * Control Equipment of the IAS system. Using this cluster, a ZigBee enabled ACE
- * device can access a IAS CIE device and manipulate the IAS system, on behalf of a
- * level-2 user.
- * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-10T07:28:44Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:42Z")
 public class GetZoneInformationResponse extends ZclCommand {
     /**
      * Zone ID command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/GetZoneStatusCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/GetZoneStatusCommand.java
@@ -28,14 +28,16 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * Cluster: <b>IAS ACE</b>. Command is sent <b>TO</b> the server.
  * This command is a <b>specific</b> command used for the IAS ACE cluster.
  * <p>
- * The IAS ACE cluster defines an interface to the functionality of any Ancillary
- * Control Equipment of the IAS system. Using this cluster, a ZigBee enabled ACE
- * device can access a IAS CIE device and manipulate the IAS system, on behalf of a
- * level-2 user.
+ * This command is used by ACE clients to request an update of the status of the IAS Zone devices managed by the ACE server
+ * (i.e., the IAS CIE). In particular, this command is useful for battery-powered ACE clients with polling rates longer than
+ * the ZigBee standard check-in rate. The command is similar to the Get Attributes Supported command in that it specifies a
+ * starting Zone ID and a number of Zone IDs for which information is requested. Depending on the number of IAS Zone devices
+ * managed by the IAS ACE server, sending the Zone Status of all zones MAY not fit into a single Get ZoneStatus Response command.
+ * IAS ACE clients MAY need to send multiple Get Zone Status commands in order to get the information they seek.
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-10T07:28:44Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:17Z")
 public class GetZoneStatusCommand extends ZclCommand {
     /**
      * Starting Zone ID command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/GetZoneStatusResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/GetZoneStatusResponse.java
@@ -24,14 +24,12 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * Cluster: <b>IAS ACE</b>. Command is sent <b>FROM</b> the server.
  * This command is a <b>specific</b> command used for the IAS ACE cluster.
  * <p>
- * The IAS ACE cluster defines an interface to the functionality of any Ancillary
- * Control Equipment of the IAS system. Using this cluster, a ZigBee enabled ACE
- * device can access a IAS CIE device and manipulate the IAS system, on behalf of a
- * level-2 user.
+ * This command updates requesting IAS ACE clients in the system of changes to the IAS Zone server statuses recorded
+ * by the ACE server (e.g., IAS CIE device).
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-10T07:28:44Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:17Z")
 public class GetZoneStatusResponse extends ZclCommand {
     /**
      * Zone Status Complete command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/PanelStatusChangedCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/PanelStatusChangedCommand.java
@@ -33,14 +33,21 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * Cluster: <b>IAS ACE</b>. Command is sent <b>FROM</b> the server.
  * This command is a <b>specific</b> command used for the IAS ACE cluster.
  * <p>
- * The IAS ACE cluster defines an interface to the functionality of any Ancillary
- * Control Equipment of the IAS system. Using this cluster, a ZigBee enabled ACE
- * device can access a IAS CIE device and manipulate the IAS system, on behalf of a
- * level-2 user.
+ * This command updates ACE clients in the system of changes to panel status recorded by the ACE server (e.g., IAS CIE
+ * device).Sending the Panel Status Changed command (vs.the Get Panel Status and Get Panel Status Response method) is
+ * generally useful only when there are IAS ACE clients that data poll within the retry timeout of the network (e.g., less than
+ * 7.68 seconds).
+ * <br>
+ * An IAS ACE server SHALL send a Panel Status Changed command upon a change to the IAS CIE’s panel status (e.g.,
+ * Disarmed to Arming Away/Stay/Night, Arming Away/Stay/Night to Armed, Armed to Disarmed) as defined in the Panel Status field.
+ * <br>
+ * When Panel Status is Arming Away/Stay/Night, an IAS ACE server SHOULD send Panel Status Changed commands every second in order to
+ * update the Seconds Remaining. In some markets (e.g., North America), the final 10 seconds of the Arming Away/Stay/Night sequence
+ * requires a separate audible notification (e.g., a double tone).
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-10T07:28:44Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:17Z")
 public class PanelStatusChangedCommand extends ZclCommand {
     /**
      * Panel Status command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/PanicCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/PanicCommand.java
@@ -18,14 +18,9 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * Cluster: <b>IAS ACE</b>. Command is sent <b>TO</b> the server.
  * This command is a <b>specific</b> command used for the IAS ACE cluster.
  * <p>
- * The IAS ACE cluster defines an interface to the functionality of any Ancillary
- * Control Equipment of the IAS system. Using this cluster, a ZigBee enabled ACE
- * device can access a IAS CIE device and manipulate the IAS system, on behalf of a
- * level-2 user.
- * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:42Z")
 public class PanicCommand extends ZclCommand {
     /**
      * Default constructor.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/SetBypassedZoneListCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/SetBypassedZoneListCommand.java
@@ -26,14 +26,12 @@ import java.util.List;
  * Cluster: <b>IAS ACE</b>. Command is sent <b>FROM</b> the server.
  * This command is a <b>specific</b> command used for the IAS ACE cluster.
  * <p>
- * The IAS ACE cluster defines an interface to the functionality of any Ancillary
- * Control Equipment of the IAS system. Using this cluster, a ZigBee enabled ACE
- * device can access a IAS CIE device and manipulate the IAS system, on behalf of a
- * level-2 user.
+ * Sets the list of bypassed zones on the IAS ACE client. This command can be sent either as a response to the
+ * GetBypassedZoneList command or unsolicited when the list of bypassed zones changes on the ACE server.
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-10T07:28:44Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:17Z")
 public class SetBypassedZoneListCommand extends ZclCommand {
     /**
      * Zone ID command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/ZoneStatusChangedCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/ZoneStatusChangedCommand.java
@@ -25,14 +25,13 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * Cluster: <b>IAS ACE</b>. Command is sent <b>FROM</b> the server.
  * This command is a <b>specific</b> command used for the IAS ACE cluster.
  * <p>
- * The IAS ACE cluster defines an interface to the functionality of any Ancillary
- * Control Equipment of the IAS system. Using this cluster, a ZigBee enabled ACE
- * device can access a IAS CIE device and manipulate the IAS system, on behalf of a
- * level-2 user.
+ * This command updates ACE clients in the system of changes to zone status recorded by the ACE server (e.g., IAS CIE device).
+ * An IAS ACE server SHOULD send a Zone Status Changed command upon a change to an IAS Zone device’s ZoneStatus that it manages (i.e.,
+ * IAS ACE server SHOULD send a Zone Status Changed command upon receipt of a Zone Status Change Notification command).
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-10T07:28:44Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:17Z")
 public class ZoneStatusChangedCommand extends ZclCommand {
     /**
      * Zone ID command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iaswd/SquawkCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iaswd/SquawkCommand.java
@@ -21,14 +21,9 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * Cluster: <b>IAS WD</b>. Command is sent <b>TO</b> the server.
  * This command is a <b>specific</b> command used for the IAS WD cluster.
  * <p>
- * The IAS WD cluster provides an interface to the functionality of any Warning
- * Device equipment of the IAS system. Using this cluster, a ZigBee enabled CIE
- * device can access a ZigBee enabled IAS WD device and issue alarm warning
- * indications (siren, strobe lighting, etc.) when a system alarm condition is detected.
- * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:42Z")
 public class SquawkCommand extends ZclCommand {
     /**
      * Header command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iaswd/StartWarningCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iaswd/StartWarningCommand.java
@@ -27,14 +27,15 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * Cluster: <b>IAS WD</b>. Command is sent <b>TO</b> the server.
  * This command is a <b>specific</b> command used for the IAS WD cluster.
  * <p>
- * The IAS WD cluster provides an interface to the functionality of any Warning
- * Device equipment of the IAS system. Using this cluster, a ZigBee enabled CIE
- * device can access a ZigBee enabled IAS WD device and issue alarm warning
- * indications (siren, strobe lighting, etc.) when a system alarm condition is detected.
+ * This command starts the WD operation. The WD alerts the surrounding area by
+ * audible (siren) and visual (strobe) signals.
+ * <br>
+ * A Start Warning command shall always terminate the effect of any previous
+ * command that is still current.
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:17Z")
 public class StartWarningCommand extends ZclCommand {
     /**
      * Header command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iaszone/ZoneEnrollRequestCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iaszone/ZoneEnrollRequestCommand.java
@@ -25,13 +25,13 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * Cluster: <b>IAS Zone</b>. Command is sent <b>FROM</b> the server.
  * This command is a <b>specific</b> command used for the IAS Zone cluster.
  * <p>
- * The IAS Zone cluster defines an interface to the functionality of an IAS security
- * zone device. IAS Zone supports up to two alarm types per zone, low battery
- * reports and supervision of the IAS network.
+ * The Zone Enroll Request command is generated when a device embodying the Zone server cluster wishes
+ * to be  enrolled as an active  alarm device. It  must do this immediately it has joined the network
+ * (during commissioning).
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:17Z")
 public class ZoneEnrollRequestCommand extends ZclCommand {
     /**
      * Zone Type command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iaszone/ZoneEnrollResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iaszone/ZoneEnrollResponse.java
@@ -21,13 +21,9 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * Cluster: <b>IAS Zone</b>. Command is sent <b>TO</b> the server.
  * This command is a <b>specific</b> command used for the IAS Zone cluster.
  * <p>
- * The IAS Zone cluster defines an interface to the functionality of an IAS security
- * zone device. IAS Zone supports up to two alarm types per zone, low battery
- * reports and supervision of the IAS network.
- * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:42Z")
 public class ZoneEnrollResponse extends ZclCommand {
     /**
      * Enroll response code command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iaszone/ZoneStatusChangeNotificationCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iaszone/ZoneStatusChangeNotificationCommand.java
@@ -21,13 +21,9 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * Cluster: <b>IAS Zone</b>. Command is sent <b>FROM</b> the server.
  * This command is a <b>specific</b> command used for the IAS Zone cluster.
  * <p>
- * The IAS Zone cluster defines an interface to the functionality of an IAS security
- * zone device. IAS Zone supports up to two alarm types per zone, low battery
- * reports and supervision of the IAS network.
- * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:42Z")
 public class ZoneStatusChangeNotificationCommand extends ZclCommand {
     /**
      * Zone Status command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/identify/IdentifyCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/identify/IdentifyCommand.java
@@ -23,16 +23,11 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * Cluster: <b>Identify</b>. Command is sent <b>TO</b> the server.
  * This command is a <b>specific</b> command used for the Identify cluster.
  * <p>
- * Attributes and commands to put a device into an Identification mode (e.g. flashing
- * a light), that indicates to an observer – e.g. an installer - which of several devices
- * it is, also to request any device that is identifying itself to respond to the initiator.
- * <p>
- * Note that this cluster cannot be disabled, and remains functional regardless of the
- * setting of the DeviceEnable attribute in the Basic cluster.
+ * The identify command starts or stops the receiving device identifying itself.
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:17Z")
 public class IdentifyCommand extends ZclCommand {
     /**
      * Identify Time command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/identify/IdentifyQueryCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/identify/IdentifyQueryCommand.java
@@ -18,16 +18,9 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * Cluster: <b>Identify</b>. Command is sent <b>TO</b> the server.
  * This command is a <b>specific</b> command used for the Identify cluster.
  * <p>
- * Attributes and commands to put a device into an Identification mode (e.g. flashing
- * a light), that indicates to an observer – e.g. an installer - which of several devices
- * it is, also to request any device that is identifying itself to respond to the initiator.
- * <p>
- * Note that this cluster cannot be disabled, and remains functional regardless of the
- * setting of the DeviceEnable attribute in the Basic cluster.
- * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:42Z")
 public class IdentifyQueryCommand extends ZclCommand {
     /**
      * Default constructor.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/identify/IdentifyQueryResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/identify/IdentifyQueryResponse.java
@@ -24,16 +24,12 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * Cluster: <b>Identify</b>. Command is sent <b>FROM</b> the server.
  * This command is a <b>specific</b> command used for the Identify cluster.
  * <p>
- * Attributes and commands to put a device into an Identification mode (e.g. flashing
- * a light), that indicates to an observer – e.g. an installer - which of several devices
- * it is, also to request any device that is identifying itself to respond to the initiator.
- * <p>
- * Note that this cluster cannot be disabled, and remains functional regardless of the
- * setting of the DeviceEnable attribute in the Basic cluster.
+ * The identify query response command is generated in response to receiving an
+ * Identify Query command in the case that the device is currently identifying itself.
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:17Z")
 public class IdentifyQueryResponse extends ZclCommand {
     /**
      * Identify Time command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/levelcontrol/MoveCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/levelcontrol/MoveCommand.java
@@ -21,13 +21,9 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * Cluster: <b>Level Control</b>. Command is sent <b>TO</b> the server.
  * This command is a <b>specific</b> command used for the Level Control cluster.
  * <p>
- * This cluster provides an interface for controlling a characteristic of a device that
- * can be set to a level, for example the brightness of a light, the degree of closure of
- * a door, or the power output of a heater.
- * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:42Z")
 public class MoveCommand extends ZclCommand {
     /**
      * Move mode command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/levelcontrol/MoveToLevelCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/levelcontrol/MoveToLevelCommand.java
@@ -32,13 +32,20 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * Cluster: <b>Level Control</b>. Command is sent <b>TO</b> the server.
  * This command is a <b>specific</b> command used for the Level Control cluster.
  * <p>
- * This cluster provides an interface for controlling a characteristic of a device that
- * can be set to a level, for example the brightness of a light, the degree of closure of
- * a door, or the power output of a heater.
+ * On receipt of this command, a device SHALL move from its current level to the
+ * value given in the Level field. The meaning of ‘level’ is device dependent –e.g.,
+ * for a light it MAY mean brightness level.The movement SHALL be as continuous as
+ * technically practical, i.e., not a step function, and the time taken to move to
+ * the new level SHALL be equal to the value of the Transition time field, in tenths
+ * of a second, or as close to this as the device is able.If the Transition time field
+ * takes the value 0xffff then the time taken to move to the new level SHALL instead
+ * be determined by the OnOffTransitionTimeattribute. If OnOffTransitionTime, which is
+ * an optional attribute, is not present, the device SHALL move to its new level as fast
+ * as it is able.
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:17Z")
 public class MoveToLevelCommand extends ZclCommand {
     /**
      * Level command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/levelcontrol/MoveToLevelWithOnOffCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/levelcontrol/MoveToLevelWithOnOffCommand.java
@@ -21,13 +21,9 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * Cluster: <b>Level Control</b>. Command is sent <b>TO</b> the server.
  * This command is a <b>specific</b> command used for the Level Control cluster.
  * <p>
- * This cluster provides an interface for controlling a characteristic of a device that
- * can be set to a level, for example the brightness of a light, the degree of closure of
- * a door, or the power output of a heater.
- * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:42Z")
 public class MoveToLevelWithOnOffCommand extends ZclCommand {
     /**
      * Level command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/levelcontrol/MoveWithOnOffCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/levelcontrol/MoveWithOnOffCommand.java
@@ -21,13 +21,9 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * Cluster: <b>Level Control</b>. Command is sent <b>TO</b> the server.
  * This command is a <b>specific</b> command used for the Level Control cluster.
  * <p>
- * This cluster provides an interface for controlling a characteristic of a device that
- * can be set to a level, for example the brightness of a light, the degree of closure of
- * a door, or the power output of a heater.
- * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:42Z")
 public class MoveWithOnOffCommand extends ZclCommand {
     /**
      * Move mode command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/levelcontrol/StepCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/levelcontrol/StepCommand.java
@@ -21,13 +21,9 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * Cluster: <b>Level Control</b>. Command is sent <b>TO</b> the server.
  * This command is a <b>specific</b> command used for the Level Control cluster.
  * <p>
- * This cluster provides an interface for controlling a characteristic of a device that
- * can be set to a level, for example the brightness of a light, the degree of closure of
- * a door, or the power output of a heater.
- * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:42Z")
 public class StepCommand extends ZclCommand {
     /**
      * Step mode command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/levelcontrol/StepWithOnOffCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/levelcontrol/StepWithOnOffCommand.java
@@ -21,13 +21,9 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * Cluster: <b>Level Control</b>. Command is sent <b>TO</b> the server.
  * This command is a <b>specific</b> command used for the Level Control cluster.
  * <p>
- * This cluster provides an interface for controlling a characteristic of a device that
- * can be set to a level, for example the brightness of a light, the degree of closure of
- * a door, or the power output of a heater.
- * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:42Z")
 public class StepWithOnOffCommand extends ZclCommand {
     /**
      * Step mode command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/levelcontrol/Stop2Command.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/levelcontrol/Stop2Command.java
@@ -18,13 +18,9 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * Cluster: <b>Level Control</b>. Command is sent <b>TO</b> the server.
  * This command is a <b>specific</b> command used for the Level Control cluster.
  * <p>
- * This cluster provides an interface for controlling a characteristic of a device that
- * can be set to a level, for example the brightness of a light, the degree of closure of
- * a door, or the power output of a heater.
- * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:42Z")
 public class Stop2Command extends ZclCommand {
     /**
      * Default constructor.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/levelcontrol/StopCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/levelcontrol/StopCommand.java
@@ -18,13 +18,9 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * Cluster: <b>Level Control</b>. Command is sent <b>TO</b> the server.
  * This command is a <b>specific</b> command used for the Level Control cluster.
  * <p>
- * This cluster provides an interface for controlling a characteristic of a device that
- * can be set to a level, for example the brightness of a light, the degree of closure of
- * a door, or the power output of a heater.
- * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:42Z")
 public class StopCommand extends ZclCommand {
     /**
      * Default constructor.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/onoff/OffCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/onoff/OffCommand.java
@@ -18,11 +18,9 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * Cluster: <b>On/Off</b>. Command is sent <b>TO</b> the server.
  * This command is a <b>specific</b> command used for the On/Off cluster.
  * <p>
- * Attributes and commands for switching devices between ‘On’ and ‘Off’ states.
- * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:42Z")
 public class OffCommand extends ZclCommand {
     /**
      * Default constructor.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/onoff/OffWithEffectCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/onoff/OffWithEffectCommand.java
@@ -23,11 +23,11 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * Cluster: <b>On/Off</b>. Command is sent <b>TO</b> the server.
  * This command is a <b>specific</b> command used for the On/Off cluster.
  * <p>
- * Attributes and commands for switching devices between ‘On’ and ‘Off’ states.
+ * The Off With Effect command allows devices to be turned off using enhanced ways of fading.
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:17Z")
 public class OffWithEffectCommand extends ZclCommand {
     /**
      * Effect Identifier command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/onoff/OnCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/onoff/OnCommand.java
@@ -18,11 +18,9 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * Cluster: <b>On/Off</b>. Command is sent <b>TO</b> the server.
  * This command is a <b>specific</b> command used for the On/Off cluster.
  * <p>
- * Attributes and commands for switching devices between ‘On’ and ‘Off’ states.
- * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:42Z")
 public class OnCommand extends ZclCommand {
     /**
      * Default constructor.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/onoff/OnWithRecallGlobalSceneCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/onoff/OnWithRecallGlobalSceneCommand.java
@@ -20,11 +20,11 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * Cluster: <b>On/Off</b>. Command is sent <b>TO</b> the server.
  * This command is a <b>specific</b> command used for the On/Off cluster.
  * <p>
- * Attributes and commands for switching devices between ‘On’ and ‘Off’ states.
+ * The On With Recall Global Scene command allows the recall of the settings when the device was turned off.
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:17Z")
 public class OnWithRecallGlobalSceneCommand extends ZclCommand {
     /**
      * Default constructor.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/onoff/OnWithTimedOffCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/onoff/OnWithTimedOffCommand.java
@@ -27,11 +27,15 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * Cluster: <b>On/Off</b>. Command is sent <b>TO</b> the server.
  * This command is a <b>specific</b> command used for the On/Off cluster.
  * <p>
- * Attributes and commands for switching devices between ‘On’ and ‘Off’ states.
+ * The On With Timed Off command allows devices to be turned on for a specific duration
+ * with a guarded off duration so that SHOULD the device be subsequently switched off,
+ * further On With Timed Off commands, received during this time, are prevented from
+ * turning the devices back on. Note that the device can be periodically re-kicked by
+ * subsequent On With Timed Off commands, e.g., from an on/off sensor.
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:17Z")
 public class OnWithTimedOffCommand extends ZclCommand {
     /**
      * On Off Control command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/onoff/ToggleCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/onoff/ToggleCommand.java
@@ -18,11 +18,9 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * Cluster: <b>On/Off</b>. Command is sent <b>TO</b> the server.
  * This command is a <b>specific</b> command used for the On/Off cluster.
  * <p>
- * Attributes and commands for switching devices between ‘On’ and ‘Off’ states.
- * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:42Z")
 public class ToggleCommand extends ZclCommand {
     /**
      * Default constructor.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/otaupgrade/ImageBlockCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/otaupgrade/ImageBlockCommand.java
@@ -37,9 +37,24 @@ import com.zsmartsystems.zigbee.IeeeAddress;
  * Cluster: <b>OTA Upgrade</b>. Command is sent <b>TO</b> the server.
  * This command is a <b>specific</b> command used for the OTA Upgrade cluster.
  * <p>
+ * The client device requests the image data at its leisure by sending Image Block Request command to
+ * the upgrade server. The client knows the total number of request commands it needs to send from the
+ * image size value received in Query Next Image Response command.
+ * <br>
+ * The client repeats Image Block Requests until it has successfully obtained all data. Manufacturer code,
+ * image type and file version are included in all further queries regarding that image. The information
+ * eliminates the need for the server to remember which OTA Upgrade Image is being used for each
+ * download process.
+ * <br>
+ * If the client supports the BlockRequestDelay attribute it shall include the value of the attribute as the
+ * BlockRequestDelay field of the Image Block Request message. The client shall ensure that it delays at
+ * least BlockRequestDelay milliseconds after the previous Image Block Request was sent before sending
+ * the next Image Block Request message. A client may delay its next Image Block Requests longer than
+ * its BlockRequestDelay attribute.
+ * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:17Z")
 public class ImageBlockCommand extends ZclCommand {
     /**
      * Field control command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/otaupgrade/ImageBlockResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/otaupgrade/ImageBlockResponse.java
@@ -42,9 +42,28 @@ import com.zsmartsystems.zigbee.zcl.field.ByteArray;
  * Cluster: <b>OTA Upgrade</b>. Command is sent <b>FROM</b> the server.
  * This command is a <b>specific</b> command used for the OTA Upgrade cluster.
  * <p>
+ * Upon receipt of an Image Block Request command the server shall generate an Image Block Response.
+ * If the server is able to retrieve the data for the client and does not wish to change the image download
+ * rate, it will respond with a status of SUCCESS and it will include all the fields in the payload. The use
+ * of file offset allows the server to send packets with variable data size during the upgrade process. This
+ * allows the server to support a case when the network topology of a client may change during the
+ * upgrade process, for example, mobile client may move around during the upgrade process. If the client
+ * has moved a few hops away, the data size shall be smaller. Moreover, using file offset eliminates the
+ * need for data padding since each Image Block Response command may contain different data size. A
+ * simple server implementation may choose to only support largest possible data size for the worst-case
+ * scenario in order to avoid supporting sending packets with variable data size.
+ * <br>
+ * The server shall respect the maximum data size value requested by the client and shall not send the data
+ * with length greater than that value. The server may send the data with length smaller than the value
+ * depending on the network topology of the client. For example, the client may be able to receive 100
+ * bytes of data at once so it sends the request with 100 as maximum data size. But after considering all
+ * the security headers (perhaps from both APS and network levels) and source routing overhead (for
+ * example, the client is five hops away), the largest possible data size that the server can send to the
+ * client shall be smaller than 100 bytes.
+ * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:17Z")
 public class ImageBlockResponse extends ZclCommand {
     /**
      * Status command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/otaupgrade/ImageNotifyCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/otaupgrade/ImageNotifyCommand.java
@@ -36,9 +36,24 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * Cluster: <b>OTA Upgrade</b>. Command is sent <b>TO</b> the server.
  * This command is a <b>specific</b> command used for the OTA Upgrade cluster.
  * <p>
+ * The purpose of sending Image Notify command is so the server has a way to notify client devices of
+ * when the OTA upgrade images are available for them. It eliminates the need for ZR client devices
+ * having to check with the server periodically of when the new images are available. However, all client
+ * devices still need to send in Query Next Image Request command in order to officially start the OTA
+ * upgrade process.
+ * <br>
+ * For ZR client devices, the upgrade server may send out a unicast, broadcast, or multicast indicating it
+ * has the next upgrade image, via an Image Notify command. Since the command may not have APS
+ * security (if it is broadcast or multicast), it is considered purely informational and not authoritative.
+ * Even in the case of a unicast, ZR shall continue to perform the query process described in later section.
+ * <br>
+ * When the command is sent with payload type value of zero, it generally means the server wishes to
+ * notify all clients disregard of their manufacturers, image types or file versions. Query jitter is needed
+ * to protect the server from being flooded with clients’ queries for next image.
+ * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:17Z")
 public class ImageNotifyCommand extends ZclCommand {
     /**
      * Payload type command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/otaupgrade/ImagePageCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/otaupgrade/ImagePageCommand.java
@@ -38,9 +38,25 @@ import com.zsmartsystems.zigbee.IeeeAddress;
  * Cluster: <b>OTA Upgrade</b>. Command is sent <b>TO</b> the server.
  * This command is a <b>specific</b> command used for the OTA Upgrade cluster.
  * <p>
+ * The support for the command is optional. The client device may choose to request OTA upgrade data
+ * in one page size at a time from upgrade server. Using Image Page Request reduces the numbers of
+ * requests sent from the client to the upgrade server, compared to using Image Block Request command.
+ * In order to conserve battery life a device may use the Image Page Request command. Using the Image
+ * Page Request command eliminates the need for the client device to send Image Block Request
+ * command for every data block it needs; possibly saving the transmission of hundreds or thousands of
+ * messages depending on the image size.
+ * <br>
+ * The client keeps track of how much data it has received by keeping a cumulative count of each data
+ * size it has received in each Image Block Response. Once the count has reach the value of the page size
+ * requested, it shall repeat Image Page Requests until it has successfully obtained all pages. Note that the
+ * client may choose to switch between using Image Block Request and Image Page Request during the
+ * upgrade process. For example, if the client does not receive all data requested in one Image Page
+ * Request, the client may choose to request the missing block of data using Image Block Request
+ * command, instead of requesting the whole page again.
+ * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:17Z")
 public class ImagePageCommand extends ZclCommand {
     /**
      * Field control command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/otaupgrade/QueryNextImageCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/otaupgrade/QueryNextImageCommand.java
@@ -35,9 +35,23 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * Cluster: <b>OTA Upgrade</b>. Command is sent <b>TO</b> the server.
  * This command is a <b>specific</b> command used for the OTA Upgrade cluster.
  * <p>
+ * Client devices shall send a Query Next Image Request command to the server to see if there is new
+ * OTA upgrade image available. ZR devices may send the command after receiving Image Notify
+ * command. ZED device shall periodically wake up and send the command to the upgrade server. Client
+ * devices query what the next image is, based on their own information.
+ * <br>
+ * The server takes the client’s information in the command and determines whether it has a suitable
+ * image for the particular client. The decision should be based on specific policy that is specific to the
+ * upgrade server and outside the scope of this document.. However, a recommended default policy is for
+ * the server to send back a response that indicates the availability of an image that matches the
+ * manufacturer code, image type, and the highest available file version of that image on the
+ * server. However, the server may choose to upgrade, downgrade, or reinstall clients’ image, as its
+ * policy dictates. If client’s hardware version is included in the command, the server shall examine the
+ * value against the minimum and maximum hardware versions included in the OTA file header.
+ * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:17Z")
 public class QueryNextImageCommand extends ZclCommand {
     /**
      * Field control command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/otaupgrade/QueryNextImageResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/otaupgrade/QueryNextImageResponse.java
@@ -36,9 +36,23 @@ import com.zsmartsystems.zigbee.zcl.ZclStatus;
  * Cluster: <b>OTA Upgrade</b>. Command is sent <b>FROM</b> the server.
  * This command is a <b>specific</b> command used for the OTA Upgrade cluster.
  * <p>
+ * The upgrade server sends a Query Next Image Response with one of the following status: SUCCESS,
+ * NO_IMAGE_AVAILABLE or NOT_AUTHORIZED. When a SUCCESS status is sent, it is
+ * considered to be the explicit authorization to a device by the upgrade server that the device may
+ * upgrade to a specific software image.
+ * <br>
+ * A status of NO_IMAGE_AVAILABLE indicates that the server is authorized to upgrade the client but
+ * it currently does not have the (new) OTA upgrade image available for the client. For all clients (both
+ * ZR and ZED)9 , they shall continue sending Query Next Image Requests to the server periodically until
+ * an image becomes available.
+ * <br>
+ * A status of NOT_AUTHORIZED indicates the server is not authorized to upgrade the client. In this
+ * case, the client may perform discovery again to find another upgrade server. The client may implement
+ * an intelligence to avoid querying the same unauthorized server.
+ * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:17Z")
 public class QueryNextImageResponse extends ZclCommand {
     /**
      * Status command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/otaupgrade/QuerySpecificFileCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/otaupgrade/QuerySpecificFileCommand.java
@@ -29,9 +29,16 @@ import com.zsmartsystems.zigbee.IeeeAddress;
  * Cluster: <b>OTA Upgrade</b>. Command is sent <b>TO</b> the server.
  * This command is a <b>specific</b> command used for the OTA Upgrade cluster.
  * <p>
+ * Client devices shall send a Query Specific File Request command to the server to request for a file that
+ * is specific and unique to it. Such file could contain non-firmware data such as security credential
+ * (needed for upgrading from Smart Energy 1.1 to Smart Energy 2.0), configuration or log. When the
+ * device decides to send the Query Specific File Request command is manufacturer specific. However,
+ * one example is during upgrading from SE 1.1 to 2.0 where the client may have already obtained new
+ * SE 2.0 image and now needs new SE 2.0 security credential data.
+ * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:17Z")
 public class QuerySpecificFileCommand extends ZclCommand {
     /**
      * Request node address command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/otaupgrade/QuerySpecificFileResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/otaupgrade/QuerySpecificFileResponse.java
@@ -32,9 +32,19 @@ import com.zsmartsystems.zigbee.zcl.ZclStatus;
  * Cluster: <b>OTA Upgrade</b>. Command is sent <b>FROM</b> the server.
  * This command is a <b>specific</b> command used for the OTA Upgrade cluster.
  * <p>
+ * The server sends Query Specific File Response after receiving Query Specific File Request from a
+ * client. The server shall determine whether it first supports the Query Specific File Request command.
+ * Then it shall determine whether it has the specific file being requested by the client using all the
+ * information included in the request. The upgrade server sends a Query Specific File Response with
+ * one of the following status: SUCCESS, NO_IMAGE_AVAILABLE or NOT_AUTHORIZED.
+ * <br>
+ * A status of NO_IMAGE_AVAILABLE indicates that the server currently does not have the device
+ * specific file available for the client. A status of NOT_AUTHORIZED indicates the server is not
+ * authorized to send the file to the client.
+ * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:17Z")
 public class QuerySpecificFileResponse extends ZclCommand {
     /**
      * Status command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/otaupgrade/UpgradeEndCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/otaupgrade/UpgradeEndCommand.java
@@ -41,9 +41,28 @@ import com.zsmartsystems.zigbee.zcl.ZclStatus;
  * Cluster: <b>OTA Upgrade</b>. Command is sent <b>TO</b> the server.
  * This command is a <b>specific</b> command used for the OTA Upgrade cluster.
  * <p>
+ * Upon reception all the image data, the client should verify the image to ensure its integrity and validity.
+ * If the device requires signed images it shall examine the image and verify the signature. Clients may perform
+ * additional manufacturer specific integrity checks to validate the image, for example, CRC check on the actual file data.
+ * <br>
+ * If the image fails any integrity checks, the client shall send an Upgrade End Request command to the
+ * upgrade server with a status of INVALID_IMAGE. In this case, the client may reinitiate the upgrade
+ * process in order to obtain a valid OTA upgrade image. The client shall not upgrade to the bad image
+ * and shall discard the downloaded image data.
+ * <br>
+ * If the image passes all integrity checks and the client does not require additional OTA upgrade image
+ * file, it shall send back an Upgrade End Request with a status of SUCCESS. However, if the client
+ * requires multiple OTA upgrade image files before performing an upgrade, it shall send an Upgrade End
+ * Request command with status REQUIRE_MORE_IMAGE. This shall indicate to the server that it
+ * cannot yet upgrade the image it received.
+ * <br>
+ * If the client decides to cancel the download process for any other reasons, it has the option of sending
+ * Upgrade End Request with status of ABORT at anytime during the download process. The client shall
+ * then try to reinitiate the download process again at a later time.
+ * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:17Z")
 public class UpgradeEndCommand extends ZclCommand {
     /**
      * Status command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/otaupgrade/UpgradeEndResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/otaupgrade/UpgradeEndResponse.java
@@ -34,9 +34,22 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * Cluster: <b>OTA Upgrade</b>. Command is sent <b>FROM</b> the server.
  * This command is a <b>specific</b> command used for the OTA Upgrade cluster.
  * <p>
+ * When an upgrade server receives an Upgrade End Request command with a status of
+ * INVALID_IMAGE, REQUIRE_MORE_IMAGE, or ABORT, no additional processing shall be done
+ * in its part. If the upgrade server receives an Upgrade End Request command with a status of
+ * SUCCESS, it shall generate an Upgrade End Response with the manufacturer code and image type
+ * received in the Upgrade End Request along with the times indicating when the device should upgrade
+ * to the new image.
+ * <br>
+ * The server may send an unsolicited Upgrade End Response command to the client. This may be used
+ * for example if the server wants to synchronize the upgrade on multiple clients simultaneously. For
+ * client devices, the upgrade server may unicast or broadcast Upgrade End Response command
+ * indicating a single client device or multiple client devices shall switch to using their new images. The
+ * command may not be reliably received by sleepy devices if it is sent unsolicited.
+ * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:17Z")
 public class UpgradeEndResponse extends ZclCommand {
     /**
      * Manufacturer code command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/AddSceneCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/AddSceneCommand.java
@@ -26,19 +26,11 @@ import com.zsmartsystems.zigbee.zcl.field.ExtensionFieldSet;
  * Cluster: <b>Scenes</b>. Command is sent <b>TO</b> the server.
  * This command is a <b>specific</b> command used for the Scenes cluster.
  * <p>
- * The scenes cluster provides attributes and commands for setting up and recalling
- * scenes. Each scene corresponds to a set of stored values of specified attributes for
- * one or more clusters on the same end point as the scenes cluster.
- * <p>
- * In most cases scenes are associated with a particular group ID. Scenes may also
- * exist without a group, in which case the value 0x0000 replaces the group ID. Note
- * that extra care is required in these cases to avoid a scene ID collision, and that
- * commands related to scenes without a group may only be unicast, i.e.: they may
- * not be multicast or broadcast.
+ * The Add Scene command shall be addressed to a single device (not a group).
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:17Z")
 public class AddSceneCommand extends ZclCommand {
     /**
      * Group ID command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/AddSceneResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/AddSceneResponse.java
@@ -21,19 +21,9 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * Cluster: <b>Scenes</b>. Command is sent <b>FROM</b> the server.
  * This command is a <b>specific</b> command used for the Scenes cluster.
  * <p>
- * The scenes cluster provides attributes and commands for setting up and recalling
- * scenes. Each scene corresponds to a set of stored values of specified attributes for
- * one or more clusters on the same end point as the scenes cluster.
- * <p>
- * In most cases scenes are associated with a particular group ID. Scenes may also
- * exist without a group, in which case the value 0x0000 replaces the group ID. Note
- * that extra care is required in these cases to avoid a scene ID collision, and that
- * commands related to scenes without a group may only be unicast, i.e.: they may
- * not be multicast or broadcast.
- * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:42Z")
 public class AddSceneResponse extends ZclCommand {
     /**
      * Status command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/GetSceneMembershipCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/GetSceneMembershipCommand.java
@@ -26,19 +26,14 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * Cluster: <b>Scenes</b>. Command is sent <b>TO</b> the server.
  * This command is a <b>specific</b> command used for the Scenes cluster.
  * <p>
- * The scenes cluster provides attributes and commands for setting up and recalling
- * scenes. Each scene corresponds to a set of stored values of specified attributes for
- * one or more clusters on the same end point as the scenes cluster.
- * <p>
- * In most cases scenes are associated with a particular group ID. Scenes may also
- * exist without a group, in which case the value 0x0000 replaces the group ID. Note
- * that extra care is required in these cases to avoid a scene ID collision, and that
- * commands related to scenes without a group may only be unicast, i.e.: they may
- * not be multicast or broadcast.
+ * The Get Scene Membership command can be used to find an unused scene
+ * number within the group when no commissioning tool is in the network, or for a
+ * commissioning tool to get used scenes for a group on a single device or on all
+ * devices in the group.
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:17Z")
 public class GetSceneMembershipCommand extends ZclCommand {
     /**
      * Group ID command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/GetSceneMembershipResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/GetSceneMembershipResponse.java
@@ -23,19 +23,9 @@ import java.util.List;
  * Cluster: <b>Scenes</b>. Command is sent <b>FROM</b> the server.
  * This command is a <b>specific</b> command used for the Scenes cluster.
  * <p>
- * The scenes cluster provides attributes and commands for setting up and recalling
- * scenes. Each scene corresponds to a set of stored values of specified attributes for
- * one or more clusters on the same end point as the scenes cluster.
- * <p>
- * In most cases scenes are associated with a particular group ID. Scenes may also
- * exist without a group, in which case the value 0x0000 replaces the group ID. Note
- * that extra care is required in these cases to avoid a scene ID collision, and that
- * commands related to scenes without a group may only be unicast, i.e.: they may
- * not be multicast or broadcast.
- * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:42Z")
 public class GetSceneMembershipResponse extends ZclCommand {
     /**
      * Status command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/RecallSceneCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/RecallSceneCommand.java
@@ -23,19 +23,11 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * Cluster: <b>Scenes</b>. Command is sent <b>TO</b> the server.
  * This command is a <b>specific</b> command used for the Scenes cluster.
  * <p>
- * The scenes cluster provides attributes and commands for setting up and recalling
- * scenes. Each scene corresponds to a set of stored values of specified attributes for
- * one or more clusters on the same end point as the scenes cluster.
- * <p>
- * In most cases scenes are associated with a particular group ID. Scenes may also
- * exist without a group, in which case the value 0x0000 replaces the group ID. Note
- * that extra care is required in these cases to avoid a scene ID collision, and that
- * commands related to scenes without a group may only be unicast, i.e.: they may
- * not be multicast or broadcast.
+ * The Recall Scene command may be addressed to a single device or to a group.
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:17Z")
 public class RecallSceneCommand extends ZclCommand {
     /**
      * Group ID command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/RemoveAllScenesCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/RemoveAllScenesCommand.java
@@ -23,19 +23,11 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * Cluster: <b>Scenes</b>. Command is sent <b>TO</b> the server.
  * This command is a <b>specific</b> command used for the Scenes cluster.
  * <p>
- * The scenes cluster provides attributes and commands for setting up and recalling
- * scenes. Each scene corresponds to a set of stored values of specified attributes for
- * one or more clusters on the same end point as the scenes cluster.
- * <p>
- * In most cases scenes are associated with a particular group ID. Scenes may also
- * exist without a group, in which case the value 0x0000 replaces the group ID. Note
- * that extra care is required in these cases to avoid a scene ID collision, and that
- * commands related to scenes without a group may only be unicast, i.e.: they may
- * not be multicast or broadcast.
+ * The Remove All Scenes may be addressed to a single device or to a group.
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:17Z")
 public class RemoveAllScenesCommand extends ZclCommand {
     /**
      * Group ID command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/RemoveAllScenesResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/RemoveAllScenesResponse.java
@@ -21,19 +21,9 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * Cluster: <b>Scenes</b>. Command is sent <b>FROM</b> the server.
  * This command is a <b>specific</b> command used for the Scenes cluster.
  * <p>
- * The scenes cluster provides attributes and commands for setting up and recalling
- * scenes. Each scene corresponds to a set of stored values of specified attributes for
- * one or more clusters on the same end point as the scenes cluster.
- * <p>
- * In most cases scenes are associated with a particular group ID. Scenes may also
- * exist without a group, in which case the value 0x0000 replaces the group ID. Note
- * that extra care is required in these cases to avoid a scene ID collision, and that
- * commands related to scenes without a group may only be unicast, i.e.: they may
- * not be multicast or broadcast.
- * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:42Z")
 public class RemoveAllScenesResponse extends ZclCommand {
     /**
      * Status command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/RemoveSceneCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/RemoveSceneCommand.java
@@ -23,19 +23,11 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * Cluster: <b>Scenes</b>. Command is sent <b>TO</b> the server.
  * This command is a <b>specific</b> command used for the Scenes cluster.
  * <p>
- * The scenes cluster provides attributes and commands for setting up and recalling
- * scenes. Each scene corresponds to a set of stored values of specified attributes for
- * one or more clusters on the same end point as the scenes cluster.
- * <p>
- * In most cases scenes are associated with a particular group ID. Scenes may also
- * exist without a group, in which case the value 0x0000 replaces the group ID. Note
- * that extra care is required in these cases to avoid a scene ID collision, and that
- * commands related to scenes without a group may only be unicast, i.e.: they may
- * not be multicast or broadcast.
+ * The Remove All Scenes may be addressed to a single device or to a group.
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:17Z")
 public class RemoveSceneCommand extends ZclCommand {
     /**
      * Group ID command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/RemoveSceneResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/RemoveSceneResponse.java
@@ -21,19 +21,9 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * Cluster: <b>Scenes</b>. Command is sent <b>FROM</b> the server.
  * This command is a <b>specific</b> command used for the Scenes cluster.
  * <p>
- * The scenes cluster provides attributes and commands for setting up and recalling
- * scenes. Each scene corresponds to a set of stored values of specified attributes for
- * one or more clusters on the same end point as the scenes cluster.
- * <p>
- * In most cases scenes are associated with a particular group ID. Scenes may also
- * exist without a group, in which case the value 0x0000 replaces the group ID. Note
- * that extra care is required in these cases to avoid a scene ID collision, and that
- * commands related to scenes without a group may only be unicast, i.e.: they may
- * not be multicast or broadcast.
- * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:42Z")
 public class RemoveSceneResponse extends ZclCommand {
     /**
      * Status command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/StoreSceneCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/StoreSceneCommand.java
@@ -23,19 +23,11 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * Cluster: <b>Scenes</b>. Command is sent <b>TO</b> the server.
  * This command is a <b>specific</b> command used for the Scenes cluster.
  * <p>
- * The scenes cluster provides attributes and commands for setting up and recalling
- * scenes. Each scene corresponds to a set of stored values of specified attributes for
- * one or more clusters on the same end point as the scenes cluster.
- * <p>
- * In most cases scenes are associated with a particular group ID. Scenes may also
- * exist without a group, in which case the value 0x0000 replaces the group ID. Note
- * that extra care is required in these cases to avoid a scene ID collision, and that
- * commands related to scenes without a group may only be unicast, i.e.: they may
- * not be multicast or broadcast.
+ * The Store Scene command may be addressed to a single device or to a group.
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:17Z")
 public class StoreSceneCommand extends ZclCommand {
     /**
      * Group ID command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/StoreSceneResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/StoreSceneResponse.java
@@ -21,19 +21,9 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * Cluster: <b>Scenes</b>. Command is sent <b>FROM</b> the server.
  * This command is a <b>specific</b> command used for the Scenes cluster.
  * <p>
- * The scenes cluster provides attributes and commands for setting up and recalling
- * scenes. Each scene corresponds to a set of stored values of specified attributes for
- * one or more clusters on the same end point as the scenes cluster.
- * <p>
- * In most cases scenes are associated with a particular group ID. Scenes may also
- * exist without a group, in which case the value 0x0000 replaces the group ID. Note
- * that extra care is required in these cases to avoid a scene ID collision, and that
- * commands related to scenes without a group may only be unicast, i.e.: they may
- * not be multicast or broadcast.
- * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:42Z")
 public class StoreSceneResponse extends ZclCommand {
     /**
      * Status command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/ViewSceneCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/ViewSceneCommand.java
@@ -23,19 +23,11 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * Cluster: <b>Scenes</b>. Command is sent <b>TO</b> the server.
  * This command is a <b>specific</b> command used for the Scenes cluster.
  * <p>
- * The scenes cluster provides attributes and commands for setting up and recalling
- * scenes. Each scene corresponds to a set of stored values of specified attributes for
- * one or more clusters on the same end point as the scenes cluster.
- * <p>
- * In most cases scenes are associated with a particular group ID. Scenes may also
- * exist without a group, in which case the value 0x0000 replaces the group ID. Note
- * that extra care is required in these cases to avoid a scene ID collision, and that
- * commands related to scenes without a group may only be unicast, i.e.: they may
- * not be multicast or broadcast.
+ * The View Scene command shall be addressed to a single device (not a group).
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:17Z")
 public class ViewSceneCommand extends ZclCommand {
     /**
      * Group ID command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/ViewSceneResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/ViewSceneResponse.java
@@ -24,19 +24,9 @@ import com.zsmartsystems.zigbee.zcl.field.ExtensionFieldSet;
  * Cluster: <b>Scenes</b>. Command is sent <b>FROM</b> the server.
  * This command is a <b>specific</b> command used for the Scenes cluster.
  * <p>
- * The scenes cluster provides attributes and commands for setting up and recalling
- * scenes. Each scene corresponds to a set of stored values of specified attributes for
- * one or more clusters on the same end point as the scenes cluster.
- * <p>
- * In most cases scenes are associated with a particular group ID. Scenes may also
- * exist without a group, in which case the value 0x0000 replaces the group ID. Note
- * that extra care is required in these cases to avoid a scene ID collision, and that
- * commands related to scenes without a group may only be unicast, i.e.: they may
- * not be multicast or broadcast.
- * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:42Z")
 public class ViewSceneResponse extends ZclCommand {
     /**
      * Status command message field.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/thermostat/GetRelayStatusLog.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/thermostat/GetRelayStatusLog.java
@@ -36,9 +36,27 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * Cluster: <b>Thermostat</b>. Command is sent <b>TO</b> the server.
  * This command is a <b>specific</b> command used for the Thermostat cluster.
  * <p>
+ * The Get Relay Status Log command is used to query the thermostat internal relay status log. This command has no payload.
+ * <br>
+ * The log storing order is First in First Out (FIFO) when the log is generated and stored into the Queue.
+ * <br>
+ * The first record in the log (i.e., the oldest) one, is the first to be replaced when there is a new record and there is
+ * no more space in the log. Thus, the newest record will overwrite the oldest one if there is no space left.
+ * <br>
+ * The log storing order is Last In First Out (LIFO) when the log is being retrieved from the Queue by a client device.
+ * Once the "Get Relay Status Log Response" frame is sent by the Server, the "Unread Entries" attribute
+ * SHOULD be decremented to indicate the number of unread records that remain in the queue.
+ * <br>
+ * If the "Unread Entries"attribute reaches zero and the Client sends a new "Get Relay Status Log Request", the Server
+ * MAY send one of the following items as a response:
+ * <br>
+ * i) resend the last Get Relay Status Log Response
+ * or
+ * ii) generate new log record at the time of request and send Get Relay Status Log Response with the new data
+ * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:42Z")
 public class GetRelayStatusLog extends ZclCommand {
     /**
      * Default constructor.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/thermostat/SetWeeklySchedule.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/thermostat/SetWeeklySchedule.java
@@ -30,9 +30,18 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * Cluster: <b>Thermostat</b>. Command is sent <b>TO</b> the server.
  * This command is a <b>specific</b> command used for the Thermostat cluster.
  * <p>
+ * The set weekly schedule command is used to update the thermostat weekly set point schedule from a management system.
+ * If the thermostat already has a weekly set point schedule programmed then it SHOULD replace each daily set point set
+ * as it receives the updates from the management system. For example if the thermostat has 4 set points for every day of
+ * the week and is sent a Set Weekly Schedule command with one set point for Saturday then the thermostat SHOULD remove
+ * all 4 set points for Saturday and replace those with the updated set point but leave all other days unchanged.
+ * <br>
+ * If the schedule is larger than what fits in one ZigBee frame or contains more than 10 transitions, the schedule SHALL
+ * then be sent using multipleSet Weekly Schedule Commands.
+ * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-04-13T17:16:42Z")
 public class SetWeeklySchedule extends ZclCommand {
     /**
      * Number of Transitions command message field.


### PR DESCRIPTION
Javadoc in commands was using the cluster documentation, not the command doc.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>