### PR TITLE
Add support for APS security

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
@@ -410,6 +410,10 @@ public class ZigBeeDongleEzsp implements ZigBeeTransportTransmit, ZigBeeTranspor
         emberApsFrame.addOptions(EmberApsOption.EMBER_APS_OPTION_ENABLE_ROUTE_DISCOVERY);
         emberApsFrame.addOptions(EmberApsOption.EMBER_APS_OPTION_ENABLE_ADDRESS_DISCOVERY);
 
+        if (apsFrame.getSecurityEnabled()) {
+            emberApsFrame.addOptions(EmberApsOption.EMBER_APS_OPTION_ENCRYPTION);
+        }
+
         if (apsFrame.getAddressMode() == ZigBeeNwkAddressMode.DEVICE && apsFrame.getDestinationAddress() < 0xfff8) {
             EzspSendUnicastRequest emberUnicast = new EzspSendUnicastRequest();
             emberUnicast.setIndexOrDestination(apsFrame.getDestinationAddress());
@@ -473,6 +477,7 @@ public class ZigBeeDongleEzsp implements ZigBeeTransportTransmit, ZigBeeTranspor
             apsFrame.setApsCounter(emberApsFrame.getSequence());
             apsFrame.setCluster(emberApsFrame.getClusterId());
             apsFrame.setProfile(emberApsFrame.getProfileId());
+            apsFrame.setSecurityEnabled(emberApsFrame.getOptions().contains(EmberApsOption.EMBER_APS_OPTION_ENCRYPTION));
 
             apsFrame.setDestinationAddress(nwkAddress);
             apsFrame.setDestinationEndpoint(emberApsFrame.getDestinationEndpoint());

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeApsFrame.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeApsFrame.java
@@ -171,11 +171,21 @@ public class ZigBeeApsFrame {
         this.radius = radius;
     }
 
-    public boolean isSecurityEnable() {
+    /**
+     * Gets APS security state
+     * 
+     * @return true if APS security is enabled
+     */
+    public boolean getSecurityEnabled() {
         return securityEnable;
     }
 
-    public void setSecurityEnable(boolean securityEnable) {
+    /**
+     * Sets APS security state
+     * 
+     * @param securityEnable true to enable APS security
+     */
+    public void setSecurityEnabled(boolean securityEnable) {
         this.securityEnable = securityEnable;
     }
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeCommand.java
@@ -40,6 +40,11 @@ public class ZigBeeCommand {
     private Integer transactionId;
 
     /**
+     * True if the command uses APS security
+     */
+    private boolean apsSecurity = false;
+
+    /**
      * Gets destination address.
      *
      * @return the destination address.
@@ -91,6 +96,24 @@ public class ZigBeeCommand {
      */
     public Integer getTransactionId() {
         return transactionId;
+    }
+
+    /**
+     * Enables or disables APS security on the command.
+     *
+     * @param apsSecurity set to true if the command uses APS security, false if not using APS security
+     */
+    public void setApsSecurity(boolean apsSecurity) {
+        this.apsSecurity = apsSecurity;
+    }
+
+    /**
+     * Gets the state of APS security for this command
+     * 
+     * @return true if the command uses APS security, false if not using APS security
+     */
+    public boolean getApsSecurity() {
+        return apsSecurity;
     }
 
     /**

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
@@ -577,6 +577,7 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
 
         apsFrame.setCluster(command.getClusterId());
         apsFrame.setApsCounter(apsCounter.getAndIncrement() & 0xff);
+        apsFrame.setSecurityEnabled(command.getApsSecurity());
 
         // TODO: Set the source address correctly?
         apsFrame.setSourceAddress(0);
@@ -704,6 +705,7 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
         command.setSourceAddress(new ZigBeeEndpointAddress(apsFrame.getSourceAddress(), apsFrame.getSourceEndpoint()));
         command.setDestinationAddress(
                 new ZigBeeEndpointAddress(apsFrame.getDestinationAddress(), apsFrame.getDestinationEndpoint()));
+        command.setApsSecurity(apsFrame.getSecurityEnabled());
 
         logger.debug("RX CMD: {}", command);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/ZclCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/ZclCluster.java
@@ -134,6 +134,12 @@ public abstract class ZclCluster {
     private final ZclAttributeNormalizer normalizer;
 
     /**
+     * If this cluster requires all frames to have APS security applied, then this will be true. Any frames not secured
+     * with the link key will be rejected and all frames sent will use APS encryption.
+     */
+    private boolean apsSecurityRequired = false;
+
+    /**
      * Abstract method called when the cluster starts to initialise the list of attributes defined in this cluster by
      * the cluster library
      *
@@ -155,6 +161,8 @@ public abstract class ZclCluster {
         if (isClient()) {
             command.setCommandDirection(ZclCommandDirection.SERVER_TO_CLIENT);
         }
+
+        command.setApsSecurity(apsSecurityRequired);
 
         return zigbeeManager.unicast(command, new ZclTransactionMatcher());
     }
@@ -434,6 +442,26 @@ public abstract class ZclCluster {
      */
     public boolean isClient() {
         return isClient;
+    }
+
+    /**
+     * Sets APS security requirement on or off for this cluster. If APS security is required, all outgoing frames will
+     * be APS secured, and any incoming frames without APS security will be ignored.
+     *
+     * @param requireApsSecurity true if APS security is required for this cluster
+     */
+    public void setApsSecurityRequired(boolean requireApsSecurity) {
+        this.apsSecurityRequired = requireApsSecurity;
+    }
+
+    /**
+     * If APS security is required, all outgoing frames will
+     * be APS secured, and any incoming frames without APS security will be ignored.
+     *
+     * @return true if APS security is required for this cluster
+     */
+    public boolean getApsSecurityRequired() {
+        return apsSecurityRequired;
     }
 
     /**

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeApsFrameTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeApsFrameTest.java
@@ -32,11 +32,11 @@ public class ZigBeeApsFrameTest {
     public void testSecurityEnable() {
         ZigBeeApsFrame frame = new ZigBeeApsFrame();
 
-        frame.setSecurityEnable(true);
-        assertTrue(frame.isSecurityEnable());
+        frame.setSecurityEnabled(true);
+        assertTrue(frame.getSecurityEnabled());
 
-        frame.setSecurityEnable(false);
-        assertFalse(frame.isSecurityEnable());
+        frame.setSecurityEnabled(false);
+        assertFalse(frame.getSecurityEnabled());
 
         System.out.println(frame);
     }

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zcl/ZclClusterTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zcl/ZclClusterTest.java
@@ -33,9 +33,11 @@ import com.zsmartsystems.zigbee.zcl.clusters.ZclLevelControlCluster;
 import com.zsmartsystems.zigbee.zcl.clusters.ZclOnOffCluster;
 import com.zsmartsystems.zigbee.zcl.clusters.general.ConfigureReportingCommand;
 import com.zsmartsystems.zigbee.zcl.clusters.general.ReadReportingConfigurationCommand;
+import com.zsmartsystems.zigbee.zcl.clusters.onoff.OnCommand;
 import com.zsmartsystems.zigbee.zcl.field.AttributeRecord;
 import com.zsmartsystems.zigbee.zcl.field.AttributeReport;
 import com.zsmartsystems.zigbee.zcl.field.AttributeReportingConfigurationRecord;
+import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 import com.zsmartsystems.zigbee.zdo.command.BindRequest;
 import com.zsmartsystems.zigbee.zdo.command.UnbindRequest;
@@ -237,6 +239,38 @@ public class ZclClusterTest {
         assertTrue(cluster.isAttributeSupported(1));
         assertTrue(cluster.isAttributeSupported(2));
         assertFalse(cluster.isAttributeSupported(3));
+    }
+
+    @Test
+    public void send() {
+        createNetworkManager();
+
+        ZigBeeNode node = new ZigBeeNode(networkManager, new IeeeAddress());
+        node.setNetworkAddress(1234);
+        ZigBeeEndpoint device = new ZigBeeEndpoint(networkManager, node, 5);
+        ZclOnOffCluster cluster = new ZclOnOffCluster(networkManager, device);
+
+        cluster.setApsSecurityRequired(true);
+        cluster.onCommand();
+        assertEquals(1, commandCapture.getAllValues().size());
+        ZigBeeCommand command = commandCapture.getValue();
+        assertNotNull(command);
+        System.out.println(command);
+        assertTrue(command instanceof OnCommand);
+        OnCommand onCommand = (OnCommand) command;
+        assertEquals(true, onCommand.getApsSecurity());
+        assertEquals(ZclCommandDirection.CLIENT_TO_SERVER, onCommand.getCommandDirection());
+
+        cluster.setApsSecurityRequired(false);
+        cluster.onCommand();
+        assertEquals(2, commandCapture.getAllValues().size());
+        command = commandCapture.getValue();
+        assertNotNull(command);
+        System.out.println(command);
+        assertTrue(command instanceof OnCommand);
+        onCommand = (OnCommand) command;
+        assertEquals(false, onCommand.getApsSecurity());
+        assertEquals(ZclCommandDirection.CLIENT_TO_SERVER, onCommand.getCommandDirection());
     }
 
 }


### PR DESCRIPTION
Adds support for flagging commands to be sent with APS security enabled, and adds APS security support to Ember NCP unicasts.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>