### PR TITLE
[296] Fixes the include setting for the license goal

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,7 @@
 					<failIfMissing>true</failIfMissing>
 					<strictCheck>true</strictCheck>
 					<includes>
-						<include>src/**/*.java</include>
+						<include>*/src/**/*.java</include>
 					</includes>
 					<properties>
 						<year>2018</year>


### PR DESCRIPTION
In https://github.com/zsmartsystems/com.zsmartsystems.zigbee/pull/290 the mycila maven-license-plugin was configured so that it will consider also files in submodules when being executed in the parent module, and will not run in the submodules anymore.
However, the includes property was not appropriately changed as well. The includes property needs to specify the source files relative to the parent module now (while it had to specify them relative to the submodules before).

This commit adapts this by prepending a "*/" to the includes specification.

Bug: https://github.com/zsmartsystems/com.zsmartsystems.zigbee/issues/296
Signed-off-by: Henning Sudbrock <henning.sudbrock@telekom.de>