### PR TITLE
Initial addition of transaction manager classes with dongle feedback

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/ash/AshFrameHandler.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/ash/AshFrameHandler.java
@@ -29,6 +29,8 @@ import org.slf4j.LoggerFactory;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.EzspFrame;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.EzspFrameRequest;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.EzspFrameResponse;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspSendBroadcastResponse;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspSendUnicastResponse;
 import com.zsmartsystems.zigbee.dongle.ember.internal.EzspFrameHandler;
 import com.zsmartsystems.zigbee.dongle.ember.internal.EzspProtocolHandler;
 import com.zsmartsystems.zigbee.dongle.ember.internal.transaction.EzspTransaction;
@@ -198,7 +200,7 @@ public class AshFrameHandler implements EzspProtocolHandler {
                                         } else if (!notifyTransactionComplete(response)) {
                                             // No transactions owned this response, so we pass it to
                                             // our unhandled response handler
-                                            handleIncomingFrame(EzspFrame.createHandler((dataPacket.getDataBuffer())));
+                                            handleIncomingFrame(response);
                                         }
                                     } else if (!dataPacket.getReTx()) {
                                         // Send a NAK - this is out of sequence and not a retransmission
@@ -630,6 +632,12 @@ public class AshFrameHandler implements EzspProtocolHandler {
                     processed = true;
                 }
             }
+        }
+
+        // For responses to higher level commands, we still want to pass these up so we can provide the
+        // update the transaction progress.
+        if (response instanceof EzspSendUnicastResponse || response instanceof EzspSendBroadcastResponse) {
+            processed = false;
         }
 
         return processed;

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/spi/SpiFrameHandler.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/spi/SpiFrameHandler.java
@@ -35,6 +35,8 @@ import com.zsmartsystems.zigbee.dongle.ember.ezsp.EzspFrameRequest;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.EzspFrameResponse;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspCallbackRequest;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspNoCallbacksResponse;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspSendBroadcastResponse;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspSendUnicastResponse;
 import com.zsmartsystems.zigbee.dongle.ember.internal.EzspFrameHandler;
 import com.zsmartsystems.zigbee.dongle.ember.internal.EzspProtocolHandler;
 import com.zsmartsystems.zigbee.dongle.ember.internal.transaction.EzspTransaction;
@@ -642,6 +644,12 @@ public class SpiFrameHandler implements EzspProtocolHandler {
                     processed = true;
                 }
             }
+        }
+
+        // For responses to higher level commands, we still want to pass these up so we can provide the
+        // update the transaction progress.
+        if (response instanceof EzspSendUnicastResponse || response instanceof EzspSendBroadcastResponse) {
+            processed = false;
         }
 
         return processed;

--- a/com.zsmartsystems.zigbee.dongle.telegesis/src/test/java/com/zsmartsystems/zigbee/dongle/telegesis/ZigBeeDongleTelegesisTest.java
+++ b/com.zsmartsystems.zigbee.dongle.telegesis/src/test/java/com/zsmartsystems/zigbee/dongle/telegesis/ZigBeeDongleTelegesisTest.java
@@ -9,16 +9,46 @@ package com.zsmartsystems.zigbee.dongle.telegesis;
 
 import static org.junit.Assert.assertEquals;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
 import org.junit.Test;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mockito;
 
 import com.zsmartsystems.zigbee.ExtendedPanId;
