### PR TITLE
Protect ASH layer against exceptions higher up the stack

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
@@ -502,6 +502,10 @@ public class ZigBeeDongleEzsp implements ZigBeeTransportTransmit, ZigBeeTranspor
         logger.debug("RX: " + response.toString());
 
         if (response instanceof EzspIncomingMessageHandler) {
+            if (nwkAddress == null) {
+                logger.debug("Ignoring received frame as stack still initialising");
+                return;
+            }
             EzspIncomingMessageHandler incomingMessage = (EzspIncomingMessageHandler) response;
             EmberApsFrame emberApsFrame = incomingMessage.getApsFrame();
 


### PR DESCRIPTION
Exceptions at EZSP level may cause the ASH layer to get out of sync when acking frames from the NCP. This adds exception handling in the ASH layer to protect against errors higher up.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>