### PR TITLE
Provide options to allow dongle to be configured as a router

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,9 @@ Note that the console is currently being refactored and this readme only documen
 |reportcfg        |Read the reporting configuration of an attribute                      |
 |otaupgrade       |Provides information about device Over The Air upgrade server status  |
 |installkey       |Adds an install key to the dongle                                     |
+|linkkey          |Sets the link key int the dongle, optionally computing the MMO Hash from the join code |
+|netstart         |Join or Form a network as a router or coordinator                                      |
+
 
 
 ### Ember NCP Commands
@@ -253,4 +256,14 @@ The following commands are available if the transport layer is using the Teleges
 
 # License
 
-The code is licensed under [Eclipse Public License](https://www.eclipse.org/legal/epl-v10.html). Some parts of this code are from [zigbee4java](https://github.com/tlaukkan/zigbee4java) which in turn is derived from [ZB4O](http://zb4osgi.aaloa.org/) projects which are licensed under the [Apache-2 license](https://www.apache.org/licenses/LICENSE-2.0). Refer to the [license file](LICENSE) for further information.
+The code is licensed under [Eclipse Public License](https://www.eclipse.org/legal/epl-v10.html). Refer to the [license file](LICENSE) for further information.
+
+Some parts of this code are from [zigbee4java](https://github.com/tlaukkan/zigbee4java) which in turn is derived from [ZB4O](http://zb4osgi.aaloa.org/) projects which are licensed under the [Apache-2 license](https://www.apache.org/licenses/LICENSE-2.0). These are being refactored out to ensure the contributions to this reportisory are understood.
+
+Some documentation used to create parts of this framework is copyright © ZigBee Alliance, Inc. All rights Reserved. The following copyright notice is copied from the ZigBee documentation.
+
+Elements of ZigBee Alliance specifications may be subject to third party intellectual property rights, in- cluding without limitation, patent, copyright or trademark rights (such a third party may or may not be a member of ZigBee). ZigBee is not responsible and shall not be held responsible in any manner for identifying or failing to identify any or all such third party intellectual property rights.
+
+No right to use any ZigBee name, logo or trademark is conferred herein. Use of any ZigBee name, logo or trademark requires membership in the ZigBee Alliance and compliance with the ZigBee Logo and Trademark Policy and related ZigBee policies.
+
+This document and the information contained herein are provided on an “AS IS” basis and ZigBee DIS- CLAIMS ALL WARRANTIES EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO (A) ANY WARRANTY THAT THE USE OF THE INFORMATION HEREIN WILL NOT INFRINGE ANY RIGHTS OF THIRD PARTIES (INCLUDING WITHOUT LIMITATION ANY INTELLECTUAL PROPERTY RIGHTS INCLUDING PATENT, COPYRIGHT OR TRADEMARK RIGHTS) OR (B) ANY IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, TITLE OR NONINFRINGEMENT. IN NO EVENT WILL ZIGBEE BE LIABLE FOR ANY LOSS OF PROFITS, LOSS OF BUSINESS, LOSS OF USE OF DATA, INTERRUPTION OF BUSINESS, OR FOR ANY OTHER DIRECT, INDIRECT, SPECIAL OR EXEMPLARY, INCIDENTIAL, PUNITIVE OR CONSEQUENTIAL DAMAGES OF ANY KIND, IN CONTRACT OR IN TORT, IN CONNECTION WITH THIS DOCUMENT OR THE INFORMATION CONTAINED HEREIN, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH LOSS OR DAMAGE. All Company, brand and product names may be trademarks that are the sole property of their respective owners.

--- a/com.zsmartsystems.zigbee.console.main/src/main/java/com/zsmartsystems/zigbee/console/main/ZigBeeConsole.java
+++ b/com.zsmartsystems.zigbee.console.main/src/main/java/com/zsmartsystems/zigbee/console/main/ZigBeeConsole.java
@@ -57,6 +57,7 @@ import com.zsmartsystems.zigbee.console.ZigBeeConsoleInstallKeyCommand;
 import com.zsmartsystems.zigbee.console.ZigBeeConsoleLinkKeyCommand;
 import com.zsmartsystems.zigbee.console.ZigBeeConsoleNetworkJoinCommand;
 import com.zsmartsystems.zigbee.console.ZigBeeConsoleNetworkLeaveCommand;
+import com.zsmartsystems.zigbee.console.ZigBeeConsoleNetworkStartCommand;
 import com.zsmartsystems.zigbee.console.ZigBeeConsoleNodeListCommand;
 import com.zsmartsystems.zigbee.console.ZigBeeConsoleOtaUpgradeCommand;
 import com.zsmartsystems.zigbee.console.ZigBeeConsoleReportingConfigCommand;
@@ -199,6 +200,8 @@ public final class ZigBeeConsole {
 
         newCommands.put("installkey", new ZigBeeConsoleInstallKeyCommand());
         newCommands.put("linkkey", new ZigBeeConsoleLinkKeyCommand());
+
+        newCommands.put("netstart", new ZigBeeConsoleNetworkStartCommand());
 
         newCommands.put("otaupgrade", new ZigBeeConsoleOtaUpgradeCommand());
 

--- a/com.zsmartsystems.zigbee.console.main/src/main/java/com/zsmartsystems/zigbee/console/main/ZigBeeConsoleMain.java
+++ b/com.zsmartsystems.zigbee.console.main/src/main/java/com/zsmartsystems/zigbee/console/main/ZigBeeConsoleMain.java
@@ -79,9 +79,7 @@ public class ZigBeeConsoleMain {
         final String serialPortName;
         final String dongleName;
         final Integer serialBaud;
-        Integer channel;
-        Integer pan;
-        ExtendedPanId extendedPan;
+
         final TransportConfig transportOptions = new TransportConfig();
         boolean resetNetwork;
         FlowControl flowControl = null;
@@ -247,6 +245,9 @@ public class ZigBeeConsoleMain {
         if (resetNetwork == true) {
             ZigBeeKey nwkKey;
             ZigBeeKey linkKey;
+            ExtendedPanId extendedPan;
+            Integer channel;
+            int pan;
 
             if (cmdline.hasOption("channel")) {
                 channel = parseDecimalOrHexInt(cmdline.getOptionValue("channel"));
@@ -303,11 +304,18 @@ public class ZigBeeConsoleMain {
             networkManager.setZigBeeLinkKey(linkKey);
         }
 
+        // Add the default ZigBeeAlliance09 HA link key
+
+        transportOptions.addOption(TransportConfigOption.TRUST_CENTRE_LINK_KEY, new ZigBeeKey(new int[] { 0x5A, 0x69,
+                0x67, 0x42, 0x65, 0x65, 0x41, 0x6C, 0x6C, 0x69, 0x61, 0x6E, 0x63, 0x65, 0x30, 0x39 }));
+        // transportOptions.addOption(TransportConfigOption.TRUST_CENTRE_LINK_KEY, new ZigBeeKey(new int[] { 0x41, 0x61,
+        // 0x8F, 0xC0, 0xC8, 0x3B, 0x0E, 0x14, 0xA5, 0x89, 0x95, 0x4B, 0x16, 0xE3, 0x14, 0x66 }));
+
         dongle.updateTransportConfig(transportOptions);
 
         if (networkManager.startup(resetNetwork) != ZigBeeStatus.SUCCESS) {
             System.out.println("ZigBee console starting up ... [FAIL]");
-            // return;
+            return;
         } else {
             System.out.println("ZigBee console starting up ... [OK]");
         }

--- a/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleNetworkStartCommand.java
+++ b/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleNetworkStartCommand.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) 2016-2018 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.console;
+
+import java.io.PrintStream;
+
+import com.zsmartsystems.zigbee.ExtendedPanId;
+import com.zsmartsystems.zigbee.ZigBeeNetworkManager;
+import com.zsmartsystems.zigbee.transport.DeviceType;
+import com.zsmartsystems.zigbee.transport.TransportConfig;
+import com.zsmartsystems.zigbee.transport.TransportConfigOption;
+
+/**
+ * Console command to start the network.
+ *
+ * @author Chris Jackson
+ *
+ */
+public class ZigBeeConsoleNetworkStartCommand extends ZigBeeConsoleAbstractCommand {
+    @Override
+    public String getCommand() {
+        return "netstart";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Join or Form a network as a router or coordinator.";
+    }
+
+    @Override
+    public String getSyntax() {
+        return "FORM|JOIN PANID EPANID ";
+    }
+
+    @Override
+    public String getHelp() {
+        return "";
+    }
+
+    @Override
+    public void process(ZigBeeNetworkManager networkManager, String[] args, PrintStream out)
+            throws IllegalArgumentException {
+        if (args.length != 4) {
+            throw new IllegalArgumentException("Invalid number of arguments");
+        }
+
+        DeviceType deviceType;
+        if (args[1].equalsIgnoreCase("form")) {
+            deviceType = DeviceType.COORDINATOR;
+        } else if (args[1].equalsIgnoreCase("join")) {
+            deviceType = DeviceType.ROUTER;
+        } else {
+            throw new IllegalArgumentException("Network must be started as coordinator (form) or router (join)");
+        }
+
+        ExtendedPanId epanId;
+        try {
+            epanId = new ExtendedPanId(args[3]);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Invalid format for extended PAN Id");
+        }
+
+        final TransportConfig transportOptions = new TransportConfig();
+        Integer panId = parseInteger(args[2]);
+
+        networkManager.setZigBeePanId(panId);
+        networkManager.setZigBeeExtendedPanId(epanId);
+        transportOptions.addOption(TransportConfigOption.DEVICE_TYPE, deviceType);
+        networkManager.getZigBeeTransport().updateTransportConfig(transportOptions);
+        networkManager.startup(true);
+    }
+}

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeChannelMask.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeChannelMask.java
@@ -11,11 +11,16 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
+ * A class to hold a set of channels and methods to construct channel masks
  *
  * @author Chris Jackson
  *
  */
 public class ZigBeeChannelMask {
+    /**
+     * No channels selected
+     */
+    public final static int CHANNEL_MASK_NONE = 0x00000000;
     /**
      * All currently defined ZigBee channels in all bands
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
@@ -232,10 +232,8 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
     /**
      * Constructor which configures serial port and ZigBee network.
      *
-     * @param transport
-     *            the dongle
-     * @param resetNetwork
-     *            whether network is to be reset
+     * @param transport the dongle
+     * @param resetNetwork whether network is to be reset
      */
     public ZigBeeNetworkManager(final ZigBeeTransportTransmit transport) {
         this.transport = transport;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transport/DeviceType.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transport/DeviceType.java
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2016-2018 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.transport;
+
+/**
+ * Defines the configuration options for {@link TransportConfigOption#DEVICE_TYPE}.
+ *
+ * @author Chris Jackson
+ *
+ */
+public enum DeviceType {
+    COORDINATOR,
+    ROUTER;
+}

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transport/TransportConfigOption.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transport/TransportConfigOption.java
@@ -72,4 +72,11 @@ public enum TransportConfigOption {
      * Value must be a {@link ZigBeeNodeKey}
      */
     INSTALL_KEY,
+
+    /**
+     * Sets the device type used by the dongle. This allows to set the dongle as a coordinator or a router.
+     * <p>
+     * Value must be {@link DeviceType}
+     */
+    DEVICE_TYPE;
 }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/field/NodeDescriptor.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/field/NodeDescriptor.java
@@ -36,8 +36,8 @@ public class NodeDescriptor {
     private boolean extendedSimpleDescriptorListAvailable;
     private int stackCompliance;
 
-    final private static int R21_BITMASK = 0xFE00;
-    final private static int R21_BITSHIFT = 9;
+    private final static int R21_BITMASK = 0xFE00;
+    private final static int R21_BITSHIFT = 9;
 
     public enum LogicalType {
         COORDINATOR,


### PR DESCRIPTION
This adds the option to configure the dongle as a router or coordinator. If configured as a coordinator, the dongle should create the network when initialised. If configured as a router, the dongle should join an existing network.

This adds the enums and options for this function, and implements the ability to join an existing network with the Ember dongle.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>