### PR TITLE
Update definition of setPreinstalledCbkeData283k1 + fix JavaDoc typo

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspAddEndpointRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspAddEndpointRequest.java
@@ -70,7 +70,7 @@ public class EzspAddEndpointRequest extends EzspFrameRequest {
     private int[] outputClusterList;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspAddOrUpdateKeyTableEntryRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspAddOrUpdateKeyTableEntryRequest.java
@@ -52,7 +52,7 @@ public class EzspAddOrUpdateKeyTableEntryRequest extends EzspFrameRequest {
     private EmberKeyData keyData;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspAddTransientLinkKeyRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspAddTransientLinkKeyRequest.java
@@ -44,7 +44,7 @@ public class EzspAddTransientLinkKeyRequest extends EzspFrameRequest {
     private EmberKeyData transientKey;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspAesMmoHashRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspAesMmoHashRequest.java
@@ -57,7 +57,7 @@ public class EzspAesMmoHashRequest extends EzspFrameRequest {
     private int[] data;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspBecomeTrustCenterRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspBecomeTrustCenterRequest.java
@@ -36,7 +36,7 @@ public class EzspBecomeTrustCenterRequest extends EzspFrameRequest {
     private EmberKeyData newNetworkKey;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspBindingIsActiveRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspBindingIsActiveRequest.java
@@ -35,7 +35,7 @@ public class EzspBindingIsActiveRequest extends EzspFrameRequest {
     private int index;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspCalculateSmacs283k1Request.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspCalculateSmacs283k1Request.java
@@ -52,7 +52,7 @@ public class EzspCalculateSmacs283k1Request extends EzspFrameRequest {
     private EmberPublicKey283k1Data partnerEphemeralPublicKey;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspCalculateSmacsHandler283k1Request.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspCalculateSmacsHandler283k1Request.java
@@ -28,7 +28,7 @@ public class EzspCalculateSmacsHandler283k1Request extends EzspFrameRequest {
     public static final int FRAME_ID = 0xEB;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspCalculateSmacsRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspCalculateSmacsRequest.java
@@ -51,7 +51,7 @@ public class EzspCalculateSmacsRequest extends EzspFrameRequest {
     private EmberPublicKeyData partnerEphemeralPublicKey;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspCallbackRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspCallbackRequest.java
@@ -25,7 +25,7 @@ public class EzspCallbackRequest extends EzspFrameRequest {
     public static final int FRAME_ID = 0x06;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspClearBindingTableRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspClearBindingTableRequest.java
@@ -25,7 +25,7 @@ public class EzspClearBindingTableRequest extends EzspFrameRequest {
     public static final int FRAME_ID = 0x2A;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspClearKeyTableRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspClearKeyTableRequest.java
@@ -25,7 +25,7 @@ public class EzspClearKeyTableRequest extends EzspFrameRequest {
     public static final int FRAME_ID = 0xB1;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspClearTemporaryDataMaybeStoreLinkKey283k1Request.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspClearTemporaryDataMaybeStoreLinkKey283k1Request.java
@@ -35,7 +35,7 @@ public class EzspClearTemporaryDataMaybeStoreLinkKey283k1Request extends EzspFra
     private boolean storeLinkKey;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspClearTemporaryDataMaybeStoreLinkKeyRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspClearTemporaryDataMaybeStoreLinkKeyRequest.java
@@ -35,7 +35,7 @@ public class EzspClearTemporaryDataMaybeStoreLinkKeyRequest extends EzspFrameReq
     private boolean storeLinkKey;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspClearTransientLinkKeysRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspClearTransientLinkKeysRequest.java
@@ -25,7 +25,7 @@ public class EzspClearTransientLinkKeysRequest extends EzspFrameRequest {
     public static final int FRAME_ID = 0x6B;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspDGpSendRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspDGpSendRequest.java
@@ -75,7 +75,7 @@ public class EzspDGpSendRequest extends EzspFrameRequest {
     private int gpTxQueueEntryLifetimeMs;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspDeleteBindingRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspDeleteBindingRequest.java
@@ -32,7 +32,7 @@ public class EzspDeleteBindingRequest extends EzspFrameRequest {
     private int index;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspEnergyScanRequestRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspEnergyScanRequestRequest.java
@@ -56,7 +56,7 @@ public class EzspEnergyScanRequestRequest extends EzspFrameRequest {
     private int scanCount;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspEraseKeyTableEntryRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspEraseKeyTableEntryRequest.java
@@ -33,7 +33,7 @@ public class EzspEraseKeyTableEntryRequest extends EzspFrameRequest {
     private int index;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspFindAndRejoinNetworkRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspFindAndRejoinNetworkRequest.java
@@ -53,7 +53,7 @@ public class EzspFindAndRejoinNetworkRequest extends EzspFrameRequest {
     private int channelMask;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspFindKeyTableEntryRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspFindKeyTableEntryRequest.java
@@ -43,7 +43,7 @@ public class EzspFindKeyTableEntryRequest extends EzspFrameRequest {
     private boolean linkKey;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspFormNetworkRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspFormNetworkRequest.java
@@ -33,7 +33,7 @@ public class EzspFormNetworkRequest extends EzspFrameRequest {
     private EmberNetworkParameters parameters;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGenerateCbkeKeys283k1Request.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGenerateCbkeKeys283k1Request.java
@@ -27,7 +27,7 @@ public class EzspGenerateCbkeKeys283k1Request extends EzspFrameRequest {
     public static final int FRAME_ID = 0xE8;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGenerateCbkeKeysHandler283k1Request.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGenerateCbkeKeysHandler283k1Request.java
@@ -28,7 +28,7 @@ public class EzspGenerateCbkeKeysHandler283k1Request extends EzspFrameRequest {
     public static final int FRAME_ID = 0xE9;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGenerateCbkeKeysRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGenerateCbkeKeysRequest.java
@@ -26,7 +26,7 @@ public class EzspGenerateCbkeKeysRequest extends EzspFrameRequest {
     public static final int FRAME_ID = 0xA4;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetAddressTableRemoteEui64Request.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetAddressTableRemoteEui64Request.java
@@ -32,7 +32,7 @@ public class EzspGetAddressTableRemoteEui64Request extends EzspFrameRequest {
     private int addressTableIndex;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetBindingRemoteNodeIdRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetBindingRemoteNodeIdRequest.java
@@ -37,7 +37,7 @@ public class EzspGetBindingRemoteNodeIdRequest extends EzspFrameRequest {
     private int index;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetBindingRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetBindingRequest.java
@@ -32,7 +32,7 @@ public class EzspGetBindingRequest extends EzspFrameRequest {
     private int index;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetCertificate283k1Request.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetCertificate283k1Request.java
@@ -25,7 +25,7 @@ public class EzspGetCertificate283k1Request extends EzspFrameRequest {
     public static final int FRAME_ID = 0xEC;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetCertificateRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetCertificateRequest.java
@@ -25,7 +25,7 @@ public class EzspGetCertificateRequest extends EzspFrameRequest {
     public static final int FRAME_ID = 0xA5;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetChildDataRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetChildDataRequest.java
@@ -33,7 +33,7 @@ public class EzspGetChildDataRequest extends EzspFrameRequest {
     private int index;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetConfigurationValueRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetConfigurationValueRequest.java
@@ -33,7 +33,7 @@ public class EzspGetConfigurationValueRequest extends EzspFrameRequest {
     private EzspConfigId configId;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetCurrentSecurityStateRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetCurrentSecurityStateRequest.java
@@ -25,7 +25,7 @@ public class EzspGetCurrentSecurityStateRequest extends EzspFrameRequest {
     public static final int FRAME_ID = 0x69;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetEui64Request.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetEui64Request.java
@@ -25,7 +25,7 @@ public class EzspGetEui64Request extends EzspFrameRequest {
     public static final int FRAME_ID = 0x26;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetExtendedTimeoutRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetExtendedTimeoutRequest.java
@@ -34,7 +34,7 @@ public class EzspGetExtendedTimeoutRequest extends EzspFrameRequest {
     private IeeeAddress remoteEui64;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetKeyRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetKeyRequest.java
@@ -33,7 +33,7 @@ public class EzspGetKeyRequest extends EzspFrameRequest {
     private EmberKeyType keyType;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetKeyTableEntryRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetKeyTableEntryRequest.java
@@ -32,7 +32,7 @@ public class EzspGetKeyTableEntryRequest extends EzspFrameRequest {
     private int index;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetLibraryStatusRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetLibraryStatusRequest.java
@@ -34,7 +34,7 @@ public class EzspGetLibraryStatusRequest extends EzspFrameRequest {
     private EmberLibraryId libraryId;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetMfgTokenRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetMfgTokenRequest.java
@@ -34,7 +34,7 @@ public class EzspGetMfgTokenRequest extends EzspFrameRequest {
     private EzspMfgTokenId tokenId;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetNeighborRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetNeighborRequest.java
@@ -34,7 +34,7 @@ public class EzspGetNeighborRequest extends EzspFrameRequest {
     private int index;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetNetworkParametersRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetNetworkParametersRequest.java
@@ -25,7 +25,7 @@ public class EzspGetNetworkParametersRequest extends EzspFrameRequest {
     public static final int FRAME_ID = 0x28;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetNodeIdRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetNodeIdRequest.java
@@ -25,7 +25,7 @@ public class EzspGetNodeIdRequest extends EzspFrameRequest {
     public static final int FRAME_ID = 0x27;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetParentChildParametersRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetParentChildParametersRequest.java
@@ -25,7 +25,7 @@ public class EzspGetParentChildParametersRequest extends EzspFrameRequest {
     public static final int FRAME_ID = 0x29;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetPolicyRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetPolicyRequest.java
@@ -33,7 +33,7 @@ public class EzspGetPolicyRequest extends EzspFrameRequest {
     private EzspPolicyId policyId;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetRouteTableEntryRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetRouteTableEntryRequest.java
@@ -33,7 +33,7 @@ public class EzspGetRouteTableEntryRequest extends EzspFrameRequest {
     private int index;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetStandaloneBootloaderVersionPlatMicroPhyRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetStandaloneBootloaderVersionPlatMicroPhyRequest.java
@@ -27,7 +27,7 @@ public class EzspGetStandaloneBootloaderVersionPlatMicroPhyRequest extends EzspF
     public static final int FRAME_ID = 0x91;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetValueRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetValueRequest.java
@@ -33,7 +33,7 @@ public class EzspGetValueRequest extends EzspFrameRequest {
     private EzspValueId valueId;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetXncpInfoRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetXncpInfoRequest.java
@@ -27,7 +27,7 @@ public class EzspGetXncpInfoRequest extends EzspFrameRequest {
     public static final int FRAME_ID = 0x13;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGpProxyTableLookupRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGpProxyTableLookupRequest.java
@@ -33,7 +33,7 @@ public class EzspGpProxyTableLookupRequest extends EzspFrameRequest {
     private EmberGpAddress addr;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGpProxyTableProcessGpPairingRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGpProxyTableProcessGpPairingRequest.java
@@ -84,7 +84,7 @@ public class EzspGpProxyTableProcessGpPairingRequest extends EzspFrameRequest {
     private EmberKeyData gpdKey;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspInvalidCommandRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspInvalidCommandRequest.java
@@ -25,7 +25,7 @@ public class EzspInvalidCommandRequest extends EzspFrameRequest {
     public static final int FRAME_ID = 0x58;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspJoinNetworkRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspJoinNetworkRequest.java
@@ -44,7 +44,7 @@ public class EzspJoinNetworkRequest extends EzspFrameRequest {
     private EmberNetworkParameters parameters;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspLaunchStandaloneBootloaderRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspLaunchStandaloneBootloaderRequest.java
@@ -38,7 +38,7 @@ public class EzspLaunchStandaloneBootloaderRequest extends EzspFrameRequest {
     private int mode;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspLeaveNetworkRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspLeaveNetworkRequest.java
@@ -27,7 +27,7 @@ public class EzspLeaveNetworkRequest extends EzspFrameRequest {
     public static final int FRAME_ID = 0x20;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspLookupEui64ByNodeIdRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspLookupEui64ByNodeIdRequest.java
@@ -33,7 +33,7 @@ public class EzspLookupEui64ByNodeIdRequest extends EzspFrameRequest {
     private int nodeId;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspLookupNodeIdByEui64Request.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspLookupNodeIdByEui64Request.java
@@ -34,7 +34,7 @@ public class EzspLookupNodeIdByEui64Request extends EzspFrameRequest {
     private IeeeAddress eui64;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspMfglibEndRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspMfglibEndRequest.java
@@ -26,7 +26,7 @@ public class EzspMfglibEndRequest extends EzspFrameRequest {
     public static final int FRAME_ID = 0x84;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspMfglibGetChannelRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspMfglibGetChannelRequest.java
@@ -25,7 +25,7 @@ public class EzspMfglibGetChannelRequest extends EzspFrameRequest {
     public static final int FRAME_ID = 0x8B;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspMfglibGetPowerRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspMfglibGetPowerRequest.java
@@ -25,7 +25,7 @@ public class EzspMfglibGetPowerRequest extends EzspFrameRequest {
     public static final int FRAME_ID = 0x8D;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspMfglibSendPacketRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspMfglibSendPacketRequest.java
@@ -35,7 +35,7 @@ public class EzspMfglibSendPacketRequest extends EzspFrameRequest {
     private int[] packetContents;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspMfglibSetChannelRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspMfglibSetChannelRequest.java
@@ -33,7 +33,7 @@ public class EzspMfglibSetChannelRequest extends EzspFrameRequest {
     private int channel;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspMfglibSetPowerRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspMfglibSetPowerRequest.java
@@ -43,7 +43,7 @@ public class EzspMfglibSetPowerRequest extends EzspFrameRequest {
     private int power;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspMfglibStartRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspMfglibStartRequest.java
@@ -35,7 +35,7 @@ public class EzspMfglibStartRequest extends EzspFrameRequest {
     private boolean rxCallback;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspMfglibStartStreamRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspMfglibStartStreamRequest.java
@@ -26,7 +26,7 @@ public class EzspMfglibStartStreamRequest extends EzspFrameRequest {
     public static final int FRAME_ID = 0x87;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspMfglibStartToneRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspMfglibStartToneRequest.java
@@ -28,7 +28,7 @@ public class EzspMfglibStartToneRequest extends EzspFrameRequest {
     public static final int FRAME_ID = 0x85;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspMfglibStopStreamRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspMfglibStopStreamRequest.java
@@ -25,7 +25,7 @@ public class EzspMfglibStopStreamRequest extends EzspFrameRequest {
     public static final int FRAME_ID = 0x88;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspMfglibStopToneRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspMfglibStopToneRequest.java
@@ -25,7 +25,7 @@ public class EzspMfglibStopToneRequest extends EzspFrameRequest {
     public static final int FRAME_ID = 0x86;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspNeighborCountRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspNeighborCountRequest.java
@@ -25,7 +25,7 @@ public class EzspNeighborCountRequest extends EzspFrameRequest {
     public static final int FRAME_ID = 0x7A;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspNetworkInitRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspNetworkInitRequest.java
@@ -27,7 +27,7 @@ public class EzspNetworkInitRequest extends EzspFrameRequest {
     public static final int FRAME_ID = 0x17;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspNetworkStateRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspNetworkStateRequest.java
@@ -25,7 +25,7 @@ public class EzspNetworkStateRequest extends EzspFrameRequest {
     public static final int FRAME_ID = 0x18;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspNoCallbacksRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspNoCallbacksRequest.java
@@ -25,7 +25,7 @@ public class EzspNoCallbacksRequest extends EzspFrameRequest {
     public static final int FRAME_ID = 0x07;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspPermitJoiningRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspPermitJoiningRequest.java
@@ -34,7 +34,7 @@ public class EzspPermitJoiningRequest extends EzspFrameRequest {
     private int duration;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspReadAndClearCountersRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspReadAndClearCountersRequest.java
@@ -26,7 +26,7 @@ public class EzspReadAndClearCountersRequest extends EzspFrameRequest {
     public static final int FRAME_ID = 0x65;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspReadCountersRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspReadCountersRequest.java
@@ -25,7 +25,7 @@ public class EzspReadCountersRequest extends EzspFrameRequest {
     public static final int FRAME_ID = 0xF1;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspRemoveDeviceRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspRemoveDeviceRequest.java
@@ -48,7 +48,7 @@ public class EzspRemoveDeviceRequest extends EzspFrameRequest {
     private IeeeAddress targetLong;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspRequestLinkKeyRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspRequestLinkKeyRequest.java
@@ -44,7 +44,7 @@ public class EzspRequestLinkKeyRequest extends EzspFrameRequest {
     private IeeeAddress partner;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspResetToFactoryDefaultsRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspResetToFactoryDefaultsRequest.java
@@ -25,7 +25,7 @@ public class EzspResetToFactoryDefaultsRequest extends EzspFrameRequest {
     public static final int FRAME_ID = 0xCC;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSendBroadcastRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSendBroadcastRequest.java
@@ -64,7 +64,7 @@ public class EzspSendBroadcastRequest extends EzspFrameRequest {
     private int[] messageContents;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSendManyToOneRouteRequestRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSendManyToOneRouteRequestRequest.java
@@ -67,7 +67,7 @@ public class EzspSendManyToOneRouteRequestRequest extends EzspFrameRequest {
     private int radius;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSendMulticastRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSendMulticastRequest.java
@@ -65,7 +65,7 @@ public class EzspSendMulticastRequest extends EzspFrameRequest {
     private int[] messageContents;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSendReplyRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSendReplyRequest.java
@@ -56,7 +56,7 @@ public class EzspSendReplyRequest extends EzspFrameRequest {
     private int[] messageContents;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSendTrustCenterLinkKeyRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSendTrustCenterLinkKeyRequest.java
@@ -42,7 +42,7 @@ public class EzspSendTrustCenterLinkKeyRequest extends EzspFrameRequest {
     private IeeeAddress destinationEui64;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSendUnicastRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSendUnicastRequest.java
@@ -84,7 +84,7 @@ public class EzspSendUnicastRequest extends EzspFrameRequest {
     private int[] messageContents;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetBindingRemoteNodeIdRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetBindingRemoteNodeIdRequest.java
@@ -40,7 +40,7 @@ public class EzspSetBindingRemoteNodeIdRequest extends EzspFrameRequest {
     private int nodeId;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetBindingRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetBindingRequest.java
@@ -40,7 +40,7 @@ public class EzspSetBindingRequest extends EzspFrameRequest {
     private EmberBindingTableEntry value;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetConcentratorRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetConcentratorRequest.java
@@ -82,7 +82,7 @@ public class EzspSetConcentratorRequest extends EzspFrameRequest {
     private int maxHops;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetConfigurationValueRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetConfigurationValueRequest.java
@@ -43,7 +43,7 @@ public class EzspSetConfigurationValueRequest extends EzspFrameRequest {
     private int value;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetExtendedTimeoutRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetExtendedTimeoutRequest.java
@@ -48,7 +48,7 @@ public class EzspSetExtendedTimeoutRequest extends EzspFrameRequest {
     private boolean extendedTimeout;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetInitialSecurityStateRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetInitialSecurityStateRequest.java
@@ -36,7 +36,7 @@ public class EzspSetInitialSecurityStateRequest extends EzspFrameRequest {
     private EmberInitialSecurityState state;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetKeyTableEntryRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetKeyTableEntryRequest.java
@@ -55,7 +55,7 @@ public class EzspSetKeyTableEntryRequest extends EzspFrameRequest {
     private EmberKeyData keyStruct;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetPolicyRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetPolicyRequest.java
@@ -41,7 +41,7 @@ public class EzspSetPolicyRequest extends EzspFrameRequest {
     private EzspDecisionId decisionId;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetPreinstalledCbkeData283k1Request.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetPreinstalledCbkeData283k1Request.java
@@ -8,16 +8,14 @@
 package com.zsmartsystems.zigbee.dongle.ember.ezsp.command;
 
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.EzspFrameRequest;
-import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EmberCertificate283k1Data;
-import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EmberPrivateKey283k1Data;
-import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EmberPublicKey283k1Data;
 import com.zsmartsystems.zigbee.dongle.ember.internal.serializer.EzspSerializer;
 
 /**
  * Class to implement the Ember EZSP command <b>setPreinstalledCbkeData283k1</b>.
  * <p>
  * Sets the device's 283k1 curve CA public key, local certificate, and static private key on the
- * NCP associated with this node.
+ * NCP associated with this node. The associated data needs to be set via the setValue method
+ * before calling this method.
  * <p>
  * This class provides methods for processing EZSP commands.
  * <p>
@@ -29,28 +27,7 @@ public class EzspSetPreinstalledCbkeData283k1Request extends EzspFrameRequest {
     public static final int FRAME_ID = 0xED;
 
     /**
-     * The Certificate Authority's public key.
-     * <p>
-     * EZSP type is <i>EmberPublicKey283k1Data</i> - Java type is {@link EmberPublicKey283k1Data}
-     */
-    private EmberPublicKey283k1Data caCert;
-
-    /**
-     * The node's new certificate signed by the CA.
-     * <p>
-     * EZSP type is <i>EmberCertificate283k1Data</i> - Java type is {@link EmberCertificate283k1Data}
-     */
-    private EmberCertificate283k1Data myCert;
-
-    /**
-     * The node's new static private key.
-     * <p>
-     * EZSP type is <i>EmberPrivateKey283k1Data</i> - Java type is {@link EmberPrivateKey283k1Data}
-     */
-    private EmberPrivateKey283k1Data myKey;
-
-    /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 
@@ -62,88 +39,17 @@ public class EzspSetPreinstalledCbkeData283k1Request extends EzspFrameRequest {
         serializer = new EzspSerializer();
     }
 
-    /**
-     * The Certificate Authority's public key.
-     * <p>
-     * EZSP type is <i>EmberPublicKey283k1Data</i> - Java type is {@link EmberPublicKey283k1Data}
-     *
-     * @return the current caCert as {@link EmberPublicKey283k1Data}
-     */
-    public EmberPublicKey283k1Data getCaCert() {
-        return caCert;
-    }
-
-    /**
-     * The Certificate Authority's public key.
-     *
-     * @param caCert the caCert to set as {@link EmberPublicKey283k1Data}
-     */
-    public void setCaCert(EmberPublicKey283k1Data caCert) {
-        this.caCert = caCert;
-    }
-
-    /**
-     * The node's new certificate signed by the CA.
-     * <p>
-     * EZSP type is <i>EmberCertificate283k1Data</i> - Java type is {@link EmberCertificate283k1Data}
-     *
-     * @return the current myCert as {@link EmberCertificate283k1Data}
-     */
-    public EmberCertificate283k1Data getMyCert() {
-        return myCert;
-    }
-
-    /**
-     * The node's new certificate signed by the CA.
-     *
-     * @param myCert the myCert to set as {@link EmberCertificate283k1Data}
-     */
-    public void setMyCert(EmberCertificate283k1Data myCert) {
-        this.myCert = myCert;
-    }
-
-    /**
-     * The node's new static private key.
-     * <p>
-     * EZSP type is <i>EmberPrivateKey283k1Data</i> - Java type is {@link EmberPrivateKey283k1Data}
-     *
-     * @return the current myKey as {@link EmberPrivateKey283k1Data}
-     */
-    public EmberPrivateKey283k1Data getMyKey() {
-        return myKey;
-    }
-
-    /**
-     * The node's new static private key.
-     *
-     * @param myKey the myKey to set as {@link EmberPrivateKey283k1Data}
-     */
-    public void setMyKey(EmberPrivateKey283k1Data myKey) {
-        this.myKey = myKey;
-    }
-
     @Override
     public int[] serialize() {
         // Serialize the header
         serializeHeader(serializer);
 
         // Serialize the fields
-        serializer.serializeEmberPublicKey283k1Data(caCert);
-        serializer.serializeEmberCertificate283k1Data(myCert);
-        serializer.serializeEmberPrivateKey283k1Data(myKey);
         return serializer.getPayload();
     }
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(117);
-        builder.append("EzspSetPreinstalledCbkeData283k1Request [caCert=");
-        builder.append(caCert);
-        builder.append(", myCert=");
-        builder.append(myCert);
-        builder.append(", myKey=");
-        builder.append(myKey);
-        builder.append(']');
-        return builder.toString();
+        return "EzspSetPreinstalledCbkeData283k1Request []";
     }
 }

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetPreinstalledCbkeData283k1Response.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetPreinstalledCbkeData283k1Response.java
@@ -14,7 +14,8 @@ import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EmberStatus;
  * Class to implement the Ember EZSP command <b>setPreinstalledCbkeData283k1</b>.
  * <p>
  * Sets the device's 283k1 curve CA public key, local certificate, and static private key on the
- * NCP associated with this node.
+ * NCP associated with this node. The associated data needs to be set via the setValue method
+ * before calling this method.
  * <p>
  * This class provides methods for processing EZSP commands.
  * <p>

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetPreinstalledCbkeDataRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetPreinstalledCbkeDataRequest.java
@@ -50,7 +50,7 @@ public class EzspSetPreinstalledCbkeDataRequest extends EzspFrameRequest {
     private EmberPrivateKeyData myKey;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetRadioChannelRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetRadioChannelRequest.java
@@ -37,7 +37,7 @@ public class EzspSetRadioChannelRequest extends EzspFrameRequest {
     private int channel;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetRadioPowerRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetRadioPowerRequest.java
@@ -39,7 +39,7 @@ public class EzspSetRadioPowerRequest extends EzspFrameRequest {
     private int power;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetSourceRouteRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetSourceRouteRequest.java
@@ -25,7 +25,7 @@ public class EzspSetSourceRouteRequest extends EzspFrameRequest {
     public static final int FRAME_ID = 0x5A;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetValueRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetValueRequest.java
@@ -40,7 +40,7 @@ public class EzspSetValueRequest extends EzspFrameRequest {
     private int[] value;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspStartScanRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspStartScanRequest.java
@@ -55,7 +55,7 @@ public class EzspStartScanRequest extends EzspFrameRequest {
     private int duration;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspStopScanRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspStopScanRequest.java
@@ -25,7 +25,7 @@ public class EzspStopScanRequest extends EzspFrameRequest {
     public static final int FRAME_ID = 0x1D;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspVersionRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspVersionRequest.java
@@ -35,7 +35,7 @@ public class EzspVersionRequest extends EzspFrameRequest {
     private int desiredProtocolVersion;
 
     /**
-     * Serialiser used to seialise to binary line data
+     * Serialiser used to serialise to binary line data
      */
     private EzspSerializer serializer;
 


### PR DESCRIPTION
Silabs UG100 describing the EZSP interface incorrectly defines the ```setPreinstalledCbkeData283k1``` function. In fact it takes no parameters and the parameters are expected to be set as values before calling ```setPreinstalledCbkeData283k1```.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>