### PR TITLE
Initial ZigBeeTransportTransmitTest implementation for Ember

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.ember/pom.xml
+++ b/com.zsmartsystems.zigbee.dongle.ember/pom.xml
@@ -1,25 +1,35 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.zsmartsystems.zigbee</groupId>
-    <artifactId>com.zsmartsystems.zigbee.dongle.ember</artifactId>
-    <packaging>jar</packaging>
+	<groupId>com.zsmartsystems.zigbee</groupId>
+	<artifactId>com.zsmartsystems.zigbee.dongle.ember</artifactId>
+	<packaging>jar</packaging>
 
-    <parent>
-        <groupId>com.zsmartsystems</groupId>
-        <artifactId>zigbee</artifactId>
-        <version>1.1.7-SNAPSHOT</version>
-    </parent>
+	<parent>
+		<groupId>com.zsmartsystems</groupId>
+		<artifactId>zigbee</artifactId>
+		<version>1.1.7-SNAPSHOT</version>
+	</parent>
 
-    <dependencies>
+	<dependencies>
 
-        <dependency>
-            <groupId>com.zsmartsystems.zigbee</groupId>
-            <artifactId>com.zsmartsystems.zigbee</artifactId>
-            <version>1.1.7-SNAPSHOT</version>
-        </dependency>
+		<dependency>
+			<groupId>com.zsmartsystems.zigbee</groupId>
+			<artifactId>com.zsmartsystems.zigbee</artifactId>
+			<version>1.1.7-SNAPSHOT</version>
+		</dependency>
 
