### PR TITLE
Improve network state transition management

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.cc2531/src/main/java/com/zsmartsystems/zigbee/dongle/cc2531/ZigBeeDongleTiCc2531.java
+++ b/com.zsmartsystems.zigbee.dongle.cc2531/src/main/java/com/zsmartsystems/zigbee/dongle/cc2531/ZigBeeDongleTiCc2531.java
@@ -7,10 +7,10 @@
  */
 package com.zsmartsystems.zigbee.dongle.cc2531;
 
-import java.util.ArrayList;
 import java.lang.reflect.Field;
-import java.util.HashMap;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,7 +48,6 @@ import com.zsmartsystems.zigbee.transport.TransportConfig;
 import com.zsmartsystems.zigbee.transport.TransportConfigOption;
 import com.zsmartsystems.zigbee.transport.ZigBeePort;
 import com.zsmartsystems.zigbee.transport.ZigBeeTransportReceive;
-import com.zsmartsystems.zigbee.transport.ZigBeeTransportState;
 import com.zsmartsystems.zigbee.transport.ZigBeeTransportTransmit;
 import com.zsmartsystems.zigbee.zdo.SynchronousResponse;
 
@@ -123,15 +122,11 @@ public class ZigBeeDongleTiCc2531
     public ZigBeeStatus initialize() {
         logger.debug("CC2531 transport initialize");
 
-        zigbeeNetworkReceive.setNetworkState(ZigBeeTransportState.UNINITIALISED);
-
         // This basically just initialises the hardware so we can communicate with the 2531
         versionString = networkManager.startup();
         if (versionString == null) {
             return ZigBeeStatus.COMMUNICATION_ERROR;
         }
-
-        zigbeeNetworkReceive.setNetworkState(ZigBeeTransportState.INITIALISING);
 
         return ZigBeeStatus.SUCCESS;
     }
@@ -232,7 +227,6 @@ public class ZigBeeDongleTiCc2531
         networkManager.addAsynchronousCommandListener(this);
 
         if (!networkManager.initializeZigBeeNetwork(reinitialize)) {
-            zigbeeNetworkReceive.setNetworkState(ZigBeeTransportState.UNINITIALISED);
             return ZigBeeStatus.INVALID_STATE;
         }
 
@@ -241,20 +235,16 @@ public class ZigBeeDongleTiCc2531
                 break;
             }
             if (networkManager.getDriverStatus() == DriverStatus.CLOSED) {
-                zigbeeNetworkReceive.setNetworkState(ZigBeeTransportState.UNINITIALISED);
                 return ZigBeeStatus.BAD_RESPONSE;
             }
             try {
                 Thread.sleep(50);
             } catch (final InterruptedException e) {
-                zigbeeNetworkReceive.setNetworkState(ZigBeeTransportState.UNINITIALISED);
                 return ZigBeeStatus.BAD_RESPONSE;
             }
         }
 
         createEndPoint(1, 0x104);
-
-        zigbeeNetworkReceive.setNetworkState(ZigBeeTransportState.ONLINE);
 
         return ZigBeeStatus.SUCCESS;
     }

--- a/com.zsmartsystems.zigbee.dongle.telegesis/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/ZigBeeDongleTelegesis.java
+++ b/com.zsmartsystems.zigbee.dongle.telegesis/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/ZigBeeDongleTelegesis.java
@@ -333,8 +333,6 @@ public class ZigBeeDongleTelegesis
 
         bootloadHandler = null;
 
-        zigbeeTransportReceive.setNetworkState(ZigBeeTransportState.UNINITIALISED);
-
         if (!serialPort.open()) {
             logger.error("Unable to open Telegesis serial port");
             return ZigBeeStatus.COMMUNICATION_ERROR;
@@ -373,8 +371,6 @@ public class ZigBeeDongleTelegesis
             ieeeAddress = productInfo.getIeeeAddress();
         }
 
-        zigbeeTransportReceive.setNetworkState(ZigBeeTransportState.INITIALISING);
-
         return ZigBeeStatus.SUCCESS;
     }
 
@@ -385,7 +381,6 @@ public class ZigBeeDongleTelegesis
         // If frameHandler is null then the serial port didn't initialise
         if (frameHandler == null) {
             logger.error("Initialising Telegesis Dongle but low level handler is not initialised.");
-            zigbeeTransportReceive.setNetworkState(ZigBeeTransportState.OFFLINE);
             return ZigBeeStatus.INVALID_STATE;
         }
 
@@ -425,7 +420,6 @@ public class ZigBeeDongleTelegesis
         // Check if the network is now up
         TelegesisDisplayNetworkInformationCommand networkInfo = new TelegesisDisplayNetworkInformationCommand();
         if (frameHandler.sendRequest(networkInfo) == null || networkInfo.getStatus() != TelegesisStatusCode.SUCCESS) {
-            zigbeeTransportReceive.setNetworkState(ZigBeeTransportState.OFFLINE);
             return ZigBeeStatus.BAD_RESPONSE;
         }
         if (networkInfo.getDevice() != TelegesisDeviceType.COO) {
@@ -446,7 +440,6 @@ public class ZigBeeDongleTelegesis
 
         startupComplete = true;
 
-        zigbeeTransportReceive.setNetworkState(ZigBeeTransportState.ONLINE);
         return ZigBeeStatus.SUCCESS;
     }
 
