### PR TITLE
Add helper method to get firmware version from OTA cluster

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/otaserver/ZclOtaUpgradeServer.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/otaserver/ZclOtaUpgradeServer.java
@@ -461,6 +461,19 @@ public class ZclOtaUpgradeServer implements ZigBeeApplication {
     }
 
     /**
+     * The file version of the running firmware image on the device. The information is available for the server to
+     * query via ZCL read attribute command. The attribute is optional on the client.
+     * <p>
+     * This calls the synchronous method in the cluster, and always performs an update (ie will not use cached data) to
+     * ensure it is updated following any OTA upgrade operation.
+     *
+     * @return the current firmware version on the remote device
+     */
+    public Integer getCurrentFileVersion() {
+        return cluster.getCurrentFileVersion(Long.MAX_VALUE);
+    }
+
+    /**
      * Send an updated status on OTA progress to the listeners
      *
      * @param updatedStatus the new {@link ZigBeeOtaServerStatus}

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/app/otaupgrade/ZclOtaUpgradeServerTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/app/otaupgrade/ZclOtaUpgradeServerTest.java
@@ -129,6 +129,16 @@ public class ZclOtaUpgradeServerTest implements ZigBeeOtaStatusCallback {
         assertTrue(notifyCommand.getQueryJitter() >= 1 && notifyCommand.getQueryJitter() <= 100);
     }
 
+    @Test
+    public void getCurrentFileVersion() {
+        ZclOtaUpgradeCluster cluster = Mockito.mock(ZclOtaUpgradeCluster.class);
+        Mockito.when(cluster.getCurrentFileVersion(ArgumentMatchers.anyLong())).thenReturn(1234);
+
+        ZclOtaUpgradeServer server = new ZclOtaUpgradeServer();
+        server.appStartup(cluster);
+        assertEquals(Integer.valueOf(1234), server.getCurrentFileVersion());
+    }
+
     @Override
     public void otaStatusUpdate(ZigBeeOtaServerStatus status, int percent) {
         otaStatusCapture.add(status);


### PR DESCRIPTION
This adds a helper method to get the current firmware version to avoid the user having to get the OTA cluster again - ie all OTA operations should be handled through the application.
https://github.com/openhab/org.openhab.binding.zigbee/issues/312
Signed-off-by: Chris Jackson <chris@cd-jackson.com>