### PR TITLE
Add default value if the normaliser fails to normalise the data type

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/ZclAttributeNormalizer.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/ZclAttributeNormalizer.java
@@ -35,22 +35,46 @@ public class ZclAttributeNormalizer {
      * @return the normalised output data
      */
     protected Object normalizeZclData(ZclDataType dataType, Object data) {
+        try {
+            switch (dataType) {
+                case BOOLEAN:
+                    if (data instanceof Integer) {
+                        logger.debug("Normalizing data Integer {} to BOOLEAN", data);
+                        return Boolean.valueOf(!((Integer) data).equals(0));
+                    }
+                    break;
+                case UNSIGNED_8_BIT_INTEGER:
+                    if (data instanceof String) {
+                        logger.debug("Normalizing data String {} to UNSIGNED_8_BIT_INTEGER", data);
+                        return Integer.parseInt((String) data);
+                    }
+                    break;
+                default:
+                    break;
+            }
+            return data;
+        } catch (NumberFormatException e) {
+            logger.warn("Exception normalizing data: Returning default value of {}", dataType);
+            return getDefaultValue(dataType);
+        }
+    }
+
+    /**
+     * Gets a default value of the specified {@link ZclDataType} which is used in the event that the normalizer fails to
+     * convert the data.
+     *
+     * @param dataType the {@link ZclDataType} to return
+     * @return an {@link Object} of the {@link ZclDataType}, or null if no conversion is provided
+     */
+    private Object getDefaultValue(ZclDataType dataType) {
         switch (dataType) {
             case BOOLEAN:
-                if (data instanceof Integer) {
-                    logger.debug("Normalizing data Integer {} to BOOLEAN", data);
-                    return Boolean.valueOf(!((Integer) data).equals(0));
-                }
-                break;
+                return Boolean.FALSE;
             case UNSIGNED_8_BIT_INTEGER:
-                if (data instanceof String) {
-                    logger.debug("Normalizing data String {} to UNSIGNED_8_BIT_INTEGER", data);
-                    return Integer.parseInt((String) data);
-                }
-                break;
+            case UNSIGNED_16_BIT_INTEGER:
+                return Integer.valueOf(0);
             default:
-                break;
+                return null;
         }
-        return data;
     }
 }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/ZclCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/ZclCluster.java
@@ -855,14 +855,7 @@ public abstract class ZclCluster {
      */
     public void handleAttributeReport(List<AttributeReport> reports) {
         for (AttributeReport report : reports) {
-            ZclAttribute attribute = attributes.get(report.getAttributeIdentifier());
-            if (attribute == null) {
-                logger.debug("{}: Unknown attribute {} in cluster {}", zigbeeEndpoint.getEndpointAddress(),
-                        report.getAttributeIdentifier(), clusterId);
-            } else {
-                attribute.updateValue(normalizer.normalizeZclData(attribute.getDataType(), report.getAttributeValue()));
-                notifyAttributeListener(attribute);
-            }
+            updateAttribute(report.getAttributeIdentifier(), report.getAttributeValue());
         }
     }
 
@@ -879,14 +872,18 @@ public abstract class ZclCluster {
                 continue;
             }
 
-            ZclAttribute attribute = attributes.get(record.getAttributeIdentifier());
-            if (attribute == null) {
-                logger.debug("{}: Unknown attribute {} in cluster {}", zigbeeEndpoint.getEndpointAddress(),
-                        record.getAttributeIdentifier(), clusterId);
-            } else {
-                attribute.updateValue(normalizer.normalizeZclData(attribute.getDataType(), record.getAttributeValue()));
-                notifyAttributeListener(attribute);
-            }
+            updateAttribute(record.getAttributeIdentifier(), record.getAttributeValue());
+        }
+    }
+
+    private void updateAttribute(int attributeId, Object attributeValue) {
+        ZclAttribute attribute = attributes.get(attributeId);
+        if (attribute == null) {
+            logger.debug("{}: Unknown attribute {} in cluster {}", zigbeeEndpoint.getEndpointAddress(), attributeId,
+                    clusterId);
+        } else {
+            attribute.updateValue(normalizer.normalizeZclData(attribute.getDataType(), attributeValue));
+            notifyAttributeListener(attribute);
         }
     }
 

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zcl/ZclAttributeNormalizerTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zcl/ZclAttributeNormalizerTest.java
@@ -20,11 +20,20 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  */
 public class ZclAttributeNormalizerTest {
     @Test
-    public void testNormalizeBoolean() {
+    public void testNormalizeBOOLEAN() {
         ZclAttributeNormalizer normalizer = new ZclAttributeNormalizer();
 
         assertEquals(Boolean.TRUE, normalizer.normalizeZclData(ZclDataType.BOOLEAN, Integer.valueOf(1)));
         assertEquals(Boolean.TRUE, normalizer.normalizeZclData(ZclDataType.BOOLEAN, Integer.valueOf(100)));
         assertEquals(Boolean.FALSE, normalizer.normalizeZclData(ZclDataType.BOOLEAN, Integer.valueOf(0)));
+    }
+
+    @Test
+    public void testNormalizeUNSIGNED_8_BIT_INTEGER() {
+        ZclAttributeNormalizer normalizer = new ZclAttributeNormalizer();
+
+        assertEquals(Integer.valueOf(123), normalizer.normalizeZclData(ZclDataType.UNSIGNED_8_BIT_INTEGER, "123"));
+        assertEquals(Integer.valueOf(0), normalizer.normalizeZclData(ZclDataType.UNSIGNED_8_BIT_INTEGER,
+                String.valueOf(new char[] { 1, 2, 3 })));
     }
 }


### PR DESCRIPTION
This adds a facility to provide a default value if the attribute normalizer throws an exception.
Closes #338
Signed-off-by: Chris Jackson <chris@cd-jackson.com>