@@ -694,7 +687,6 @@ public class ZigBeeDongleTelegesis
         TelegesisSetChannelMaskCommand maskCommand = new TelegesisSetChannelMaskCommand();
         maskCommand.setChannelMask(channelMask.getChannelMask() >> 11);
         if (frameHandler.sendRequest(maskCommand) == null || maskCommand.getStatus() != TelegesisStatusCode.SUCCESS) {
-            zigbeeTransportReceive.setNetworkState(ZigBeeTransportState.OFFLINE);
             return ZigBeeStatus.BAD_RESPONSE;
         }
 
@@ -702,7 +694,6 @@ public class ZigBeeDongleTelegesis
         channelCommand.setChannel(channel.getChannel());
         if (frameHandler.sendRequest(channelCommand) == null
                 || channelCommand.getStatus() != TelegesisStatusCode.SUCCESS) {
-            zigbeeTransportReceive.setNetworkState(ZigBeeTransportState.OFFLINE);
             return ZigBeeStatus.BAD_RESPONSE;
         }
 
@@ -959,6 +950,9 @@ public class ZigBeeDongleTelegesis
      * @param state true if the handler is online, false if offline
      */
     public void notifyStateUpdate(boolean state) {
+        if (!startupComplete) {
+            return;
+        }
         zigbeeTransportReceive.setNetworkState(state ? ZigBeeTransportState.ONLINE : ZigBeeTransportState.OFFLINE);
     }
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transport/ZigBeeTransportReceive.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transport/ZigBeeTransportReceive.java
@@ -47,12 +47,13 @@ public interface ZigBeeTransportReceive {
     void receiveCommand(final ZigBeeApsFrame apsFrame);
 
     /**
-     * Set the network state.
+     * Set the network state. Note that this will only allow valid state transitions, and an attempt to transition
+     * between states that are not allowed will result in the state remaining as it was.
      * <p>
      * This is a callback from the {@link ZigBeeTransportTransmit} when the state of the transport changes
      * </p>
      *
-     * @param state
+     * @param state the updated {@link ZigBeeTransportState}
      */
     void setNetworkState(final ZigBeeTransportState state);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transport/ZigBeeTransportState.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transport/ZigBeeTransportState.java
@@ -14,6 +14,14 @@ import com.zsmartsystems.zigbee.ZigBeeNetworkStateListener;
  * <p>
  * This is used to provide status updates to higher layer listeners registered through the
  * {@link ZigBeeNetworkStateListener} interface.
+ * <p>
+ * Valid state transitions are -:
+ * <ul>
+ * <li>UNITIALISED to INITIALISING or OFFLINE
+ * <li>INITIALISING to ONLINE or OFFLINE
+ * <li>ONLINE to OFFLINE
+ * <li>OFFLINE to ONLINE
+ * </ul
  *
  * @author Chris Jackson
  *

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transport/ZigBeeTransportTransmit.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transport/ZigBeeTransportTransmit.java
@@ -50,14 +50,16 @@ public interface ZigBeeTransportTransmit {
     ZigBeeStatus initialize();
 
     /**
-     * Starts the transport interface.
+     * Starts the transport interface and brings the transport state {@link ZigBeeTransportState#ONLINE}.
      * <p>
      * This call will optionally reconfigure the interface if the reinitialize parameter is true.
-     * Startup would normally be called once after {@link #initialize()} on system start, and may be called again after
+     * Startup would normally be called once after {@link #initialize()} on system start, and may be called again
+     * subsequently if the dongle is taken offline.
      *
      * @param reinitialize true if the provider is to reinitialise the network with the parameters configured since the
      *            {@link #initialize} method was called.
-     * @return {@link ZigBeeStatus} with the status of function
+     * @return {@link ZigBeeStatus} with the return status. If the dongle is online, {@link ZigBeeStatus#SUCCESS} will
+     *         be returned and the network state will be set to {@link ZigBeeTransportState#ONLINE}.
      */
     ZigBeeStatus startup(boolean reinitialize);
 

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeNetworkManagerTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeNetworkManagerTest.java
@@ -235,12 +235,15 @@ public class ZigBeeNetworkManagerTest implements ZigBeeNetworkNodeListener, ZigB
     public void testNetworkStateListener() {
         ZigBeeNetworkManager networkManager = mockZigBeeNetworkManager();
 
+        // This will be ignored as an illegal state transition
         networkManager.setNetworkState(ZigBeeTransportState.INITIALISING);
+
+        networkManager.setNetworkState(ZigBeeTransportState.UNINITIALISED);
 
         org.awaitility.Awaitility.await().until(networkStateUpdatedSize(), org.hamcrest.Matchers.equalTo(1));
 
         assertEquals(1, networkStateListenerCapture.size());
-        assertEquals(ZigBeeTransportState.INITIALISING, networkStateListenerCapture.get(0));
+        assertEquals(ZigBeeTransportState.UNINITIALISED, networkStateListenerCapture.get(0));
 
         networkManager.removeNetworkStateListener(mockedStateListener);
     }


### PR DESCRIPTION
This moves most network state transition management out of the dongle and into ```ZigBeeNetworkManager```, using the responses from the transport ```initialisation``` and ```startup``` methods to update the state. This also ensures that the dongles don't update the state until after ```startup()``` has been called.

It also adds transition checks to ensure that only specific transition sequences are allowed.

Valid state transitions are -:
 * UNITIALISED to INITIALISING or OFFLINE
 * INITIALISING to ONLINE or OFFLINE
 * ONLINE to OFFLINE
 * OFFLINE to ONLINE

The main goal is to ensure a clean transition of states and avoid online/offline/online type transition sequences while the dongle is initialising.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>