### PR TITLE
Use status from main response for reporting response commands

### DIFF
--- a/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleReportingSubscribeCommand.java
+++ b/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleReportingSubscribeCommand.java
@@ -91,7 +91,7 @@ public class ZigBeeConsoleReportingSubscribeCommand extends ZigBeeConsoleAbstrac
         final CommandResult result = cluster.setReporting(attribute, minInterval, maxInterval, reportableChange).get();
         if (result.isSuccess()) {
             final ConfigureReportingResponse response = result.getResponse();
-            final ZclStatus statusCode = response.getRecords().get(0).getStatus();
+            final ZclStatus statusCode = response.getStatus();
             if (statusCode == ZclStatus.SUCCESS) {
                 out.println("Attribute value configure reporting success.");
             } else {

--- a/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleReportingUnsubscribeCommand.java
+++ b/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleReportingUnsubscribeCommand.java
@@ -64,7 +64,7 @@ public class ZigBeeConsoleReportingUnsubscribeCommand extends ZigBeeConsoleAbstr
         final CommandResult result = cluster.setReporting(attribute, 0, 0xFFFF, null).get();
         if (result.isSuccess()) {
             final ConfigureReportingResponse response = result.getResponse();
-            final ZclStatus statusCode = response.getRecords().get(0).getStatus();
+            final ZclStatus statusCode = response.getStatus();
             if (statusCode == ZclStatus.SUCCESS) {
                 out.println("Attribute value configure reporting success.");
             } else {


### PR DESCRIPTION
To avoid the situation seen in #439 where the reporting command from a bulb doesn't include the reporting response record, the command now reports the main packet response status.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>