### PR TITLE
Fix main class reference in console main manifest

### DIFF
--- a/com.zsmartsystems.zigbee.console.main/pom.xml
+++ b/com.zsmartsystems.zigbee.console.main/pom.xml
@@ -131,7 +131,7 @@
                         <manifest>
                             <addClasspath>true</addClasspath>
                             <classpathPrefix>lib/</classpathPrefix>
-                            <mainClass>com.zsmartsystems.zigbee.console.ZigBeeConsoleMain</mainClass>
+                            <mainClass>com.zsmartsystems.zigbee.console.main.ZigBeeConsoleMain</mainClass>
                         </manifest>
                     </archive>
                 </configuration>


### PR DESCRIPTION
Fixes error when running console main jar from command line.
"Error: Could not find or load main class com.zsmartsystems.zigbee.console.ZigBeeConsoleMain"

Signed-off-by: Charles Schwer charles.schwer@gmail.com