### PR TITLE
Increase ASH buffer size

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/ash/AshFrame.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/ash/AshFrame.java
@@ -159,7 +159,7 @@ public class AshFrame {
         }
 
         // Remove byte stuffing
-        int[] unstuffedData = new int[131];
+        int[] unstuffedData = new int[buffer.length];
         int outLength = 0;
         boolean escape = false;
         for (int data : buffer) {

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/ash/AshFrameHandler.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/ash/AshFrameHandler.java
@@ -81,7 +81,7 @@ public class AshFrameHandler implements EzspProtocolHandler {
     private final int ASH_OFF_BYTE = 0x13;
     private final int ASH_TIMEOUT = -1;
 
-    private final int ASH_MAX_LENGTH = 131;
+    private final int ASH_MAX_LENGTH = 220;
 
     private Integer ackNum = 0;
     private int frmNum = 0;

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/serializer/EzspDeserializer.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/serializer/EzspDeserializer.java
@@ -61,7 +61,7 @@ import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EzspStatus;
  *
  */
 public class EzspDeserializer {
-    private int[] buffer = new int[131];
+    private int[] buffer = new int[220];
     private int position = 0;
 
     public EzspDeserializer(int[] inputBuffer) {

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/serializer/EzspSerializer.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/serializer/EzspSerializer.java
@@ -55,7 +55,7 @@ import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EzspValueId;
  *
  */
 public class EzspSerializer {
-    private int[] buffer = new int[131];
+    private int[] buffer = new int[220];
     private int length = 0;
 
     /**


### PR DESCRIPTION
Silabs document UG101 that describes the ASH protocol states that the largest data size can be 128 bytes, making a maximum frame of 131 bytes. However there are some (at least 1) EZSP command that violates this.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>