### PR TITLE
Change ZigBee OCTET_STRING type to use ByteArray

### DIFF
--- a/com.zsmartsystems.zigbee.autocode/src/main/java/com/zsmartsystems/zigbee/autocode/zcl/ZclDataType.java
+++ b/com.zsmartsystems.zigbee.autocode/src/main/java/com/zsmartsystems/zigbee/autocode/zcl/ZclDataType.java
@@ -97,7 +97,7 @@ public class ZclDataType {
         dataTypeMapping.put("ENUMERATION_16_BIT", new DataTypeMap("Integer", 0x31, 2, false, 0xffff));
         dataTypeMapping.put("ENUMERATION_8_BIT", new DataTypeMap("Integer", 0x30, 1, false, 0xff));
         dataTypeMapping.put("DATA_8_BIT", new DataTypeMap("Integer", 0x08, 1, false));
-        dataTypeMapping.put("OCTET_STRING", new DataTypeMap("String", 0x41, -1, false));
+        dataTypeMapping.put("OCTET_STRING", new DataTypeMap("ByteArray", 0x41, -1, false));
         dataTypeMapping.put("UTCTIME", new DataTypeMap("Calendar", 0xe2, 4, true, 0xffffffff));
         dataTypeMapping.put("ZDO_STATUS", new DataTypeMap("ZdoStatus", 0, 0, false));
         dataTypeMapping.put("ZCL_STATUS", new DataTypeMap("ZclStatus", 0, 0, false));

--- a/com.zsmartsystems.zigbee.console.main/src/main/java/com/zsmartsystems/zigbee/console/main/ZigBeeApi.java
+++ b/com.zsmartsystems.zigbee.console.main/src/main/java/com/zsmartsystems/zigbee/console/main/ZigBeeApi.java
@@ -22,8 +22,6 @@ import com.zsmartsystems.zigbee.zcl.ZclCluster;
 import com.zsmartsystems.zigbee.zcl.ZclTransactionMatcher;
 import com.zsmartsystems.zigbee.zcl.clusters.ZclOnOffCluster;
 import com.zsmartsystems.zigbee.zcl.clusters.colorcontrol.MoveToColorCommand;
-import com.zsmartsystems.zigbee.zcl.clusters.doorlock.LockDoorCommand;
-import com.zsmartsystems.zigbee.zcl.clusters.doorlock.UnlockDoorCommand;
 import com.zsmartsystems.zigbee.zcl.clusters.groups.AddGroupCommand;
 import com.zsmartsystems.zigbee.zcl.clusters.groups.GetGroupMembershipCommand;
 import com.zsmartsystems.zigbee.zcl.clusters.groups.RemoveGroupCommand;
@@ -170,36 +168,6 @@ public class ZigBeeApi {
 
         command.setLevel(l);
         command.setTransitionTime((int) (time * 10));
-
-        return networkManager.send(destination, command);
-    }
-
-    /**
-     * Locks door.
-     *
-     * @param destination the {@link ZigBeeAddress}
-     * @param pinCode the pin code
-     * @return the command result future.
-     */
-    public Future<CommandResult> lock(final ZigBeeAddress destination, final String pinCode) {
-        final LockDoorCommand command = new LockDoorCommand();
-
-        command.setPinCode(pinCode);
-
-        return networkManager.send(destination, command);
-    }
-
-    /**
-     * Unlocks door.
-     *
-     * @param destination the {@link ZigBeeAddress}
-     * @param pinCode the pin code
-     * @return the command result future.
-     */
-    public Future<CommandResult> unlock(final ZigBeeAddress destination, final String pinCode) {
-        final UnlockDoorCommand command = new UnlockDoorCommand();
-
-        command.setPinCode(pinCode);
 
         return networkManager.send(destination, command);
     }

--- a/com.zsmartsystems.zigbee.console.main/src/main/java/com/zsmartsystems/zigbee/console/main/ZigBeeConsole.java
+++ b/com.zsmartsystems.zigbee.console.main/src/main/java/com/zsmartsystems/zigbee/console/main/ZigBeeConsole.java
@@ -124,7 +124,7 @@ public final class ZigBeeConsole {
      * Constructor which configures ZigBee API and constructs commands.
      *
      * @param dongle the dongle
-     * @param commands2
+     * @param transportCommands
      */
     public ZigBeeConsole(final ZigBeeNetworkManager networkManager, final ZigBeeTransportTransmit dongle,
             List<Class<? extends ZigBeeConsoleCommand>> transportCommands) {
@@ -159,8 +159,6 @@ public final class ZigBeeConsole {
         commands.put("lqi", new LqiCommand());
         commands.put("warn", new WarnCommand());
         commands.put("squawk", new SquawkCommand());
-        commands.put("lock", new DoorLockCommand());
-        commands.put("unlock", new DoorUnlockCommand());
         commands.put("enroll", new EnrollCommand());
 
         commands.put("firmware", new FirmwareCommand());
@@ -908,88 +906,6 @@ public final class ZigBeeConsole {
             }
 
             final CommandResult response = zigbeeApi.level(destination, level, time).get();
-            return defaultResponseProcessing(response, out);
-        }
-    }
-
-    /**
-     * Locks door.
-     */
-    private class DoorLockCommand implements ConsoleCommand {
-        /**
-         * {@inheritDoc}
-         */
-        @Override
-        public String getDescription() {
-            return "Locks door.";
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        @Override
-        public String getSyntax() {
-            return "lock DEVICEID PINCODE";
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        @Override
-        public boolean process(final ZigBeeApi zigbeeApi, final String[] args, PrintStream out) throws Exception {
-            if (args.length != 3) {
-                return false;
-            }
-
-            final ZigBeeAddress destination = getDestination(zigbeeApi, args[1], out);
-            if (destination == null) {
-                return false;
-            }
-
-            final String pinCode = args[2];
-
-            final CommandResult response = zigbeeApi.lock(destination, pinCode).get();
-            return defaultResponseProcessing(response, out);
-        }
-    }
-
-    /**
-     * Locks door.
-     */
-    private class DoorUnlockCommand implements ConsoleCommand {
-        /**
-         * {@inheritDoc}
-         */
-        @Override
-        public String getDescription() {
-            return "Unlocks door.";
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        @Override
-        public String getSyntax() {
-            return "unlock DEVICEID PINCODE";
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        @Override
-        public boolean process(final ZigBeeApi zigbeeApi, final String[] args, PrintStream out) throws Exception {
-            if (args.length != 3) {
-                return false;
-            }
-
-            final ZigBeeAddress destination = getDestination(zigbeeApi, args[1], out);
-            if (destination == null) {
-                return false;
-            }
-
-            final String pinCode = args[2];
-
-            final CommandResult response = zigbeeApi.unlock(destination, pinCode).get();
             return defaultResponseProcessing(response, out);
         }
     }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/serialization/DefaultDeserializer.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/serialization/DefaultDeserializer.java
@@ -71,21 +71,25 @@ public class DefaultDeserializer implements ZigBeeDeserializer {
             case BOOLEAN:
                 value[0] = payload[index++] == 0 ? false : true;
                 break;
-            case CHARACTER_STRING:
             case OCTET_STRING:
-                int size = payload[index++];
-                if (size == 255) {
+                int octetSize = payload[index++];
+                value[0] = new ByteArray(payload, index, octetSize);
+                index += octetSize;
+                break;
+            case CHARACTER_STRING:
+                int stringSize = payload[index++];
+                if (stringSize == 255) {
                     value[0] = null;
                     break;
                 }
-                int length = size;
-                for (int cnt = 0; cnt < size; cnt++) {
+                int length = stringSize;
+                for (int cnt = 0; cnt < stringSize; cnt++) {
                     if (payload[index + cnt] == 0) {
                         length = cnt;
                     }
                 }
                 value[0] = new String(payload, index, length);
-                index += size;
+                index += stringSize;
                 break;
             case ENDPOINT:
             case BITMAP_8_BIT:

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/serialization/DefaultSerializer.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/serialization/DefaultSerializer.java
@@ -140,10 +140,16 @@ public class DefaultSerializer implements ZigBeeSerializer {
                 break;
             case N_X_WRITE_ATTRIBUTE_STATUS_RECORD:
                 break;
-            case CHARACTER_STRING:
             case OCTET_STRING:
+                final ByteArray array = (ByteArray) data;
+                buffer[length++] = ((byte) (array.size() & 0xFF));
+                for (byte arrayByte : array.get()) {
+                    buffer[length++] = arrayByte;
+                }
+                break;
+            case CHARACTER_STRING:
                 final String str = (String) data;
-                buffer[length++] = ((byte) (str.length() & (0xFF)));
+                buffer[length++] = ((byte) (str.length() & 0xFF));
                 for (int strByte : str.getBytes()) {
                     buffer[length++] = strByte;
                 }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclDoorLockCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclDoorLockCluster.java
@@ -17,6 +17,7 @@ import com.zsmartsystems.zigbee.zcl.clusters.doorlock.LockDoorCommand;
 import com.zsmartsystems.zigbee.zcl.clusters.doorlock.LockDoorResponse;
 import com.zsmartsystems.zigbee.zcl.clusters.doorlock.UnlockDoorCommand;
 import com.zsmartsystems.zigbee.zcl.clusters.doorlock.UnlockDoorResponse;
+import com.zsmartsystems.zigbee.zcl.field.ByteArray;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Future;
@@ -27,7 +28,7 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-05-20T09:08:50Z")
 public class ZclDoorLockCluster extends ZclCluster {
     /**
      * The ZigBee Cluster Library Cluster ID
@@ -59,10 +60,10 @@ public class ZclDoorLockCluster extends ZclCluster {
     /**
      * The Lock Door Command
      *
-     * @param pinCode {@link String} Pin code
+     * @param pinCode {@link ByteArray} Pin code
      * @return the {@link Future<CommandResult>} command result future
      */
-    public Future<CommandResult> lockDoorCommand(String pinCode) {
+    public Future<CommandResult> lockDoorCommand(ByteArray pinCode) {
         LockDoorCommand command = new LockDoorCommand();
 
         // Set the fields
@@ -74,10 +75,10 @@ public class ZclDoorLockCluster extends ZclCluster {
     /**
      * The Unlock Door Command
      *
-     * @param pinCode {@link String} Pin code
+     * @param pinCode {@link ByteArray} Pin code
      * @return the {@link Future<CommandResult>} command result future
      */
-    public Future<CommandResult> unlockDoorCommand(String pinCode) {
+    public Future<CommandResult> unlockDoorCommand(ByteArray pinCode) {
         UnlockDoorCommand command = new UnlockDoorCommand();
 
         // Set the fields

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/doorlock/LockDoorCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/doorlock/LockDoorCommand.java
@@ -14,6 +14,7 @@ import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
+import com.zsmartsystems.zigbee.zcl.field.ByteArray;
 
 /**
  * Lock Door Command value object class.
@@ -23,12 +24,12 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-05-20T09:08:50Z")
 public class LockDoorCommand extends ZclCommand {
     /**
      * Pin code command message field.
      */
-    private String pinCode;
+    private ByteArray pinCode;
 
     /**
      * Default constructor.
@@ -45,7 +46,7 @@ public class LockDoorCommand extends ZclCommand {
      *
      * @return the Pin code
      */
-    public String getPinCode() {
+    public ByteArray getPinCode() {
         return pinCode;
     }
 
@@ -54,7 +55,7 @@ public class LockDoorCommand extends ZclCommand {
      *
      * @param pinCode the Pin code
      */
-    public void setPinCode(final String pinCode) {
+    public void setPinCode(final ByteArray pinCode) {
         this.pinCode = pinCode;
     }
 
@@ -65,7 +66,7 @@ public class LockDoorCommand extends ZclCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        pinCode = (String) deserializer.deserialize(ZclDataType.OCTET_STRING);
+        pinCode = (ByteArray) deserializer.deserialize(ZclDataType.OCTET_STRING);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/doorlock/UnlockDoorCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/doorlock/UnlockDoorCommand.java
@@ -14,6 +14,7 @@ import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
+import com.zsmartsystems.zigbee.zcl.field.ByteArray;
 
 /**
  * Unlock Door Command value object class.
@@ -23,12 +24,12 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-14T23:37:27Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-05-20T09:08:50Z")
 public class UnlockDoorCommand extends ZclCommand {
     /**
      * Pin code command message field.
      */
-    private String pinCode;
+    private ByteArray pinCode;
 
     /**
      * Default constructor.
@@ -45,7 +46,7 @@ public class UnlockDoorCommand extends ZclCommand {
      *
      * @return the Pin code
      */
-    public String getPinCode() {
+    public ByteArray getPinCode() {
         return pinCode;
     }
 
@@ -54,7 +55,7 @@ public class UnlockDoorCommand extends ZclCommand {
      *
      * @param pinCode the Pin code
      */
-    public void setPinCode(final String pinCode) {
+    public void setPinCode(final ByteArray pinCode) {
         this.pinCode = pinCode;
     }
 
@@ -65,7 +66,7 @@ public class UnlockDoorCommand extends ZclCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        pinCode = (String) deserializer.deserialize(ZclDataType.OCTET_STRING);
+        pinCode = (ByteArray) deserializer.deserialize(ZclDataType.OCTET_STRING);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/field/ByteArray.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/field/ByteArray.java
@@ -28,6 +28,21 @@ public class ByteArray {
     }
 
     /**
+     * Constructor taking part of an existing integer array
+     *
+     * @param payload the existing integer array
+     * @param from the start offset of the array
+     * @param to the end offset of the array
+     */
+    public ByteArray(int[] payload, int start, int finish) {
+        value = new byte[finish - start + 1];
+        int outCnt = 0;
+        for (int cnt = start; cnt <= finish; cnt++) {
+            value[outCnt++] = (byte) (payload[cnt] & 0xFF);
+        }
+    }
+
+    /**
      * Gets the byte array value.
      *
      * @return the value
@@ -42,19 +57,29 @@ public class ByteArray {
      * @return the length of the data in the array
      */
     public int size() {
-        if (value == null) {
-            return 0;
-        }
         return value.length;
     }
 
     /**
      * Sets the byte array value.
      *
-     * @param value the value
+     * @param value the value as a byte array
      */
     public void set(byte[] value) {
         this.value = value;
+    }
+
+    /**
+     * Sets the byte array value from an integer array.
+     *
+     * @param value the value as an integer array
+     */
+    public void set(int[] value) {
+        this.value = new byte[value.length];
+        int outCnt = 0;
+        for (int intValue : value) {
+            this.value[outCnt++] = (byte) (intValue & 0xFF);
+        }
     }
 
     @Override
@@ -83,7 +108,7 @@ public class ByteArray {
     @Override
     public String toString() {
         StringBuilder builder = new StringBuilder(120);
-        builder.append("ByteArray: value=");
+        builder.append("ByteArray [value=");
         boolean first = true;
         for (byte val : value) {
             if (!first) {
@@ -91,7 +116,9 @@ public class ByteArray {
             }
             builder.append(String.format("%02X", val & 0xFF));
         }
+        builder.append(']');
 
         return builder.toString();
     }
+
 }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/protocol/ZclDataType.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/protocol/ZclDataType.java
@@ -26,7 +26,7 @@ import com.zsmartsystems.zigbee.ExtendedPanId;
  *
  * @author Chris Jackson
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-03-31T14:10:45Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZclProtocolCodeGenerator", date = "2018-05-20T09:08:50Z")
 public enum ZclDataType {
     BITMAP_16_BIT("16-bit Bitmap", Integer.class, 0x19, false),
     BITMAP_32_BIT("32-bit Bitmap", Integer.class, 0x1B, false),
@@ -53,7 +53,7 @@ public enum ZclDataType {
     N_X_UNSIGNED_8_BIT_INTEGER("N x Unsigned 8-bit Integer", Integer.class, 0x00, false),
     N_X_WRITE_ATTRIBUTE_RECORD("N X Write attribute record", WriteAttributeRecord.class, 0x00, false),
     N_X_WRITE_ATTRIBUTE_STATUS_RECORD("N X Write attribute status record", WriteAttributeStatusRecord.class, 0x00, false),
-    OCTET_STRING("Octet string", String.class, 0x41, false),
+    OCTET_STRING("Octet string", ByteArray.class, 0x41, false),
     SIGNED_16_BIT_INTEGER("Signed 16-bit Integer", Integer.class, 0x29, true),
     SIGNED_32_BIT_INTEGER("Signed 32-bit Integer", Integer.class, 0x2B, true),
     SIGNED_8_BIT_INTEGER("Signed 8-bit Integer", Integer.class, 0x28, true),

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/serialization/SerializerIntegrationTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/serialization/SerializerIntegrationTest.java
@@ -54,6 +54,12 @@ public class SerializerIntegrationTest {
     }
 
     @Test
+    public void testDeserialize_OCTET_STRING() {
+        ByteArray valIn = new ByteArray(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 });
+        testSerializer(valIn, ZclDataType.OCTET_STRING);
+    }
+
+    @Test
     public void testDeserialize_N_X_ATTRIBUTE_IDENTIFIER() {
         List<Integer> valIn = Arrays.asList(new Integer[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 192 });
         testSerializer(valIn, ZclDataType.N_X_UNSIGNED_8_BIT_INTEGER);

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zcl/field/ByteArrayTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zcl/field/ByteArrayTest.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2016-2018 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.zcl.field;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+
+/**
+ *
+ * @author Chris Jackson
+ *
+ */
+public class ByteArrayTest {
+    @Test
+    public void testSetting() {
+        ByteArray array = new ByteArray(new byte[] { 1, 2, 3, 4, 5 });
+        System.out.println(array);
+
+        assertTrue(Arrays.equals(new byte[] { 1, 2, 3, 4, 5 }, array.get()));
+        assertEquals(5, array.size());
+
+        array.set(new byte[] { 9, 8, 7, 6, 5, 4, 3, 2, 1 });
+        assertTrue(Arrays.equals(new byte[] { 9, 8, 7, 6, 5, 4, 3, 2, 1 }, array.get()));
+
+        array.set(new int[] { 1, 2, 3, 4, 5 });
+        assertTrue(Arrays.equals(new byte[] { 1, 2, 3, 4, 5 }, array.get()));
+
+        assertEquals(new ByteArray(new byte[] { 1, 2, 3, 4, 5 }), array);
+    }
+}


### PR DESCRIPTION
OCTET_STRING should be backed by a byte array and not a string.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>