### PR TITLE
Fix main class name in console.main module

### DIFF
--- a/com.zsmartsystems.zigbee.console.main/pom.xml
+++ b/com.zsmartsystems.zigbee.console.main/pom.xml
@@ -131,7 +131,7 @@
                         <manifest>
                             <addClasspath>true</addClasspath>
                             <classpathPrefix>lib/</classpathPrefix>
-                            <mainClass>com.zsmartsystems.zigbee.console.ZigBeeConsoleMain</mainClass>
+                            <mainClass>com.zsmartsystems.zigbee.console.main.ZigBeeConsoleMain</mainClass>
                         </manifest>
                     </archive>
                 </configuration>


### PR DESCRIPTION
The package of the ZigBeeConsoleMain class was incorrect in the mainClass field for the console app jar file (probably leftover from module split), this is fixed here.

Signed-off-by: Henning Sudbrock <henning.sudbrock@telekom.de>