### PR TITLE
Add module to maven build that creates a p2 repository with built bundles

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,16 @@
 		<module>com.zsmartsystems.zigbee.serial</module>
 		<module>com.zsmartsystems.zigbee.test</module>
 	</modules>
+
+	<profiles>
+	  <profile>
+	    <!-- Profile generates p2 repo for built artifacts in releng/p2repo/target/repository -->
+	    <id>p2repo</id>
+	    <modules>
+	      <module>releng/p2repo</module>
+	    </modules>
+	  </profile>
+	</profiles>
     
     <reporting>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -43,17 +43,8 @@
         <module>com.zsmartsystems.zigbee.console.telegesis</module>
 		<module>com.zsmartsystems.zigbee.serial</module>
 		<module>com.zsmartsystems.zigbee.test</module>
+		<module>releng/p2repo</module>
 	</modules>
-
-	<profiles>
-	  <profile>
-	    <!-- Profile generates p2 repo for built artifacts in releng/p2repo/target/repository -->
-	    <id>p2repo</id>
-	    <modules>
-	      <module>releng/p2repo</module>
-	    </modules>
-	  </profile>
-	</profiles>
     
     <reporting>
         <plugins>

--- a/releng/p2repo/assembly.xml
+++ b/releng/p2repo/assembly.xml
@@ -1,0 +1,37 @@
+<assembly
+	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
+
+  <id>bin</id>
+  
+  <formats>
+    <format>dir</format>
+  </formats>
+  
+  <includeBaseDirectory>false</includeBaseDirectory>
+  
+  <moduleSets>
+    <moduleSet>
+      
+      <!-- Enable access to all projects in the current multimodule build! -->
+      <useAllReactorProjects>true</useAllReactorProjects>
+      
+      <!-- Now, select which artifacts to include in this module-set. -->
+      <excludes>
+	<exclude>com.zsmartsystems.zigbee:com.zsmartsystems.zigbee.console.main</exclude>
+	<exclude>com.zsmartsystems.zigbee:com.zsmartsystems.zigbee.test</exclude>
+	<exclude>com.zsmartsystems.zigbee:com.zsmartsystems.zigbee.autocode</exclude>
+      </excludes>
+
+      <!-- And put all selected files to a plugins directory -->
+      <binaries>
+	<outputDirectory>plugins</outputDirectory>
+	<unpack>false</unpack>
+	<includeDependencies>false</includeDependencies>
+      </binaries>
+      
+    </moduleSet>
+  </moduleSets>
+</assembly>
+  

--- a/releng/p2repo/pom.xml
+++ b/releng/p2repo/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.zsmartsystems.zigbee</groupId>
+    <artifactId>com.zsmartsystems.zigbee.p2repo</artifactId>
+    <packaging>pom</packaging>
+
+    <parent>
+        <groupId>com.zsmartsystems</groupId>
+        <artifactId>zigbee</artifactId>
+        <version>1.0.13-SNAPSHOT</version>
+    </parent>
+
+    <build>
+      <plugins>
+
+	<plugin>
+	  <artifactId>maven-assembly-plugin</artifactId>
+	  <version>2.6</version>
+	  <executions>
+	    <execution>
+	      <id>aggregate</id>
+	      <phase>package</phase>
+	      <goals>
+		<goal>single</goal>
+	      </goals>
+	      <configuration>
+		<appendAssemblyId>false</appendAssemblyId>
+		<finalName>bundles</finalName>
+		<descriptors>
+		  <descriptor>assembly.xml</descriptor>
+		</descriptors>
+	      </configuration>
+	    </execution>
+	  </executions>
+	</plugin>
+	
+	<plugin>
+	  <groupId>org.eclipse.tycho.extras</groupId>
+	  <artifactId>tycho-p2-extras-plugin</artifactId>
+	  <version>1.0.0</version>
+	  <executions>
+	    <execution>
+	      <id>p2</id>
+	      <goals>
+		<goal>publish-features-and-bundles</goal>
+	      </goals>
+	      <phase>package</phase>
+	    </execution>
+	  </executions>
+	  <configuration>
+	    <sourceLocation>${project.build.directory}/bundles</sourceLocation>
+	  </configuration>
+	</plugin>
+      </plugins>
+    </build>
+
+</project>

--- a/releng/p2repo/pom.xml
+++ b/releng/p2repo/pom.xml
@@ -13,48 +13,55 @@
         <version>1.0.13-SNAPSHOT</version>
     </parent>
 
-    <build>
-      <plugins>
+    <profiles>
+      <profile>
+	<!-- Profile generates p2 repo for built artifacts in releng/p2repo/target/repository -->
+	<id>p2repo</id>
 
-	<plugin>
-	  <artifactId>maven-assembly-plugin</artifactId>
-	  <version>2.6</version>
-	  <executions>
-	    <execution>
-	      <id>aggregate</id>
-	      <phase>package</phase>
-	      <goals>
-		<goal>single</goal>
-	      </goals>
+	<build>
+	  <plugins>
+	    
+	    <plugin>
+	      <artifactId>maven-assembly-plugin</artifactId>
+	      <version>2.6</version>
+	      <executions>
+		<execution>
+		  <id>aggregate</id>
+		  <phase>package</phase>
+		  <goals>
+		    <goal>single</goal>
+		  </goals>
+		  <configuration>
+		    <appendAssemblyId>false</appendAssemblyId>
+		    <finalName>bundles</finalName>
+		    <descriptors>
+		      <descriptor>assembly.xml</descriptor>
+		    </descriptors>
+		  </configuration>
+		</execution>
+	      </executions>
+	    </plugin>
+	    
+	    <plugin>
+	      <groupId>org.eclipse.tycho.extras</groupId>
+	      <artifactId>tycho-p2-extras-plugin</artifactId>
+	      <version>1.0.0</version>
+	      <executions>
+		<execution>
+		  <id>p2</id>
+		  <goals>
+		    <goal>publish-features-and-bundles</goal>
+		  </goals>
+		  <phase>package</phase>
+		</execution>
+	      </executions>
 	      <configuration>
-		<appendAssemblyId>false</appendAssemblyId>
-		<finalName>bundles</finalName>
-		<descriptors>
-		  <descriptor>assembly.xml</descriptor>
-		</descriptors>
+		<sourceLocation>${project.build.directory}/bundles</sourceLocation>
 	      </configuration>
-	    </execution>
-	  </executions>
-	</plugin>
-	
-	<plugin>
-	  <groupId>org.eclipse.tycho.extras</groupId>
-	  <artifactId>tycho-p2-extras-plugin</artifactId>
-	  <version>1.0.0</version>
-	  <executions>
-	    <execution>
-	      <id>p2</id>
-	      <goals>
-		<goal>publish-features-and-bundles</goal>
-	      </goals>
-	      <phase>package</phase>
-	    </execution>
-	  </executions>
-	  <configuration>
-	    <sourceLocation>${project.build.directory}/bundles</sourceLocation>
-	  </configuration>
-	</plugin>
-      </plugins>
-    </build>
+	    </plugin>
+	  </plugins>
+	</build>
+      </profile>
+    </profiles>
 
 </project>


### PR DESCRIPTION
The p2 repository will be created in folder releng/p2repo/target/repository if the maven profile 'p2repo' is active (e.g., when running `mvn clean install -Pp2repo`).

This p2 repository is, imho, quite useful when building OSGi applications like the openhab ZigBee binding with maven, in case one wants to build the openhab ZigBee binding against a self-compiled version of this zigbee core library

If you think that this is useful functionality to be included in the zsmartsystems zigbee library, I'd be happy if this PR gets merged.