### PR TITLE
Enhance logging while writing an attribute by adding the node address

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/ZclCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/ZclCluster.java
@@ -202,8 +202,8 @@ public abstract class ZclCluster {
      * @return command future {@link CommandResult}
      */
     public Future<CommandResult> write(final int attribute, final ZclDataType dataType, final Object value) {
-        logger.debug("{}: Writing cluster {}, attribute {}, value {}, as dataType {}", clusterId, attribute, value,
-                dataType);
+        logger.debug("{}: Writing cluster {}, attribute {}, value {}, as dataType {}", zigbeeEndpoint.getIeeeAddress(),
+                clusterId, attribute, value, dataType);
 
         final WriteAttributesCommand command = new WriteAttributesCommand();
 


### PR DESCRIPTION
In this PR, we enhanced the logging while writing an attribute (`ZclCluster#write`) by adding the missing node address.