### PR TITLE
Don't remove nodes when they leave - mark them OFFLINE

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 # Overview
 
-This project aims to provide a ZigBee Framework written in Java. It provides a ZigBee Cluster Library implementation, and network management functions, aiming to provide a full featured ZigBee framework that can be implemented within end systems.
+This project aims to provide a ZigBee compatible framework written in Java and compatible with Android. It provides a ZigBee Cluster Library implementation, and network management functions, aiming to provide a full featured ZigBee framework that can be implemented within end systems. This repository aims to provide a high quality framework, with quality documentation and a thorough set of test cases to ensure against regression.
 
-Packages are broken down to provide the main ZigBee  framework, separate packages for dongles, and a console application that allows full use of the framework. The bundles include OSGi headers for use within an OSGi framework.
+Packages are broken down to provide the main ZigBee framework, separate packages for dongles, and a console application that allows full use of the framework. The bundles include OSGi headers for use within an OSGi framework.
 
 Minimum Android support is currently API19, Android 4.4 (KitKat). It is highly recommended to move to Android 8 as this may become the minimum requirement in the future to allow the framework to use the newer classes available from API26.
  
@@ -169,6 +169,7 @@ Command handlers for commands specific to each dongle implementation are in the 
 Command handlers take a set of arguments as provided by the user and will throw ```IllegalArgumentException``` if there are any errors with arguments, or ```IllegalStateException``` if there are any issues with the network state that prevent the command execution.
 
 ## Starting the Console
+
 The console application takes the following parameters -:
 
 | Option                      | Description                                                               |
@@ -202,6 +203,7 @@ Example -:
 ## Console Commands
 
 ### General Commands
+
 Note that the console is currently being refactored and this readme only documents the commands that have been migrated. For a full list of commands, use the _help_ command in the console.
 
 | Command         | Description                                                          |
@@ -229,6 +231,7 @@ Note that the console is currently being refactored and this readme only documen
 
 
 ### Ember NCP Commands
+
 The following commands are available if the transport layer is using the Silabs Ember NCP.
 
 | Command         | Description                                           |
@@ -244,6 +247,7 @@ The following commands are available if the transport layer is using the Silabs 
 |ncpmmohash       |Uses the NCP to perform the MMO hash                   |
 
 ### Telegesis Commands
+
 The following commands are available if the transport layer is using the Telegesis dongle.
 
 | Command         | Description                                           |
@@ -257,7 +261,7 @@ The following commands are available if the transport layer is using the Teleges
 * Run the findBugs goal and check that you have not introduced any bugs into your code. FindBugs reports are generated with the ```mvn site``` goal, and reports are located in the ```target/site/findbugs.html``` file.
 * Please consider raising issues before working on an enhancement to provide some coordination with other contributors.
 * Keep PRs short - try and keep a single PR per enhancement. This makes tracking and reviewing easier.
