### PR TITLE
Added extension concept to work at the application layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,14 +98,30 @@ The following table provides a summary of some of the dongles / chipsets that ar
 * Receive: Defines the typical receive performance. A lower number is best.
 * Transmit: Defines the maximum output power. A higher number is best.
 
-## Applications
+# Application Extensions
 
-The framework includes functional applications to support higher layer functionality. This includes -:
+The framework includes optional functional applications to support higher layer functionality. Extensions implement the ```ZigBeeNetworkExtension``` interface and are registered with the network manager with the ```ZigBeeNetworkManager.addExtension()``` method. Extensions provide the top level network manager functionality and are normally augmented with lower level client/server functions associated with specific clusters. These client/server applications implement the ```ZigBeeApplication``` interface and are registered with the endpoint with the ```ZigBeeEndpoint.addApplication()``` method.
 
-* IAS CIE client
-* OTA Upgrade Server
+Currently implemented extensions include -:
 
-These provide minimal functionality and can be extended as required.
+* IAS CIE client (```ZigBeeIasCieExtension```)
+* OTA Upgrade Server (```ZigBeeOtaUpgradeExtension```)
+
+These provide basic functionality and can be extended as required to meet the application needs.
+
+## Overview
+
+Extensions may provide different levels of functionality - an extension may be as simple as configuring the framework to work with a specific feature, or could provide a detailed application.
+
+An example of a simple extension is the ```ZigBeeOtaUpgradeExtension``` which simply listens for new devices on the network, and adds the ```ZclOtaUpgradeServer``` to the endpoint.
+
+A more complex extension could for example handle the CIE IAS zones, providing a cross device implementation to coordinate the allocation of zones and handling of alarms.
+
+Extensions should normally register as a ```ZigBeeNetworkNodeListener``` to get notified when a node is discovered or removed from the network so that they can add support to the node. The extension will then register a client or server application with the endpoint. The client/server application may register for callbacks with the endpoint (or node).
+
+Extension may want to register a supported cluster with the ```ZigBeeNetworkManager.addSupportedCluster()``` method so that the services provided are discoverable.
+
+Client/Server implementations will normally be linked to a specific cluster and provide the application logic for the cluster. The client/server implementation class should be named with the same name as the cluster, but exchanging ```Cluster``` for ```Client``` or ```Server``` (eg a server supporting the ```ZclOtaUpgradeCluster``` would be named ```ZclOtaUpgradeServer```).
 
 # Console Application
 
@@ -115,7 +131,7 @@ All commands implement the ```ZigBeeConsoleCommand``` interface, providing an ea
 
 The command handlers used in the console application are in the package ```com.zsmartsystems.zigbee.console```. This is separate from the main console application, and this allows the command handlers to be incorporated into other frameworks.
 
-Command handlers for commands specific to each dongle implementation are in the package ```com.zsmartsystems.zigbee.console.xxx``` (where xxx is the name of the dongle). These commands allow access to non standard API relating solely to each dongle.
+Command handlers for commands specific to each dongle implementation are in the package ```com.zsmartsystems.zigbee.console.abc``` (where abc is the name of the dongle). These commands allow access to non standard API relating solely to each dongle.
 
 Command handlers take a set of arguments as provided by the user and will throw ```IllegalArgumentException``` if there are any errors with arguments, or ```IllegalStateException``` if there are any issues with the network state that prevent the command execution.
 
@@ -131,24 +147,25 @@ Syntax: [EMBER|CC2531|TELEGESIS|CONBEE|XBEE] SERIALPORT SERIALBAUD CHANNEL PAN E
 ### General Commands
 Note that the console is currently being refactored and this readme only documents the commands that have been migrated. For a full list of commands, use the _help_ command in the console.
 
