### PR TITLE
Refactor Ember initialisation to improve testability

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
@@ -770,10 +770,10 @@ public class ZigBeeDongleEzsp implements ZigBeeTransportTransmit, ZigBeeTranspor
 
         switch (protocol) {
             case ASH2:
-                frameHandler = new AshFrameHandler(this);
+                frameHandler = new AshFrameHandler(this, serialPort);
                 break;
             case SPI:
-                frameHandler = new SpiFrameHandler(this);
+                frameHandler = new SpiFrameHandler(this, serialPort);
                 break;
             default:
                 logger.error("Unknown Ember serial protocol {}", protocol);
@@ -782,7 +782,7 @@ public class ZigBeeDongleEzsp implements ZigBeeTransportTransmit, ZigBeeTranspor
         EmberNcp ncp = getEmberNcp();
 
         // Connect to the ASH handler and NCP
-        frameHandler.start(serialPort);
+        frameHandler.start();
         frameHandler.connect();
 
         // We MUST send the version command first.

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/EzspProtocolHandler.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/EzspProtocolHandler.java
@@ -13,7 +13,6 @@ import java.util.concurrent.Future;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.EzspFrame;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.EzspFrameRequest;
 import com.zsmartsystems.zigbee.dongle.ember.internal.transaction.EzspTransaction;
-import com.zsmartsystems.zigbee.transport.ZigBeePort;
 
 /**
  * Interface for the EZSP protocol handler. The protocol handler manages the low level data transfer of EZSP frames.
@@ -24,12 +23,9 @@ import com.zsmartsystems.zigbee.transport.ZigBeePort;
 public interface EzspProtocolHandler {
 
     /**
-     * Starts the handler. Sets input stream where the packet is read from the and
-     * handler which further processes the received packet.
-     *
-     * @param port the {@link ZigBeePort}
+     * Starts the handler.
      */
-    public void start(final ZigBeePort port);
+    public void start();
 
     /**
      * Set the close flag to true.

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/ash/AshFrameHandler.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/ash/AshFrameHandler.java
@@ -120,7 +120,7 @@ public class AshFrameHandler implements EzspProtocolHandler {
     /**
      * The port.
      */
-    private ZigBeePort port;
+    private final ZigBeePort port;
 
     /**
      * The parser parserThread.
@@ -137,14 +137,15 @@ public class AshFrameHandler implements EzspProtocolHandler {
      * Construct the handler and provide the {@link EzspFrameHandler}
      *
      * @param frameHandler the {@link EzspFrameHandler} packet handler
+     * @param serialPort the {@link ZigBeePort} used for communications
      */
-    public AshFrameHandler(final EzspFrameHandler frameHandler) {
+    public AshFrameHandler(final EzspFrameHandler frameHandler, final ZigBeePort serialPort) {
         this.frameHandler = frameHandler;
+        this.port = serialPort;
     }
 
     @Override
-    public void start(final ZigBeePort port) {
-        this.port = port;
+    public void start() {
 
         parserThread = new Thread("AshFrameHandler") {
             @Override

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/spi/SpiFrameHandler.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/spi/SpiFrameHandler.java
@@ -130,7 +130,7 @@ public class SpiFrameHandler implements EzspProtocolHandler {
     /**
      * The port.
      */
-    private ZigBeePort port;
+    private final ZigBeePort port;
 
     /**
      * The parser parserThread.
@@ -152,10 +152,12 @@ public class SpiFrameHandler implements EzspProtocolHandler {
      * Construct the handler and provide the {@link EzspFrameHandler}
      *
      * @param frameHandler the {@link EzspFrameHandler} packet handler
+     * @param serialPort the {@link ZigBeePort} used for communications
      */
-    public SpiFrameHandler(final EzspFrameHandler frameHandler) {
+    public SpiFrameHandler(final EzspFrameHandler frameHandler, final ZigBeePort serialPort) {
         logger.debug("SpiFrameHandler created");
         this.frameHandler = frameHandler;
+        this.port = serialPort;
 
         errorMessages.put(SPI_CMD_RESET, "Reset");
         errorMessages.put(SPI_CMD_OVERSIZE, "Oversized Frame");
@@ -166,9 +168,7 @@ public class SpiFrameHandler implements EzspProtocolHandler {
     }
 
     @Override
-    public void start(final ZigBeePort port) {
-        this.port = port;
-
+    public void start() {
         pollingScheduler = Executors.newSingleThreadScheduledExecutor();
 
         parserThread = new Thread("SpiFrameHandler") {

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/ash/AshFrameHandlerTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/ash/AshFrameHandlerTest.java
@@ -36,7 +36,7 @@ import com.zsmartsystems.zigbee.transport.ZigBeePort;
 public class AshFrameHandlerTest {
 
     private int[] getPacket(int[] data) {
-        AshFrameHandler frameHandler = new AshFrameHandler(null);
+        AshFrameHandler frameHandler = new AshFrameHandler(null, null);
         byte[] bytedata = new byte[data.length];
         int cnt = 0;
         for (int value : data) {
@@ -105,8 +105,8 @@ public class AshFrameHandlerTest {
 
     @Test
     public void testRunning() {
-        AshFrameHandler frameHandler = new AshFrameHandler(null);
-        frameHandler.start(null);
+        AshFrameHandler frameHandler = new AshFrameHandler(null, null);
+        frameHandler.start();
 
         assertTrue(frameHandler.isAlive());
         frameHandler.close();
@@ -252,7 +252,7 @@ public class AshFrameHandlerTest {
 
     @Test
     public void testGetCounters() {
-        AshFrameHandler frameHandler = new AshFrameHandler(null);
+        AshFrameHandler frameHandler = new AshFrameHandler(null, null);
 
         assertNotNull(frameHandler.getCounters());
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/spi/SpiFrameHandlerTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/spi/SpiFrameHandlerTest.java
@@ -47,27 +47,22 @@ public class SpiFrameHandlerTest {
     private ArgumentCaptor<EzspFrame> responseCaptor;
 
     private int[] getPacket(int[] data) {
-        SpiFrameHandler frameHandler = new SpiFrameHandler(null);
         byte[] bytedata = new byte[data.length];
         int cnt = 0;
         for (int value : data) {
             bytedata[cnt++] = (byte) value;
         }
         ByteArrayInputStream stream = new ByteArrayInputStream(bytedata);
-        ZigBeePort port = new TestPort(stream, null);
+        SpiFrameHandler frameHandler = new SpiFrameHandler(null, new TestPort(stream, null));
 
         Method privateMethod;
         try {
-            Field field = frameHandler.getClass().getDeclaredField("port");
-            field.setAccessible(true);
-            field.set(frameHandler, port);
-
             privateMethod = SpiFrameHandler.class.getDeclaredMethod("getPacket");
             privateMethod.setAccessible(true);
 
             return (int[]) privateMethod.invoke(frameHandler);
         } catch (NoSuchMethodException | SecurityException | IllegalArgumentException | IllegalAccessException
-                | InvocationTargetException | NoSuchFieldException e) {
+                | InvocationTargetException e) {
             e.printStackTrace();
         }
 
@@ -116,8 +111,8 @@ public class SpiFrameHandlerTest {
         Mockito.doNothing().when(receiveHandler).handleLinkStateChange(stateCaptor.capture());
         Mockito.doNothing().when(receiveHandler).handlePacket(responseCaptor.capture());
 
-        SpiFrameHandler frameHandler = new SpiFrameHandler(receiveHandler);
-        frameHandler.start(new TestPort(null, null));
+        SpiFrameHandler frameHandler = new SpiFrameHandler(receiveHandler, new TestPort(null, null));
+        frameHandler.start();
 
         Method privateMethod;
         try {
@@ -182,8 +177,8 @@ public class SpiFrameHandlerTest {
 
     @Test
     public void testRunning() {
-        SpiFrameHandler frameHandler = new SpiFrameHandler(null);
-        frameHandler.start(null);
+        SpiFrameHandler frameHandler = new SpiFrameHandler(null, null);
+        frameHandler.start();
 
         assertTrue(frameHandler.isAlive());
         frameHandler.close();
@@ -255,9 +250,8 @@ public class SpiFrameHandlerTest {
     @Test
     public void testConnect() {
         portOutData = new ArrayList<>();
-        SpiFrameHandler handler = new SpiFrameHandler(null);
+        SpiFrameHandler handler = new SpiFrameHandler(null, new TestPort(null, null));
 
-        handler.start(new TestPort(null, null));
         handler.connect();
 
         // Verify the version command is sent
@@ -269,8 +263,7 @@ public class SpiFrameHandlerTest {
     @Test
     public void testSendEzspFrame() {
         portOutData = new ArrayList<>();
-        SpiFrameHandler handler = new SpiFrameHandler(null);
-        handler.start(new TestPort(null, null));
+        SpiFrameHandler handler = new SpiFrameHandler(null, new TestPort(null, null));
 
         EzspVersionRequest command = new EzspVersionRequest();
         command.setDesiredProtocolVersion(4);


### PR DESCRIPTION
This is a small refactoring so that ```start``` does not need to be called for the test, so we do not start the polling. This should fix the test failure in #333.
@TomTravaglino please advise if this fixes your issue.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>