### PR TITLE
Add Ember MfgLib handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,14 @@ The library provide a standard set of configuration constants to configure the N
 
 The Ember dongle driver includes a public method ```getEmberNcp()``` which returns a ```EmberNcp``` class. This class provides high level methods for interacting directly with the NCP.
 
+#### Ember MfgLib use
+
+The library provides access to the ```mfglib``` functions in the NCP to facilitate device testing. To use this function, create the ```ZigBeeDongleEzsp``` and then call the ```getEmberMfglib(EmberMfglibListener)``` method to get the ```EmberMfglib``` class and also set the callback listener. The ```EmberMfglib``` class provides access to the ```mfglib``` functions.
+
+Note that this can only be used if the dongle is not configured for use in the network (ie ```initialize``` has not been called).
+
+The [com.zsmartsystems.zigbee.sniffer](https://github.com/zsmartsystems/com.zsmartsystems.zigbee.sniffer) project is an example of the use of these features to provide a network sniffer to route frames to [Wireshark](https://www.wireshark.org/).
+
 ### Texas Instruments CC2531
 
 The library supports the Texas Instruments ZNP protocol over a serial interface.

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/EmberMfglib.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/EmberMfglib.java
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) 2016-2018 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.dongle.ember;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.zsmartsystems.zigbee.ZigBeeChannel;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspMfglibEndRequest;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspMfglibEndResponse;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspMfglibSetChannelRequest;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspMfglibSetChannelResponse;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspMfglibStartRequest;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspMfglibStartResponse;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EmberStatus;
+import com.zsmartsystems.zigbee.dongle.ember.internal.EmberNetworkInitialisation;
+import com.zsmartsystems.zigbee.dongle.ember.internal.EzspProtocolHandler;
+import com.zsmartsystems.zigbee.dongle.ember.internal.transaction.EzspSingleResponseTransaction;
+
+/**
+ * This class provides access to the Ember NCP Manufacturing Library. This interface is intended to be used for testing
+ * of final products.
+ *
+ * @author Chris Jackson
+ *
+ */
+public class EmberMfglib {
+    /**
+     * The {@link Logger}.
+     */
+    private final Logger logger = LoggerFactory.getLogger(EmberNetworkInitialisation.class);
+
+    /**
+     * The frame handler used to send the EZSP frames to the NCP
+     */
+    private EzspProtocolHandler protocolHandler;
+
+    public EmberMfglib(EzspProtocolHandler protocolHandler) {
+        this.protocolHandler = protocolHandler;
+    }
+
+    /**
+     * Activate use of mfglib test routines and enables the radio receiver to report packets it receives to the
+     * mfgLibRxHandler() callback. These packets will not be passed up with a CRC failure. All other mfglib functions
+     * will return an error until the mfglibStart() has been called
+     *
+     * @return true if the request succeeded
+     */
+    public boolean doMfglibStart() {
+        EzspMfglibStartRequest mfgStartRequest = new EzspMfglibStartRequest();
+        mfgStartRequest.setRxCallback(true);
+        EzspSingleResponseTransaction transaction = new EzspSingleResponseTransaction(mfgStartRequest,
+                EzspMfglibStartResponse.class);
+        protocolHandler.sendEzspTransaction(transaction);
+
+        EzspMfglibStartResponse mfgStartResponse = (EzspMfglibStartResponse) transaction.getResponse();
+        logger.debug(mfgStartResponse.toString());
+        if (mfgStartResponse.getStatus() != EmberStatus.EMBER_SUCCESS) {
+            logger.debug("Error with mfgStart: {}", mfgStartResponse);
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Deactivate use of mfglib test routines; restores the hardware to the state it was in prior to mfglibStart() and
+     * stops receiving packets started by mfglibStart() at the same time.
+     *
+     * @return true if the request succeeded
+     */
+    public boolean doMfglibEnd() {
+        EzspMfglibEndRequest mfgEndRequest = new EzspMfglibEndRequest();
+        EzspSingleResponseTransaction transaction = new EzspSingleResponseTransaction(mfgEndRequest,
+                EzspMfglibEndResponse.class);
+        protocolHandler.sendEzspTransaction(transaction);
+
+        EzspMfglibEndResponse mfgEndResponse = (EzspMfglibEndResponse) transaction.getResponse();
+        logger.debug(mfgEndResponse.toString());
+        if (mfgEndResponse.getStatus() != EmberStatus.EMBER_SUCCESS) {
+            logger.debug("Error with mfgEnd: {}", mfgEndResponse);
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Sets the radio channel. Calibration occurs if this is the first time the channel has been used.
+     *
+     * @param channel the {@link ZigBeeChannel} to use
+     * @return true if the request succeeded
+     */
+    public boolean doMfglibSetChannel(ZigBeeChannel channel) {
+        EzspMfglibSetChannelRequest channelRequest = new EzspMfglibSetChannelRequest();
+        channelRequest.setChannel(channel.getChannel());
+        EzspSingleResponseTransaction transaction = new EzspSingleResponseTransaction(channelRequest,
+                EzspMfglibEndResponse.class);
+        protocolHandler.sendEzspTransaction(transaction);
+
+        EzspMfglibSetChannelResponse channelResponse = (EzspMfglibSetChannelResponse) transaction.getResponse();
+        logger.debug(channelResponse.toString());
+        if (channelResponse.getStatus() != EmberStatus.EMBER_SUCCESS) {
+            logger.debug("Error with mfgChannel: {}", channelResponse);
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/EmberMfglibListener.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/EmberMfglibListener.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2016-2018 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.dongle.ember;
+
+/**
+ * A listener interface to return data to a user of the Manufacturing Library
+ *
+ * @author Chris Jackson
+ *
+ */
+public interface EmberMfglibListener {
+    /**
+     *
+     * @param linkQuality
+     * @param rssi
+     * @param data
+     */
+    void emberMfgLibPacketReceived(int linkQuality, int rssi, int[] data);
+}

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
@@ -32,6 +32,7 @@ import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspGetParentChildPara
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspIncomingMessageHandler;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspLaunchStandaloneBootloaderRequest;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspLaunchStandaloneBootloaderResponse;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspMfglibRxHandler;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspNetworkInitRequest;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspNetworkInitResponse;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspSendBroadcastRequest;
@@ -161,6 +162,12 @@ public class ZigBeeDongleEzsp implements ZigBeeTransportTransmit, ZigBeeTranspor
     private boolean networkStateUp = false;
 
     /**
+     * If the dongle is being used with the manufacturing library, then this records the listener to be called when
+     * packets are received.
+     */
+    private EmberMfglibListener mfglibListener;
+
+    /**
      * Create a {@link ZigBeeDongleEzsp} with the default ASH2 frame handler
      *
      * @param serialPort the {@link ZigBeePort} to use for the connection
@@ -246,6 +253,23 @@ public class ZigBeeDongleEzsp implements ZigBeeTransportTransmit, ZigBeeTranspor
             return stackPolicies.remove(policyId);
         }
         return stackPolicies.put(policyId, decisionId);
+    }
+
+    /**
+     * Gets an {@link EmberMfglib} instance that can be used for low level testing of the Ember dongle.
+     * <p>
+     * This may only be used if the {@link ZigBeeDongleEmber} instance has not been initialized on a ZigBee network.
+     *
+     * @return the {@link EmberMfglib} instance, or null on error
+     */
+    public EmberMfglib getEmberMfglib(EmberMfglibListener mfglibListener) {
+        if (!initialiseEzspProtocol()) {
+            return null;
+        }
+
+        this.mfglibListener = mfglibListener;
+
+        return new EmberMfglib(frameHandler);
     }
 
     @Override
@@ -539,6 +563,15 @@ public class ZigBeeDongleEzsp implements ZigBeeTransportTransmit, ZigBeeTranspor
             return;
         }
 
+        if (response instanceof EzspMfglibRxHandler) {
+            if (mfglibListener != null) {
+                EzspMfglibRxHandler mfglibHandler = (EzspMfglibRxHandler) response;
+                mfglibListener.emberMfgLibPacketReceived(mfglibHandler.getLinkQuality(), mfglibHandler.getLinkQuality(),
+                        mfglibHandler.getPacketContents());
+            }
+            return;
+        }
+
         logger.debug("Unhandled EZSP Frame: {}", response.toString());
     }
 
@@ -681,6 +714,10 @@ public class ZigBeeDongleEzsp implements ZigBeeTransportTransmit, ZigBeeTranspor
     }
 
     private boolean initialiseEzspProtocol() {
+        if (frameHandler != null) {
+            logger.error("Attempt to initialise Ember dongle when already initialised");
+            return false;
+        }
         if (!serialPort.open()) {
             logger.error("Unable to open Ember serial port");
             return false;


### PR DESCRIPTION
Provides an initial ```mfglib``` implementation to allow use of these functions, and processing of received frames for use in a packet sniffer.

#210 

Signed-off-by: Chris Jackson <chris@cd-jackson.com>