### PR TITLE
Move debug log message for unsuccessful leave command to correct place.

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
@@ -1003,7 +1003,8 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
                             logger.debug("{}: No node found after successful leave command", leaveAddress);
                         }
                     } else {
-                    	logger.debug("{}: No successful response received to leave command (status code {})", leaveAddress, response.getStatusCode());
+                        logger.debug("{}: No successful response received to leave command (status code {})",
+                                leaveAddress, response.getStatusCode());
                     }
                 } catch (InterruptedException | ExecutionException e) {
                     logger.debug("Error sending leave command.", e);

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
@@ -1000,8 +1000,10 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
                         if (node != null) {
                             removeNode(node);
                         } else {
-                            logger.debug("{}: No response receoved to leave command", leaveAddress);
+                            logger.debug("{}: No node found after successful leave command", leaveAddress);
                         }
+                    } else {
+                    	logger.debug("{}: No successful response received to leave command (status code {})", leaveAddress, response.getStatusCode());
                     }
                 } catch (InterruptedException | ExecutionException e) {
                     logger.debug("Error sending leave command.", e);


### PR DESCRIPTION
When trying to make a non-reachable node from the network I did not get any debug-level logging. I believe that the log message that is already in the code needs to be moved to the enclosing `if` statement, and did this in this PR.

Correct?