### PR TITLE
Check device is online before changing channels

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.telegesis/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/ZigBeeDongleTelegesis.java
+++ b/com.zsmartsystems.zigbee.dongle.telegesis/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/ZigBeeDongleTelegesis.java
@@ -715,6 +715,14 @@ public class ZigBeeDongleTelegesis
             return ZigBeeStatus.BAD_RESPONSE;
         }
 
+        TelegesisDisplayNetworkInformationCommand netInfoCommand = new TelegesisDisplayNetworkInformationCommand();
+        if (frameHandler.sendRequest(netInfoCommand) == null
+                || netInfoCommand.getStatus() != TelegesisStatusCode.SUCCESS
+                || netInfoCommand.getDevice() == TelegesisDeviceType.NOPAN) {
+            // If we are not connected to the network, there is no need to change the channel and we can return now
+            return ZigBeeStatus.SUCCESS;
+        }
+
         TelegesisChangeChannelCommand channelCommand = new TelegesisChangeChannelCommand();
         channelCommand.setChannel(channel.getChannel());
         if (frameHandler.sendRequest(channelCommand) == null


### PR DESCRIPTION
This ensures that the Telegesis dongle is online before changing the channel. If the device is offline, there is no need to change the channel...
@TomTravaglino this should remove the error that was seen in your log when setting the channel in #440 discussion.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>