### PR TITLE
Perform critical Telegesis initialisation prior to performing any transactions

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.telegesis/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/ZigBeeDongleTelegesis.java
+++ b/com.zsmartsystems.zigbee.dongle.telegesis/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/ZigBeeDongleTelegesis.java
@@ -343,6 +343,8 @@ public class ZigBeeDongleTelegesis
         frameHandler.start(serialPort);
         frameHandler.addEventListener(this);
 
+        initialiseCriticalConfiguration();
+
         // Software reset the stick so we are in a known state on startup!
         // For the first command, we add a retry mechanism
         // in case the serial port takes some time to get started
@@ -466,16 +468,39 @@ public class ZigBeeDongleTelegesis
         return 0;
     }
 
-    private boolean initialiseDongle() {
+    /**
+     * This method configures the Telegesis dongle registers into a state that is required
+     * for the transactions to work correctly.
+     * <p>
+     * This includes -:
+     * <ul>
+     * <li>Disable echo
+     * <li>Enable OK responses
+     * <li>Enable ERROR responses
+     */
+    private void initialiseCriticalConfiguration() {
         // Disable echo on the serial port
         TelegesisSetRegisterBitCommand setRegister = new TelegesisSetRegisterBitCommand();
         setRegister.setRegister(0x12);
         setRegister.setBit(4);
         setRegister.setState(true);
-        if (frameHandler.sendRequest(setRegister) == null) {
-            logger.debug("Error setting Telegesis port echo");
-            return false;
-        }
+        frameHandler.sendRequest(setRegister);
+
+        setRegister = new TelegesisSetRegisterBitCommand();
+        setRegister.setRegister(0x0E);
+        setRegister.setBit(1);
+        setRegister.setState(false);
+        frameHandler.sendRequest(setRegister);
+
+        setRegister = new TelegesisSetRegisterBitCommand();
+        setRegister.setRegister(0x0E);
+        setRegister.setBit(0);
+        setRegister.setState(false);
+        frameHandler.sendRequest(setRegister);
+    }
+
+    private boolean initialiseDongle() {
+        initialiseCriticalConfiguration();
 
         // Configure the dongle
         TelegesisSetPromptEnable1Command prompt1Function = new TelegesisSetPromptEnable1Command();

--- a/com.zsmartsystems.zigbee.dongle.telegesis/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/internal/TelegesisFrameHandler.java
+++ b/com.zsmartsystems.zigbee.dongle.telegesis/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/internal/TelegesisFrameHandler.java
@@ -697,7 +697,7 @@ public class TelegesisFrameHandler {
         pollingTimer = pollingScheduler.scheduleAtFixedRate(new Runnable() {
             @Override
             public void run() {
-                if (sendQueue.isEmpty()) {
+                if (sendQueue.isEmpty() && sentCommand == null) {
                     queueFrame(new TelegesisDisplayNetworkInformationCommand());
                     sendNextFrame();
                 }


### PR DESCRIPTION
This adds a method to send all commands required to complete transactions. This is then called before the stick is configured, and also again during the initialisation in case the stick was reset.

This also holds off the periodic status polling if a command is currently outstanding.

I tested this by setting all 3 of these configurations incorrectly, and the dongle correctly recovers.

@TomTravaglino I hope that this will resolve your issue - please can you test this ASAP as I'd like to flow this into the latest OH binding which will be released quite soon.  Thanks.

Fixes #435 

Signed-off-by: Chris Jackson <chris@cd-jackson.com>