### PR TITLE
Modify NCP configuration calls to return EzspState rather than boolean

### DIFF
--- a/com.zsmartsystems.zigbee.console.ember/src/main/java/com/zsmartsystems/zigbee/console/ember/EmberConsoleNcpConfigurationCommand.java
+++ b/com.zsmartsystems.zigbee.console.ember/src/main/java/com/zsmartsystems/zigbee/console/ember/EmberConsoleNcpConfigurationCommand.java
@@ -43,7 +43,7 @@ public class EmberConsoleNcpConfigurationCommand extends EmberConsoleAbstractCom
     public String getHelp() {
         return "CONFIGID is the Ember NCP configuration enumeration\n" + "VALUE is the value to write\n"
                 + "If VALUE is not defined, then the memory will be read.\n"
-                + "If no arguments are supplied then all configiration will be displayed.";
+                + "If no arguments are supplied then all configuration values will be displayed.";
     }
 
     @Override
@@ -88,9 +88,29 @@ public class EmberConsoleNcpConfigurationCommand extends EmberConsoleAbstractCom
         } else {
             try {
                 Integer value = Integer.parseInt(args[2]);
-                boolean response = ncp.setConfiguration(configId, value);
-                out.println("Writing Ember NCP configuration " + configId.toString() + " was " + (response ? "" : "un")
-                        + "successful.");
+                String result;
+                switch (ncp.setConfiguration(configId, value)) {
+                    case EZSP_SUCCESS:
+                        result = "successful.";
+                        break;
+                    case EZSP_ERROR_OUT_OF_MEMORY:
+                        result = "unsuccessful. NCP is out of memory.";
+                        break;
+                    case EZSP_ERROR_INVALID_VALUE:
+                        result = "unsuccessful. Specified value was out of bounds.";
+                        break;
+                    case EZSP_ERROR_INVALID_ID:
+                        result = "unsuccessful. Config ID is unknown.";
+                        break;
+                    case EZSP_ERROR_INVALID_CALL:
+                        result = "unsuccessful. Configuration can not be modified in current NCP state.";
+                        break;
+                    default:
+                        result = "UNKNOWN";
+                        break;
+                }
+                out.println("Writing Ember NCP configuration " + configId.toString() + " was " + result);
+
             } catch (NumberFormatException e) {
                 throw new IllegalArgumentException("Unable to convert data to integer");
             }

--- a/com.zsmartsystems.zigbee.console.ember/src/main/java/com/zsmartsystems/zigbee/console/ember/EmberConsoleNcpValueCommand.java
+++ b/com.zsmartsystems.zigbee.console.ember/src/main/java/com/zsmartsystems/zigbee/console/ember/EmberConsoleNcpValueCommand.java
@@ -15,6 +15,7 @@ import java.util.TreeMap;
 
 import com.zsmartsystems.zigbee.ZigBeeNetworkManager;
 import com.zsmartsystems.zigbee.dongle.ember.EmberNcp;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EzspStatus;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EzspValueId;
 
 /**
@@ -90,9 +91,9 @@ public class EmberConsoleNcpValueCommand extends EmberConsoleAbstractCommand {
             if (value == null) {
                 throw new IllegalArgumentException("Unable to convert data to value array");
             }
-            boolean response = ncp.setValue(valueId, value);
-            out.println(
-                    "Writing Ember NCP value " + valueId.toString() + " was " + (response ? "" : "un") + "successful.");
+            EzspStatus response = ncp.setValue(valueId, value);
+            out.println("Writing Ember NCP value " + valueId.toString() + " was "
+                    + (response == EzspStatus.EZSP_SUCCESS ? "" : "un") + "successful.");
         }
     }
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/EmberNcp.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/EmberNcp.java
@@ -381,9 +381,9 @@ public class EmberNcp {
      *
      * @param configId the {@link EzspConfigId} to set
      * @param value the value to set
-     * @return true if the configuration returns success
+     * @return the {@link EzspStatus} of the response
      */
-    public boolean setConfiguration(EzspConfigId configId, Integer value) {
+    public EzspStatus setConfiguration(EzspConfigId configId, Integer value) {
         EzspSetConfigurationValueRequest request = new EzspSetConfigurationValueRequest();
         request.setConfigId(configId);
         request.setValue(value);
@@ -395,7 +395,7 @@ public class EmberNcp {
         lastStatus = null;
         logger.debug(response.toString());
 
-        return response.getStatus() == EzspStatus.EZSP_SUCCESS;
+        return response.getStatus();
     }
 
     /**
@@ -403,9 +403,9 @@ public class EmberNcp {
      *
      * @param policyId the {@link EzspPolicyId} to set
      * @param decisionId the {@link EzspDecisionId} to set to
-     * @return true if the policy setting was successful
+     * @return the {@link EzspStatus} of the response
      */
-    public boolean setPolicy(EzspPolicyId policyId, EzspDecisionId decisionId) {
+    public EzspStatus setPolicy(EzspPolicyId policyId, EzspDecisionId decisionId) {
         EzspSetPolicyRequest setPolicyRequest = new EzspSetPolicyRequest();
         setPolicyRequest.setPolicyId(policyId);
         setPolicyRequest.setDecisionId(decisionId);
@@ -417,10 +417,9 @@ public class EmberNcp {
         logger.debug(setPolicyResponse.toString());
         if (setPolicyResponse.getStatus() != EzspStatus.EZSP_SUCCESS) {
             logger.debug("Error during setting policy: {}", setPolicyResponse);
-            return false;
         }
 
-        return true;
+        return setPolicyResponse.getStatus();
     }
 
     /**
@@ -452,9 +451,9 @@ public class EmberNcp {
      *
      * @param valueId the {@link EzspValueId} to set
      * @param value the value to set to
-     * @return true if the value setting was successful
+     * @return the {@link EzspStatus} of the response
      */
-    public boolean setValue(EzspValueId valueId, int[] value) {
+    public EzspStatus setValue(EzspValueId valueId, int[] value) {
         EzspSetValueRequest request = new EzspSetValueRequest();
         request.setValueId(valueId);
         request.setValue(value);
@@ -466,10 +465,9 @@ public class EmberNcp {
         logger.debug(response.toString());
         if (response.getStatus() != EzspStatus.EZSP_SUCCESS) {
             logger.debug("Error setting value: {}", response);
-            return false;
         }
 
-        return true;
+        return response.getStatus();
     }
 
     /**

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/EmberNetworkInitialisation.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/EmberNetworkInitialisation.java
@@ -46,6 +46,7 @@ import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EmberNetworkStatus;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EmberNodeType;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EmberStatus;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EzspNetworkScanType;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EzspStatus;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EzspValueId;
 import com.zsmartsystems.zigbee.dongle.ember.internal.serializer.EzspSerializer;
 import com.zsmartsystems.zigbee.dongle.ember.internal.transaction.EzspMultiResponseTransaction;
@@ -352,14 +353,16 @@ public class EmberNetworkInitialisation {
         if (networkKey.hasOutgoingFrameCounter()) {
             EzspSerializer serializer = new EzspSerializer();
             serializer.serializeUInt32(networkKey.getOutgoingFrameCounter());
-            if (!ncp.setValue(EzspValueId.EZSP_VALUE_NWK_FRAME_COUNTER, serializer.getPayload())) {
+            if (ncp.setValue(EzspValueId.EZSP_VALUE_NWK_FRAME_COUNTER,
+                    serializer.getPayload()) != EzspStatus.EZSP_SUCCESS) {
                 return false;
             }
         }
         if (linkKey.hasOutgoingFrameCounter()) {
             EzspSerializer serializer = new EzspSerializer();
             serializer.serializeUInt32(linkKey.getOutgoingFrameCounter());
-            if (!ncp.setValue(EzspValueId.EZSP_VALUE_APS_FRAME_COUNTER, serializer.getPayload())) {
+            if (ncp.setValue(EzspValueId.EZSP_VALUE_APS_FRAME_COUNTER,
+                    serializer.getPayload()) != EzspStatus.EZSP_SUCCESS) {
                 return false;
             }
         }

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/EmberStackConfiguration.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/EmberStackConfiguration.java
@@ -16,6 +16,7 @@ import com.zsmartsystems.zigbee.dongle.ember.EmberNcp;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EzspConfigId;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EzspDecisionId;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EzspPolicyId;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EzspStatus;
 
 /**
  * This class provides utility functions to configure, and read the configuration from the Ember stack.
@@ -50,7 +51,7 @@ public class EmberStackConfiguration {
 
         EmberNcp ncp = new EmberNcp(protocolHandler);
         for (Entry<EzspConfigId, Integer> config : configuration.entrySet()) {
-            if (!ncp.setConfiguration(config.getKey(), config.getValue())) {
+            if (ncp.setConfiguration(config.getKey(), config.getValue()) != EzspStatus.EZSP_SUCCESS) {
                 success = false;
             }
         }
@@ -88,7 +89,7 @@ public class EmberStackConfiguration {
 
         EmberNcp ncp = new EmberNcp(protocolHandler);
         for (Entry<EzspPolicyId, EzspDecisionId> policy : policies.entrySet()) {
-            if (!ncp.setPolicy(policy.getKey(), policy.getValue())) {
+            if (ncp.setPolicy(policy.getKey(), policy.getValue()) != EzspStatus.EZSP_SUCCESS) {
                 success = false;
             }
         }


### PR DESCRIPTION
This provides the error code back to the caller when setting configuration. The console application is also updated to provide feedback to the user in case of failure configuring the NCP.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>