### PR TITLE
Periodically poll Telegesis dongle to ensure network is still up

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.telegesis/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/ZigBeeDongleTelegesis.java
+++ b/com.zsmartsystems.zigbee.dongle.telegesis/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/ZigBeeDongleTelegesis.java
@@ -333,7 +333,7 @@ public class ZigBeeDongleTelegesis
         }
 
         // Create and start the frame handler
-        frameHandler = new TelegesisFrameHandler();
+        frameHandler = new TelegesisFrameHandler(this);
         frameHandler.start(serialPort);
         frameHandler.addEventListener(this);
 
@@ -862,6 +862,15 @@ public class ZigBeeDongleTelegesis
         }
 
         return TransportConfigResult.SUCCESS;
+    }
+
+    /**
+     * Callback method from the handler to notify if the handler goes on/off line
+     * 
+     * @param state true if the handler is online, false if offline
+     */
+    public void notifyStateUpdate(boolean state) {
+        zigbeeTransportReceive.setNetworkState(state ? ZigBeeTransportState.ONLINE : ZigBeeTransportState.OFFLINE);
     }
 
 }

--- a/com.zsmartsystems.zigbee.dongle.telegesis/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/internal/TelegesisEventListener.java
+++ b/com.zsmartsystems.zigbee.dongle.telegesis/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/internal/TelegesisEventListener.java
@@ -18,9 +18,8 @@ import com.zsmartsystems.zigbee.dongle.telegesis.internal.protocol.TelegesisEven
 public interface TelegesisEventListener {
     /**
      * Listeners are called when a new {@link TelegesisEvent} is received
-     * 
+     *
      * @param event the received {@link TelegesisEvent}
      */
     void telegesisEventReceived(TelegesisEvent event);
-
 }

--- a/com.zsmartsystems.zigbee.dongle.telegesis/src/test/java/com/zsmartsystems/zigbee/dongle/telegesis/internal/TelegesisFrameHandlerTest.java
+++ b/com.zsmartsystems.zigbee.dongle.telegesis/src/test/java/com/zsmartsystems/zigbee/dongle/telegesis/internal/TelegesisFrameHandlerTest.java
@@ -41,7 +41,7 @@ public class TelegesisFrameHandlerTest {
     private String CRLF = "\r\n";
 
     private int[] getPacket(String packet) {
-        TelegesisFrameHandler frameHandler = new TelegesisFrameHandler();
+        TelegesisFrameHandler frameHandler = new TelegesisFrameHandler(null);
         ByteArrayInputStream stream = new ByteArrayInputStream(packet.getBytes());
 
         ZigBeePort port = new TestPort(stream, null);
@@ -106,7 +106,7 @@ public class TelegesisFrameHandlerTest {
 
     @Test
     public void testRunning() {
-        TelegesisFrameHandler frameHandler = new TelegesisFrameHandler();
+        TelegesisFrameHandler frameHandler = new TelegesisFrameHandler(null);
         frameHandler.start(null);
 
         assertTrue(frameHandler.isAlive());
@@ -125,7 +125,7 @@ public class TelegesisFrameHandlerTest {
     @Ignore
     @Test
     public void testEventWait() {
-        final TelegesisFrameHandler frameHandler = new TelegesisFrameHandler();
+        final TelegesisFrameHandler frameHandler = new TelegesisFrameHandler(null);
 
         final List<TelegesisEvent> eventCapture = new ArrayList<TelegesisEvent>();
 


### PR DESCRIPTION
Adds a periodic polling to the Telegesis dongle polling network state. If the polls timeout the notification will be sent to the ZigBeeNetworkManager.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>