### PR TITLE
Improve Telegesis dongle initialisation

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.telegesis/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/internal/TelegesisFrameHandler.java
+++ b/com.zsmartsystems.zigbee.dongle.telegesis/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/internal/TelegesisFrameHandler.java
@@ -105,7 +105,7 @@ public class TelegesisFrameHandler {
     /**
      * The maximum number of milliseconds to wait for the completion of the transaction after it's queued
      */
-    private final int DEFAULT_COMMAND_TIMEOUT = 3000;
+    private final int DEFAULT_COMMAND_TIMEOUT = 5000;
 
     /**
      * The maximum number of milliseconds to wait for the response from the stick once the request was sent
@@ -181,7 +181,7 @@ public class TelegesisFrameHandler {
 
                         StringBuilder builder = new StringBuilder();
                         for (int value : responseData) {
-                            builder.append(String.format(" %02X", value));
+                            builder.append(String.format("%c", value));
                         }
                         logger.debug("RX Telegesis Data:{}", builder.toString());
 
@@ -369,7 +369,7 @@ public class TelegesisFrameHandler {
             // Send the data
             StringBuilder builder = new StringBuilder();
             for (int sendByte : nextFrame.serialize()) {
-                builder.append(String.format(" %02X", sendByte));
+                builder.append(String.format("%c", sendByte));
                 serialPort.write(sendByte);
             }
             logger.debug("TX Telegesis Data:{}", builder.toString());
@@ -472,6 +472,11 @@ public class TelegesisFrameHandler {
         }
     }
 
+    /**
+     * Add a {@link TelegesisEventListener} to receive events from the dongle
+     *
+     * @param listener the {@link TelegesisEventListener} which will be notified of incoming events
+     */
     public void addEventListener(TelegesisEventListener listener) {
         synchronized (eventListeners) {
             if (eventListeners.contains(listener)) {
@@ -482,6 +487,11 @@ public class TelegesisFrameHandler {
         }
     }
 
+    /**
+     * Remove a {@link TelegesisEventListener}
+     *
+     * @param listener the {@link TelegesisEventListener}
+     */
     public void removeEventListener(TelegesisEventListener listener) {
         synchronized (eventListeners) {
             eventListeners.remove(listener);


### PR DESCRIPTION
Very occasionally, the first commands to the Telegesis dongle may fail. This PR adds a retry mechanism on the startup to give the serial port a chance to get up and running. It also adds a software reset of the dongle as the first command, so that we start with the dongle in a known state.

If the dongle is to be reinitialised, a "set to factory default" is performed to ensure we are in a known state rather than simply leaving the existing network.

Processing of the create network was previously occasionally failing - the event wait timeout has been extended to avoid this, and the driver now waits for the JPAN response before continuing.

We also now gate notification processing so that notifications do not get processed until the initialisation is complete. This is designed to prevent the application receiving ONLINE|OFFLINE|ONLINE type notifications during the initialisation process as the dongle is initialised.

@TomTravaglino FYI.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>