-| Command         | Description                                           |
-|-----------------|-------------------------------------------------------|
-|join             |Enable or disable network join                         |
-|leave            |Remove a node from the network                         |
-|nodelist         |Lists the known nodes in the network                   |
-|node             |Provides detailed information about a node             |
-|endpoint         |Provides detailed information about an endpoint        |
-|info             |Get basic info about a device                          |
-|read             |Read an attribute                                      |
-|write            |Write an attribute                                     |
-|bind             |Binds a device to another device                       |
-|unbind           |Unbinds a device from another device                   |
-|bindtable        |Reads and displays the binding table from a node       |
-|attsupported     |Check what attributes are supported within a cluster   |
-|subscribe        |Subscribe to attribute reports                         |
-|unsubscribe      |Unsubscribe from attribute reports                     |
-|reportcfg        |Read the reporting configuration of an attribute       |
-|installkey       |Adds an install key to the dongle                      |
+| Command         | Description                                                          |
+|-----------------|----------------------------------------------------------------------|
+|join             |Enable or disable network join                                        |
+|leave            |Remove a node from the network                                        |
+|nodelist         |Lists the known nodes in the network                                  |
+|node             |Provides detailed information about a node                            |
+|endpoint         |Provides detailed information about an endpoint                       |
+|info             |Get basic info about a device                                         |
+|read             |Read an attribute                                                     |
+|write            |Write an attribute                                                    |
+|bind             |Binds a device to another device                                      |
+|unbind           |Unbinds a device from another device                                  |
+|bindtable        |Reads and displays the binding table from a node                      |
+|attsupported     |Check what attributes are supported within a cluster                  |
+|subscribe        |Subscribe to attribute reports                                        |
+|unsubscribe      |Unsubscribe from attribute reports                                    |
+|reportcfg        |Read the reporting configuration of an attribute                      |
+|otaupgrade       |Provides information about device Over The Air upgrade server status  |
+|installkey       |Adds an install key to the dongle                                     |
 
 
 ### Ember NCP Commands

