### PR TITLE
Fix the relative parent path in the releng/p2repo module

### DIFF
--- a/releng/p2repo/pom.xml
+++ b/releng/p2repo/pom.xml
@@ -11,6 +11,7 @@
         <groupId>com.zsmartsystems</groupId>
         <artifactId>zigbee</artifactId>
         <version>1.0.14-SNAPSHOT</version>
+        <relativePath>../../</relativePath>
     </parent>
 
     <profiles>


### PR DESCRIPTION
To be able to find the parent pom, even if the parent pom has not yet been installed to the local maven repository, the relative path must be set.

Unfortunately, I forgot this when adding the releng/p2repo module to the project, and realized this only when I tried to build after the version was bumped to 1.0.14 :/