-* Contributions must be supported with tests.
+* Contributions must be supported with tests. Ideally, you should aim to acheive full coverage of the code changes. Code coverage reports are located in the ```com.zsmartsystems.zigbee.test/target/site/jacoco-aggregate``` folder and opening the ```index.html``` file.
 * Code must be formatted using the Eclipse code formatter provided in the project.
 * Contributions must be your own and you must agree with the license.
 * You must sign the PR and commits and must agree to the [Contributor License Agreement](https://cla-assistant.io/zsmartsystems/com.zsmartsystems.zigbee).
@@ -313,6 +317,7 @@ dependencies
 ```
 
 ## Note: 
+
 Change 1.x.x to desired/latest version (24.12.2018 1.x.x -> 1.1.7)
 
 # License

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeNetworkDiscoverer.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeNetworkDiscoverer.java
@@ -26,6 +26,7 @@ import com.zsmartsystems.zigbee.ZigBeeCommandListener;
 import com.zsmartsystems.zigbee.ZigBeeEndpointAddress;
 import com.zsmartsystems.zigbee.ZigBeeNetworkManager;
 import com.zsmartsystems.zigbee.ZigBeeNode;
+import com.zsmartsystems.zigbee.ZigBeeNode.ZigBeeNodeState;
 import com.zsmartsystems.zigbee.ZigBeeNodeStatus;
 import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zdo.ZdoStatus;
@@ -390,6 +391,7 @@ public class ZigBeeNetworkDiscoverer implements ZigBeeCommandListener, ZigBeeAnn
             if (node.getNetworkAddress() != networkAddress) {
                 logger.debug("{}: Network address updated to {}", ieeeAddress, networkAddress);
             }
+            node.setNodeState(ZigBeeNodeState.ONLINE);
             node.setNetworkAddress(networkAddress);
             networkManager.updateNode(node);
             return;

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeNodeTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeNodeTest.java
@@ -21,6 +21,7 @@ import org.junit.Test;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
+import com.zsmartsystems.zigbee.ZigBeeNode.ZigBeeNodeState;
 import com.zsmartsystems.zigbee.serialization.DefaultDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zdo.field.NeighborTable;
@@ -428,5 +429,15 @@ public class ZigBeeNodeTest {
         node.commandReceived(unicast);
         Mockito.verify(endpoint1, Mockito.times(1)).commandReceived(unicast);
         Mockito.verify(endpoint2, Mockito.times(0)).commandReceived(unicast);
+    }
+
+    @Test
+    public void setNodeState() {
+        ZigBeeNode node = new ZigBeeNode(Mockito.mock(ZigBeeNetworkManager.class), new IeeeAddress("1234567890"));
+
+        assertFalse(node.setNodeState(ZigBeeNodeState.UNKNOWN));
+        assertTrue(node.setNodeState(ZigBeeNodeState.ONLINE));
+        assertTrue(node.setNodeState(ZigBeeNodeState.OFFLINE));
+        assertFalse(node.setNodeState(ZigBeeNodeState.OFFLINE));
     }
 }

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeNetworkDiscovererTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeNetworkDiscovererTest.java
@@ -31,6 +31,7 @@ import com.zsmartsystems.zigbee.ZigBeeCommand;
 import com.zsmartsystems.zigbee.ZigBeeEndpointAddress;
 import com.zsmartsystems.zigbee.ZigBeeNetworkManager;
 import com.zsmartsystems.zigbee.ZigBeeNode;
+import com.zsmartsystems.zigbee.ZigBeeNode.ZigBeeNodeState;
 import com.zsmartsystems.zigbee.transaction.ZigBeeTransactionFuture;
 import com.zsmartsystems.zigbee.transaction.ZigBeeTransactionMatcher;
 import com.zsmartsystems.zigbee.zdo.ZdoCommandType;
@@ -159,6 +160,7 @@ public class ZigBeeNetworkDiscovererTest {
 
         ZigBeeNode node = nodeCapture.getValue();
         assertNotNull(node);
+        assertEquals(ZigBeeNodeState.ONLINE, node.getNodeState());
         assertEquals(Integer.valueOf(0), node.getNetworkAddress());
         assertEquals(new IeeeAddress("1234567890ABCDEF"), node.getIeeeAddress());
         assertEquals(1, node.getEndpoints().size());

--- a/com.zsmartsystems.zigbee/src/test/resource/logs/cluster-FFFF-General.txt
+++ b/com.zsmartsystems.zigbee/src/test/resource/logs/cluster-FFFF-General.txt
@@ -1,0 +1,15 @@
+# This file contains commands that will be parsed, and processed in the tests.
+# The format must be two lines, with a ZigBeeApsFrame frame followed by the ZigBeeCommand it translates to
+# Comments can be added with the # on the first character and empty lines are allowed
+
+ZigBeeApsFrame [sourceAddress=0/1, destinationAddress=29303/3, profile=0104, cluster=0006, addressMode=DEVICE, radius=31, apsSecurity=false, apsCounter=51, payload=00 51 06 00 00 00 10 01 00 20 1C]
+ConfigureReportingCommand [On/Off: 0/0 -> 29303/3, cluster=0006, TID=51, records=[AttributeReportingConfigurationRecord: [attributeDataType=BOOLEAN, attributeIdentifier=0, direction=0, minimumReportingInterval=1, maximumReportingInterval=7200]]]
+
+ZigBeeApsFrame [sourceAddress=0/1, destinationAddress=18314/3, profile=0104, cluster=0006, addressMode=DEVICE, radius=31, apsSecurity=false, apsCounter=15, payload=00 15 0C 00 00 0A]
+DiscoverAttributesCommand [On/Off: 0/0 -> 18314/3, cluster=0006, TID=15, startAttributeIdentifier=0, maximumAttributeIdentifiers=10]
+
+ZigBeeApsFrame [sourceAddress=18314/3, destinationAddress=0/1, profile=0104, cluster=0006, addressMode=null, radius=0, apsSecurity=false, apsCounter=17, payload=18 15 0D 01 00 00 10 00 40 10 01 40 21 02 40 21]
+DiscoverAttributesResponse [On/Off: 18314/3 -> 0/1, cluster=0006, TID=15, discoveryComplete=true, attributeInformation=[Attribute Information [dataType=BOOLEAN, identifier=0], Attribute Information [dataType=BOOLEAN, identifier=16384], Attribute Information [dataType=UNSIGNED_16_BIT_INTEGER, identifier=16385], Attribute Information [dataType=UNSIGNED_16_BIT_INTEGER, identifier=16386]]]
+
+ZigBeeApsFrame [sourceAddress=0/1, destinationAddress=18314/3, profile=0104, cluster=0006, addressMode=DEVICE, radius=31, apsSecurity=false, apsCounter=11, payload=00 11 11 00 14]
+DiscoverCommandsReceived [On/Off: 0/0 -> 18314/3, cluster=0006, TID=11, startCommandIdentifier=0, maximumCommandIdentifiers=20]


### PR DESCRIPTION
With this PR, the framework will no longer remove nodes when the coordinator reports they have LEFT the network. Instead the node is marked OFFLINE, and it is marked ONLINE again when an ANNOUNCE is received.

This avoids having to rediscover information about the device when the device leaves the network and immediately rejoins.

It is expected that the application remove the node when it knowns it will not be coming back.

Closes #462 
Signed-off-by: Chris Jackson <chris@cd-jackson.com>