### PR TITLE
Get registered extension

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
@@ -1357,6 +1357,23 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
     }
 
     /**
+     * Gets a functional extension that has been registered with the network.
+     *
+     * @param <T> {@link ZigBeeNetworkExtension}
+     * @param requestedExtension the {@link ZigBeeNetworkExtension} to get
+     * @return the requested {@link ZigBeeNetworkExtension} if it exists, or null
+     */
+    public <T extends ZigBeeNetworkExtension> ZigBeeNetworkExtension getExtension(Class<T> requestedExtension) {
+        for (ZigBeeNetworkExtension extensionCheck : extensions) {
+            if (requestedExtension.isInstance(extensionCheck)) {
+                return extensionCheck;
+            }
+        }
+
+        return null;
+    }
+
+    /**
      * Gets the current {@link ZigBeeTransportState}
      *
      * @return the current {@link ZigBeeTransportState}

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeNetworkManagerTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeNetworkManagerTest.java
@@ -24,6 +24,8 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
+import com.zsmartsystems.zigbee.app.ZigBeeNetworkExtension;
+import com.zsmartsystems.zigbee.app.otaserver.ZigBeeOtaUpgradeExtension;
 import com.zsmartsystems.zigbee.serialization.DefaultDeserializer;
 import com.zsmartsystems.zigbee.serialization.DefaultSerializer;
 import com.zsmartsystems.zigbee.transport.ZigBeeTransportState;
@@ -529,4 +531,15 @@ public class ZigBeeNetworkManagerTest implements ZigBeeNetworkNodeListener, ZigB
         System.out.println(apsFrame);
         return apsFrame;
     }
+
+    @Test
+    public void testExtensions() {
+        ZigBeeNetworkManager manager = new ZigBeeNetworkManager(Mockito.mock(ZigBeeTransportTransmit.class));
+
+        manager.addExtension(new ZigBeeOtaUpgradeExtension());
+
+        ZigBeeNetworkExtension returnedExtension = manager.getExtension(ZigBeeOtaUpgradeExtension.class);
+        assertTrue(returnedExtension instanceof ZigBeeOtaUpgradeExtension);
+    }
+
 }


### PR DESCRIPTION
Adds a method to the ZigBeeNetworkManager to retrieve a registered extension.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>