### PR TITLE
XBee does not return the channel, but, a channel mask. 

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.xbee/src/main/java/com/zsmartsystems/zigbee/dongle/xbee/ZigBeeDongleXBee.java
+++ b/com.zsmartsystems.zigbee.dongle.xbee/src/main/java/com/zsmartsystems/zigbee/dongle/xbee/ZigBeeDongleXBee.java
@@ -415,7 +415,12 @@ public class ZigBeeDongleXBee implements ZigBeeTransportTransmit, XBeeEventListe
         XBeeGetOperatingChannelCommand request = new XBeeGetOperatingChannelCommand();
         XBeeOperatingChannelResponse response = (XBeeOperatingChannelResponse) frameHandler.sendRequest(request);
 
-        return ZigBeeChannel.create(response.getChannel());
+        int channel = response.getChannel();
+        int count;
+        
+        for(count = 0; (channel & 0x01) == 0 && count < (Integer.SIZE*8); channel >>= 1, count ++);
+        
+        return ZigBeeChannel.create(count + 11);
     }
 
     @Override


### PR DESCRIPTION
XBee SC command do not returns the channel, but, a channel mask. We need to transform the mask back to the channel number in order to OH2 shows it correctly at XBee Coordinator thing.