+import com.zsmartsystems.zigbee.IeeeAddress;
+import com.zsmartsystems.zigbee.ZigBeeNodeStatus;
+import com.zsmartsystems.zigbee.dongle.telegesis.internal.protocol.TelegesisAckMessageEvent;
+import com.zsmartsystems.zigbee.dongle.telegesis.internal.protocol.TelegesisDeviceJoinedNetworkEvent;
+import com.zsmartsystems.zigbee.dongle.telegesis.internal.protocol.TelegesisDeviceLeftNetworkEvent;
+import com.zsmartsystems.zigbee.dongle.telegesis.internal.protocol.TelegesisNackMessageEvent;
+import com.zsmartsystems.zigbee.dongle.telegesis.internal.protocol.TelegesisNetworkJoinedEvent;
+import com.zsmartsystems.zigbee.dongle.telegesis.internal.protocol.TelegesisNetworkLeftEvent;
+import com.zsmartsystems.zigbee.dongle.telegesis.internal.protocol.TelegesisNetworkLostEvent;
+import com.zsmartsystems.zigbee.transport.ZigBeeTransportProgressState;
+import com.zsmartsystems.zigbee.transport.ZigBeeTransportReceive;
+import com.zsmartsystems.zigbee.transport.ZigBeeTransportState;
 
 /**
+ * Tests for {@link ZigBeeDongleTelegesis}
  *
  * @author Chris Jackson
  *
  */
 public class ZigBeeDongleTelegesisTest {
+    private static int TIMEOUT = 5000;
+
+    protected void setField(Class clazz, Object object, String fieldName, Object newValue) throws Exception {
+        Field field = clazz.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        Field modifiersField = Field.class.getDeclaredField("modifiers");
+        modifiersField.setAccessible(true);
+        modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
+        field.set(object, newValue);
+    }
 
     @Test
     public void setZigBeeExtendedPanId() {
@@ -48,5 +78,136 @@ public class ZigBeeDongleTelegesisTest {
         ZigBeeDongleTelegesis dongle = new ZigBeeDongleTelegesis(null);
 
         assertEquals("", dongle.getFirmwareVersion());
+    }
+
+    @Test
+    public void testTelegesisAckMessageEvent() throws Exception {
+        ZigBeeTransportReceive transport = Mockito.mock(ZigBeeTransportReceive.class);
+
+        ZigBeeDongleTelegesis dongle = new ZigBeeDongleTelegesis(null);
+        dongle.setZigBeeTransportReceive(transport);
+
+        setField(ZigBeeDongleTelegesis.class, dongle, "startupComplete", true);
+
+        TelegesisAckMessageEvent response = Mockito.mock(TelegesisAckMessageEvent.class);
+        Mockito.when(response.getMessageId()).thenReturn(123);
+
+        dongle.telegesisEventReceived(response);
+        Mockito.verify(transport, Mockito.times(0)).receiveCommandStatus(ArgumentMatchers.anyInt(),
+                ArgumentMatchers.any(ZigBeeTransportProgressState.class));
+
+        Map<Integer, Integer> messageIdMap = new ConcurrentHashMap<>();
+        messageIdMap.put(123, 44);
+        setField(ZigBeeDongleTelegesis.class, dongle, "messageIdMap", messageIdMap);
+
+        dongle.telegesisEventReceived(response);
+        Mockito.verify(transport, Mockito.timeout(TIMEOUT)).receiveCommandStatus(44,
+                ZigBeeTransportProgressState.RX_ACK);
+    }
+
+    @Test
+    public void testTelegesisNackMessageEvent() throws Exception {
+        ZigBeeTransportReceive transport = Mockito.mock(ZigBeeTransportReceive.class);
+
+        ZigBeeDongleTelegesis dongle = new ZigBeeDongleTelegesis(null);
+        dongle.setZigBeeTransportReceive(transport);
+
+        setField(ZigBeeDongleTelegesis.class, dongle, "startupComplete", true);
+
+        TelegesisNackMessageEvent response = Mockito.mock(TelegesisNackMessageEvent.class);
+        Mockito.when(response.getMessageId()).thenReturn(123);
+
+        dongle.telegesisEventReceived(response);
+        Mockito.verify(transport, Mockito.times(0)).receiveCommandStatus(ArgumentMatchers.anyInt(),
+                ArgumentMatchers.any(ZigBeeTransportProgressState.class));
+
+        Map<Integer, Integer> messageIdMap = new ConcurrentHashMap<>();
+        messageIdMap.put(123, 44);
+        setField(ZigBeeDongleTelegesis.class, dongle, "messageIdMap", messageIdMap);
+
+        dongle.telegesisEventReceived(response);
+        Mockito.verify(transport, Mockito.timeout(TIMEOUT)).receiveCommandStatus(44,
+                ZigBeeTransportProgressState.RX_NAK);
+    }
+
+    @Test
+    public void testTelegesisDeviceJoinedNetworkEvent() throws Exception {
+        ZigBeeTransportReceive transport = Mockito.mock(ZigBeeTransportReceive.class);
+
+        ZigBeeDongleTelegesis dongle = new ZigBeeDongleTelegesis(null);
+        dongle.setZigBeeTransportReceive(transport);
+
+        setField(ZigBeeDongleTelegesis.class, dongle, "startupComplete", true);
+
+        TelegesisDeviceJoinedNetworkEvent response = Mockito.mock(TelegesisDeviceJoinedNetworkEvent.class);
+        Mockito.when(response.getNetworkAddress()).thenReturn(123);
+        Mockito.when(response.getIeeeAddress()).thenReturn(new IeeeAddress("1234567890ABCDEF"));
+        dongle.telegesisEventReceived(response);
+
+        Mockito.verify(transport, Mockito.timeout(TIMEOUT)).nodeStatusUpdate(ZigBeeNodeStatus.UNSECURED_JOIN, 123,
+                new IeeeAddress("1234567890ABCDEF"));
+    }
+
+    @Test
+    public void testTelegesisDeviceLeftNetworkEvent() throws Exception {
+        ZigBeeTransportReceive transport = Mockito.mock(ZigBeeTransportReceive.class);
+
+        ZigBeeDongleTelegesis dongle = new ZigBeeDongleTelegesis(null);
+        dongle.setZigBeeTransportReceive(transport);
+
+        setField(ZigBeeDongleTelegesis.class, dongle, "startupComplete", true);
+
+        TelegesisDeviceLeftNetworkEvent response = Mockito.mock(TelegesisDeviceLeftNetworkEvent.class);
+        Mockito.when(response.getNetworkAddress()).thenReturn(123);
+        Mockito.when(response.getIeeeAddress()).thenReturn(new IeeeAddress("1234567890ABCDEF"));
+        dongle.telegesisEventReceived(response);
+
+        Mockito.verify(transport, Mockito.timeout(TIMEOUT)).nodeStatusUpdate(ZigBeeNodeStatus.DEVICE_LEFT, 123,
+                new IeeeAddress("1234567890ABCDEF"));
+    }
+
+    @Test
+    public void testTelegesisNetworkLeftEvent() throws Exception {
+        ZigBeeTransportReceive transport = Mockito.mock(ZigBeeTransportReceive.class);
+
+        ZigBeeDongleTelegesis dongle = new ZigBeeDongleTelegesis(null);
+        dongle.setZigBeeTransportReceive(transport);
+
+        setField(ZigBeeDongleTelegesis.class, dongle, "startupComplete", true);
+
+        TelegesisNetworkLeftEvent response = Mockito.mock(TelegesisNetworkLeftEvent.class);
+        dongle.telegesisEventReceived(response);
+
+        Mockito.verify(transport, Mockito.timeout(TIMEOUT)).setNetworkState(ZigBeeTransportState.OFFLINE);
+    }
+
+    @Test
+    public void testTelegesisNetworkLostEvent() throws Exception {
+        ZigBeeTransportReceive transport = Mockito.mock(ZigBeeTransportReceive.class);
+
+        ZigBeeDongleTelegesis dongle = new ZigBeeDongleTelegesis(null);
+        dongle.setZigBeeTransportReceive(transport);
+
+        setField(ZigBeeDongleTelegesis.class, dongle, "startupComplete", true);
+
+        TelegesisNetworkLostEvent response = Mockito.mock(TelegesisNetworkLostEvent.class);
+        dongle.telegesisEventReceived(response);
+
+        Mockito.verify(transport, Mockito.timeout(TIMEOUT)).setNetworkState(ZigBeeTransportState.OFFLINE);
+    }
+
+    @Test
+    public void testTelegesisNetworkJoinedEvent() throws Exception {
+        ZigBeeTransportReceive transport = Mockito.mock(ZigBeeTransportReceive.class);
+
+        ZigBeeDongleTelegesis dongle = new ZigBeeDongleTelegesis(null);
+        dongle.setZigBeeTransportReceive(transport);
+
+        setField(ZigBeeDongleTelegesis.class, dongle, "startupComplete", true);
+
+        TelegesisNetworkJoinedEvent response = Mockito.mock(TelegesisNetworkJoinedEvent.class);
+        dongle.telegesisEventReceived(response);
+
+        Mockito.verify(transport, Mockito.timeout(TIMEOUT)).setNetworkState(ZigBeeTransportState.ONLINE);
     }
 }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/CommandResult.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/CommandResult.java
@@ -37,7 +37,7 @@ public class CommandResult {
      * Constructor for timeout situations.
      */
     public CommandResult() {
-        this.response = null;
+        response = null;
     }
 
     /**
@@ -59,9 +59,9 @@ public class CommandResult {
     }
 
     /**
-     * Checks if message status code was received in default response.
+     * Checks if command was successful, or resulted in an error.
      *
-     * @return the message status code
+     * @return true if the command resulted in an error
      */
     public boolean isError() {
         if (hasStatusCode()) {
@@ -87,7 +87,7 @@ public class CommandResult {
     /**
      * Gets status code received in default response.
      *
-     * @return the status code
+     * @return the status code as {@link Integer}
      */
     public Integer getStatusCode() {
         if (hasStatusCode()) {

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeAddress.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeAddress.java
@@ -20,14 +20,14 @@ public abstract class ZigBeeAddress implements Comparable<ZigBeeAddress> {
     /**
      * Gets the network address for this address.
      *
-     * @return network address as {@link int}
+     * @return network address as int
      */
     public abstract int getAddress();
 
     /**
      * Sets the network address for this address
      *
-     * @param address the network address as {@link int}
+     * @param address the network address as int
      */
     public abstract void setAddress(final int address);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeGroupAddress.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeGroupAddress.java
@@ -36,8 +36,7 @@ public class ZigBeeGroupAddress extends ZigBeeAddress {
     /**
      * Constructor which sets group ID.
      *
-     * @param groupId
-     *            the group ID
+     * @param groupId the group ID
      */
     public ZigBeeGroupAddress(final int groupId) {
         this.groupId = groupId;
@@ -46,10 +45,8 @@ public class ZigBeeGroupAddress extends ZigBeeAddress {
     /**
      * Constructor which sets group ID and label.
      *
-     * @param groupId
-     *            the group ID
-     * @param label
-     *            the group label
+     * @param groupId the group ID
+     * @param label the group label
      */
     public ZigBeeGroupAddress(final int groupId, final String label) {
         this.groupId = groupId;
@@ -78,8 +75,7 @@ public class ZigBeeGroupAddress extends ZigBeeAddress {
     /**
      * Sets group ID.
      *
-     * @param groupId
-     *            the group ID
+     * @param groupId the group ID
      */
     public void setGroupId(final int groupId) {
         this.groupId = groupId;
@@ -97,8 +93,7 @@ public class ZigBeeGroupAddress extends ZigBeeAddress {
     /**
      * Sets group name.
      *
-     * @param label
-     *            the group label
+     * @param label the group label
      */
     public void setLabel(final String label) {
         this.label = label;
@@ -139,5 +134,10 @@ public class ZigBeeGroupAddress extends ZigBeeAddress {
         }
         final ZigBeeGroupAddress other = (ZigBeeGroupAddress) obj;
         return other.getGroupId() == getGroupId();
+    }
+
+    @Override
+    public String toString() {
+        return "ZigBeeGroupAddress [groupId=" + groupId + ", label=" + label + "]";
     }
 }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransaction.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransaction.java
@@ -7,7 +7,6 @@
  */
 package com.zsmartsystems.zigbee.transaction;
 
-import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledFuture;
 
 import org.slf4j.Logger;
@@ -15,9 +14,8 @@ import org.slf4j.LoggerFactory;
 
 import com.zsmartsystems.zigbee.CommandResult;
 import com.zsmartsystems.zigbee.ZigBeeCommand;
-import com.zsmartsystems.zigbee.ZigBeeCommandListener;
 import com.zsmartsystems.zigbee.ZigBeeNetworkManager;
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
+import com.zsmartsystems.zigbee.transport.ZigBeeTransportProgressState;
 
 /**
  * Transaction class to handle the sending of commands and timeout in the event there is no response.
@@ -25,62 +23,110 @@ import com.zsmartsystems.zigbee.zcl.ZclCommand;
  * @author Chris Jackson
  *
  */
-public class ZigBeeTransaction implements ZigBeeCommandListener {
+public class ZigBeeTransaction {
     /**
      * The logger.
      */
     private final Logger logger = LoggerFactory.getLogger(ZigBeeTransaction.class);
 
-    private final ZigBeeNetworkManager networkManager;
+    public enum TransactionState {
+        /**
+         * Transaction is idle and should be waiting in the queue to be sent
+         */
+        WAITING,
+
+        /**
+         * Transaction has been sent, but no response has been received from the transport
+         */
+        DISPATCHED,
+
+        /**
+         * Transaction has been sent, and the ACK received from the transport to confirm it has been sent over the air
+         */
+        TRANSMITTED,
+
+        /**
+         * The low level ACK was received to confirm the command was received by the remote device
+         */
+        ACKED,
+
+        /**
+         * Transaction has been completed successfully
+         */
+        COMPLETE,
+
+        /**
+         * Transaction failed - no response received
+         */
+        FAILED
+    }
+
+    private final ZigBeeTransactionManager transactionManager;
     private ZigBeeTransactionFuture transactionFuture;
     private ZigBeeTransactionMatcher responseMatcher;
     private ZigBeeCommand command;
     private ScheduledFuture<?> timeoutTask;
 
-    private final static int DEFAULT_TIMEOUT_MILLISECONDS = 8000;
+    private TransactionState state = TransactionState.WAITING;
 
-    private int timeout = DEFAULT_TIMEOUT_MILLISECONDS;
+    /**
+     * The amount of time (in milliseconds) from when the command is sent to the transport, until when the transport
+     * acknowledges it has been transmitted.
+     * This must account for the total time from when the data is sent, until the response is expected, included any
+     * queueing delay in the transport.
+     */
+    private final static int TRANSACTION_TIMER = 12000;
+
+    /**
+     * The amount of time (in milliseconds) to wait for a response from the transport to acknowledge the command was
+     * transmitted.
+     */
+    private final static int TRANSACTION_TIMER_BEFORE_TX = 4000;
+
+    /**
+     * The amount of time (in milliseconds) to wait for a response from the transport once the command has been
+     * transmitted.
+     */
+    private final static int TRANSACTION_TIMER_AFTER_TX = 8000;
+
+    private int timeout = TRANSACTION_TIMER;
 
     /**
      * Transaction constructor
-     * 
-     * @param networkManager the {@link ZigBeeNetworkManager} to which the transaction is being sent
+     *
+     * @param networkManager the {@link ZigBeeNetworkManager} to which the transaction is being sent.
+     * @param command the {@link ZigBeeCommand}.
+     * @param responseMatcher the {@link ZigBeeTransactionMatcher} to match the response and complete the transaction.
+     *            May be null if no response is expected.
      */
-    public ZigBeeTransaction(ZigBeeNetworkManager networkManager) {
-        this.networkManager = networkManager;
+    public ZigBeeTransaction(ZigBeeTransactionManager transactionManager, final ZigBeeCommand command,
+            final ZigBeeTransactionMatcher responseMatcher) {
+        this.transactionManager = transactionManager;
+        this.command = command;
+        this.responseMatcher = responseMatcher;
     }
 
     /**
      * Sends {@link ZigBeeCommand} command and uses the {@link ZigBeeTransactionMatcher} to match the response.
      * The task will be timed out if there is no response.
      *
-     * @param command the {@link ZigBeeCommand}
-     * @param responseMatcher the {@link ZigBeeTransactionMatcher}
      * @return the {@link CommandResult} future.
      */
-    public Future<CommandResult> sendTransaction(final ZigBeeCommand command,
-            final ZigBeeTransactionMatcher responseMatcher) {
-        this.command = command;
-        this.responseMatcher = responseMatcher;
-        synchronized (this.command) {
-            transactionFuture = new ZigBeeTransactionFuture();
+    public void send() {
+        logger.debug("Sending transaction: {} ==== {}", command, responseMatcher);
+        synchronized (command) {
+            // If we have no response matcher then we don't worry about adding the listener, or starting the
+            if (responseMatcher != null) {
+                transactionManager.addTransactionListener(this);
 
-            // Schedule a task to timeout the transaction
-            timeoutTask = networkManager.scheduleTask(new Runnable() {
-                @Override
-                public void run() {
-                    timeoutTransaction();
-                }
-            }, timeout);
-
-            networkManager.addCommandListener(this);
-
-            int transactionId = networkManager.sendCommand(command);
-            if (command instanceof ZclCommand) {
-                ((ZclCommand) command).setTransactionId(transactionId);
+                // Schedule a task to timeout the transaction
+                startTimer(timeout);
+            } else {
+                // Wait for the transport layer to confirm the command was sent
+                startTimer(TRANSACTION_TIMER_BEFORE_TX);
             }
 
-            return transactionFuture;
+            transactionManager.send(command);
         }
     }
 
@@ -98,33 +144,121 @@ public class ZigBeeTransaction implements ZigBeeCommandListener {
         this.timeout = timeout;
     }
 
-    @Override
+    protected void setFuture(ZigBeeTransactionFuture transactionFuture) {
+        this.transactionFuture = transactionFuture;
+    }
+
+    protected ZigBeeTransactionFuture getFuture() {
+        return transactionFuture;
+    }
+
+    /**
+     * Called by the transaction manager when a {@link ZigBeeCommand} is received. The transaction should check this
+     * command to see if it completes the transaction.
+     *
+     * @param receivedCommand the incoming {@link ZigBeeCommand}
+     */
     public void commandReceived(ZigBeeCommand receivedCommand) {
         // Ensure that received command is not processed before command is sent
         // and hence transaction ID for the command set.
         synchronized (command) {
             if (responseMatcher.isTransactionMatch(command, receivedCommand)) {
-                logger.debug("Transaction complete: {}", command);
-
-                timeoutTask.cancel(false);
-
-                synchronized (transactionFuture) {
-                    transactionFuture.set(new CommandResult(receivedCommand));
-                    transactionFuture.notify();
-                }
-                networkManager.removeCommandListener(this);
+                completeTransaction(receivedCommand);
             }
         }
     }
 
-    private void timeoutTransaction() {
-        logger.debug("Transaction timeout: {}", command);
-        synchronized (command) {
+    private void startTimer(int timeout) {
+        if (timeoutTask != null) {
+            timeoutTask.cancel(false);
+        }
+
+        // Schedule a task to timeout the transaction
+        timeoutTask = transactionManager.scheduleTask(new Runnable() {
+            @Override
+            public void run() {
+                cancelTransaction();
+            }
+        }, timeout);
+    }
+
+    private void completeTransaction(ZigBeeCommand receivedCommand) {
+        if (timeoutTask != null) {
+            timeoutTask.cancel(false);
+        }
+        logger.debug("Transaction complete: {}", command);
+        if (transactionFuture != null) {
+            synchronized (transactionFuture) {
+                transactionFuture.set(new CommandResult(receivedCommand));
+                transactionFuture.notify();
+            }
+        }
+        if (responseMatcher != null) {
+            transactionManager.removeTransactionListener(this);
+        }
+        state = TransactionState.COMPLETE;
+    }
+
+    private void cancelTransaction() {
+        if (timeoutTask != null) {
+            timeoutTask.cancel(false);
+        }
+        logger.debug("Transaction cancelled: {}", command);
+        if (transactionFuture != null) {
             synchronized (transactionFuture) {
                 transactionFuture.cancel(false);
                 transactionFuture.notify();
             }
-            networkManager.removeCommandListener(this);
         }
+        if (responseMatcher != null) {
+            transactionManager.removeTransactionListener(this);
+        }
+        state = TransactionState.FAILED;
+    }
+
+    /**
+     *
+     * @param state
+     * @param transactionId
+     */
+    public void commandStatusReceived(ZigBeeTransportProgressState progress, int transactionId) {
+        synchronized (command) {
+            if (command.getTransactionId() != transactionId) {
+                return;
+            }
+
+            logger.debug("Transaction state update : TID {} -> {} == {}", transactionId, progress, state);
+
+            switch (progress) {
+                case TX_NAK:
+                    // The transport layer failed to send the command
+                    cancelTransaction();
+                    break;
+                case TX_ACK:
+                    // If we aren't waiting for a response, then we're done
+                    if (responseMatcher == null) {
+                        completeTransaction(null);
+                        break;
+                    }
+
+                    // The command was transmitted ok
+                    state = TransactionState.TRANSMITTED;
+
+                    // The timer is reset here as we have confirmation the command is sent
+                    startTimer(TRANSACTION_TIMER_AFTER_TX);
+                    break;
+                case RX_NAK:
+                    // The transport layer failed to get an ack from the remote device
+                    cancelTransaction();
+                    break;
+                case RX_ACK:
+                    // The remote device confirmed receipt of the command
+                    state = TransactionState.ACKED;
+                    break;
+                default:
+                    break;
+            }
+        }
+        logger.debug("Transaction state updated: TID {} -> {} == {}", transactionId, progress, state);
     }
 }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransactionManager.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransactionManager.java
@@ -1,0 +1,175 @@
+/**
+ * Copyright (c) 2016-2018 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.transaction;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import com.zsmartsystems.zigbee.CommandResult;
+import com.zsmartsystems.zigbee.ZigBeeCommand;
+import com.zsmartsystems.zigbee.ZigBeeNetworkManager;
+import com.zsmartsystems.zigbee.internal.NotificationService;
+import com.zsmartsystems.zigbee.transport.ZigBeeTransportProgressState;
+
+/**
+ * The centralised transaction manager
+ *
+ * @author Chris Jackson
+ *
+ */
+public class ZigBeeTransactionManager {
+    /**
+     * The {@link ZigBeeNetworkManager} to which this manager belongs
+     */
+    private final ZigBeeNetworkManager networkManager;
+
+    /**
+     * The set of outstanding transactions - used to notify transactions when responses are received.
+     */
+    private Set<ZigBeeTransaction> outstandingTransactions = new HashSet<>();
+
+    /**
+     * Executor service to execute update threads for discovery or mesh updates etc.
+     * We use a {@link Executors.newScheduledThreadPool} to provide a fixed number of threads as otherwise this could
+     * result in a large number of simultaneous threads in large networks.
+     */
+    private final ScheduledExecutorService executorService = Executors.newScheduledThreadPool(6);
+
+    public ZigBeeTransactionManager(ZigBeeNetworkManager manager) {
+        this.networkManager = manager;
+    }
+
+    /**
+     * Sends a command without waiting for a response
+     *
+     * @param command the {@link ZigBeeCommand} to send
+     */
+    public void sendTransaction(ZigBeeCommand command) {
+        sendTransaction(command, null);
+    }
+
+    /**
+     * Sends a command, and uses the {@link ZigBeeTransactionMatcher} to match the response which will complete the
+     * transaction.
+     *
+     * @param command the {@link ZigBeeCommand} to send
+     * @param responseMatcher the {@link ZigBeeTransactionMatcher} to match the response which will complete the
+     *            transaction.
+     * @return the future {@link CommandResult}
+     */
+    public Future<CommandResult> sendTransaction(ZigBeeCommand command, ZigBeeTransactionMatcher responseMatcher) {
+        ZigBeeTransactionFuture transactionFuture = new ZigBeeTransactionFuture();
+        ZigBeeTransaction transaction = new ZigBeeTransaction(this, command, responseMatcher);
+        transaction.setFuture(transactionFuture);
+        transaction.send();
+
+        return transactionFuture;
+    }
+
+    /**
+     * Sends the command to the transport layer
+     *
+     * @param command the {@link ZigBeeCommand} to send
+     */
+    protected void send(ZigBeeCommand command) {
+        networkManager.sendCommand(command);
+    }
+
+    /**
+     * Processes a received frame within the transaction manager, and returns the frame that is to fed up the stack. The
+     * transaction manager may return null from this command if it should not be processed up the stack.
+     *
+     * @param command the received {@link ZigBeeCommand}
+     * @return the {@link ZigBeeCommand} to be used within the library or null if the frame is not to be fed into the
+     *         rest of the system
+     */
+    public ZigBeeCommand receive(final ZigBeeCommand command) {
+        notifyTransactionCommand(command);
+        return command;
+    }
+
+    /**
+     * Callback from the transport layer when it has progressed the state of the transaction.
+     *
+     * @param transactionId the transaction ID whose state is updated
+     * @param status the updated {@link ZigBeeTransportProgressState} for the transaction
+     */
+    public void receiveCommandStatus(int transactionId, ZigBeeTransportProgressState status) {
+        notifyTransactionProgress(transactionId, status);
+    }
+
+    /**
+     * Adds a transaction to the list of outstanding transactions. Transactions will receive notifications when a
+     * command is received, or when the status is updated
+     *
+     * @param transaction the {@link ZigBeeTransaction} that will receive the notifications
+     */
+    public void addTransactionListener(ZigBeeTransaction transaction) {
+        synchronized (outstandingTransactions) {
+            outstandingTransactions.add(transaction);
+        }
+    }
+
+    /**
+     * Removes a transaction from the list of outstanding transactions.
+     *
+     * @param transaction the {@link ZigBeeTransaction} to remove
+     */
+    public void removeTransactionListener(ZigBeeTransaction transaction) {
+        synchronized (outstandingTransactions) {
+            outstandingTransactions.remove(transaction);
+        }
+    }
+
+    protected ScheduledFuture<?> scheduleTask(Runnable runnableTask, long delay) {
+        return executorService.schedule(runnableTask, delay, TimeUnit.MILLISECONDS);
+    }
+
+    /**
+     * Notify transactions of the received command
+     *
+     * @param command the {@link ZigBeeCommand} to send to the transactions
+     */
+    private void notifyTransactionCommand(final ZigBeeCommand command) {
+        synchronized (outstandingTransactions) {
+            // Notify the listeners
+            for (final ZigBeeTransaction transaction : outstandingTransactions) {
+                NotificationService.execute(new Runnable() {
+                    @Override
+                    public void run() {
+                        transaction.commandReceived(command);
+                    }
+                });
+            }
+        }
+    }
+
+    /**
+     * Notify transactions of the progress
+     *
+     * @param command the {@link ZigBeeCommand} to send to the listeners
+     */
+    private void notifyTransactionProgress(final int transactionId, ZigBeeTransportProgressState state) {
+        synchronized (outstandingTransactions) {
+            // Notify the listeners
+            for (final ZigBeeTransaction transaction : outstandingTransactions) {
+                NotificationService.execute(new Runnable() {
+                    @Override
+                    public void run() {
+                        transaction.commandStatusReceived(state, transactionId);
+                    }
+                });
+            }
+        }
+    }
+}

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transport/ZigBeeTransportProgressState.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transport/ZigBeeTransportProgressState.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2016-2018 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.transport;
+
+/**
+ * Response states for feedback responses
+ *
+ * @author Chris Jackson
+ *
+ */
+public enum ZigBeeTransportProgressState {
+    /**
+     * The command was successfully sent
+     */
+    TX_ACK,
+
+    /**
+     * The command was not sent
+     */
+    TX_NAK,
+
+    /**
+     * The command was sent and the acknowledgement was received from the remote device
+     */
+    RX_ACK,
+
+    /**
+     * The command was sent but not acknowledgement by the remote device
+     */
+    RX_NAK
+}

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transport/ZigBeeTransportReceive.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transport/ZigBeeTransportReceive.java
@@ -69,4 +69,14 @@ public interface ZigBeeTransportReceive {
      */
     void nodeStatusUpdate(final ZigBeeNodeStatus deviceStatus, final Integer networkAddress,
             final IeeeAddress ieeeAddress);
+
+    /**
+     * A callback called by the {@link ZigBeeTransportTransmit} when a transaction sent using
+     * {@link ZigBeeTransportTransmit#sendCommand(ZigBeeApsFrame)} is received.
+     *
+     * @param transactionId the transaction ID to which a response has been received
+     * @param status the acknowledge status
+     */
+    void receiveCommandStatus(int transactionId, ZigBeeTransportProgressState status);
+
 }

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeGroupAddressTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeGroupAddressTest.java
@@ -12,10 +12,9 @@ import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
-import com.zsmartsystems.zigbee.ZigBeeGroupAddress;
-
 /**
- *
+ * Tests for {@link ZigBeeGroupAddress}
+ * 
  * @author Chris Jackson
  *
  */
@@ -44,5 +43,7 @@ public class ZigBeeGroupAddressTest {
 
         group2.setGroupId(2);
         assertEquals(1, group1.compareTo(group2));
+
+        System.out.println(group2);
     }
 }

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeNetworkManagerTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeNetworkManagerTest.java
@@ -279,11 +279,7 @@ public class ZigBeeNetworkManagerTest implements ZigBeeNetworkNodeListener, ZigB
 
         networkManager.setNetworkState(ZigBeeTransportState.UNINITIALISED);
 
-        // Awaitility.await().until(() -> networkStateUpdatedSize());
         Mockito.verify(stateListener, Mockito.timeout(TIMEOUT)).networkStateUpdated(ZigBeeTransportState.UNINITIALISED);
-
-        // assertEquals(1, networkStateListenerCapture.size());
-        // assertEquals(ZigBeeTransportState.UNINITIALISED, networkStateListenerCapture.get(0));
 
         networkManager.setNetworkState(ZigBeeTransportState.INITIALISING);
         Mockito.verify(stateListener, Mockito.timeout(TIMEOUT)).networkStateUpdated(ZigBeeTransportState.INITIALISING);
@@ -388,15 +384,6 @@ public class ZigBeeNetworkManagerTest implements ZigBeeNetworkNodeListener, ZigB
     @Override
     public void networkStateUpdated(ZigBeeTransportState state) {
         networkStateListenerCapture.add(state);
-    }
-
-    private Callable<Integer> networkStateUpdatedSize() {
-        return new Callable<Integer>() {
-            @Override
-            public Integer call() throws Exception {
-                return networkStateListenerCapture.size(); // The condition that must be fulfilled
-            }
-        };
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransactionManagerTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransactionManagerTest.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2016-2018 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.transaction;
+
+import static org.junit.Assert.assertNotNull;
+
+import java.util.concurrent.Future;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.zsmartsystems.zigbee.CommandResult;
+import com.zsmartsystems.zigbee.IeeeAddress;
+import com.zsmartsystems.zigbee.ZigBeeCommand;
+import com.zsmartsystems.zigbee.ZigBeeEndpointAddress;
+import com.zsmartsystems.zigbee.ZigBeeNetworkManager;
+import com.zsmartsystems.zigbee.ZigBeeNode;
+import com.zsmartsystems.zigbee.transport.ZigBeeTransportProgressState;
+
+/**
+ *
+ * @author Chris Jackson
+ *
+ */
+public class ZigBeeTransactionManagerTest {
+    private static int TIMEOUT = 5000;
+
+    @Test
+    public void sendTransaction() {
+        ZigBeeNetworkManager networkManager = Mockito.mock(ZigBeeNetworkManager.class);
+        ZigBeeCommand command = Mockito.mock(ZigBeeCommand.class);
+        Mockito.when(command.getDestinationAddress()).thenReturn(new ZigBeeEndpointAddress(123));
+        ZigBeeTransactionMatcher responseMatcher = Mockito.mock(ZigBeeTransactionMatcher.class);
+        ZigBeeNode node = Mockito.mock(ZigBeeNode.class);
+        Mockito.when(node.getIeeeAddress()).thenReturn(new IeeeAddress("1234567890ABCDEF"));
+
+        Mockito.when(networkManager.getNode(123)).thenReturn(node);
+
+        ZigBeeTransactionManager transactionManager = new ZigBeeTransactionManager(networkManager);
+
+        transactionManager.sendTransaction(command);
+
+        Future<CommandResult> cmdResult = transactionManager.sendTransaction(command, responseMatcher);
+        assertNotNull(cmdResult);
+
+        ZigBeeCommand unknownCommand = Mockito.mock(ZigBeeCommand.class);
+        Mockito.when(unknownCommand.getDestinationAddress()).thenReturn(new ZigBeeEndpointAddress(456));
+        cmdResult = transactionManager.sendTransaction(unknownCommand, responseMatcher);
+        // assertNull(cmdResult);
+    }
+
+    @Test
+    public void receive() {
+        ZigBeeNetworkManager networkManager = Mockito.mock(ZigBeeNetworkManager.class);
+        ZigBeeTransactionManager transactionManager = new ZigBeeTransactionManager(networkManager);
+
+        ZigBeeTransaction transactionListener = Mockito.mock(ZigBeeTransaction.class);
+
+        transactionManager.addTransactionListener(transactionListener);
+
+        ZigBeeCommand command = Mockito.mock(ZigBeeCommand.class);
+
+        transactionManager.receive(command);
+        Mockito.verify(transactionListener, Mockito.timeout(TIMEOUT)).commandReceived(command);
+
+        transactionManager.receiveCommandStatus(123, ZigBeeTransportProgressState.RX_ACK);
+        Mockito.verify(transactionListener, Mockito.timeout(TIMEOUT))
+                .commandStatusReceived(ZigBeeTransportProgressState.RX_ACK, 123);
+
+        transactionManager.removeTransactionListener(null);
+        transactionManager.removeTransactionListener(transactionListener);
+        transactionManager.removeTransactionListener(transactionListener);
+
+        // Send another command and make sure the commandReceived method is not called again
+        transactionManager.receive(command);
+        Mockito.verify(transactionListener, Mockito.times(1)).commandReceived(command);
+    }
+
+}

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransactionTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransactionTest.java
@@ -7,21 +7,20 @@
  */
 package com.zsmartsystems.zigbee.transaction;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledFuture;
 
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Matchers;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
-import com.zsmartsystems.zigbee.CommandResult;
 import com.zsmartsystems.zigbee.ZigBeeCommand;
-import com.zsmartsystems.zigbee.ZigBeeNetworkManager;
+import com.zsmartsystems.zigbee.transport.ZigBeeTransportProgressState;
 
 /**
  *
@@ -31,17 +30,23 @@ import com.zsmartsystems.zigbee.ZigBeeNetworkManager;
 public class ZigBeeTransactionTest {
     @Test
     public void testTimeout() {
-        ZigBeeNetworkManager networkManager = Mockito.mock(ZigBeeNetworkManager.class);
+        ZigBeeTransactionManager transactionManager = Mockito.mock(ZigBeeTransactionManager.class);
         ScheduledFuture timerFuture = Mockito.mock(ScheduledFuture.class);
-        ZigBeeTransaction transaction = new ZigBeeTransaction(networkManager);
+        ZigBeeCommand command = Mockito.mock(ZigBeeCommand.class);
+        ZigBeeTransactionMatcher matcher = Mockito.mock(ZigBeeTransactionMatcher.class);
+
+        ZigBeeTransactionFuture transactionFuture = new ZigBeeTransactionFuture();
+
+        ZigBeeTransaction transaction = new ZigBeeTransaction(transactionManager, command, matcher);
+        transaction.setFuture(transactionFuture);
 
         ArgumentCaptor<Runnable> timerCaptor = ArgumentCaptor.forClass(Runnable.class);
-        Mockito.when(networkManager.scheduleTask(timerCaptor.capture(), Matchers.anyLong())).thenReturn(timerFuture);
+        Mockito.when(transactionManager.scheduleTask(timerCaptor.capture(), ArgumentMatchers.anyLong()))
+                .thenReturn(timerFuture);
 
-        ZigBeeCommand command = Mockito.mock(ZigBeeCommand.class);
-        ZigBeeTransactionMatcher transactionMatcher = Mockito.mock(ZigBeeTransactionMatcher.class);
-        Future<CommandResult> transactionFuture = transaction.sendTransaction(command, transactionMatcher);
-        Mockito.verify(networkManager, Mockito.times(1)).addCommandListener(transaction);
+        transaction.send();
+        Mockito.verify(transactionManager, Mockito.times(1)).addTransactionListener(transaction);
+        Mockito.verify(transactionManager, Mockito.times(1)).send(command);
 
         Runnable timeout = timerCaptor.getValue();
         assertNotNull(timeout);
@@ -50,9 +55,139 @@ public class ZigBeeTransactionTest {
         assertFalse(transactionFuture.isCancelled());
 
         timeout.run();
-        Mockito.verify(networkManager, Mockito.times(1)).removeCommandListener(transaction);
+        Mockito.verify(transactionManager, Mockito.times(1)).removeTransactionListener(transaction);
 
         assertTrue(transactionFuture.isDone());
         assertTrue(transactionFuture.isCancelled());
+    }
+
+    @Test
+    public void testTxNak() {
+        ZigBeeTransactionManager transactionManager = Mockito.mock(ZigBeeTransactionManager.class);
+        ZigBeeCommand command = Mockito.mock(ZigBeeCommand.class);
+        Mockito.when(command.getTransactionId()).thenReturn(12);
+        ZigBeeTransactionMatcher matcher = Mockito.mock(ZigBeeTransactionMatcher.class);
+
+        ZigBeeTransactionFuture transactionFuture = new ZigBeeTransactionFuture();
+
+        ZigBeeTransaction transaction = new ZigBeeTransaction(transactionManager, command, matcher);
+        transaction.setFuture(transactionFuture);
+
+        transaction.send();
+        Mockito.verify(transactionManager, Mockito.times(1)).scheduleTask(ArgumentMatchers.any(Runnable.class),
+                ArgumentMatchers.anyLong());
+        Mockito.verify(transactionManager, Mockito.times(1)).addTransactionListener(transaction);
+        Mockito.verify(transactionManager, Mockito.times(1)).send(ArgumentMatchers.any(ZigBeeCommand.class));
+
+        // Wrong TID so gets ignored
+        transaction.commandStatusReceived(ZigBeeTransportProgressState.TX_NAK, 123);
+        assertFalse(transactionFuture.isDone());
+        assertFalse(transactionFuture.isCancelled());
+
+        // Correct TID
+        transaction.commandStatusReceived(ZigBeeTransportProgressState.TX_NAK, 12);
+
+        Mockito.verify(transactionManager, Mockito.times(1)).removeTransactionListener(transaction);
+
+        assertTrue(transactionFuture.isDone());
+        assertTrue(transactionFuture.isCancelled());
+    }
+
+    @Test
+    public void testRxNak() {
+        ZigBeeTransactionManager transactionManager = Mockito.mock(ZigBeeTransactionManager.class);
+        ZigBeeCommand command = Mockito.mock(ZigBeeCommand.class);
+        Mockito.when(command.getTransactionId()).thenReturn(12);
+        ZigBeeTransactionMatcher matcher = Mockito.mock(ZigBeeTransactionMatcher.class);
+
+        ZigBeeTransactionFuture transactionFuture = new ZigBeeTransactionFuture();
+
+        ZigBeeTransaction transaction = new ZigBeeTransaction(transactionManager, command, matcher);
+        transaction.setFuture(transactionFuture);
+
+        transaction.send();
+        Mockito.verify(transactionManager, Mockito.times(1)).scheduleTask(ArgumentMatchers.any(Runnable.class),
+                ArgumentMatchers.anyLong());
+        Mockito.verify(transactionManager, Mockito.times(1)).addTransactionListener(transaction);
+        Mockito.verify(transactionManager, Mockito.times(1)).send(command);
+
+        transaction.commandStatusReceived(ZigBeeTransportProgressState.TX_ACK, 12);
+
+        Mockito.verify(transactionManager, Mockito.times(2)).scheduleTask(ArgumentMatchers.any(Runnable.class),
+                ArgumentMatchers.anyLong());
+
+        transaction.commandStatusReceived(ZigBeeTransportProgressState.RX_NAK, 12);
+
+        Mockito.verify(transactionManager, Mockito.times(1)).removeTransactionListener(transaction);
+
+        assertTrue(transactionFuture.isDone());
+        assertTrue(transactionFuture.isCancelled());
+    }
+
+    @Test
+    public void testSendOnly() {
+        ZigBeeTransactionManager transactionManager = Mockito.mock(ZigBeeTransactionManager.class);
+        ZigBeeCommand command = Mockito.mock(ZigBeeCommand.class);
+        Mockito.when(command.getTransactionId()).thenReturn(12);
+
+        ZigBeeTransactionFuture transactionFuture = new ZigBeeTransactionFuture();
+
+        ZigBeeTransaction transaction = new ZigBeeTransaction(transactionManager, command, null);
+        transaction.setFuture(transactionFuture);
+
+        transaction.send();
+        Mockito.verify(transactionManager, Mockito.times(1)).scheduleTask(ArgumentMatchers.any(Runnable.class),
+                ArgumentMatchers.anyLong());
+        Mockito.verify(transactionManager, Mockito.times(1)).send(command);
+        Mockito.verify(transactionManager, Mockito.times(0)).addTransactionListener(transaction);
+
+        // Wrong TID so gets ignored
+        transaction.commandStatusReceived(ZigBeeTransportProgressState.TX_NAK, 123);
+        assertFalse(transactionFuture.isDone());
+        assertFalse(transactionFuture.isCancelled());
+
+        // Correct TID
+        transaction.commandStatusReceived(ZigBeeTransportProgressState.TX_ACK, 12);
+
+        Mockito.verify(transactionManager, Mockito.times(0)).removeTransactionListener(transaction);
+
+        assertTrue(transactionFuture.isDone());
+        assertFalse(transactionFuture.isCancelled());
+    }
+
+    @Test
+    public void commandReceived() {
+        ZigBeeTransactionManager transactionManager = Mockito.mock(ZigBeeTransactionManager.class);
+        ZigBeeCommand command = Mockito.mock(ZigBeeCommand.class);
+        Mockito.when(command.getTransactionId()).thenReturn(12);
+
+        ZigBeeTransactionFuture transactionFuture = new ZigBeeTransactionFuture();
+
+        ZigBeeCommand matchRequest = Mockito.mock(ZigBeeCommand.class);
+        ZigBeeCommand nomatchRequest = Mockito.mock(ZigBeeCommand.class);
+        ZigBeeTransactionMatcher matcher = Mockito.mock(ZigBeeTransactionMatcher.class);
+        Mockito.when(matcher.isTransactionMatch(command, matchRequest)).thenReturn(true);
+        Mockito.when(matcher.isTransactionMatch(command, nomatchRequest)).thenReturn(false);
+
+        ZigBeeTransaction transaction = new ZigBeeTransaction(transactionManager, command, matcher);
+        transaction.setFuture(transactionFuture);
+        assertEquals(transactionFuture, transaction.getFuture());
+
+        transaction.commandReceived(nomatchRequest);
+        assertFalse(transactionFuture.isDone());
+        assertFalse(transactionFuture.isCancelled());
+
+        transaction.commandReceived(matchRequest);
+        assertTrue(transactionFuture.isDone());
+        assertFalse(transactionFuture.isCancelled());
+    }
+
+    @Test
+    public void getTimeout() {
+        ZigBeeTransaction transaction = new ZigBeeTransaction(null, null, null);
+
+        int timeout = transaction.getTimeout();
+        transaction.setTimeout(timeout + 23);
+        assertEquals(timeout + 23, transaction.getTimeout());
     }
 }

--- a/com.zsmartsystems.zigbee/src/test/resource/logs/logtests.txt
+++ b/com.zsmartsystems.zigbee/src/test/resource/logs/logtests.txt
@@ -35,3 +35,9 @@ DiscoverAttributesResponse [On/Off: 18314/3 -> 0/1, cluster=0006, TID=15, discov
 ZigBeeApsFrame [sourceAddress=0/1, destinationAddress=18314/3, profile=0104, cluster=0006, addressMode=DEVICE, radius=31, apsSecurity=false, apsCounter=11, payload=00 11 11 00 14]
 DiscoverCommandsReceived [On/Off: 0/0 -> 18314/3, cluster=0006, TID=11, startCommandIdentifier=0, maximumCommandIdentifiers=20]
 
+ZigBeeApsFrame [sourceAddress=0/0, destinationAddress=65532/0, profile=0000, cluster=0036, addressMode=DEVICE, radius=31, apsSecurity=false, apsCounter=0A, payload=00 6F 01]
+ManagementPermitJoiningRequest [0/0 -> 65532/0, cluster=0036, TID=0A, permitDuration=111, tcSignificance=true]
+
+ZigBeeApsFrame [sourceAddress=0/0, destinationAddress=0/0, profile=0000, cluster=8036, addressMode=null, radius=0, apsSecurity=false, apsCounter=00, payload=00 00]
+ManagementPermitJoiningResponse [0/0 -> 0/0, cluster=8036, TID=NULL, status=SUCCESS]
+


### PR DESCRIPTION
This refactors the transaction handling in the framework. It introduces a new ```ZigBeeTransactionManager``` class which manages the transactions. It also introduces a new method ```ZigBeeTransportReceive. receiveCommandStatus()``` which provides a mechanism for the transport layer to provide feedback on the state of its transaction management.

```ZigBeeTransportReceive. receiveCommandStatus()``` should be called by the dongle when there is an update to the transaction - eg when the dongle actually sends the data over the air, or when it decides the transaction has timed out and is no longer going to pass the response up the stack. With this feedback, the ```ZigBeeTransaction``` is able to terminate earlier than it currently does - thus freeing the thread to continue.

If the dongle does not implement this feedback, then the transaction will ultimately time out in the same way as it always has.

The Telegesis and Ember dongles have had this feedback implemented in this PR.

The Telegesis dongle does not allow the user to set a message tag (used to correlate responses), so we need to add additional processing of the frame to translate the Telegesis SEQ to the transaction ID used in the framework.

Ember implementation allows the user to set their own tag, making this much simpler.

Closes #95 

Signed-off-by: Chris Jackson <chris@cd-jackson.com>
