### PR TITLE
Don't pass EZSP frames to the handler if ASH is offline still

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/ash/AshFrameHandler.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/ash/AshFrameHandler.java
@@ -197,7 +197,7 @@ public class AshFrameHandler implements EzspProtocolHandler {
                                             // No transactions owned this response, so we pass it to
                                             // our unhandled response handler
                                             EzspFrame ezspFrame = EzspFrame.createHandler((dataPacket.getDataBuffer()));
-                                            if (ezspFrame != null) {
+                                            if (stateConnected && ezspFrame != null) {
                                                 frameHandler.handlePacket(ezspFrame);
                                             }
                                         }


### PR DESCRIPTION
If ASH is still not connected (ie there has been no response to the reset) then don't send frames to the EZSP handler. This avoids a possible NPE if there are frames in the Ember buffer that are sent at the start of the session when the EZSP handler is still waiting for the system to come online.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>