### PR TITLE
Remove listener when Telegesis dongle closes

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.telegesis/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/ZigBeeDongleTelegesis.java
+++ b/com.zsmartsystems.zigbee.dongle.telegesis/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/ZigBeeDongleTelegesis.java
@@ -303,7 +303,7 @@ public class ZigBeeDongleTelegesis
 
     /**
      * Constructor for Telegesis dongle.
-     * 
+     *
      * @param serialPort the {@link ZigBeePort} for communicating with the dongle
      */
     public ZigBeeDongleTelegesis(final ZigBeePort serialPort) {
@@ -444,6 +444,7 @@ public class ZigBeeDongleTelegesis
         if (frameHandler == null) {
             return;
         }
+        frameHandler.removeEventListener(this);
         frameHandler.setClosing();
         zigbeeTransportReceive.setNetworkState(ZigBeeTransportState.OFFLINE);
         serialPort.close();


### PR DESCRIPTION
Removes the listener from the handler when the dongle is closed.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>