### PR TITLE
Return coordinator network address in getNwkAddress()

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.xbee/src/main/java/com/zsmartsystems/zigbee/dongle/xbee/ZigBeeDongleXBee.java
+++ b/com.zsmartsystems.zigbee.dongle.xbee/src/main/java/com/zsmartsystems/zigbee/dongle/xbee/ZigBeeDongleXBee.java
@@ -297,12 +297,11 @@ public class ZigBeeDongleXBee implements ZigBeeTransportTransmit, XBeeEventListe
 
     @Override
     public Integer getNwkAddress() {
-        // TODO Auto-generated method stub
-        return null;
+        return 0;
     }
 
     private void initialiseNetwork() {
-
+        // TODO
     }
 
     @Override


### PR DESCRIPTION
```getNwkAddress()``` with null return throws an error - this now returns the network address for a coordinator.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>