### PR TITLE
Disable the license-maven-plugin in submodules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,8 +138,10 @@
 				<groupId>com.mycila</groupId>
 				<artifactId>license-maven-plugin</artifactId>
 				<version>3.0</version>
+				<inherited>false</inherited>
 				<configuration>
 					<header>src/etc/header.txt</header>
+					<aggregate>true</aggregate>
 					<failIfMissing>true</failIfMissing>
 					<strictCheck>true</strictCheck>
 					<includes>


### PR DESCRIPTION
This PR implements one solution to resolve https://github.com/zsmartsystems/com.zsmartsystems.zigbee/issues/289, by:
* The license-maven-plugin is now disabled in submodules.
* When run in the parent module, the plugin will now also check source files in all submodules.

Another option to resolve the issue would be to reference the required license file explicitly from each submodule.

What do you think about using this solution?