### PR TITLE
Update XBee autocoder to fix minor issues with refactored classes

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.xbee.autocode/src/main/java/com/zsmartsystems/zigbee/dongle/xbee/autocode/CommandGenerator.java
+++ b/com.zsmartsystems.zigbee.dongle.xbee.autocode/src/main/java/com/zsmartsystems/zigbee/dongle/xbee/autocode/CommandGenerator.java
@@ -31,6 +31,7 @@ import com.zsmartsystems.zigbee.dongle.xbee.autocode.xml.Value;
  */
 public class CommandGenerator extends ClassGenerator {
     final String zigbeePackage = "com.zsmartsystems.zigbee";
+    final String zigbeeSecurityPackage = "com.zsmartsystems.zigbee.security";
     final String internalPackage = "com.zsmartsystems.zigbee.dongle.xbee.internal";
     final String commandPackage = "com.zsmartsystems.zigbee.dongle.xbee.internal.protocol";
     final String enumPackage = "com.zsmartsystems.zigbee.dongle.xbee.internal.protocol";
@@ -250,8 +251,8 @@ public class CommandGenerator extends ClassGenerator {
             if (Boolean.TRUE.equals(group.multiple)) {
                 out.println("    /**");
                 out.println("     *");
-                out.println("     * @return the " + stringToLowerCamelCase(group.name)
-                        + "s as a {@link List} of {@link " + stringToUpperCamelCase(group.name) + "}");
+                out.println("     * @return the " + stringToLowerCamelCase(group.name) + "s as a List of {@link "
+                        + stringToUpperCamelCase(group.name) + "}");
                 out.println("     */");
                 out.println("    public List<" + stringToUpperCamelCase(group.name) + "> get"
                         + stringToUpperCamelCase(group.name) + "s() {");
@@ -524,8 +525,8 @@ public class CommandGenerator extends ClassGenerator {
             }
             out.println(indent + " *");
             if (parameter.multiple) {
-                out.println(indent + " * @return the " + stringToLowerCamelCase(parameter.name)
-                        + " as {@link List} of {@link " + getTypeClass(parameter.data_type) + "}");
+                out.println(indent + " * @return the " + stringToLowerCamelCase(parameter.name) + " as List of {@link "
+                        + getTypeClass(parameter.data_type) + "}");
             } else {
                 out.println(indent + " * @return the " + stringToLowerCamelCase(parameter.name) + " as {@link "
                         + getTypeClass(parameter.data_type) + "}");
@@ -564,7 +565,7 @@ public class CommandGenerator extends ClassGenerator {
             if (parameter.multiple | parameter.bitfield) {
                 addImport("java.util.Collection");
                 out.println(indent + " * @param " + stringToLowerCamelCase(parameter.name) + " the "
-                        + stringToLowerCamelCase(parameter.name) + " to add to the {@link Set} as {@link "
+                        + stringToLowerCamelCase(parameter.name) + " to add to the Set as {@link "
                         + getTypeClass(parameter.data_type) + "}");
                 out.println(indent + " */");
                 out.println(indent + "public void add" + stringToUpperCamelCase(parameter.name) + "("
@@ -579,7 +580,7 @@ public class CommandGenerator extends ClassGenerator {
                 }
                 out.println(indent + " *");
                 out.println(indent + " * @param " + stringToLowerCamelCase(parameter.name) + " the "
-                        + stringToLowerCamelCase(parameter.name) + " to remove to the {@link Set} as {@link "
+                        + stringToLowerCamelCase(parameter.name) + " to remove to the Set as {@link "
                         + getTypeClass(parameter.data_type) + "}");
                 out.println(indent + " */");
                 out.println(indent + "public void remove" + stringToUpperCamelCase(parameter.name) + "("
@@ -594,7 +595,7 @@ public class CommandGenerator extends ClassGenerator {
                 }
                 out.println(indent + " *");
                 out.println(indent + " * @param " + stringToLowerCamelCase(parameter.name) + " the "
-                        + stringToLowerCamelCase(parameter.name) + " to set to the {@link Set} as {@link "
+                        + stringToLowerCamelCase(parameter.name) + " to set to the Set as {@link "
                         + getTypeClass(parameter.data_type) + "}");
                 out.println(indent + " */");
                 out.println(indent + "public void set" + stringToUpperCamelCase(parameter.name) + "(Collection<"
@@ -1123,7 +1124,7 @@ public class CommandGenerator extends ClassGenerator {
             case "String":
                 return "String";
             case "ZigBeeKey":
-                addImport(zigbeePackage + ".ZigBeeKey");
+                addImport(zigbeeSecurityPackage + ".ZigBeeKey");
                 return "ZigBeeKey";
             case "IeeeAddress":
                 addImport(zigbeePackage + ".IeeeAddress");

--- a/com.zsmartsystems.zigbee.dongle.xbee/src/main/java/com/zsmartsystems/zigbee/dongle/xbee/internal/XBeeFrameHandler.java
+++ b/com.zsmartsystems.zigbee.dongle.xbee/src/main/java/com/zsmartsystems/zigbee/dongle/xbee/internal/XBeeFrameHandler.java
@@ -430,7 +430,7 @@ public class XBeeFrameHandler {
      * Sets the transaction timeout. This is the number of milliseconds to wait for a response from the stick once the
      * command has been initially queued.
      *
-     * @param commandTimeout the number of milliseconds to wait for a response from the stick once the
+     * @param transactionTimeout the number of milliseconds to wait for a response from the stick once the
      *            command has been initially queued.
      */
     public void setTransactionTimeout(int transactionTimeout) {

--- a/com.zsmartsystems.zigbee.dongle.xbee/src/main/java/com/zsmartsystems/zigbee/dongle/xbee/internal/protocol/XBeeSetEncryptionOptionsCommand.java
+++ b/com.zsmartsystems.zigbee.dongle.xbee/src/main/java/com/zsmartsystems/zigbee/dongle/xbee/internal/protocol/XBeeSetEncryptionOptionsCommand.java
@@ -42,7 +42,7 @@ public class XBeeSetEncryptionOptionsCommand extends XBeeFrame implements XBeeCo
 
     /**
      *
-     * @param encryptionOptions the encryptionOptions to add to the {@link Set} as {@link EncryptionOptions}
+     * @param encryptionOptions the encryptionOptions to add to the Set as {@link EncryptionOptions}
      */
     public void addEncryptionOptions(EncryptionOptions encryptionOptions) {
         this.encryptionOptions.add(encryptionOptions);
@@ -50,7 +50,7 @@ public class XBeeSetEncryptionOptionsCommand extends XBeeFrame implements XBeeCo
 
     /**
      *
-     * @param encryptionOptions the encryptionOptions to remove to the {@link Set} as {@link EncryptionOptions}
+     * @param encryptionOptions the encryptionOptions to remove to the Set as {@link EncryptionOptions}
      */
     public void removeEncryptionOptions(EncryptionOptions encryptionOptions) {
         this.encryptionOptions.remove(encryptionOptions);
@@ -58,7 +58,7 @@ public class XBeeSetEncryptionOptionsCommand extends XBeeFrame implements XBeeCo
 
     /**
      *
-     * @param encryptionOptions the encryptionOptions to set to the {@link Set} as {@link EncryptionOptions}
+     * @param encryptionOptions the encryptionOptions to set to the Set as {@link EncryptionOptions}
      */
     public void setEncryptionOptions(Collection<EncryptionOptions> encryptionOptions) {
         this.encryptionOptions.addAll(encryptionOptions);

--- a/com.zsmartsystems.zigbee.dongle.xbee/src/main/java/com/zsmartsystems/zigbee/dongle/xbee/internal/protocol/XBeeTransmitRequestCommand.java
+++ b/com.zsmartsystems.zigbee.dongle.xbee/src/main/java/com/zsmartsystems/zigbee/dongle/xbee/internal/protocol/XBeeTransmitRequestCommand.java
@@ -104,7 +104,7 @@ public class XBeeTransmitRequestCommand extends XBeeFrame implements XBeeCommand
      * bit causes the stack to set the extended transmission timeout for the destination address.
      * See Transmission, addressing, and routing. All unused and unsupported bits must be set to 0.
      *
-     * @param options the options to add to the {@link Set} as {@link TransmitOptions}
+     * @param options the options to add to the Set as {@link TransmitOptions}
      */
     public void addOptions(TransmitOptions options) {
         this.options.add(options);
@@ -117,7 +117,7 @@ public class XBeeTransmitRequestCommand extends XBeeFrame implements XBeeCommand
      * bit causes the stack to set the extended transmission timeout for the destination address.
      * See Transmission, addressing, and routing. All unused and unsupported bits must be set to 0.
      *
-     * @param options the options to remove to the {@link Set} as {@link TransmitOptions}
+     * @param options the options to remove to the Set as {@link TransmitOptions}
      */
     public void removeOptions(TransmitOptions options) {
         this.options.remove(options);
@@ -130,7 +130,7 @@ public class XBeeTransmitRequestCommand extends XBeeFrame implements XBeeCommand
      * bit causes the stack to set the extended transmission timeout for the destination address.
      * See Transmission, addressing, and routing. All unused and unsupported bits must be set to 0.
      *
-     * @param options the options to set to the {@link Set} as {@link TransmitOptions}
+     * @param options the options to set to the Set as {@link TransmitOptions}
      */
     public void setOptions(Collection<TransmitOptions> options) {
         this.options.addAll(options);

--- a/com.zsmartsystems.zigbee.dongle.xbee/src/main/java/com/zsmartsystems/zigbee/dongle/xbee/internal/protocol/XBeeTransmitRequestExplicitCommand.java
+++ b/com.zsmartsystems.zigbee.dongle.xbee/src/main/java/com/zsmartsystems/zigbee/dongle/xbee/internal/protocol/XBeeTransmitRequestExplicitCommand.java
@@ -183,7 +183,7 @@ public class XBeeTransmitRequestExplicitCommand extends XBeeFrame implements XBe
      * transmission timeout for the destination address. See Transmission, addressing, and
      * routing. All unused and unsupported bits must be set to 0.
      *
-     * @param options the options to add to the {@link Set} as {@link TransmitOptions}
+     * @param options the options to add to the Set as {@link TransmitOptions}
      */
     public void addOptions(TransmitOptions options) {
         this.options.add(options);
@@ -198,7 +198,7 @@ public class XBeeTransmitRequestExplicitCommand extends XBeeFrame implements XBe
      * transmission timeout for the destination address. See Transmission, addressing, and
      * routing. All unused and unsupported bits must be set to 0.
      *
-     * @param options the options to remove to the {@link Set} as {@link TransmitOptions}
+     * @param options the options to remove to the Set as {@link TransmitOptions}
      */
     public void removeOptions(TransmitOptions options) {
         this.options.remove(options);
@@ -213,7 +213,7 @@ public class XBeeTransmitRequestExplicitCommand extends XBeeFrame implements XBe
      * transmission timeout for the destination address. See Transmission, addressing, and
      * routing. All unused and unsupported bits must be set to 0.
      *
-     * @param options the options to set to the {@link Set} as {@link TransmitOptions}
+     * @param options the options to set to the Set as {@link TransmitOptions}
      */
     public void setOptions(Collection<TransmitOptions> options) {
         this.options.addAll(options);


### PR DESCRIPTION
ZigBeeKey was moved into a separate package. When this was refactored it was done in the IDE, but the autocoder wasn't updated.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>