### PR TITLE
Match Descriptor Response with Wrong Network Of Interest?

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/internal/ClusterMatcher.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/internal/ClusterMatcher.java
@@ -95,7 +95,7 @@ public class ClusterMatcher implements ZigBeeCommandListener {
             matchResponse.setMatchList(matchList);
 
             matchResponse.setDestinationAddress(command.getSourceAddress());
-            matchResponse.setNwkAddrOfInterest(command.getSourceAddress().getAddress());
+            matchResponse.setNwkAddrOfInterest(matchRequest.getNwkAddrOfInterest());
             logger.debug("{}: ClusterMatcher sending match {}", networkManager.getZigBeeExtendedPanId(), matchResponse);
             networkManager.sendCommand(matchResponse);
         }


### PR DESCRIPTION
Chris,

I managed to put my Nyce Sensors to work. This patch is what I've done.

In the zigbee specification. The Network Of Interest must be the same address of the request, or, the address of the device who matched the cluster.

"If the NWKAddrOfInterest field of the original Match_Desc_req was not equal to
the broadcast network address for all devices for which macRxOnWhenIdle =
TRUE (0xfffd), the remote device shall set the NWKAddrOfInterest field to the
same network address that was specified in the original Match_Desc_req
command."

I understand that they are talking about the same field NWKAddrOfInterest of Match_Desc_req.

If there are multiple matchs they say to use the address of the device who matched the criteria:

"If the above procedure produces one or more matches, the remote device shall
construct a separate Match_Desc_rsp command for each matching device
(including itself). For each response, the Status field shall be set to SUCCESS, the
NWKAddrOfInterest field shall be set to the address of the appropriate matching
device, the MatchLength field shall be set to the number of simple descriptors that
matched the criteria for the appropriate matching device, and the MatchList field
shall contain an ascending list of the endpoints on which a simple descriptor
matched the criteria for the appropriate matching device."

Well, at least, my sensors are working...

regards,
Otávio Ribeiro