### PR TITLE
Fix initialisation response issue with Telegesis and Ember dongles

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
@@ -329,12 +329,7 @@ public class ZigBeeDongleEzsp implements ZigBeeTransportTransmit, ZigBeeTranspor
 
         zigbeeTransportReceive.setNetworkState(ZigBeeTransportState.INITIALISING);
 
-        logger.debug("EZSP dongle initialize done: Initialised {}", initResponse == EmberStatus.EMBER_NOT_JOINED);
-
-        // Check if the network is initialised or if we're yet to join
-        if (initResponse == EmberStatus.EMBER_NOT_JOINED) {
-            return ZigBeeStatus.BAD_RESPONSE;
-        }
+        logger.debug("EZSP dongle initialize done: Initialised {}", initResponse != EmberStatus.EMBER_NOT_JOINED);
 
         return ZigBeeStatus.SUCCESS;
     }

--- a/com.zsmartsystems.zigbee.dongle.telegesis/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/ZigBeeDongleTelegesis.java
+++ b/com.zsmartsystems.zigbee.dongle.telegesis/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/ZigBeeDongleTelegesis.java
@@ -372,15 +372,6 @@ public class ZigBeeDongleTelegesis
             ieeeAddress = productInfo.getIeeeAddress();
         }
 
-        // Get network information
-        TelegesisDisplayNetworkInformationCommand networkInfo = new TelegesisDisplayNetworkInformationCommand();
-        if (frameHandler.sendRequest(networkInfo) == null || networkInfo.getStatus() != TelegesisStatusCode.SUCCESS) {
-            return ZigBeeStatus.BAD_RESPONSE;
-        }
-        if (networkInfo.getDevice() != TelegesisDeviceType.COO) {
-            return ZigBeeStatus.INVALID_STATE;
-        }
-
         zigbeeTransportReceive.setNetworkState(ZigBeeTransportState.INITIALISING);
 
         return ZigBeeStatus.SUCCESS;
@@ -411,6 +402,9 @@ public class ZigBeeDongleTelegesis
         if (frameHandler.sendRequest(networkInfo) == null || networkInfo.getStatus() != TelegesisStatusCode.SUCCESS) {
             zigbeeTransportReceive.setNetworkState(ZigBeeTransportState.OFFLINE);
             return ZigBeeStatus.BAD_RESPONSE;
+        }
+        if (networkInfo.getDevice() != TelegesisDeviceType.COO) {
+            return ZigBeeStatus.INVALID_STATE;
         }
 
         radioChannel = ZigBeeChannel.create(networkInfo.getChannel());


### PR DESCRIPTION
The ```initialize()``` method should not fail if the dongles don't restore the network.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>