--- a/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleOtaUpgradeCommand.java
+++ b/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleOtaUpgradeCommand.java
@@ -1,0 +1,116 @@
+/**
+ * Copyright (c) 2016-2018 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.console;
+
+import java.io.PrintStream;
+import java.util.Map;
+import java.util.TreeMap;
+
+import com.zsmartsystems.zigbee.ZigBeeEndpoint;
+import com.zsmartsystems.zigbee.ZigBeeNetworkManager;
+import com.zsmartsystems.zigbee.ZigBeeNode;
+import com.zsmartsystems.zigbee.app.ZigBeeApplication;
+import com.zsmartsystems.zigbee.app.otaserver.ZclOtaUpgradeServer;
+import com.zsmartsystems.zigbee.zcl.clusters.ZclOtaUpgradeCluster;
+
+/**
+ *
+ * @author Chris Jackson
+ *
+ */
+public class ZigBeeConsoleOtaUpgradeCommand extends ZigBeeConsoleAbstractCommand {
+    @Override
+    public String getCommand() {
+        return "otaupgrade";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Provides detailed information about device over the air upgrade server status.";
+    }
+
+    @Override
+    public String getSyntax() {
+        return "[NODEID]";
+    }
+
+    @Override
+    public String getHelp() {
+        return "";
+    }
+
+    @Override
+    public void process(ZigBeeNetworkManager networkManager, String[] args, PrintStream out)
+            throws IllegalArgumentException {
+        if (args.length == 1) {
+            cmdDisplayAllNodes(networkManager, out);
+            return;
+        }
+
+        Map<Integer, ZigBeeEndpoint> applications = getApplications(networkManager, ZclOtaUpgradeCluster.CLUSTER_ID);
+
+        ZigBeeNode node = getNode(networkManager, args[1]);
+
+        ZigBeeEndpoint endpoint = null;
+        ZclOtaUpgradeServer server = null;
+        for (ZigBeeEndpoint applicationEndpoint : applications.values()) {
+            if (applicationEndpoint.getParentNode().equals(node)) {
+                endpoint = applicationEndpoint;
+                server = (ZclOtaUpgradeServer) endpoint.getApplication(ZclOtaUpgradeCluster.CLUSTER_ID);
+            }
+        }
+
+        if (server == null) {
+            throw new IllegalArgumentException(
+                    "Node " + node.getNetworkAddress().toString() + " does not implement the OTA Upgrade server");
+        }
+
+        if (args.length == 2) {
+            cmdDisplayNode(endpoint, server, out);
+            return;
+        }
+
+        throw new IllegalArgumentException("Invalid number of arguments");
+    }
+
+    private void cmdDisplayAllNodes(ZigBeeNetworkManager networkManager, PrintStream out) {
+        Map<Integer, ZigBeeEndpoint> applications = getApplications(networkManager, ZclOtaUpgradeCluster.CLUSTER_ID);
+        if (applications.isEmpty()) {
+            out.println("No OTA upgrade servers found.");
+            return;
+        }
+
+        out.println("Address    Ieee Address      State     ");
+        for (ZigBeeEndpoint endpoint : applications.values()) {
+            ZclOtaUpgradeServer otaServer = (ZclOtaUpgradeServer) endpoint
+                    .getApplication(ZclOtaUpgradeCluster.CLUSTER_ID);
+            out.println(String.format("%-9s  %s  %-8s", endpoint.getEndpointAddress(), endpoint.getIeeeAddress(),
+                    otaServer.getServerStatus()));
+        }
+    }
+
+    private void cmdDisplayNode(ZigBeeEndpoint endpoint, ZclOtaUpgradeServer otaServer, PrintStream out) {
+        out.println("OTA Upgrade configuration for " + endpoint.getEndpointAddress());
+        out.println("Current state : " + otaServer.getServerStatus());
+    }
+
+    private Map<Integer, ZigBeeEndpoint> getApplications(ZigBeeNetworkManager networkManager, int clusterId) {
+        Map<Integer, ZigBeeEndpoint> applications = new TreeMap<>();
+
+        for (ZigBeeNode node : networkManager.getNodes()) {
+            for (ZigBeeEndpoint endpoint : node.getEndpoints()) {
+                ZigBeeApplication application = endpoint.getApplication(clusterId);
+                if (application != null) {
+                    applications.put(endpoint.getEndpointId(), endpoint);
+                }
+            }
+        }
+
+        return applications;
+    }
+}

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeEndpoint.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeEndpoint.java
@@ -38,7 +38,7 @@ public class ZigBeeEndpoint {
     /**
      * The {@link Logger}.
      */
-    private final static Logger logger = LoggerFactory.getLogger(ZigBeeEndpoint.class);
+    private final Logger logger = LoggerFactory.getLogger(ZigBeeEndpoint.class);
 
     /**
      * The {@link ZigBeeNetworkManager} that manages this endpoint

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNode.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNode.java
@@ -30,12 +30,9 @@ import com.zsmartsystems.zigbee.internal.NotificationService;
 import com.zsmartsystems.zigbee.internal.ZigBeeNodeServiceDiscoverer;
 import com.zsmartsystems.zigbee.internal.ZigBeeNodeServiceDiscoverer.NodeDiscoveryTask;
 import com.zsmartsystems.zigbee.zcl.ZclCommand;
-import com.zsmartsystems.zigbee.zdo.ZdoStatus;
 import com.zsmartsystems.zigbee.zdo.command.ManagementBindRequest;
 import com.zsmartsystems.zigbee.zdo.command.ManagementBindResponse;
 import com.zsmartsystems.zigbee.zdo.command.ManagementPermitJoiningRequest;
-import com.zsmartsystems.zigbee.zdo.command.MatchDescriptorRequest;
-import com.zsmartsystems.zigbee.zdo.command.MatchDescriptorResponse;
 import com.zsmartsystems.zigbee.zdo.field.BindingTable;
 import com.zsmartsystems.zigbee.zdo.field.NeighborTable;
 import com.zsmartsystems.zigbee.zdo.field.NodeDescriptor;
@@ -617,43 +614,6 @@ public class ZigBeeNode implements ZigBeeCommandListener {
         // Check if it's our address
         if (command.getSourceAddress().getAddress() != networkAddress) {
             return;
-        }
-
-        // If we have local servers matching the request, then we need to respond
-        if (command instanceof MatchDescriptorRequest) {
-            MatchDescriptorRequest matchRequest = (MatchDescriptorRequest) command;
-            if (matchRequest.getProfileId() != 0x104) {
-                // TODO: Remove this constant ?
-                return;
-            }
-
-            // We want to match any of our local servers (ie our input clusters) with any
-            // requested clusters in the requests cluster list
-            boolean matched = false;
-            for (ZigBeeEndpoint endpoint : endpoints.values()) {
-                for (int clusterId : matchRequest.getInClusterList()) {
-                    if (endpoint.getApplication(clusterId) != null) {
-                        matched = true;
-                        break;
-                    }
-                }
-                if (matched) {
-                    break;
-                }
-            }
-
-            if (!matched) {
-                return;
-            }
-
-            MatchDescriptorResponse matchResponse = new MatchDescriptorResponse();
-            matchResponse.setStatus(ZdoStatus.SUCCESS);
-            List<Integer> matchList = new ArrayList<Integer>();
-            matchList.add(1);
-            matchResponse.setMatchList(matchList);
-
-            matchResponse.setDestinationAddress(command.getSourceAddress());
-            networkManager.sendCommand(matchResponse);
         }
 
         if (!(command instanceof ZclCommand)) {

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/ZigBeeApplication.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/ZigBeeApplication.java
@@ -15,9 +15,12 @@ import com.zsmartsystems.zigbee.zcl.ZclCluster;
 /**
  * Defines the interface for a ZigBee Application
  * <p>
- * Applications provide specific functionality in the framework and can be instantiated and registered with a node.
+ * Applications provide specific functionality in the framework and can be instantiated and registered with an endpoint.
  * An application is registered with the {@link ZigBeeEndpoint}, and the endpoint will take care of starting and
  * stopping the application, and passing any received commands to the application.
+ * <p>
+ * Normally, this will be managed through a {@link ZigBeeNetworkExtension} which will manage the addition of the
+ * application to the endpoint when the node joins the network, along with responding to the service discovery requests.
  *
  * @author Chris Jackson
  *

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/ZigBeeNetworkExtension.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/ZigBeeNetworkExtension.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2016-2018 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.app;
+
+import com.zsmartsystems.zigbee.ZigBeeAnnounceListener;
+import com.zsmartsystems.zigbee.ZigBeeCommandListener;
+import com.zsmartsystems.zigbee.ZigBeeNetworkManager;
+import com.zsmartsystems.zigbee.ZigBeeNetworkNodeListener;
+import com.zsmartsystems.zigbee.ZigBeeNetworkStateListener;
+
+/**
+ * Defines the interface for a ZigBee Extension.
+ * <p>
+ * Extensions provide specific functionality in the framework and can be instantiated and registered with the network
+ * manager. An extension is registered with the {@link ZigBeeNetworkManager}, and the manager will take care of
+ * starting and stopping the extension.
+ * <p>
+ * Extensions should register with the standard {@link ZigBeeNetworkManager} listeners to receive network notifications
+ * -:
+ * <ul>
+ * <li>{@link ZigBeeNetworkStateListener} for network state changes
+ * <li>{@link ZigBeeNetworkNodeListener} for updates to nodes
+ * <li>{@link ZigBeeCommandListener} to receive incoming commands
+ * <li>{@link ZigBeeAnnounceListener} to receive announcement messages
+ * </ul>
+ *
+ * @author Chris Jackson
+ *
+ */
+public interface ZigBeeNetworkExtension {
+
+    /**
+     * Starts an extension. The extension should perform any initialisation. This gets called when
+     * the extension is registered.
+     *
+     * @param networkManager The {@link ZigBeeNetworkManager} of the network
+     * @return true if the extension started successfully
+     */
+    public boolean extensionStartup(final ZigBeeNetworkManager networkManager);
+
+    /**
+     * Shuts down an extension. The extension should perform any shutdown and cleanup as required.
+     */
+    public void extensionShutdown();
+}

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/iasclient/ZclIasZoneClient.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/iasclient/ZclIasZoneClient.java
@@ -87,11 +87,11 @@ import com.zsmartsystems.zigbee.zcl.clusters.iaszone.ZoneTypeEnum;
  * @author Chris Jackson
  *
  */
-public class ZigBeeIasCieApp implements ZigBeeApplication {
+public class ZclIasZoneClient implements ZigBeeApplication {
     /**
      * The logger.
      */
-    private final Logger logger = LoggerFactory.getLogger(ZigBeeIasCieApp.class);
+    private final Logger logger = LoggerFactory.getLogger(ZclIasZoneClient.class);
 
     /**
      * The IAS cluster to which we're bound
@@ -116,7 +116,7 @@ public class ZigBeeIasCieApp implements ZigBeeApplication {
     /**
      * Constructor
      */
-    public ZigBeeIasCieApp(IeeeAddress ieeeAddress, int zone) {
+    public ZclIasZoneClient(IeeeAddress ieeeAddress, int zone) {
         this.ieeeAddress = ieeeAddress;
         this.zone = zone;
     }
@@ -152,6 +152,12 @@ public class ZigBeeIasCieApp implements ZigBeeApplication {
     public boolean appStartup(ZclCluster cluster) {
         iasZoneCluster = (ZclIasZoneCluster) cluster;
 
+        initialise();
+
+        return true;
+    }
+
+    private void initialise() {
         Integer currentState = iasZoneCluster.getZoneState(0);
         if (currentState != null) {
             ZoneStateEnum currentStateEnum = ZoneStateEnum.getByValue(currentState);
@@ -184,8 +190,6 @@ public class ZigBeeIasCieApp implements ZigBeeApplication {
             logger.debug("{}: IAS CIE zone type is 0x{}, {}", iasZoneCluster.getZigBeeAddress(),
                     String.format("%04X", zoneType), ZoneTypeEnum.getByValue(zoneType));
         }
-
-        return false;
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/iasclient/ZigBeeIasCieExtension.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/iasclient/ZigBeeIasCieExtension.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2016-2018 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.app.iasclient;
+
+import com.zsmartsystems.zigbee.ZigBeeEndpoint;
+import com.zsmartsystems.zigbee.ZigBeeNetworkManager;
+import com.zsmartsystems.zigbee.ZigBeeNetworkNodeListener;
+import com.zsmartsystems.zigbee.ZigBeeNode;
+import com.zsmartsystems.zigbee.app.ZigBeeNetworkExtension;
+import com.zsmartsystems.zigbee.zcl.clusters.ZclIasZoneCluster;
+
+/**
+ * IAS extension. This provides the top level functionality for the IAS application.
+ * <p>
+ * It listens for new nodes that are discovered on the network and registers the {@link ZclIasZoneCluster} if the
+ * device supports IAS Zone control.
+ *
+ * @author Chris Jackson
+ *
+ */
+public class ZigBeeIasCieExtension implements ZigBeeNetworkExtension, ZigBeeNetworkNodeListener {
+    // private final Map<Integer, IeeeAddress> zoneMap = new ConcurrentHashMap<>();
+
+    private ZigBeeNetworkManager networkManager;
+
+    @Override
+    public boolean extensionStartup(ZigBeeNetworkManager networkManager) {
+        this.networkManager = networkManager;
+
+        networkManager.addSupportedCluster(ZclIasZoneCluster.CLUSTER_ID);
+        networkManager.addNetworkNodeListener(this);
+        return false;
+    }
+
+    @Override
+    public void extensionShutdown() {
+        networkManager.removeNetworkNodeListener(this);
+    }
+
+    @Override
+    public void nodeAdded(ZigBeeNode node) {
+        for (ZigBeeEndpoint endpoint : node.getEndpoints()) {
+            if (endpoint.getInputCluster(ZclIasZoneCluster.CLUSTER_ID) != null) {
+                endpoint.addApplication(new ZclIasZoneClient(networkManager.getNode(0).getIeeeAddress(), 0));
+                break;
+            }
+        }
+    }
+
+    @Override
+    public void nodeUpdated(ZigBeeNode node) {
+        // Not used
+    }
+
+    @Override
+    public void nodeRemoved(ZigBeeNode node) {
+        // Not used
+    }
+}

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/otaserver/ZclOtaUpgradeServer.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/otaserver/ZclOtaUpgradeServer.java
@@ -81,7 +81,7 @@ import com.zsmartsystems.zigbee.zcl.field.ByteArray;
  * <li>Server sends <i>Image Block Response</i>
  * <li>... repeat to end of transfer
  * <li>Client sends <i>Upgrade End Request</i>. Status set to {@link ZigBeeOtaServerStatus#OTA_TRANSFER_COMPLETE}.
- * <li>Server waits for {@link #completeUpgrade()} to be called unless {@link ZigBeeOtaServer#autoUpgrade} is true.
+ * <li>Server waits for {@link #completeUpgrade()} to be called unless {@link ZclOtaUpgradeServer#autoUpgrade} is true.
  * <li>Server checks the client state. If it is {@link ImageUpgradeStatus.DOWNLOAD_COMPLETE} it sends <i>Upgrade End
  * Response</i>.
  * <li>Client should respond with the default response, but this may not always be implemented as the device may start
@@ -105,7 +105,7 @@ import com.zsmartsystems.zigbee.zcl.field.ByteArray;
  *
  * @author Chris Jackson
  */
-public class ZigBeeOtaServer implements ZigBeeApplication {
+public class ZclOtaUpgradeServer implements ZigBeeApplication {
     /**
      * A static Thread pool is used here to ensure that we don't end up with large numbers of page requests
      * spawning multiple threads. This should ensure a level of pacing if we had a lot of devices on the network that
@@ -116,7 +116,7 @@ public class ZigBeeOtaServer implements ZigBeeApplication {
     /**
      * The logger.
      */
-    private final Logger logger = LoggerFactory.getLogger(ZigBeeOtaServer.class);
+    private final Logger logger = LoggerFactory.getLogger(ZclOtaUpgradeServer.class);
 
     /**
      * The current {@link ZigBeeOtaServerStatus} associated with this server.
@@ -225,7 +225,7 @@ public class ZigBeeOtaServer implements ZigBeeApplication {
     /**
      * Constructor
      */
-    public ZigBeeOtaServer() {
+    public ZclOtaUpgradeServer() {
         status = ZigBeeOtaServerStatus.OTA_UNINITIALISED;
 
         // queryJitter needs to be a random value between 1 and 100

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/otaserver/ZigBeeOtaFile.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/otaserver/ZigBeeOtaFile.java
@@ -22,7 +22,7 @@ import com.zsmartsystems.zigbee.zcl.field.ByteArray;
  * Defines a ZigBee Over The Air upgrade file.
  * <p>
  * This class will read the file header, and each tag from the file and provide methods to read this data within the
- * {@link ZigBeeOtaServer}.
+ * {@link ZclOtaUpgradeServer}.
  * <p>
  * The OTA file format is composed of a header followed by a number of sub-elements. The header
  * describes general information about the file such as version, the manufacturer that created it, and the

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/otaserver/ZigBeeOtaServerStatus.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/otaserver/ZigBeeOtaServerStatus.java
@@ -8,7 +8,7 @@
 package com.zsmartsystems.zigbee.app.otaserver;
 
 /**
- * An enumeration defining the {@link ZigBeeOtaServer} status provided to the {@link ZigBeeStatusCallback}
+ * An enumeration defining the {@link ZclOtaUpgradeServer} status provided to the {@link ZigBeeStatusCallback}
  *
  * @author Chris Jackson
  *

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/otaserver/ZigBeeOtaUpgradeExtension.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/otaserver/ZigBeeOtaUpgradeExtension.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2016-2018 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.app.otaserver;
+
+import com.zsmartsystems.zigbee.ZigBeeEndpoint;
+import com.zsmartsystems.zigbee.ZigBeeNetworkManager;
+import com.zsmartsystems.zigbee.ZigBeeNetworkNodeListener;
+import com.zsmartsystems.zigbee.ZigBeeNode;
+import com.zsmartsystems.zigbee.app.ZigBeeNetworkExtension;
+import com.zsmartsystems.zigbee.zcl.clusters.ZclOtaUpgradeCluster;
+
+/**
+ * Over The Air Upgrade extension. This provides the top level functionality for the OTA client.
+ * <p>
+ * It listens for new nodes that are discovered on the network and registers the {@link ZclOtaUpgradeServer} if the
+ * device supports OTA.
+ *
+ * @author Chris Jackson
+ *
+ */
+public class ZigBeeOtaUpgradeExtension implements ZigBeeNetworkExtension, ZigBeeNetworkNodeListener {
+    private ZigBeeNetworkManager networkManager;
+
+    @Override
+    public boolean extensionStartup(ZigBeeNetworkManager networkManager) {
+        this.networkManager = networkManager;
+
+        networkManager.addSupportedCluster(ZclOtaUpgradeCluster.CLUSTER_ID);
+        networkManager.addNetworkNodeListener(this);
+        return false;
+    }
+
+    @Override
+    public void extensionShutdown() {
+        networkManager.removeNetworkNodeListener(this);
+    }
+
+    @Override
+    public void nodeAdded(ZigBeeNode node) {
+        for (ZigBeeEndpoint endpoint : node.getEndpoints()) {
+            if (endpoint.getOutputCluster(ZclOtaUpgradeCluster.CLUSTER_ID) != null) {
+                endpoint.addApplication(new ZclOtaUpgradeServer());
+                break;
+            }
+        }
+    }
+
+    @Override
+    public void nodeUpdated(ZigBeeNode node) {
+        // Not used
+    }
+
+    @Override
+    public void nodeRemoved(ZigBeeNode node) {
+        // Not used
+    }
+
+}

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/app/otaupgrade/ZclOtaUpgradeServerTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/app/otaupgrade/ZclOtaUpgradeServerTest.java
@@ -5,7 +5,7 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  */
-package com.zsmartsystems.zigbee.otaserver;
+package com.zsmartsystems.zigbee.app.otaupgrade;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -32,8 +32,8 @@ import com.zsmartsystems.zigbee.ZigBeeEndpointAddress;
 import com.zsmartsystems.zigbee.ZigBeeNetworkManager;
 import com.zsmartsystems.zigbee.ZigBeeNode;
 import com.zsmartsystems.zigbee.ZigBeeTransactionMatcher;
+import com.zsmartsystems.zigbee.app.otaserver.ZclOtaUpgradeServer;
 import com.zsmartsystems.zigbee.app.otaserver.ZigBeeOtaFile;
-import com.zsmartsystems.zigbee.app.otaserver.ZigBeeOtaServer;
 import com.zsmartsystems.zigbee.app.otaserver.ZigBeeOtaServerStatus;
 import com.zsmartsystems.zigbee.app.otaserver.ZigBeeOtaStatusCallback;
 import com.zsmartsystems.zigbee.zcl.clusters.ZclOtaUpgradeCluster;
@@ -45,7 +45,7 @@ import com.zsmartsystems.zigbee.zdo.field.NodeDescriptor;
  * @author Chris Jackson
  *
  */
-public class ZigBeeOtaServerTest implements ZigBeeOtaStatusCallback {
+public class ZclOtaUpgradeServerTest implements ZigBeeOtaStatusCallback {
     private List<ZigBeeOtaServerStatus> otaStatusCapture;
 
     @Test
@@ -100,7 +100,7 @@ public class ZigBeeOtaServerTest implements ZigBeeOtaStatusCallback {
 
         ZclOtaUpgradeCluster cluster = new ZclOtaUpgradeCluster(mockedNetworkManager, endpoint);
 
-        ZigBeeOtaServer server = new ZigBeeOtaServer();
+        ZclOtaUpgradeServer server = new ZclOtaUpgradeServer();
         assertTrue(server.appStartup(cluster));
         server.addListener(this);
 

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/app/otaupgrade/ZigBeeOtaFileTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/app/otaupgrade/ZigBeeOtaFileTest.java
@@ -5,7 +5,7 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  */
-package com.zsmartsystems.zigbee.otaserver;
+package com.zsmartsystems.zigbee.app.otaupgrade;
 
 import static org.junit.Assert.assertEquals;
 


### PR DESCRIPTION
This adds a top level extension concept to allow application extension. This is a light interface allowing the extensions to hook in to the existing Network Manager listeners to extend the system functionality in a common way. The network manager takes care of starting and stopping extensions.

This is meant to work alongside the existing application extensions that work at the cluster/endpoint level.

Extensions may provide different levels of functionality - an extension may be as simple as configuring the framework to work with a specific feature, or could provide a detailed application.

An example of a simple extension is the ```ZigBeeOtaUpgradeExtension``` which simply listens for new devices on the network, and adds the ```ZclOtaUpgradeServer``` to the endpoint.

A more complex extension could for example handle the CIE IAS zones, providing a cross device implementation to coordinate the allocation of zones and handling of alarms.

Extensions should normally register as a ```ZigBeeNetworkNodeListener``` to get notified when a node is discovered or removed from the network so that they can add support to the node. The extension will then register a client or server application with the endpoint. The client/server application may register for callbacks with the endpoint (or node).

Extension may want to register a supported cluster with the ```ZigBeeNetworkManager.addSupportedCluster()``` method so that the services provided are discoverable.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>