### PR TITLE
Perform ASH disconnection when ERR frame received

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
@@ -595,6 +595,7 @@ public class ZigBeeDongleEzsp implements ZigBeeTransportTransmit, ZigBeeTranspor
 
     @Override
     public void handleLinkStateChange(final boolean linkState) {
+        // Only act on changes
         if (networkStateUp == linkState) {
             return;
         }
@@ -610,7 +611,7 @@ public class ZigBeeDongleEzsp implements ZigBeeTransportTransmit, ZigBeeTranspor
                         nwkAddress = addr;
                     }
                 }
-                // Handle link changes and notify framework or just reset link with dongle?
+                // Handle link changes and notify framework
                 zigbeeTransportReceive
                         .setNetworkState(linkState ? ZigBeeTransportState.ONLINE : ZigBeeTransportState.OFFLINE);
             }
@@ -783,11 +784,12 @@ public class ZigBeeDongleEzsp implements ZigBeeTransportTransmit, ZigBeeTranspor
                 logger.error("Unknown Ember serial protocol {}", protocol);
                 return false;
         }
-        EmberNcp ncp = getEmberNcp();
 
         // Connect to the ASH handler and NCP
         frameHandler.start(serialPort);
         frameHandler.connect();
+
+        EmberNcp ncp = getEmberNcp();
 
         // We MUST send the version command first.
         EzspVersionResponse version = ncp.getVersion(4);


### PR DESCRIPTION
When Ember NCP sends an ERROR frame, it enters the FAILED state and must be reset. Currently, nothing happens which leaves the dongle in an unusable state, but the application does not know this.

This can not be handled solely at the ASH layer since once the NCP is reset, it must be reconfigured in a specific way and brought back online. This needs to be handled at application level, or possibly at the Dongle level.

This PR will ensure that higher layers are aware of the issue by taking the dongle offline, and can then take action.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>