### PR TITLE
Add MMO Hash Algorithm to generate link keys from join codes

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/security/MmoHash.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/security/MmoHash.java
@@ -1,0 +1,185 @@
+/**
+ * Copyright (c) 2016-2018 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.security;
+
+import java.security.InvalidKeyException;
+import java.security.Key;
+import java.security.NoSuchAlgorithmException;
+
+import javax.crypto.BadPaddingException;
+import javax.crypto.Cipher;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.NoSuchPaddingException;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * ZigBee Cryptographic Hash Function, described in ZigBee specification sections B.1.3 and B.6.
+ * <p>
+ * This is a Matyas-Meyer-Oseas hash function using the AES-128 cipher. Input may be any length.
+ * <p>
+ * MMO Hash function is used for generating link keys from install codes for ZigBee 3 and Smart Energy.
+ *
+ * @author Chris Jackson
+ *
+ */
+public class MmoHash {
+    private final Logger logger = LoggerFactory.getLogger(MmoHash.class);
+
+    /**
+     * Internal hash.
+     * Using a byte array internally as it's required by the cryptographic methods
+     */
+    private byte[] hash;
+
+    private static final int ZIGBEE_BLOCKSIZE = 16;
+    private static final String AES = "AES";
+
+    /**
+     * Creates a hash of the data using the Matyas-Meyer-Oseas hash function
+     *
+     * @param input array to create hash from
+     */
+    public MmoHash(int[] input) {
+        hash = new byte[ZIGBEE_BLOCKSIZE];
+
+        updateHash(input);
+    }
+
+    /**
+     * Creates a hash of the data using the Matyas-Meyer-Oseas hash function
+     *
+     * @param input array to create hash from
+     */
+    public MmoHash(String input) {
+        hash = new byte[ZIGBEE_BLOCKSIZE];
+
+        updateHash(input);
+    }
+
+    /**
+     * Update the hash with the input data
+     *
+     * @param input string of data to update with
+     */
+    public void updateHash(String input) {
+        String hexString = input.replace(":", "").replace(" ", "");
+
+        if (hexString.length() % 2 != 0) {
+            throw new IllegalArgumentException("Code string must contain an even number of hexadecimal numbers");
+        }
+
+        int[] code = new int[hexString.length() / 2];
+        char enc[] = hexString.toCharArray();
+        for (int i = 0; i < enc.length; i += 2) {
+            StringBuilder curr = new StringBuilder(2);
+            curr.append(enc[i]).append(enc[i + 1]);
+            code[i / 2] = Integer.parseInt(curr.toString(), 16);
+        }
+
+        updateHash(code);
+    }
+
+    /**
+     * Update the hash with the input data
+     *
+     * @param input array of data to update with
+     */
+    public void updateHash(int[] input) {
+        byte[] output = new byte[ZIGBEE_BLOCKSIZE];
+        byte[] cipher_in = new byte[ZIGBEE_BLOCKSIZE];
+
+        int inputCnt = 0;
+        int outputCnt = 0;
+        while (inputCnt < input.length) {
+            cipher_in[outputCnt++] = (byte) input[inputCnt++];
+
+            if (outputCnt >= ZIGBEE_BLOCKSIZE) {
+                // End of the block
+                output = doBlock(output, cipher_in);
+
+                outputCnt = 0;
+            }
+        }
+
+        cipher_in[outputCnt++] = (byte) 0x80;
+
+        // Pad with 0 until we're 16 bits (2 bytes) from the end
+        while (outputCnt != ZIGBEE_BLOCKSIZE - 2) {
+            if (outputCnt >= ZIGBEE_BLOCKSIZE) {
+                // End of the block
+                output = doBlock(output, cipher_in);
+
+                outputCnt = 0;
+            }
+            cipher_in[outputCnt++] = 0x00;
+        }
+
+        // Add the 'n'-bit representation of 'l' to the end of the block.
+        cipher_in[outputCnt++] = (byte) ((input.length * 8) >> 8);
+        cipher_in[outputCnt] = (byte) ((input.length * 8) >> 0);
+
+        hash = doBlock(output, cipher_in);
+    }
+
+    /**
+     * Gets the current value of the hash
+     *
+     * @return integer array containing the hash value
+     */
+    public int[] getHash() {
+        int[] outArray = new int[ZIGBEE_BLOCKSIZE];
+
+        // Copy back to an int array
+        for (int cnt = 0; cnt < ZIGBEE_BLOCKSIZE; cnt++) {
+            outArray[cnt] = hash[cnt] & 0xFF;
+        }
+
+        return outArray;
+    }
+
+    private byte[] doBlock(byte[] keyBytes, byte[] inBytes) {
+        try {
+            Cipher cipher;
+            Key key = new SecretKeySpec(keyBytes, AES);
+            cipher = Cipher.getInstance("AES/ECB/NoPadding");
+            cipher.init(Cipher.ENCRYPT_MODE, key);
+            byte[] output = cipher.doFinal(inBytes, 0, ZIGBEE_BLOCKSIZE);
+
+            for (int cnt = 0; cnt < ZIGBEE_BLOCKSIZE; cnt++) {
+                output[cnt] ^= inBytes[cnt];
+            }
+
+            return output;
+        } catch (InvalidKeyException | NoSuchAlgorithmException | NoSuchPaddingException | IllegalBlockSizeException
+                | BadPaddingException e) {
+            logger.error("Error hashing MMO block", e);
+        }
+
+        return new byte[ZIGBEE_BLOCKSIZE];
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+
+        int cntDelim = 0;
+        for (int cnt = 0; cnt < hash.length; cnt++) {
+            int value = hash[cnt];
+            if (cntDelim++ == 2) {
+                builder.append(':');
+                cntDelim = 1;
+            }
+            builder.append(String.format("%02X", (value & 0xFF)));
+        }
+
+        return builder.toString();
+    }
+}

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/security/MmoHashTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/security/MmoHashTest.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2016-2018 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.security;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+/**
+ * Tests for MMO Hash function used for generating link keys from install codes for ZigBee 3 and Smart Energy.
+ *
+ * @author Chris Jackson
+ *
+ */
+public class MmoHashTest {
+
+    @Test
+    public void testString() {
+        MmoHash hash;
+
+        hash = new MmoHash("11223344556677884AF7");
+        assertEquals("4161:8FC0:C83B:0E14:A589:954B:16E3:1466", hash.toString());
+        System.out.println(hash.toString());
+
+        hash = new MmoHash(new int[] { 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x4A, 0xF7 });
+        assertEquals("4161:8FC0:C83B:0E14:A589:954B:16E3:1466", hash.toString());
+        System.out.println(hash.toString());
+
+        hash = new MmoHash("1122 3344 5566 7788 4AF7");
+        System.out.println(hash.toString());
+        assertEquals("4161:8FC0:C83B:0E14:A589:954B:16E3:1466", hash.toString());
+
+        hash = new MmoHash("1122:3344:5566:7788:4AF7");
+        System.out.println(hash.toString());
+        assertEquals("4161:8FC0:C83B:0E14:A589:954B:16E3:1466", hash.toString());
+
+        hash = new MmoHash("83FED3407A939738c552");
+        System.out.println(hash.toString());
+        assertEquals("A833:A774:34F3:BFBD:7A7A:B979:4214:9287", hash.toString());
+    }
+
+    @Test
+    public void testArray() {
+        MmoHash hash;
+
+        hash = new MmoHash(new int[] { 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x4A, 0xF7 });
+        assertEquals("4161:8FC0:C83B:0E14:A589:954B:16E3:1466", hash.toString());
+        System.out.println(hash.toString());
+    }
+}


### PR DESCRIPTION
Adds a helper class for performing the MMO hash used to generate temporary link keys from join codes.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>