### PR TITLE
Add option to configure Ember Radio TX Power

### DIFF
--- a/com.zsmartsystems.zigbee.console.main/src/main/java/com/zsmartsystems/zigbee/console/main/ZigBeeConsoleMain.java
+++ b/com.zsmartsystems.zigbee.console.main/src/main/java/com/zsmartsystems/zigbee/console/main/ZigBeeConsoleMain.java
@@ -181,6 +181,8 @@ public class ZigBeeConsoleMain {
         } else if (dongleName.toUpperCase().equals("EMBER")) {
             dongle = new ZigBeeDongleEzsp(serialPort);
 
+            transportOptions.addOption(TransportConfigOption.RADIO_TX_POWER, 8);
+
             // Configure the concentrator
             // Max Hops defaults to system max
             ConcentratorConfig concentratorConfig = new ConcentratorConfig();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/EmberNcp.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/EmberNcp.java
@@ -62,6 +62,8 @@ import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspSetConfigurationVa
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspSetConfigurationValueResponse;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspSetPolicyRequest;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspSetPolicyResponse;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspSetRadioPowerRequest;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspSetRadioPowerResponse;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspSetValueRequest;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspSetValueResponse;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspVersionRequest;
@@ -617,6 +619,26 @@ public class EmberNcp {
         protocolHandler.sendEzspTransaction(transaction);
         EzspGetNodeIdResponse response = (EzspGetNodeIdResponse) transaction.getResponse();
         return response.getNodeId();
+    }
+
+    /**
+     * Sets the radio output power at which a node is operating. Ember radios have discrete power settings. For a list
+     * of available power settings, see the technical specification for the RF communication module in your Developer
+     * Kit. Note: Care should be taken when using this API on a running network, as it will directly impact the
+     * established link qualities neighboring nodes have with the node on which it is called. This can lead to
+     * disruption of existing routes and erratic network behavior.
+     *
+     * @param power Desired radio output power, in dBm.
+     * @return the response {@link EmberStatus} of the request
+     */
+    public EmberStatus setRadioPower(int power) {
+        EzspSetRadioPowerRequest request = new EzspSetRadioPowerRequest();
+        request.setPower(power);
+        EzspSingleResponseTransaction transaction = new EzspSingleResponseTransaction(request,
+                EzspSetRadioPowerResponse.class);
+        protocolHandler.sendEzspTransaction(transaction);
+        EzspSetRadioPowerResponse response = (EzspSetRadioPowerResponse) transaction.getResponse();
+        return response.getStatus();
     }
 
     /**

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transport/TransportConfigOption.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transport/TransportConfigOption.java
@@ -78,5 +78,12 @@ public enum TransportConfigOption {
      * <p>
      * Value must be {@link DeviceType}
      */
-    DEVICE_TYPE;
+    DEVICE_TYPE,
+
+    /**
+     * Sets the device radio power. Power level is defined in dBm.
+     * <p>
+     * Value must be {@link Integer}
+     */
+    RADIO_TX_POWER;
 }


### PR DESCRIPTION
Adds a new transport config option to set the radio power, and implements this for the Ember dongle.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>