### PR TITLE
CC2531 AF_REGISTER IasZone Cluster to Match Descriptor

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.cc2531/src/main/java/com/zsmartsystems/zigbee/dongle/cc2531/ZigBeeDongleTiCc2531.java
+++ b/com.zsmartsystems.zigbee.dongle.cc2531/src/main/java/com/zsmartsystems/zigbee/dongle/cc2531/ZigBeeDongleTiCc2531.java
@@ -420,7 +420,7 @@ public class ZigBeeDongleTiCc2531
 
         AF_REGISTER_SRSP result;
         result = networkManager.sendAFRegister(
-                new AF_REGISTER(endpointId, profileId, (short) 0, (byte) 0, new int[] {}, new int[] {}));
+                new AF_REGISTER(endpointId, profileId, (short) 0, (byte) 0, new int[] {}, new int[] {0x500}));
         // FIX We should retry only when Status != 0xb8 ( Z_APS_DUPLICATE_ENTRY )
         if (result.getStatus() != 0) {
             // TODO We should provide a workaround for the maximum number of registered EndPoint


### PR DESCRIPTION
Chris,

I've been trying to use my Nyce Motion Sensor with the CC2531EMK dongle. Z-Stack handles the Match Descriptor Request internally, and, in order to give a successfully response we need to inform it at the AF_REGISTER command that we have an IAS Zone Cluster. Otherwise it will not be able to match the descriptor and will fail.

If you need something, please, fell free to ask.

PS.: I'm working on what you requested at the other commit. But, xstick can not handle the size of my house, and, I'm trying to make it works with CC2531EMK.

regards. 