### PR TITLE
Fix error with cluster matcher address matching and add tests.

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/internal/ClusterMatcher.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/internal/ClusterMatcher.java
@@ -95,7 +95,7 @@ public class ClusterMatcher implements ZigBeeCommandListener {
             matchResponse.setMatchList(matchList);
 
             matchResponse.setDestinationAddress(command.getSourceAddress());
-            matchResponse.setNwkAddrOfInterest(command.getSourceAddress().getAddress());
+            matchResponse.setNwkAddrOfInterest(matchRequest.getNwkAddrOfInterest());
             logger.debug("{}: ClusterMatcher sending match {}", networkManager.getZigBeeExtendedPanId(), matchResponse);
             networkManager.sendCommand(matchResponse);
         }

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/internal/ClusterMatcherTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/internal/ClusterMatcherTest.java
@@ -22,6 +22,7 @@ import com.zsmartsystems.zigbee.ZigBeeCommand;
 import com.zsmartsystems.zigbee.ZigBeeEndpointAddress;
 import com.zsmartsystems.zigbee.ZigBeeNetworkManager;
 import com.zsmartsystems.zigbee.zdo.command.MatchDescriptorRequest;
+import com.zsmartsystems.zigbee.zdo.command.MatchDescriptorResponse;
 
 /**
  *
@@ -112,11 +113,15 @@ public class ClusterMatcherTest {
         clusterListOut.add(0x500);
         MatchDescriptorRequest request = new MatchDescriptorRequest();
         request.setSourceAddress(new ZigBeeEndpointAddress(1234, 5));
+        request.setNwkAddrOfInterest(4321);
         request.setProfileId(0x104);
         request.setInClusterList(clusterListIn);
         request.setOutClusterList(clusterListOut);
 
         matcher.commandReceived(request);
         assertEquals(1, mockedCommandCaptor.getAllValues().size());
+        MatchDescriptorResponse response = (MatchDescriptorResponse) mockedCommandCaptor.getValue();
+        assertEquals(1234, response.getDestinationAddress().getAddress());
+        assertEquals(Integer.valueOf(4321), response.getNwkAddrOfInterest());
     }
 }


### PR DESCRIPTION
As reported in #405 the response to the match cluster should return to the network address of interest. This replaces #405 and adds tests.
Closes #405 
Signed-off-by: Chris Jackson <chris@cd-jackson.com>