### PR TITLE
Add a console command for displaying supported commands for a given cluster

### DIFF
--- a/com.zsmartsystems.zigbee.console.main/src/main/java/com/zsmartsystems/zigbee/console/main/ZigBeeConsole.java
+++ b/com.zsmartsystems.zigbee.console.main/src/main/java/com/zsmartsystems/zigbee/console/main/ZigBeeConsole.java
@@ -23,7 +23,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
-import java.util.concurrent.Future;
 
 import org.apache.commons.lang.StringUtils;
 
@@ -126,7 +125,7 @@ public final class ZigBeeConsole {
     /**
      * Constructor which configures ZigBee API and constructs commands.
      *
-     * @param dongle the dongle
+     * @param dongle            the dongle
      * @param transportCommands
      */
     public ZigBeeConsole(final ZigBeeNetworkManager networkManager, final ZigBeeTransportTransmit dongle,
@@ -175,8 +174,6 @@ public final class ZigBeeConsole {
         commands.put("rediscover", new RediscoverCommand());
 
         commands.put("stress", new StressCommand());
-
-        commands.put("cmdsupported", new CmdSupportedCommand());
 
         newCommands.put("nodes", new ZigBeeConsoleNodeListCommand());
         newCommands.put("endpoint", new ZigBeeConsoleDescribeEndpointCommand());
@@ -295,7 +292,7 @@ public final class ZigBeeConsole {
      * Processes text input line.
      *
      * @param inputLine the input line
-     * @param out the output stream
+     * @param out       the output stream
      */
     public void processInputLine(final String inputLine, final PrintStream out) {
         if (inputLine.length() == 0) {
@@ -309,7 +306,7 @@ public final class ZigBeeConsole {
      * Processes input arguments.
      *
      * @param args the input arguments
-     * @param out the output stream
+     * @param out  the output stream
      */
     public void processArgs(final String[] args, final PrintStream out) {
         try {
@@ -332,8 +329,8 @@ public final class ZigBeeConsole {
      * Executes command.
      *
      * @param networkManager the {@link ZigBeeNetworkManager}
-     * @param args the arguments including the command
-     * @param out the output stream
+     * @param args           the arguments including the command
+     * @param out            the output stream
      */
     private void executeCommand(final ZigBeeNetworkManager networkManager, final String[] args, final PrintStream out) {
         final ConsoleCommand consoleCommand = commands.get(args[0].toLowerCase());
@@ -394,7 +391,7 @@ public final class ZigBeeConsole {
     /**
      * Gets destination by device identifier or group ID.
      *
-     * @param zigbeeApi the ZigBee API
+     * @param zigbeeApi             the ZigBee API
      * @param destinationIdentifier the device identifier or group ID
      * @return the device
      */
@@ -422,7 +419,7 @@ public final class ZigBeeConsole {
     /**
      * Gets device by device identifier.
      *
-     * @param zigbeeApi the ZigBee API
+     * @param zigbeeApi        the ZigBee API
      * @param deviceIdentifier the device identifier
      * @return the device
      */
@@ -459,8 +456,8 @@ public final class ZigBeeConsole {
          * Processes console command.
          *
          * @param zigbeeApi the ZigBee API
-         * @param args the command arguments
-         * @param out the output PrintStream
+         * @param args      the command arguments
+         * @param out       the output PrintStream
          * @return true if command syntax was correct.
          */
         boolean process(final ZigBeeApi zigbeeApi, final String[] args, PrintStream out) throws Exception;
@@ -1251,84 +1248,6 @@ public final class ZigBeeConsole {
     }
 
     /**
-     * Reads the list of supported commands in a specific cluster of a device.
-     */
-    private class CmdSupportedCommand implements ConsoleCommand {
-        /**
-         * {@inheritDoc}
-         */
-        @Override
-        public String getDescription() {
-            return "Check what commands are supported.";
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        @Override
-        public String getSyntax() {
-            return "cmdsupported [DEVICE] [CLUSTER]";
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        @Override
-        public boolean process(final ZigBeeApi zigbeeApi, final String[] args, PrintStream out) throws Exception {
-            if (args.length != 3) {
-                return false;
-            }
-
-            final int clusterId;
-            try {
-                clusterId = Integer.parseInt(args[2]);
-            } catch (final NumberFormatException e) {
-                return false;
-            }
-
-            final ZigBeeEndpoint device = getDevice(zigbeeApi, args[1]);
-            if (device == null) {
-                print("Device not found.", out);
-                return false;
-            }
-
-            ZclCluster cluster = device.getInputCluster(clusterId);
-            if (cluster == null) {
-                cluster = device.getOutputCluster(clusterId);
-                if (cluster == null) {
-                    print("Cluster not found.", out);
-                    return false;
-                }
-            }
-
-            Future<Boolean> future = cluster.discoverCommandsReceived(false);
-            Boolean result = future.get();
-
-            if (result) {
-                for (Integer cmd : cluster.getSupportedCommandsReceived()) {
-                    out.println("Cluster " + cluster.getClusterId() + ", Command=" + cmd);
-                }
-            } else {
-                out.println("Error getting list of commands received");
-            }
-
-            future = cluster.discoverCommandsGenerated(false);
-            result = future.get();
-
-            if (result) {
-                for (Integer cmd : cluster.getSupportedCommandsGenerated()) {
-                    out.println("Cluster " + cluster.getClusterId() + ", Command=" + cmd);
-                }
-
-            } else {
-                out.println("Error getting list of commands generated");
-            }
-
-            return true;
-        }
-    }
-
-    /**
      * Writes an attribute to a device.
      */
     private class LqiCommand implements ConsoleCommand {
@@ -2076,7 +1995,7 @@ public final class ZigBeeConsole {
      * Default processing for command result.
      *
      * @param result the command result
-     * @param out the output
+     * @param out    the output
      * @return TRUE if result is success
      */
     private boolean defaultResponseProcessing(CommandResult result, PrintStream out) {

--- a/com.zsmartsystems.zigbee.console.main/src/main/java/com/zsmartsystems/zigbee/console/main/ZigBeeConsole.java
+++ b/com.zsmartsystems.zigbee.console.main/src/main/java/com/zsmartsystems/zigbee/console/main/ZigBeeConsole.java
@@ -50,6 +50,7 @@ import com.zsmartsystems.zigbee.console.ZigBeeConsoleAttributeWriteCommand;
 import com.zsmartsystems.zigbee.console.ZigBeeConsoleBindCommand;
 import com.zsmartsystems.zigbee.console.ZigBeeConsoleBindingTableCommand;
 import com.zsmartsystems.zigbee.console.ZigBeeConsoleCommand;
+import com.zsmartsystems.zigbee.console.ZigBeeConsoleCommandsSupportedCommand;
 import com.zsmartsystems.zigbee.console.ZigBeeConsoleDescribeEndpointCommand;
 import com.zsmartsystems.zigbee.console.ZigBeeConsoleDescribeNodeCommand;
 import com.zsmartsystems.zigbee.console.ZigBeeConsoleDeviceInformationCommand;
@@ -188,6 +189,7 @@ public final class ZigBeeConsole {
         newCommands.put("write", new ZigBeeConsoleAttributeWriteCommand());
 
         newCommands.put("attsupported", new ZigBeeConsoleAttributeSupportedCommand());
+        newCommands.put("cmdsupported", new ZigBeeConsoleCommandsSupportedCommand());
 
         newCommands.put("info", new ZigBeeConsoleDeviceInformationCommand());
         newCommands.put("join", new ZigBeeConsoleNetworkJoinCommand());

--- a/com.zsmartsystems.zigbee.console.main/src/main/java/com/zsmartsystems/zigbee/console/main/ZigBeeConsole.java
+++ b/com.zsmartsystems.zigbee.console.main/src/main/java/com/zsmartsystems/zigbee/console/main/ZigBeeConsole.java
@@ -125,7 +125,7 @@ public final class ZigBeeConsole {
     /**
      * Constructor which configures ZigBee API and constructs commands.
      *
-     * @param dongle            the dongle
+     * @param dongle the dongle
      * @param transportCommands
      */
     public ZigBeeConsole(final ZigBeeNetworkManager networkManager, final ZigBeeTransportTransmit dongle,
@@ -292,7 +292,7 @@ public final class ZigBeeConsole {
      * Processes text input line.
      *
      * @param inputLine the input line
-     * @param out       the output stream
+     * @param out the output stream
      */
     public void processInputLine(final String inputLine, final PrintStream out) {
         if (inputLine.length() == 0) {
@@ -306,7 +306,7 @@ public final class ZigBeeConsole {
      * Processes input arguments.
      *
      * @param args the input arguments
-     * @param out  the output stream
+     * @param out the output stream
      */
     public void processArgs(final String[] args, final PrintStream out) {
         try {
@@ -329,8 +329,8 @@ public final class ZigBeeConsole {
      * Executes command.
      *
      * @param networkManager the {@link ZigBeeNetworkManager}
-     * @param args           the arguments including the command
-     * @param out            the output stream
+     * @param args the arguments including the command
+     * @param out the output stream
      */
     private void executeCommand(final ZigBeeNetworkManager networkManager, final String[] args, final PrintStream out) {
         final ConsoleCommand consoleCommand = commands.get(args[0].toLowerCase());
@@ -391,7 +391,7 @@ public final class ZigBeeConsole {
     /**
      * Gets destination by device identifier or group ID.
      *
-     * @param zigbeeApi             the ZigBee API
+     * @param zigbeeApi the ZigBee API
      * @param destinationIdentifier the device identifier or group ID
      * @return the device
      */
@@ -419,7 +419,7 @@ public final class ZigBeeConsole {
     /**
      * Gets device by device identifier.
      *
-     * @param zigbeeApi        the ZigBee API
+     * @param zigbeeApi the ZigBee API
      * @param deviceIdentifier the device identifier
      * @return the device
      */
@@ -456,8 +456,8 @@ public final class ZigBeeConsole {
          * Processes console command.
          *
          * @param zigbeeApi the ZigBee API
-         * @param args      the command arguments
-         * @param out       the output PrintStream
+         * @param args the command arguments
+         * @param out the output PrintStream
          * @return true if command syntax was correct.
          */
         boolean process(final ZigBeeApi zigbeeApi, final String[] args, PrintStream out) throws Exception;
@@ -1995,7 +1995,7 @@ public final class ZigBeeConsole {
      * Default processing for command result.
      *
      * @param result the command result
-     * @param out    the output
+     * @param out the output
      * @return TRUE if result is success
      */
     private boolean defaultResponseProcessing(CommandResult result, PrintStream out) {

--- a/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleAbstractCommand.java
+++ b/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleAbstractCommand.java
@@ -107,7 +107,7 @@ public abstract class ZigBeeConsoleAbstractCommand implements ZigBeeConsoleComma
      * </ul>
      *
      * @param endpoint the ZigBee endpoint to get the cluster from (must be non-null)
-     * @param clusterSpecified a cluster specified as described above (must be non-null)
+     * @param clusterSpecifier a cluster specified as described above (must be non-null)
      * @return the specified cluster provided by the endpoint or null if no such cluster is found
      * @throws IllegalArgumentException if the clusterSpecifier uses an invalid number format, or if no cluster is found
      */
@@ -121,6 +121,13 @@ public abstract class ZigBeeConsoleAbstractCommand implements ZigBeeConsoleComma
             String prefix = clusterSpecifier.substring(0, clusterSpecifier.indexOf(':'));
             isInput = prefix.equalsIgnoreCase("in") || prefix.equalsIgnoreCase("server");
             isOutput = prefix.equalsIgnoreCase("out") || prefix.equalsIgnoreCase("client");
+
+            if (!(isInput || isOutput)) {
+                throw new IllegalArgumentException(
+                        "The prefix of the cluster specifier must be 'in', 'out', 'server', or 'client', but it was: "
+                                + prefix);
+            }
+
             clusterIdString = clusterSpecifier.substring(clusterSpecifier.indexOf(':') + 1);
         } else {
             isInput = false;
@@ -267,8 +274,8 @@ public abstract class ZigBeeConsoleAbstractCommand implements ZigBeeConsoleComma
      * @return a String containing information about the cluster, example 'OnOff server cluster 0x00A4'
      */
     protected String printCluster(ZclCluster cluster) {
-        String typePrefix = cluster.isServer() ? "server " : "client ";
-        return String.format("%s %s cluster %s", cluster.getClusterName(), typePrefix,
+        String typePrefix = cluster.isServer() ? "server" : "client";
+        return String.format("%s cluster %s (%s)", typePrefix, cluster.getClusterName(),
                 printClusterId(cluster.getClusterId()));
     }
 

--- a/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleAbstractCommand.java
+++ b/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleAbstractCommand.java
@@ -8,7 +8,6 @@
 package com.zsmartsystems.zigbee.console;
 
 import java.io.PrintStream;
-import java.util.concurrent.ExecutionException;
 
 import com.zsmartsystems.zigbee.CommandResult;
 import com.zsmartsystems.zigbee.IeeeAddress;
@@ -25,27 +24,12 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  *
  */
 public abstract class ZigBeeConsoleAbstractCommand implements ZigBeeConsoleCommand {
-    @Override
-    public abstract String getCommand();
-
-    @Override
-    public abstract String getDescription();
-
-    @Override
-    public abstract String getSyntax();
-
-    @Override
-    public abstract String getHelp();
-
-    @Override
-    public abstract void process(final ZigBeeNetworkManager networkManager, final String[] args, PrintStream out)
-            throws IllegalArgumentException, IllegalStateException, ExecutionException, InterruptedException;
 
     /**
      * Gets a {@link ZigBeeNode}
      *
      * @param networkManager the {@link ZigBeeNetworkManager}
-     * @param nodeId         a {@link String} with the node Id
+     * @param nodeId a {@link String} with the node Id
      * @return the {@link ZigBeeNode}
      * @throws IllegalArgumentException
      */
@@ -74,7 +58,7 @@ public abstract class ZigBeeConsoleAbstractCommand implements ZigBeeConsoleComma
      * Gets {@link ZigBeeEndpoint} by device identifier.
      *
      * @param networkManager the {@link ZigBeeNetworkManager}
-     * @param endpointId     the device identifier
+     * @param endpointId the device identifier
      * @return the {@link ZigBeeEndpoint}
      * @throws IllegalArgumentException
      */
@@ -122,7 +106,7 @@ public abstract class ZigBeeConsoleAbstractCommand implements ZigBeeConsoleComma
      * <li>server:11
      * </ul>
      *
-     * @param endpoint         the ZigBee endpoint to get the cluster from (must be non-null)
+     * @param endpoint the ZigBee endpoint to get the cluster from (must be non-null)
      * @param clusterSpecified a cluster specified as described above (must be non-null)
      * @return the specified cluster provided by the endpoint or null if no such cluster is found
      * @throws IllegalArgumentException if the clusterSpecifier uses an invalid number format
@@ -180,7 +164,7 @@ public abstract class ZigBeeConsoleAbstractCommand implements ZigBeeConsoleComma
      * Default processing for command result.
      *
      * @param result the command result
-     * @param out    the output
+     * @param out the output
      * @return true if result is success
      */
     protected boolean processDefaultResponse(CommandResult result, PrintStream out) {

--- a/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleAbstractCommand.java
+++ b/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleAbstractCommand.java
@@ -133,7 +133,7 @@ public abstract class ZigBeeConsoleAbstractCommand implements ZigBeeConsoleComma
         boolean isOutput = clusterSpecifier.startsWith("out:") || clusterSpecifier.startsWith("client:");
 
         Integer clusterId = (isInput || isOutput)
-                ? parseClusterId(clusterSpecifier.substring(clusterSpecifier.indexOf(":") + 1))
+                ? parseClusterId(clusterSpecifier.substring(clusterSpecifier.indexOf(':') + 1))
                 : parseClusterId(clusterSpecifier);
 
         if (isInput) {

--- a/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleAttributeReadCommand.java
+++ b/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleAttributeReadCommand.java
@@ -52,7 +52,7 @@ public class ZigBeeConsoleAttributeReadCommand extends ZigBeeConsoleAbstractComm
         }
 
         final ZigBeeEndpoint endpoint = getEndpoint(networkManager, args[1]);
-        final Integer clusterId = parseCluster(args[2]);
+        final Integer clusterId = parseClusterId(args[2]);
         ZclCluster cluster = endpoint.getInputCluster(clusterId);
         if (cluster != null) {
             out.println("Using input cluster");

--- a/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleAttributeReadCommand.java
+++ b/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleAttributeReadCommand.java
@@ -52,19 +52,7 @@ public class ZigBeeConsoleAttributeReadCommand extends ZigBeeConsoleAbstractComm
         }
 
         final ZigBeeEndpoint endpoint = getEndpoint(networkManager, args[1]);
-        final Integer clusterId = parseClusterId(args[2]);
-        ZclCluster cluster = endpoint.getInputCluster(clusterId);
-        if (cluster != null) {
-            out.println("Using input cluster");
-        } else {
-            cluster = endpoint.getOutputCluster(clusterId);
-            if (cluster != null) {
-                out.println("Using output cluster");
-            } else {
-                throw new IllegalArgumentException(
-                        "Cluster " + String.format("%d [0x%04X]", clusterId, clusterId) + " not found");
-            }
-        }
+        ZclCluster cluster = getCluster(endpoint, args[2]);
 
         final Integer attributeId = parseAttribute(args[3]);
         String attributeName;
@@ -75,7 +63,7 @@ public class ZigBeeConsoleAttributeReadCommand extends ZigBeeConsoleAbstractComm
             attributeName = attribute.getName();
         }
 
-        out.println("Reading " + cluster.getClusterName() + ", " + attributeName);
+        out.println("Reading " + printCluster(cluster) + ", " + attributeName);
 
         CommandResult result;
         result = cluster.read(attributeId).get();

--- a/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleAttributeSupportedCommand.java
+++ b/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleAttributeSupportedCommand.java
@@ -50,26 +50,12 @@ public class ZigBeeConsoleAttributeSupportedCommand extends ZigBeeConsoleAbstrac
         }
 
         final ZigBeeEndpoint endpoint = getEndpoint(networkManager, args[1]);
-        final Integer clusterId = parseClusterId(args[2]);
-
-        ZclCluster cluster = endpoint.getInputCluster(clusterId);
-        if (cluster != null) {
-            out.println("Using input cluster");
-        } else {
-            cluster = endpoint.getOutputCluster(clusterId);
-            if (cluster != null) {
-                out.println("Using output cluster");
-            } else {
-                out.println("Cluster not found");
-                return;
-            }
-        }
+        ZclCluster cluster = getCluster(endpoint, args[2]);
 
         final Future<Boolean> future = cluster.discoverAttributes(false);
         Boolean result = future.get();
         if (result) {
-            out.println("Supported attributes for " + cluster.getClusterName() + " Cluster "
-                    + printClusterId(cluster.getClusterId()));
+            out.println("Supported attributes for " + printCluster(cluster));
             out.println("AttrId  Data Type                  Name");
             for (Integer attributeId : cluster.getSupportedAttributes()) {
                 out.print(" ");

--- a/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleAttributeSupportedCommand.java
+++ b/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleAttributeSupportedCommand.java
@@ -50,7 +50,7 @@ public class ZigBeeConsoleAttributeSupportedCommand extends ZigBeeConsoleAbstrac
         }
 
         final ZigBeeEndpoint endpoint = getEndpoint(networkManager, args[1]);
-        final Integer clusterId = parseCluster(args[2]);
+        final Integer clusterId = parseClusterId(args[2]);
 
         ZclCluster cluster = endpoint.getInputCluster(clusterId);
         if (cluster != null) {

--- a/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleAttributeWriteCommand.java
+++ b/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleAttributeWriteCommand.java
@@ -52,7 +52,7 @@ public class ZigBeeConsoleAttributeWriteCommand extends ZigBeeConsoleAbstractCom
         }
 
         final ZigBeeEndpoint endpoint = getEndpoint(networkManager, args[1]);
-        final int clusterId = parseCluster(args[3]);
+        final int clusterId = parseClusterId(args[3]);
         final int attributeId = parseAttribute(args[4]);
 
         final ZclCluster cluster;

--- a/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleAttributeWriteCommand.java
+++ b/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleAttributeWriteCommand.java
@@ -36,7 +36,7 @@ public class ZigBeeConsoleAttributeWriteCommand extends ZigBeeConsoleAbstractCom
 
     @Override
     public String getSyntax() {
-        return "ENDPOINT IN|OUT CLUSTER ATTRIBUTE VALUE";
+        return "ENDPOINT CLUSTER ATTRIBUTE VALUE";
     }
 
     @Override
@@ -51,22 +51,22 @@ public class ZigBeeConsoleAttributeWriteCommand extends ZigBeeConsoleAbstractCom
             throw new IllegalArgumentException("Invalid number of arguments");
         }
 
-        final ZigBeeEndpoint endpoint = getEndpoint(networkManager, args[1]);
-        final int clusterId = parseClusterId(args[3]);
-        final int attributeId = parseAttribute(args[4]);
+        String endpointIdParam = args[1];
+        String clusterIdParam = args[2];
+        String attributeIdParam = args[3];
+        String attributeValueParam = args[4];
 
-        final ZclCluster cluster;
-        final String direction = args[2].toUpperCase();
-        if ("IN".equals(direction)) {
-            cluster = endpoint.getInputCluster(clusterId);
-        } else if ("OUT".equals(direction)) {
-            cluster = endpoint.getOutputCluster(clusterId);
-        } else {
-            throw new IllegalArgumentException("Cluster direction must be IN or OUT");
-        }
+        final ZigBeeEndpoint endpoint = getEndpoint(networkManager, endpointIdParam);
+        final ZclCluster cluster = getCluster(endpoint, clusterIdParam);
+
+        final int attributeId = parseAttribute(attributeIdParam);
 
         final ZclAttribute attribute = cluster.getAttribute(attributeId);
-        final Object value = parseValue(args[4], attribute.getDataType());
+        if (attribute == null) {
+            throw new IllegalArgumentException("Could not find attribute with ID " + attributeId);
+        }
+
+        final Object value = parseValue(attributeValueParam, attribute.getDataType());
         final CommandResult result = cluster.write(attribute, value).get();
         if (result.isSuccess()) {
             final WriteAttributesResponse response = result.getResponse();

--- a/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleBindCommand.java
+++ b/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleBindCommand.java
@@ -50,7 +50,7 @@ public class ZigBeeConsoleBindCommand extends ZigBeeConsoleAbstractCommand {
             throw new IllegalArgumentException("Invalid number of arguments");
         }
 
-        final int clusterId = parseCluster(args[1]);
+        final int clusterId = parseClusterId(args[1]);
 
         final ZigBeeEndpoint source = getEndpoint(networkManager, args[2]);
         ZclCluster cluster = source.getInputCluster(clusterId);

--- a/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleBindCommand.java
+++ b/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleBindCommand.java
@@ -35,7 +35,7 @@ public class ZigBeeConsoleBindCommand extends ZigBeeConsoleAbstractCommand {
 
     @Override
     public String getSyntax() {
-        return "CLUSTERID SOURCE [DESTINATION]";
+        return "CLUSTER SOURCE-ENDPOINT [DESTINATION-ENDPOINT]";
     }
 
     @Override
@@ -46,26 +46,21 @@ public class ZigBeeConsoleBindCommand extends ZigBeeConsoleAbstractCommand {
     @Override
     public void process(ZigBeeNetworkManager networkManager, String[] args, PrintStream out)
             throws IllegalArgumentException, InterruptedException, ExecutionException {
-        if (args.length < 3) {
+        if (args.length < 3 || args.length > 4) {
             throw new IllegalArgumentException("Invalid number of arguments");
         }
 
-        final int clusterId = parseClusterId(args[1]);
+        String clusterSpecParam = args[1];
+        String sourceEndpointParam = args[2];
+        String destEndpointParam = (args.length == 4) ? args[3] : null;
 
-        final ZigBeeEndpoint source = getEndpoint(networkManager, args[2]);
-        ZclCluster cluster = source.getInputCluster(clusterId);
-        if (cluster == null) {
-            cluster = source.getOutputCluster(clusterId);
-        }
-
-        if (cluster == null) {
-            throw new IllegalArgumentException("Cluster '" + clusterId + "' not found.");
-        }
+        final ZigBeeEndpoint sourceEndpoint = getEndpoint(networkManager, sourceEndpointParam);
+        ZclCluster cluster = getCluster(sourceEndpoint, clusterSpecParam);
 
         IeeeAddress destAddress;
         int destEndpoint;
-        if (args.length >= 4) {
-            ZigBeeEndpoint destination = getEndpoint(networkManager, args[3]);
+        if (destEndpointParam != null) {
+            ZigBeeEndpoint destination = getEndpoint(networkManager, destEndpointParam);
             destAddress = destination.getIeeeAddress();
             destEndpoint = destination.getEndpointId();
         } else {

--- a/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleCommandsSupportedCommand.java
+++ b/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleCommandsSupportedCommand.java
@@ -1,0 +1,111 @@
+/**
+ * Copyright (c) 2016-2018 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.console;
+
+import java.io.PrintStream;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+
+import com.zsmartsystems.zigbee.ZigBeeEndpoint;
+import com.zsmartsystems.zigbee.ZigBeeNetworkManager;
+import com.zsmartsystems.zigbee.zcl.ZclCluster;
+import com.zsmartsystems.zigbee.zcl.ZclCommand;
+
+/**
+ * Console command that prints the commands that are supported by a given cluster.
+ *
+ * @author Henning Sudbrock
+ */
+public class ZigBeeConsoleCommandsSupportedCommand extends ZigBeeConsoleAbstractCommand {
+
+    @Override
+    public String getCommand() {
+        return "cmdsupported";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Check what commands are supported within a cluster, optionally restricted to generated / received commands";
+    }
+
+    @Override
+    public String getSyntax() {
+        return "ENDPOINT CLUSTER [gen|rcv]";
+    }
+
+    @Override
+    public String getHelp() {
+        return "";
+    }
+
+    @Override
+    public void process(ZigBeeNetworkManager networkManager, String[] args, PrintStream out)
+            throws IllegalArgumentException, InterruptedException, ExecutionException {
+        if (args.length < 3 || args.length > 4) {
+            throw new IllegalArgumentException("Invalid number of arguments");
+        }
+
+        final ZigBeeEndpoint endpoint = getEndpoint(networkManager, args[1]);
+        final Integer clusterId = parseCluster(args[2]);
+        ZclCluster cluster = getCluster(endpoint, clusterId);
+
+        if (cluster == null) {
+            out.println("Cluster not found");
+            return;
+        }
+
+        if (showGenerated(args)) {
+            if (cluster.discoverCommandsGenerated(false).get()) {
+                out.println("Supported generated commands for " + cluster.getClusterName() + " cluster "
+                        + printClusterId(cluster.getClusterId()));
+                printCommands(out, cluster, cluster.getSupportedCommandsGenerated());
+
+            } else {
+                out.println("Failed to retrieve supported generated commands");
+            }
+            out.println();
+        }
+
+        if (showReceived(args)) {
+            if (cluster.discoverCommandsReceived(false).get()) {
+                out.println("Supported received commands for " + cluster.getClusterName() + " cluster "
+                        + printClusterId(cluster.getClusterId()));
+                printCommands(out, cluster, cluster.getSupportedCommandsReceived());
+            } else {
+                out.println("Failed to retrieve supported received commands");
+            }
+        }
+    }
+
+    private ZclCluster getCluster(ZigBeeEndpoint endpoint, Integer clusterId) {
+        ZclCluster result = endpoint.getInputCluster(clusterId);
+        if (result == null) {
+            result = endpoint.getOutputCluster(clusterId);
+        }
+        return result;
+    }
+
+    private void printCommands(PrintStream out, ZclCluster cluster, Set<Integer> commandIds) {
+        out.println("CommandId  Command");
+        for (Integer commandId : commandIds) {
+            out.print(" ");
+            ZclCommand command = cluster.getCommandFromId(commandId);
+            String commandName = (command != null) ? command.getClass().getSimpleName() : "unknown";
+            out.print(String.format("%8d  %s", commandId, commandName));
+            out.println();
+        }
+    }
+
+    private boolean showGenerated(String[] args) {
+        return args.length < 4 || "gen".equals(args[3]);
+    }
+
+    private boolean showReceived(String[] args) {
+        return args.length < 4 || "rcv".equals(args[3]);
+    }
+}

--- a/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleCommandsSupportedCommand.java
+++ b/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleCommandsSupportedCommand.java
@@ -50,14 +50,14 @@ public class ZigBeeConsoleCommandsSupportedCommand extends ZigBeeConsoleAbstract
             throw new IllegalArgumentException("Invalid number of arguments");
         }
 
-        final ZigBeeEndpoint endpoint = getEndpoint(networkManager, args[1]);
-        ZclCluster cluster = getCluster(endpoint, args[2]);
+        String endpointParam = args[1];
+        String clusterSpecParam = args[2];
+        String genRcvParam = (args.length == 4) ? args[3] : null;
 
-        if (cluster == null) {
-            throw new IllegalArgumentException("Could not find cluster specified by " + args[2]);
-        }
+        final ZigBeeEndpoint endpoint = getEndpoint(networkManager, endpointParam);
+        ZclCluster cluster = getCluster(endpoint, clusterSpecParam);
 
-        if (showGenerated(args)) {
+        if (showGenerated(genRcvParam)) {
             if (cluster.discoverCommandsGenerated(false).get()) {
                 out.println("Supported generated commands for " + printCluster(cluster));
                 printCommands(out, cluster, cluster.getSupportedCommandsGenerated());
@@ -68,7 +68,7 @@ public class ZigBeeConsoleCommandsSupportedCommand extends ZigBeeConsoleAbstract
             out.println();
         }
 
-        if (showReceived(args)) {
+        if (showReceived(genRcvParam)) {
             if (cluster.discoverCommandsReceived(false).get()) {
                 out.println("Supported received commands for " + printCluster(cluster));
                 printCommands(out, cluster, cluster.getSupportedCommandsReceived());
@@ -87,17 +87,11 @@ public class ZigBeeConsoleCommandsSupportedCommand extends ZigBeeConsoleAbstract
         }
     }
 
-    private boolean showGenerated(String[] args) {
-        return args.length < 4 || "gen".equals(args[3]);
+    private boolean showGenerated(String genRcvParam) {
+        return genRcvParam == null || "gen".equals(genRcvParam);
     }
 
-    private boolean showReceived(String[] args) {
-        return args.length < 4 || "rcv".equals(args[3]);
-    }
-
-    private String printCluster(ZclCluster cluster) {
-        String typePrefix = cluster.isServer() ? "server " : "client ";
-        return String.format("%s %s cluster %s", cluster.getClusterName(), typePrefix,
-                printClusterId(cluster.getClusterId()));
+    private boolean showReceived(String genRcvParam) {
+        return genRcvParam == null || "rcv".equals(genRcvParam);
     }
 }

--- a/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleCommandsSupportedCommand.java
+++ b/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleCommandsSupportedCommand.java
@@ -59,8 +59,7 @@ public class ZigBeeConsoleCommandsSupportedCommand extends ZigBeeConsoleAbstract
 
         if (showGenerated(args)) {
             if (cluster.discoverCommandsGenerated(false).get()) {
-                out.println("Supported generated commands for " + (cluster.isServer() ? "server " : "client ")
-                        + cluster.getClusterName() + " cluster " + printClusterId(cluster.getClusterId()));
+                out.println("Supported generated commands for " + printCluster(cluster));
                 printCommands(out, cluster, cluster.getSupportedCommandsGenerated());
 
             } else {
@@ -71,8 +70,7 @@ public class ZigBeeConsoleCommandsSupportedCommand extends ZigBeeConsoleAbstract
 
         if (showReceived(args)) {
             if (cluster.discoverCommandsReceived(false).get()) {
-                out.println("Supported received commands for " + (cluster.isServer() ? "server " : "client ")
-                        + cluster.getClusterName() + " cluster " + printClusterId(cluster.getClusterId()));
+                out.println("Supported received commands for " + printCluster(cluster));
                 printCommands(out, cluster, cluster.getSupportedCommandsReceived());
             } else {
                 out.println("Failed to retrieve supported received commands");
@@ -95,5 +93,11 @@ public class ZigBeeConsoleCommandsSupportedCommand extends ZigBeeConsoleAbstract
 
     private boolean showReceived(String[] args) {
         return args.length < 4 || "rcv".equals(args[3]);
+    }
+
+    private String printCluster(ZclCluster cluster) {
+        String typePrefix = cluster.isServer() ? "server " : "client ";
+        return String.format("%s %s cluster %s", cluster.getClusterName(), typePrefix,
+                printClusterId(cluster.getClusterId()));
     }
 }

--- a/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleReportingConfigCommand.java
+++ b/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleReportingConfigCommand.java
@@ -52,7 +52,7 @@ public class ZigBeeConsoleReportingConfigCommand extends ZigBeeConsoleAbstractCo
         }
 
         final ZigBeeEndpoint endpoint = getEndpoint(networkManager, args[1]);
-        final int clusterId = parseCluster(args[3]);
+        final int clusterId = parseClusterId(args[3]);
         final ZclCluster cluster;
         final String direction = args[2].toUpperCase();
         if ("IN".equals(direction)) {

--- a/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleReportingConfigCommand.java
+++ b/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleReportingConfigCommand.java
@@ -36,7 +36,7 @@ public class ZigBeeConsoleReportingConfigCommand extends ZigBeeConsoleAbstractCo
 
     @Override
     public String getSyntax() {
-        return "ENDPOINT IN|OUT CLUSTER ATTRIBUTE";
+        return "ENDPOINT CLUSTER ATTRIBUTE";
     }
 
     @Override
@@ -47,27 +47,22 @@ public class ZigBeeConsoleReportingConfigCommand extends ZigBeeConsoleAbstractCo
     @Override
     public void process(ZigBeeNetworkManager networkManager, String[] args, PrintStream out)
             throws IllegalArgumentException, InterruptedException, ExecutionException {
-        if (args.length != 5) {
+        if (args.length != 4) {
             throw new IllegalArgumentException("Invalid number of arguments");
         }
 
-        final ZigBeeEndpoint endpoint = getEndpoint(networkManager, args[1]);
-        final int clusterId = parseClusterId(args[3]);
-        final ZclCluster cluster;
-        final String direction = args[2].toUpperCase();
-        if ("IN".equals(direction)) {
-            cluster = endpoint.getInputCluster(clusterId);
-        } else if ("OUT".equals(direction)) {
-            cluster = endpoint.getOutputCluster(clusterId);
-        } else {
-            throw new IllegalArgumentException("Cluster direction must be IN or OUT");
-        }
+        String endpointIdParam = args[1];
+        String clusterSpecParam = args[2];
+        String attributeIdParam = args[3];
 
-        final int attributeId = parseAttribute(args[4]);
+        final ZigBeeEndpoint endpoint = getEndpoint(networkManager, endpointIdParam);
+        final ZclCluster cluster = getCluster(endpoint, clusterSpecParam);
+
+        final int attributeId = parseAttribute(attributeIdParam);
         final ZclAttribute attribute = cluster.getAttribute(attributeId);
         if (attribute == null) {
             throw new IllegalArgumentException(
-                    "Attribute " + attributeId + " was not found in cluster " + cluster.getClusterName());
+                    "Attribute " + attributeId + " was not found in " + printCluster(cluster));
         }
 
         final CommandResult result = cluster.getReporting(attribute).get();

--- a/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleReportingSubscribeCommand.java
+++ b/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleReportingSubscribeCommand.java
@@ -36,7 +36,7 @@ public class ZigBeeConsoleReportingSubscribeCommand extends ZigBeeConsoleAbstrac
 
     @Override
     public String getSyntax() {
-        return "ENDPOINT IN|OUT CLUSTER ATTRIBUTE MIN-INTERVAL MAX-INTERVAL REPORTABLE-CHANGE";
+        return "ENDPOINT CLUSTER ATTRIBUTE MIN-INTERVAL MAX-INTERVAL REPORTABLE-CHANGE";
     }
 
     @Override
@@ -47,45 +47,43 @@ public class ZigBeeConsoleReportingSubscribeCommand extends ZigBeeConsoleAbstrac
     @Override
     public void process(ZigBeeNetworkManager networkManager, String[] args, PrintStream out)
             throws IllegalArgumentException, InterruptedException, ExecutionException {
-        if (args.length < 7) {
+        if (args.length < 6 || args.length > 7) {
             throw new IllegalArgumentException("Invalid number of arguments");
         }
 
-        final ZigBeeEndpoint endpoint = getEndpoint(networkManager, args[1]);
-        final int clusterId = parseClusterId(args[3]);
-        final ZclCluster cluster;
-        final String direction = args[2].toUpperCase();
-        if ("IN".equals(direction)) {
-            cluster = endpoint.getInputCluster(clusterId);
-        } else if ("OUT".equals(direction)) {
-            cluster = endpoint.getOutputCluster(clusterId);
-        } else {
-            throw new IllegalArgumentException("Cluster direction must be IN or OUT");
-        }
+        String endpointIdParam = args[1];
+        String clusterSpecParam = args[2];
+        String attributeIdParam = args[3];
+        String minIntervalParam = args[4];
+        String maxIntervalParam = args[5];
+        String reportableChangeParam = (args.length == 7) ? args[6] : null;
 
-        final int minInterval;
-        try {
-            minInterval = Integer.parseInt(args[5]);
-        } catch (final NumberFormatException e) {
-            throw new IllegalArgumentException("Min Interval has invalid format");
-        }
-        final int maxInterval;
-        try {
-            maxInterval = Integer.parseInt(args[6]);
-        } catch (final NumberFormatException e) {
-            throw new IllegalArgumentException("Max Interval has invalid format");
-        }
+        final ZigBeeEndpoint endpoint = getEndpoint(networkManager, endpointIdParam);
+        final ZclCluster cluster = getCluster(endpoint, clusterSpecParam);
 
-        final int attributeId = parseAttribute(args[4]);
+        final int attributeId = parseAttribute(attributeIdParam);
         final ZclAttribute attribute = cluster.getAttribute(attributeId);
         if (attribute == null) {
             throw new IllegalArgumentException(
                     "Attribute " + attributeId + " was not found in cluster " + cluster.getClusterName());
         }
 
+        final int minInterval;
+        try {
+            minInterval = Integer.parseInt(minIntervalParam);
+        } catch (final NumberFormatException e) {
+            throw new IllegalArgumentException("Min Interval has invalid format");
+        }
+        final int maxInterval;
+        try {
+            maxInterval = Integer.parseInt(maxIntervalParam);
+        } catch (final NumberFormatException e) {
+            throw new IllegalArgumentException("Max Interval has invalid format");
+        }
+
         final Object reportableChange;
-        if (args.length > 7) {
-            reportableChange = parseValue(args[7], attribute.getDataType());
+        if (reportableChangeParam != null) {
+            reportableChange = parseValue(reportableChangeParam, attribute.getDataType());
         } else {
             reportableChange = null;
         }

--- a/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleReportingSubscribeCommand.java
+++ b/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleReportingSubscribeCommand.java
@@ -52,7 +52,7 @@ public class ZigBeeConsoleReportingSubscribeCommand extends ZigBeeConsoleAbstrac
         }
 
         final ZigBeeEndpoint endpoint = getEndpoint(networkManager, args[1]);
-        final int clusterId = parseCluster(args[3]);
+        final int clusterId = parseClusterId(args[3]);
         final ZclCluster cluster;
         final String direction = args[2].toUpperCase();
         if ("IN".equals(direction)) {

--- a/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleReportingUnsubscribeCommand.java
+++ b/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleReportingUnsubscribeCommand.java
@@ -36,7 +36,7 @@ public class ZigBeeConsoleReportingUnsubscribeCommand extends ZigBeeConsoleAbstr
 
     @Override
     public String getSyntax() {
-        return "ENDPOINT IN|OUT CLUSTER ATTRIBUTE";
+        return "ENDPOINT CLUSTER ATTRIBUTE";
     }
 
     @Override
@@ -47,23 +47,18 @@ public class ZigBeeConsoleReportingUnsubscribeCommand extends ZigBeeConsoleAbstr
     @Override
     public void process(ZigBeeNetworkManager networkManager, String[] args, PrintStream out)
             throws IllegalArgumentException, InterruptedException, ExecutionException {
-        if (args.length != 6) {
+        if (args.length != 4) {
             throw new IllegalArgumentException("Invalid number of arguments");
         }
 
-        final ZigBeeEndpoint endpoint = getEndpoint(networkManager, args[1]);
-        final int clusterId = parseClusterId(args[3]);
-        final ZclCluster cluster;
-        final String direction = args[2].toUpperCase();
-        if ("IN".equals(direction)) {
-            cluster = endpoint.getInputCluster(clusterId);
-        } else if ("OUT".equals(direction)) {
-            cluster = endpoint.getOutputCluster(clusterId);
-        } else {
-            throw new IllegalArgumentException("Cluster direction must be IN or OUT");
-        }
+        String endpointIdParam = args[1];
+        String clusterSpecParam = args[2];
+        String attributeIdParam = args[3];
 
-        final int attributeId = parseAttribute(args[4]);
+        final ZigBeeEndpoint endpoint = getEndpoint(networkManager, endpointIdParam);
+        final ZclCluster cluster = getCluster(endpoint, clusterSpecParam);
+
+        final int attributeId = parseAttribute(attributeIdParam);
         final ZclAttribute attribute = cluster.getAttribute(attributeId);
 
         final CommandResult result = cluster.setReporting(attribute, 0, 0xFFFF, null).get();

--- a/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleReportingUnsubscribeCommand.java
+++ b/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleReportingUnsubscribeCommand.java
@@ -52,7 +52,7 @@ public class ZigBeeConsoleReportingUnsubscribeCommand extends ZigBeeConsoleAbstr
         }
 
         final ZigBeeEndpoint endpoint = getEndpoint(networkManager, args[1]);
-        final int clusterId = parseCluster(args[3]);
+        final int clusterId = parseClusterId(args[3]);
         final ZclCluster cluster;
         final String direction = args[2].toUpperCase();
         if ("IN".equals(direction)) {

--- a/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleUnbindCommand.java
+++ b/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleUnbindCommand.java
@@ -35,7 +35,7 @@ public class ZigBeeConsoleUnbindCommand extends ZigBeeConsoleAbstractCommand {
 
     @Override
     public String getSyntax() {
-        return "CLUSTERID SOURCE [DESTINATION]";
+        return "CLUSTER SOURCE-ENDPOINT [DESTINATION-ENDPOINT]";
     }
 
     @Override
@@ -46,22 +46,21 @@ public class ZigBeeConsoleUnbindCommand extends ZigBeeConsoleAbstractCommand {
     @Override
     public void process(ZigBeeNetworkManager networkManager, String[] args, PrintStream out)
             throws IllegalArgumentException, InterruptedException, ExecutionException {
-        if (args.length < 3) {
+        if (args.length < 3 || args.length > 4) {
             throw new IllegalArgumentException("Invalid number of arguments");
         }
 
-        final int clusterId = parseClusterId(args[1]);
+        String clusterSpecParam = args[1];
+        String sourceEndpointParam = args[2];
+        String destEndpointParam = (args.length == 4) ? args[3] : null;
 
-        final ZigBeeEndpoint source = getEndpoint(networkManager, args[2]);
-        ZclCluster cluster = source.getInputCluster(clusterId);
-        if (cluster == null) {
-            throw new IllegalArgumentException("Cluster '" + clusterId + "' not found.");
-        }
+        final ZigBeeEndpoint sourceEndpoint = getEndpoint(networkManager, sourceEndpointParam);
+        ZclCluster cluster = getCluster(sourceEndpoint, clusterSpecParam);
 
         IeeeAddress destAddress;
         int destEndpoint;
-        if (args.length >= 4) {
-            ZigBeeEndpoint destination = getEndpoint(networkManager, args[3]);
+        if (destEndpointParam != null) {
+            ZigBeeEndpoint destination = getEndpoint(networkManager, destEndpointParam);
             destAddress = destination.getIeeeAddress();
             destEndpoint = destination.getEndpointId();
         } else {

--- a/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleUnbindCommand.java
+++ b/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleUnbindCommand.java
@@ -50,7 +50,7 @@ public class ZigBeeConsoleUnbindCommand extends ZigBeeConsoleAbstractCommand {
             throw new IllegalArgumentException("Invalid number of arguments");
         }
 
-        final int clusterId = parseCluster(args[1]);
+        final int clusterId = parseClusterId(args[1]);
 
         final ZigBeeEndpoint source = getEndpoint(networkManager, args[2]);
         ZclCluster cluster = source.getInputCluster(clusterId);


### PR DESCRIPTION
Provides a new console command `cmdsupported` for showing commands supported by a cluster (analogously to the console command `attsupported` that does this for supported attributes).

The command can show only the supported generated commands, only the supported received commands, or both. 

Basically, the command calls the `ZclCluster#discoverCommands(Generated|Received)` methods to
trigger discovering the information from the device, and then the `ZclCluster#getSupportedCommands(Generated|Received)` methods for reading the result of this discovery.