### PR TITLE
Modify Ember ncpstate cli command to bring net up/down

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ The following commands are available if the transport layer is using the Silabs 
 |ncpchildren      |Gets the NCP child information                         |
 |ncpconfig        |Read or write an NCP configuration value               |
 |ncpcounters      |Gets the NCP debug counters                            |
-|ncpstate         |Gets the NCP network state                             |
+|ncpstate         |Gets the NCP network state and optionally brings the network up or down     |
 |ncpvalue         |Read or write an NCP memory value                      |
 |ncpversion       |Gets the NCP firmware version                          |
 |ncpsecuritystate |Gets the current NCP security state and configuration  |
@@ -263,8 +263,10 @@ Some parts of this code are from [zigbee4java](https://github.com/tlaukkan/zigbe
 
 Some documentation used to create parts of this framework is copyright © ZigBee Alliance, Inc. All rights Reserved. The following copyright notice is copied from the ZigBee documentation.
 
-Elements of ZigBee Alliance specifications may be subject to third party intellectual property rights, in- cluding without limitation, patent, copyright or trademark rights (such a third party may or may not be a member of ZigBee). ZigBee is not responsible and shall not be held responsible in any manner for identifying or failing to identify any or all such third party intellectual property rights.
+Elements of ZigBee Alliance specifications may be subject to third party intellectual property rights, including without limitation, patent, copyright or trademark rights (such a third party may or may not be a member of ZigBee). ZigBee is not responsible and shall not be held responsible in any manner for identifying or failing to identify any or all such third party intellectual property rights.
 
 No right to use any ZigBee name, logo or trademark is conferred herein. Use of any ZigBee name, logo or trademark requires membership in the ZigBee Alliance and compliance with the ZigBee Logo and Trademark Policy and related ZigBee policies.
 
-This document and the information contained herein are provided on an “AS IS” basis and ZigBee DIS- CLAIMS ALL WARRANTIES EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO (A) ANY WARRANTY THAT THE USE OF THE INFORMATION HEREIN WILL NOT INFRINGE ANY RIGHTS OF THIRD PARTIES (INCLUDING WITHOUT LIMITATION ANY INTELLECTUAL PROPERTY RIGHTS INCLUDING PATENT, COPYRIGHT OR TRADEMARK RIGHTS) OR (B) ANY IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, TITLE OR NONINFRINGEMENT. IN NO EVENT WILL ZIGBEE BE LIABLE FOR ANY LOSS OF PROFITS, LOSS OF BUSINESS, LOSS OF USE OF DATA, INTERRUPTION OF BUSINESS, OR FOR ANY OTHER DIRECT, INDIRECT, SPECIAL OR EXEMPLARY, INCIDENTIAL, PUNITIVE OR CONSEQUENTIAL DAMAGES OF ANY KIND, IN CONTRACT OR IN TORT, IN CONNECTION WITH THIS DOCUMENT OR THE INFORMATION CONTAINED HEREIN, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH LOSS OR DAMAGE. All Company, brand and product names may be trademarks that are the sole property of their respective owners.
+This document and the information contained herein are provided on an “AS IS” basis and ZigBee DISCLAIMS ALL WARRANTIES EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO (A) ANY WARRANTY THAT THE USE OF THE INFORMATION HEREIN WILL NOT INFRINGE ANY RIGHTS OF THIRD PARTIES (INCLUDING WITHOUT LIMITATION ANY INTELLECTUAL PROPERTY RIGHTS INCLUDING PATENT, COPYRIGHT OR TRADEMARK RIGHTS) OR (B) ANY IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, TITLE OR NONINFRINGEMENT. IN NO EVENT WILL ZIGBEE BE LIABLE FOR ANY LOSS OF PROFITS, LOSS OF BUSINESS, LOSS OF USE OF DATA, INTERRUPTION OF BUSINESS, OR FOR ANY OTHER DIRECT, INDIRECT, SPECIAL OR EXEMPLARY, INCIDENTIAL, PUNITIVE OR CONSEQUENTIAL DAMAGES OF ANY KIND, IN CONTRACT OR IN TORT, IN CONNECTION WITH THIS DOCUMENT OR THE INFORMATION CONTAINED HEREIN, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH LOSS OR DAMAGE.
+
+All Company, brand and product names may be trademarks that are the sole property of their respective owners.

--- a/com.zsmartsystems.zigbee.console.ember/src/main/java/com/zsmartsystems/zigbee/console/ember/EmberConsoleNcpStateCommand.java
+++ b/com.zsmartsystems.zigbee.console.ember/src/main/java/com/zsmartsystems/zigbee/console/ember/EmberConsoleNcpStateCommand.java
@@ -16,6 +16,7 @@ import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspGetNetworkParamete
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspVersionResponse;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EmberNetworkParameters;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EmberNetworkStatus;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EmberStatus;
 
 /**
  *
@@ -30,12 +31,12 @@ public class EmberConsoleNcpStateCommand extends EmberConsoleAbstractCommand {
 
     @Override
     public String getDescription() {
-        return "Gets the NCP network state";
+        return "Gets the NCP network state. Optionally brings the NCP online or offline.";
     }
 
     @Override
     public String getSyntax() {
-        return "";
+        return "[ONLINE | OFFLINE]";
     }
 
     @Override
@@ -46,6 +47,42 @@ public class EmberConsoleNcpStateCommand extends EmberConsoleAbstractCommand {
     @Override
     public void process(ZigBeeNetworkManager networkManager, String[] args, PrintStream out)
             throws IllegalArgumentException {
+        if (args.length > 2) {
+            throw new IllegalArgumentException("Incorrect number of arguments.");
+        }
+
+        if (args.length == 1) {
+            ncpState(networkManager, out);
+            return;
+        }
+
+        switch (args[1].toLowerCase()) {
+            case "online":
+                ncpOnline(networkManager, out);
+                break;
+            case "offline":
+                ncpOffline(networkManager, out);
+                break;
+            default:
+                throw new IllegalArgumentException("Unknown option specified: " + args[1].toUpperCase());
+        }
+    }
+
+    private void ncpOnline(ZigBeeNetworkManager networkManager, PrintStream out) {
+        EmberNcp ncp = getEmberNcp(networkManager);
+        EmberStatus response = ncp.networkInit();
+
+        out.println("NCP network initialisation result was " + response);
+    }
+
+    private void ncpOffline(ZigBeeNetworkManager networkManager, PrintStream out) {
+        EmberNcp ncp = getEmberNcp(networkManager);
+        EmberStatus response = ncp.leaveNetwork();
+
+        out.println("NCP network leave result was " + response);
+    }
+
+    private void ncpState(ZigBeeNetworkManager networkManager, PrintStream out) {
         EmberNcp ncp = getEmberNcp(networkManager);
 
         EmberNetworkStatus status = ncp.getNetworkState();

--- a/com.zsmartsystems.zigbee.console.main/src/main/java/com/zsmartsystems/zigbee/console/main/ZigBeeConsoleMain.java
+++ b/com.zsmartsystems.zigbee.console.main/src/main/java/com/zsmartsystems/zigbee/console/main/ZigBeeConsoleMain.java
@@ -198,7 +198,6 @@ public class ZigBeeConsoleMain {
             commands.add(EmberConsoleTransientKeyCommand.class);
             commands.add(EmberConsoleMmoHashCommand.class);
             commands.add(EmberConsoleNcpStateCommand.class);
-            commands.add(EmberConsoleNcpStateCommand.class);
             commands.add(EmberConsoleNcpValueCommand.class);
             commands.add(EmberConsoleNcpVersionCommand.class);
             commands.add(EmberConsoleSecurityStateCommand.class);

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/EmberNcp.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/EmberNcp.java
@@ -50,6 +50,10 @@ import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspGetPolicyRequest;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspGetPolicyResponse;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspGetValueRequest;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspGetValueResponse;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspLeaveNetworkRequest;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspLeaveNetworkResponse;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspNetworkInitRequest;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspNetworkInitResponse;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspNetworkStateRequest;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspNetworkStateResponse;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspReadCountersRequest;
@@ -143,6 +147,39 @@ public class EmberNcp {
         lastStatus = null;
 
         return response;
+    }
+
+    /**
+     * Resume network operation after a reboot. The node retains its original type. This should be called on startup
+     * whether or not the node was previously part of a network. EMBER_NOT_JOINED is returned if the node is not part of
+     * a network.
+     *
+     * @return {@link EmberStatus} if success or failure
+     */
+    public EmberStatus networkInit() {
+        EzspNetworkInitRequest request = new EzspNetworkInitRequest();
+        EzspTransaction transaction = protocolHandler
+                .sendEzspTransaction(new EzspSingleResponseTransaction(request, EzspNetworkInitResponse.class));
+        EzspNetworkInitResponse response = (EzspNetworkInitResponse) transaction.getResponse();
+        logger.debug(response.toString());
+
+        return response.getStatus();
+    }
+
+    /**
+     * Causes the stack to leave the current network. This generates a stackStatusHandler callback to indicate that the
+     * network is down. The radio will not be used until after sending a formNetwork or joinNetwork command.
+     *
+     * @return {@link EmberStatus} if success or failure
+     */
+    public EmberStatus leaveNetwork() {
+        EzspLeaveNetworkRequest request = new EzspLeaveNetworkRequest();
+        EzspTransaction transaction = protocolHandler
+                .sendEzspTransaction(new EzspSingleResponseTransaction(request, EzspLeaveNetworkResponse.class));
+        EzspLeaveNetworkResponse response = (EzspLeaveNetworkResponse) transaction.getResponse();
+        logger.debug(response.toString());
+
+        return response.getStatus();
     }
 
     /**

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
@@ -33,8 +33,6 @@ import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspIncomingMessageHan
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspLaunchStandaloneBootloaderRequest;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspLaunchStandaloneBootloaderResponse;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspMfglibRxHandler;
-import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspNetworkInitRequest;
-import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspNetworkInitResponse;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspSendBroadcastRequest;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspSendMulticastRequest;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspSendUnicastRequest;
@@ -324,22 +322,17 @@ public class ZigBeeDongleEzsp implements ZigBeeTransportTransmit, ZigBeeTranspor
         ncp.addEndpoint(1, 0, ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION.getId(), new int[] { 0 }, new int[] { 0 });
 
         // Now initialise the network
-        EzspNetworkInitRequest networkInitRequest = new EzspNetworkInitRequest();
-        EzspTransaction networkInitTransaction = frameHandler.sendEzspTransaction(
-                new EzspSingleResponseTransaction(networkInitRequest, EzspNetworkInitResponse.class));
-        EzspNetworkInitResponse networkInitResponse = (EzspNetworkInitResponse) networkInitTransaction.getResponse();
-        logger.debug(networkInitResponse.toString());
+        EmberStatus initResponse = ncp.networkInit();
 
         networkParameters = ncp.getNetworkParameters().getParameters();
         ncp.getCurrentSecurityState();
 
         zigbeeTransportReceive.setNetworkState(ZigBeeTransportState.INITIALISING);
 
-        logger.debug("EZSP dongle initialize done: Initialised {}",
-                networkInitResponse.getStatus() == EmberStatus.EMBER_NOT_JOINED);
+        logger.debug("EZSP dongle initialize done: Initialised {}", initResponse == EmberStatus.EMBER_NOT_JOINED);
 
         // Check if the network is initialised or if we're yet to join
-        if (networkInitResponse.getStatus() == EmberStatus.EMBER_NOT_JOINED) {
+        if (initResponse == EmberStatus.EMBER_NOT_JOINED) {
             return ZigBeeStatus.BAD_RESPONSE;
         }
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/EmberNetworkInitialisation.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/EmberNetworkInitialisation.java
@@ -29,8 +29,6 @@ import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspGetNetworkParamete
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspGetNetworkParametersResponse;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspJoinNetworkRequest;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspJoinNetworkResponse;
-import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspLeaveNetworkRequest;
-import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspLeaveNetworkResponse;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspNetworkFoundHandler;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspNetworkStateRequest;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspNetworkStateResponse;
@@ -116,7 +114,8 @@ public class EmberNetworkInitialisation {
 
         // Leave the current network so we can initialise a new network
         if (checkNetworkJoined()) {
-            doLeaveNetwork();
+            EmberNcp ncp = new EmberNcp(protocolHandler);
+            ncp.leaveNetwork();
         }
 
         // Perform an energy scan to find a clear channel
@@ -174,7 +173,8 @@ public class EmberNetworkInitialisation {
 
         // Leave the current network so we can initialise a new network
         if (checkNetworkJoined()) {
-            doLeaveNetwork();
+            EmberNcp ncp = new EmberNcp(protocolHandler);
+            ncp.leaveNetwork();
         }
 
         // Initialise security - no network key as we'll get that from the coordinator
@@ -202,17 +202,6 @@ public class EmberNetworkInitialisation {
         logger.debug("EZSP networkStateResponse {}", networkStateResponse.getStatus());
 
         return networkStateResponse.getStatus() == EmberNetworkStatus.EMBER_JOINED_NETWORK;
-    }
-
-    private boolean doLeaveNetwork() {
-        EzspLeaveNetworkRequest leaveNetworkRequest = new EzspLeaveNetworkRequest();
-        EzspTransaction leaveNetworkTransaction = protocolHandler.sendEzspTransaction(
-                new EzspSingleResponseTransaction(leaveNetworkRequest, EzspLeaveNetworkResponse.class));
-        EzspLeaveNetworkResponse leaveNetworkResponse = (EzspLeaveNetworkResponse) leaveNetworkTransaction
-                .getResponse();
-        logger.debug(leaveNetworkResponse.toString());
-
-        return leaveNetworkResponse.getStatus() == EmberStatus.EMBER_SUCCESS;
     }
 
     /**

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transport/ZigBeeTransportTransmit.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transport/ZigBeeTransportTransmit.java
@@ -53,6 +53,7 @@ public interface ZigBeeTransportTransmit {
      * Starts the transport interface.
      * <p>
      * This call will optionally reconfigure the interface if the reinitialize parameter is true.
+     * Startup would normally be called once after {@link #initialize()} on system start, and may be called again after
      *
      * @param reinitialize true if the provider is to reinitialise the network with the parameters configured since the
      *            {@link #initialize} method was called.
@@ -61,7 +62,8 @@ public interface ZigBeeTransportTransmit {
     ZigBeeStatus startup(boolean reinitialize);
 
     /**
-     * Shuts down a transport interface.
+     * Shuts down a transport interface. This method shall free all resources, and the interface may not be used again
+     * until {@link #initialize()} is called.
      */
     void shutdown();
 


### PR DESCRIPTION
Provides an optional online/offline subcommand to the ncpstate command to bring the NCP up or down.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>