-    </dependencies>
+		<dependency>
+			<groupId>com.zsmartsystems.zigbee</groupId>
+			<artifactId>com.zsmartsystems.zigbee</artifactId>
+			<version>1.1.7-SNAPSHOT</version>
+			<classifier>tests</classifier>
+			<scope>test</scope>
+		</dependency>
+
+	</dependencies>
 
 </project>

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/EmberSerialProtocol.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/EmberSerialProtocol.java
@@ -15,6 +15,10 @@ package com.zsmartsystems.zigbee.dongle.ember;
  */
 public enum EmberSerialProtocol {
     /**
+     * No protocol - used for testing
+     */
+    NONE,
+    /**
      * Serial Peripheral Interface
      */
     SPI,

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
@@ -301,12 +301,12 @@ public class ZigBeeDongleEzsp implements ZigBeeTransportTransmit, ZigBeeTranspor
     public ZigBeeStatus initialize() {
         logger.debug("EZSP dongle initialize with protocol {}.", protocol);
 
-        if (!initialiseEzspProtocol()) {
+        if (protocol != EmberSerialProtocol.NONE && !initialiseEzspProtocol()) {
             return ZigBeeStatus.COMMUNICATION_ERROR;
         }
 
         // Perform any stack configuration
-        EmberStackConfiguration stackConfigurer = new EmberStackConfiguration(frameHandler);
+        EmberStackConfiguration stackConfigurer = new EmberStackConfiguration(getEmberNcp());
 
         Map<EzspConfigId, Integer> configuration = stackConfigurer.getConfiguration(stackConfiguration.keySet());
         for (Entry<EzspConfigId, Integer> config : configuration.entrySet()) {
@@ -829,6 +829,8 @@ public class ZigBeeDongleEzsp implements ZigBeeTransportTransmit, ZigBeeTranspor
             case SPI:
                 frameHandler = new SpiFrameHandler(this);
                 break;
+            case NONE:
+                return true;
             default:
                 logger.error("Unknown Ember serial protocol {}", protocol);
                 return false;

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/EmberStackConfiguration.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/EmberStackConfiguration.java
@@ -26,17 +26,17 @@ import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EzspStatus;
  */
 public class EmberStackConfiguration {
     /**
-     * The frame handler used to send the EZSP frames to the NCP
+     * The {@link EmberNcp} used to send the EZSP frames to the NCP
      */
-    private EzspProtocolHandler protocolHandler;
+    private EmberNcp ncp;
 
     /**
      * Constructor to set the {@link EzspProtocolHandler}
      *
      * @param frameHandler the {@link EzspProtocolHandler} used to communicate with the NCP
      */
-    public EmberStackConfiguration(EzspProtocolHandler protocolHandler) {
-        this.protocolHandler = protocolHandler;
+    public EmberStackConfiguration(EmberNcp ncp) {
+        this.ncp = ncp;
     }
 
     /**
@@ -49,7 +49,6 @@ public class EmberStackConfiguration {
     public boolean setConfiguration(Map<EzspConfigId, Integer> configuration) {
         boolean success = true;
 
-        EmberNcp ncp = new EmberNcp(protocolHandler);
         for (Entry<EzspConfigId, Integer> config : configuration.entrySet()) {
             if (ncp.setConfiguration(config.getKey(), config.getValue()) != EzspStatus.EZSP_SUCCESS) {
                 success = false;
@@ -69,7 +68,6 @@ public class EmberStackConfiguration {
     public Map<EzspConfigId, Integer> getConfiguration(Set<EzspConfigId> configuration) {
         Map<EzspConfigId, Integer> response = new HashMap<EzspConfigId, Integer>();
 
-        EmberNcp ncp = new EmberNcp(protocolHandler);
         for (EzspConfigId configId : configuration) {
             response.put(configId, ncp.getConfiguration(configId));
         }
@@ -87,7 +85,6 @@ public class EmberStackConfiguration {
     public boolean setPolicy(Map<EzspPolicyId, EzspDecisionId> policies) {
         boolean success = true;
 
-        EmberNcp ncp = new EmberNcp(protocolHandler);
         for (Entry<EzspPolicyId, EzspDecisionId> policy : policies.entrySet()) {
             if (ncp.setPolicy(policy.getKey(), policy.getValue()) != EzspStatus.EZSP_SUCCESS) {
                 success = false;
@@ -107,7 +104,6 @@ public class EmberStackConfiguration {
     public Map<EzspPolicyId, EzspDecisionId> getPolicy(Set<EzspPolicyId> policies) {
         Map<EzspPolicyId, EzspDecisionId> response = new HashMap<EzspPolicyId, EzspDecisionId>();
 
-        EmberNcp ncp = new EmberNcp(protocolHandler);
         for (EzspPolicyId policyId : policies) {
             response.put(policyId, ncp.getPolicy(policyId));
         }

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeTransportTransmitTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeTransportTransmitTest.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2016-2018 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.dongle.ember;
+
+import org.junit.Before;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mockito;
+
+import com.zsmartsystems.zigbee.IeeeAddress;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspGetNetworkParametersResponse;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspGetParentChildParametersResponse;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EmberCurrentSecurityState;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EmberNetworkParameters;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EmberNetworkStatus;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EmberStatus;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EzspDecisionId;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EzspPolicyId;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EzspStatus;
+import com.zsmartsystems.zigbee.dongle.ember.internal.EzspProtocolHandler;
+import com.zsmartsystems.zigbee.transport.ZigBeePort;
+import com.zsmartsystems.zigbee.transport.ZigBeeTransportTransmitAbstractTest;
+
+/**
+ *
+ * @author Chris Jackson
+ *
+ */
+public class ZigBeeTransportTransmitTest extends ZigBeeTransportTransmitAbstractTest {
+
+    @Before
+    public void initialiseTransport() throws Exception {
+        EmberNetworkParameters networkParameters = Mockito.mock(EmberNetworkParameters.class);
+        Mockito.when(networkParameters.getRadioTxPower()).thenReturn(Integer.valueOf(0));
+
+        EzspGetNetworkParametersResponse nwkParametersResponse = Mockito.mock(EzspGetNetworkParametersResponse.class);
+        Mockito.when(nwkParametersResponse.getParameters()).thenReturn(networkParameters);
+
+        final EmberNcp ncp = Mockito.mock(EmberNcp.class);
+        Mockito.when(
+                ncp.setPolicy(ArgumentMatchers.any(EzspPolicyId.class), ArgumentMatchers.any(EzspDecisionId.class)))
+                .thenReturn(EzspStatus.EZSP_SUCCESS);
+        Mockito.when(ncp.getNetworkState()).thenReturn(EmberNetworkStatus.EMBER_JOINED_NETWORK);
+        Mockito.when(ncp.getNetworkParameters()).thenReturn(nwkParametersResponse);
+        Mockito.when(ncp.getCurrentSecurityState()).thenReturn(new EmberCurrentSecurityState());
+        Mockito.when(ncp.getChildParameters()).thenReturn(Mockito.mock(EzspGetParentChildParametersResponse.class));
+        Mockito.when(ncp.setRadioPower(ArgumentMatchers.anyInt())).thenReturn(EmberStatus.EMBER_SUCCESS);
+        Mockito.when(ncp.getNwkAddress()).thenReturn(Integer.valueOf(0));
+        Mockito.when(ncp.getIeeeAddress()).thenReturn(new IeeeAddress("1234567890ABCDEF"));
+
+        ZigBeePort port = Mockito.mock(ZigBeePort.class);
+        Mockito.when(port.open()).thenReturn(Boolean.TRUE);
+
+        ZigBeeDongleEzsp dongle = new ZigBeeDongleEzsp(port, EmberSerialProtocol.NONE) {
+            @Override
+            public EmberNcp getEmberNcp() {
+                return ncp;
+            }
+        };
+
+        setField(ZigBeeDongleEzsp.class, dongle, "frameHandler", Mockito.mock(EzspProtocolHandler.class));
+
+        transport = dongle;
+    }
+}

--- a/com.zsmartsystems.zigbee/pom.xml
+++ b/com.zsmartsystems.zigbee/pom.xml
@@ -1,15 +1,33 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.zsmartsystems.zigbee</groupId>
-    <artifactId>com.zsmartsystems.zigbee</artifactId>
-    <packaging>jar</packaging>
+	<groupId>com.zsmartsystems.zigbee</groupId>
+	<artifactId>com.zsmartsystems.zigbee</artifactId>
+	<packaging>jar</packaging>
 
-    <parent>
-        <groupId>com.zsmartsystems</groupId>
-        <artifactId>zigbee</artifactId>
-        <version>1.1.7-SNAPSHOT</version>
-    </parent>
+	<parent>
+		<groupId>com.zsmartsystems</groupId>
+		<artifactId>zigbee</artifactId>
+		<version>1.1.7-SNAPSHOT</version>
+	</parent>
 
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>test-jar</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/transport/ZigBeeTransportTransmitAbstractTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/transport/ZigBeeTransportTransmitAbstractTest.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2016-2018 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.transport;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+
+import org.junit.Test;
+
+import com.zsmartsystems.zigbee.ZigBeeStatus;
+
+/**
+ * Abstract set of tests that should be extended for each implementation of {@link ZigBeeTransportTransmit} to ensure
+ * that certain system expectations are respected.
+ *
+ * @author Chris Jackson
+ *
+ */
+public abstract class ZigBeeTransportTransmitAbstractTest {
+    protected ZigBeeTransportTransmit transport;
+
+    protected void setField(Class clazz, Object object, String fieldName, Object newValue) throws Exception {
+        Field field = clazz.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        Field modifiersField = Field.class.getDeclaredField("modifiers");
+        modifiersField.setAccessible(true);
+        modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
+        field.set(object, newValue);
+    }
+
+    /**
+     * Tests that after {@link ZigBeeTransportTransmit#initialize()} has been called,
+     * {@link ZigBeeTransportTransmit#getIeeeAddress()} does not return null.
+     */
+    @Test
+    public void getIeeeAddress() {
+        assertEquals(ZigBeeStatus.SUCCESS, transport.initialize());
+        assertNotNull(transport.getIeeeAddress());
+    }
+
+    /**
+     * Tests that after {@link ZigBeeTransportTransmit#startup()} has been called,
+     * {@link ZigBeeTransportTransmit#getNwkAddress()} does not return null.
+     */
+    @Test
+    public void getNwkAddress() {
+        assertEquals(ZigBeeStatus.SUCCESS, transport.initialize());
+        assertEquals(ZigBeeStatus.SUCCESS, transport.startup(false));
+        assertNotNull(transport.getNwkAddress());
+    }
+}


### PR DESCRIPTION
This implements an initial small set of tests to check that expectation from the ```ZigBeeTransportTransmit``` interface are fulfilled. Ideally these tests should pass on all dongles, but for now just implemented on Ember.

Some small internal refactoring of the Ember dongle is included to improve the testability of the implementation.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>