### PR TITLE
Remove nodes from set of discovered nodes when they are removed from the network.

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
@@ -186,7 +186,7 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
     /**
      * A Set used to remember if node discovery has been completed. This is used to manage the lifecycle notifications.
      */
-    private Set<IeeeAddress> nodeDiscoveryComplete = new HashSet<IeeeAddress>();
+    private Set<IeeeAddress> nodeDiscoveryComplete = Collections.synchronizedSet(new HashSet<IeeeAddress>());
 
     /**
      * The serializer class used to serialize commands to data packets
@@ -1161,6 +1161,8 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
 
         logger.debug("{}: Node {} is removed from the network", node.getIeeeAddress(), node.getNetworkAddress());
 
+        nodeDiscoveryComplete.remove(node.getIeeeAddress());
+
         synchronized (networkNodes) {
             // Don't update if the node is not known
             // We especially don't want to notify listeners of a device we removed, that didn't exist!
@@ -1169,6 +1171,7 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
             }
             networkNodes.remove(node.getIeeeAddress());
         }
+
         synchronized (this) {
             for (final ZigBeeNetworkNodeListener listener : nodeListeners) {
                 NotificationService.execute(new Runnable() {


### PR DESCRIPTION
Resolves #362 by removing nodes from the set `nodeDiscoveryComplete` when they are removed from the set of network nodes.