### PR TITLE
Updates to start/stop discovery and add more discovery tests

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeNodeServiceDiscoverer.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeNodeServiceDiscoverer.java
@@ -232,6 +232,8 @@ public class ZigBeeNodeServiceDiscoverer {
     }
 
     /**
+     * Gets the maximum backoff counter. If this number of retries are sent, the request will fail.
+     *
      * @return the maxBackoff
      */
     public int getMaxBackoff() {
@@ -239,6 +241,8 @@ public class ZigBeeNodeServiceDiscoverer {
     }
 
     /**
+     * Sets the maximum backoff counter. If this number of retries are sent, the request will fail.
+     *
      * @param maxBackoff the maxBackoff to set
      */
     public void setMaxBackoff(int maxBackoff) {
@@ -560,9 +564,7 @@ public class ZigBeeNodeServiceDiscoverer {
         @Override
         public void run() {
             try {
-                logger.debug("{}: Node SVC Discovery: running", node.getIeeeAddress());
                 NodeDiscoveryTask discoveryTask;
-
                 synchronized (discoveryTasks) {
                     discoveryTask = discoveryTasks.peek();
                 }
@@ -572,6 +574,7 @@ public class ZigBeeNodeServiceDiscoverer {
                     networkManager.updateNode(node);
                     return;
                 }
+                logger.debug("{}: Node SVC Discovery: running {}", node.getIeeeAddress(), discoveryTask);
 
                 boolean success = false;
                 switch (discoveryTask) {
@@ -607,9 +610,8 @@ public class ZigBeeNodeServiceDiscoverer {
                     synchronized (discoveryTasks) {
                         discoveryTasks.remove(discoveryTask);
                     }
-                    logger.debug("{}: Node SVC Discovery: request {} successful. Advanced to {}.",
+                    logger.debug("{}: Node SVC Discovery: request {} successful. Advancing to {}.",
                             node.getIeeeAddress(), discoveryTask, discoveryTasks.peek());
-
                     retryCnt = 0;
                 } else if (retryCnt > maxBackoff) {
                     logger.debug("{}: Node SVC Discovery: request {} failed after {} attempts.", node.getIeeeAddress(),
@@ -667,8 +669,9 @@ public class ZigBeeNodeServiceDiscoverer {
 
     /**
      * Starts service discovery for the node in order to update the mesh. This adds the
-     * {@link NodeDiscoveryTask#NEIGHBORS} and {@link NodeDiscoveryTask#ROUTES} tasks to the task list. Note that
-     * {@link NodeDiscoveryTask#ROUTES} is not added for end devices.
+     * {@link NodeDiscoveryTask#NEIGHBORS} and {@link NodeDiscoveryTask#ROUTES} tasks to the task list.
+     * <p>
+     * Note that {@link NodeDiscoveryTask#ROUTES} is not added for end devices.
      */
     public void updateMesh() {
         logger.debug("{}: Node SVC Discovery: Update mesh", node.getIeeeAddress());

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/TestUtilities.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/TestUtilities.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2016-2018 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+
+/**
+ *
+ * @author Chris Jackson
+ *
+ */
+public class TestUtilities {
+
+    static public void setField(Class clazz, Object object, String fieldName, Object newValue) throws Exception {
+        Field field = clazz.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        Field modifiersField = Field.class.getDeclaredField("modifiers");
+        modifiersField.setAccessible(true);
+        modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
+        field.set(object, newValue);
+    }
+
+}

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeDiscoveryExtensionTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeDiscoveryExtensionTest.java
@@ -9,14 +9,23 @@ package com.zsmartsystems.zigbee.app.discovery;
 
 import static org.junit.Assert.assertEquals;
 
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
 import org.junit.Test;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
+import com.zsmartsystems.zigbee.IeeeAddress;
+import com.zsmartsystems.zigbee.TestUtilities;
 import com.zsmartsystems.zigbee.ZigBeeCommandListener;
 import com.zsmartsystems.zigbee.ZigBeeNetworkManager;
 import com.zsmartsystems.zigbee.ZigBeeNetworkNodeListener;
+import com.zsmartsystems.zigbee.ZigBeeNode;
+import com.zsmartsystems.zigbee.ZigBeeNode.ZigBeeNodeState;
 import com.zsmartsystems.zigbee.ZigBeeStatus;
+import com.zsmartsystems.zigbee.zdo.command.DeviceAnnounce;
+import com.zsmartsystems.zigbee.zdo.command.ManagementLeaveResponse;
 
 /**
  *
@@ -25,19 +34,80 @@ import com.zsmartsystems.zigbee.ZigBeeStatus;
  */
 public class ZigBeeDiscoveryExtensionTest {
     @Test
-    public void test() {
+    public void test() throws Exception {
         ZigBeeNetworkManager networkManager = Mockito.mock(ZigBeeNetworkManager.class);
 
-        ZigBeeDiscoveryExtension extension = new ZigBeeDiscoveryExtension();
+        ZigBeeNode node = Mockito.mock(ZigBeeNode.class);
+        Mockito.when(node.getIeeeAddress()).thenReturn(new IeeeAddress("1234567890ABCDEF"));
+        Mockito.when(node.getNodeState()).thenReturn(ZigBeeNodeState.ONLINE);
+
+        ZigBeeDiscoveryExtension extension = Mockito.spy(ZigBeeDiscoveryExtension.class);
+        Mockito.doNothing().when(extension).startDiscovery(node);
+        Mockito.doNothing().when(extension).stopDiscovery(node);
+        Mockito.doNothing().when(extension).startScheduler(ArgumentMatchers.any(int.class));
+
         extension.setUpdatePeriod(0);
 
         assertEquals(ZigBeeStatus.SUCCESS, extension.extensionInitialize(networkManager));
         extension.extensionStartup();
 
+        extension.setUpdatePeriod(0);
+        Mockito.verify(extension, Mockito.times(1)).stopScheduler();
+        assertEquals(0, extension.getUpdatePeriod());
+
+        extension.setUpdatePeriod(1);
+        Mockito.verify(extension, Mockito.times(1)).startScheduler(1);
+        assertEquals(1, extension.getUpdatePeriod());
+
         Mockito.verify(networkManager, Mockito.timeout(1000).atLeast(1))
                 .addNetworkNodeListener(ArgumentMatchers.any(ZigBeeNetworkNodeListener.class));
         Mockito.verify(networkManager, Mockito.timeout(1000).atLeast(1))
                 .addCommandListener(ArgumentMatchers.any(ZigBeeCommandListener.class));
+
+        extension.nodeAdded(node);
+        Mockito.verify(extension, Mockito.times(1)).startDiscovery(node);
+
+        Map<IeeeAddress, ZigBeeNodeServiceDiscoverer> nodeDiscovery = new ConcurrentHashMap<>();
+        nodeDiscovery.put(node.getIeeeAddress(), Mockito.mock(ZigBeeNodeServiceDiscoverer.class));
+        TestUtilities.setField(ZigBeeDiscoveryExtension.class, extension, "nodeDiscovery", nodeDiscovery);
+
+        assertEquals(1, extension.getNodeDiscoverers().size());
+
+        // Add again and make sure we don't call startDiscovery again
+        extension.nodeAdded(node);
+        Mockito.verify(extension, Mockito.times(1)).startDiscovery(node);
+
+        // Updated node when ONLINE should not do anything
+        extension.nodeUpdated(node);
+        Mockito.verify(extension, Mockito.times(1)).startDiscovery(node);
+        Mockito.verify(extension, Mockito.times(0)).stopDiscovery(node);
+
+        // Updated node when OFFLINE should stop discovery
+        Mockito.when(node.getNodeState()).thenReturn(ZigBeeNodeState.OFFLINE);
+        extension.nodeUpdated(node);
+        Mockito.verify(extension, Mockito.times(1)).startDiscovery(node);
+        Mockito.verify(extension, Mockito.times(1)).stopDiscovery(node);
+
+        // Remove node should also stopDiscovery
+        extension.nodeRemoved(node);
+        Mockito.verify(extension, Mockito.times(1)).startDiscovery(node);
+        Mockito.verify(extension, Mockito.times(2)).stopDiscovery(node);
+
+        nodeDiscovery.clear();
+
+        // Updated node when ONLINE and node not known should start discovery
+        Mockito.when(node.getNodeState()).thenReturn(ZigBeeNodeState.ONLINE);
+        extension.nodeUpdated(node);
+        Mockito.verify(extension, Mockito.times(2)).startDiscovery(node);
+        Mockito.verify(extension, Mockito.times(2)).stopDiscovery(node);
+
+        ManagementLeaveResponse leave = Mockito.mock(ManagementLeaveResponse.class);
+        extension.commandReceived(leave);
+        Mockito.verify(extension, Mockito.times(1)).refresh();
+
+        DeviceAnnounce announce = Mockito.mock(DeviceAnnounce.class);
+        extension.commandReceived(announce);
+        Mockito.verify(extension, Mockito.times(2)).refresh();
 
         extension.extensionShutdown();
 
@@ -45,7 +115,5 @@ public class ZigBeeDiscoveryExtensionTest {
                 .removeNetworkNodeListener(ArgumentMatchers.any(ZigBeeNetworkNodeListener.class));
         Mockito.verify(networkManager, Mockito.timeout(1000).atLeast(1))
                 .removeCommandListener(ArgumentMatchers.any(ZigBeeCommandListener.class));
-
-        assertEquals(0, extension.getUpdatePeriod());
     }
 }

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeNetworkDiscovererTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeNetworkDiscovererTest.java
@@ -10,14 +10,11 @@ package com.zsmartsystems.zigbee.app.discovery;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Future;
 
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
@@ -31,20 +28,13 @@ import com.zsmartsystems.zigbee.ZigBeeCommand;
 import com.zsmartsystems.zigbee.ZigBeeEndpointAddress;
 import com.zsmartsystems.zigbee.ZigBeeNetworkManager;
 import com.zsmartsystems.zigbee.ZigBeeNode;
-import com.zsmartsystems.zigbee.ZigBeeNode.ZigBeeNodeState;
 import com.zsmartsystems.zigbee.transaction.ZigBeeTransactionFuture;
 import com.zsmartsystems.zigbee.transaction.ZigBeeTransactionMatcher;
+import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zdo.ZdoCommandType;
 import com.zsmartsystems.zigbee.zdo.ZdoStatus;
-import com.zsmartsystems.zigbee.zdo.command.ActiveEndpointsResponse;
 import com.zsmartsystems.zigbee.zdo.command.DeviceAnnounce;
 import com.zsmartsystems.zigbee.zdo.command.IeeeAddressResponse;
-import com.zsmartsystems.zigbee.zdo.command.NodeDescriptorResponse;
-import com.zsmartsystems.zigbee.zdo.command.PowerDescriptorResponse;
-import com.zsmartsystems.zigbee.zdo.command.SimpleDescriptorResponse;
-import com.zsmartsystems.zigbee.zdo.field.NodeDescriptor;
-import com.zsmartsystems.zigbee.zdo.field.PowerDescriptor;
-import com.zsmartsystems.zigbee.zdo.field.SimpleDescriptor;
 
 /**
  *
@@ -52,20 +42,16 @@ import com.zsmartsystems.zigbee.zdo.field.SimpleDescriptor;
  *
  */
 public class ZigBeeNetworkDiscovererTest {
+    static final int TIMEOUT = 5000;
+
     ZigBeeNetworkManager networkManager;
     ArgumentCaptor<ZigBeeNode> nodeCapture;
-    // ArgumentCaptor<ZigBeeCommand> commandCapture;
-    // ArgumentCaptor<CommandResponseMatcher> matcherCapture;
     Map<Integer, ZigBeeCommand> responses = new HashMap<Integer, ZigBeeCommand>();
 
     @Before
     public void setupTest() {
         networkManager = Mockito.mock(ZigBeeNetworkManager.class);
         nodeCapture = ArgumentCaptor.forClass(ZigBeeNode.class);
-        // commandCapture = ArgumentCaptor.forClass(ZigBeeCommand.class);
-        // matcherCapture = ArgumentCaptor.forClass(CommandResponseMatcher.class);
-
-        // Mockito.when(networkManager.unicast(commandCapture.capture(), matcherCapture.capture())).thenReturn(null);
 
         Mockito.doAnswer(new Answer<Future<CommandResult>>() {
             @Override
@@ -90,7 +76,6 @@ public class ZigBeeNetworkDiscovererTest {
         }).when(networkManager).executeTask(ArgumentMatchers.any(Runnable.class));
     }
 
-    @Ignore
     @Test
     public void testNormal() {
         // Add all the required responses to a list
@@ -100,51 +85,6 @@ public class ZigBeeNetworkDiscovererTest {
         ieeeResponse.setDestinationAddress(new ZigBeeEndpointAddress(0));
         ieeeResponse.setIeeeAddrRemoteDev(new IeeeAddress("1234567890ABCDEF"));
         responses.put(ZdoCommandType.IEEE_ADDRESS_REQUEST.getClusterId(), ieeeResponse);
-
-        NodeDescriptorResponse nodeResponse = new NodeDescriptorResponse();
-        nodeResponse.setStatus(ZdoStatus.SUCCESS);
-        nodeResponse.setSourceAddress(new ZigBeeEndpointAddress(0));
-        nodeResponse.setDestinationAddress(new ZigBeeEndpointAddress(0));
-        nodeResponse.setNwkAddrOfInterest(0);
-        NodeDescriptor nodeDescriptor = new NodeDescriptor();
-        nodeResponse.setNodeDescriptor(nodeDescriptor);
-        responses.put(ZdoCommandType.NODE_DESCRIPTOR_REQUEST.getClusterId(), nodeResponse);
-
-        PowerDescriptorResponse powerResponse = new PowerDescriptorResponse();
-        powerResponse.setStatus(ZdoStatus.SUCCESS);
-        powerResponse.setSourceAddress(new ZigBeeEndpointAddress(0));
-        powerResponse.setDestinationAddress(new ZigBeeEndpointAddress(0));
-        powerResponse.setNwkAddrOfInterest(0);
-        PowerDescriptor powerDescriptor = new PowerDescriptor();
-        powerResponse.setPowerDescriptor(powerDescriptor);
-        responses.put(ZdoCommandType.POWER_DESCRIPTOR_REQUEST.getClusterId(), powerResponse);
-
-        ActiveEndpointsResponse endpointsResponse = new ActiveEndpointsResponse();
-        endpointsResponse.setStatus(ZdoStatus.SUCCESS);
-        endpointsResponse.setSourceAddress(new ZigBeeEndpointAddress(0));
-        endpointsResponse.setDestinationAddress(new ZigBeeEndpointAddress(0));
-        endpointsResponse.setNwkAddrOfInterest(0);
-        List<Integer> activeEpList = new ArrayList<Integer>();
-        activeEpList.add(1);
-        endpointsResponse.setActiveEpList(activeEpList);
-        responses.put(ZdoCommandType.ACTIVE_ENDPOINTS_REQUEST.getClusterId(), endpointsResponse);
-
-        SimpleDescriptorResponse simpleResponse = new SimpleDescriptorResponse();
-        simpleResponse.setStatus(ZdoStatus.SUCCESS);
-        simpleResponse.setSourceAddress(new ZigBeeEndpointAddress(0));
-        simpleResponse.setDestinationAddress(new ZigBeeEndpointAddress(0, 1));
-        simpleResponse.setNwkAddrOfInterest(0);
-        SimpleDescriptor simpleDescriptor = new SimpleDescriptor();
-        simpleDescriptor.setDeviceId(0);
-        simpleDescriptor.setDeviceVersion(0);
-        simpleDescriptor.setEndpoint(1);
-        simpleDescriptor.setProfileId(0x104);
-        List<Integer> inputClusterList = new ArrayList<Integer>();
-        List<Integer> outputClusterList = new ArrayList<Integer>();
-        simpleDescriptor.setInputClusterList(inputClusterList);
-        simpleDescriptor.setOutputClusterList(outputClusterList);
-        simpleResponse.setSimpleDescriptor(simpleDescriptor);
-        responses.put(ZdoCommandType.SIMPLE_DESCRIPTOR_REQUEST.getClusterId(), simpleResponse);
 
         ZigBeeNetworkDiscoverer discoverer = new ZigBeeNetworkDiscoverer(networkManager);
 
@@ -156,14 +96,13 @@ public class ZigBeeNetworkDiscovererTest {
         Mockito.verify(networkManager).addAnnounceListener(discoverer);
 
         // Then wait for the node to be added
-        Mockito.verify(networkManager, Mockito.timeout(5000).times(1)).addNode(nodeCapture.capture());
+        Mockito.verify(networkManager, Mockito.timeout(TIMEOUT).times(1)).addNode(nodeCapture.capture());
 
         ZigBeeNode node = nodeCapture.getValue();
         assertNotNull(node);
-        assertEquals(ZigBeeNodeState.ONLINE, node.getNodeState());
         assertEquals(Integer.valueOf(0), node.getNetworkAddress());
         assertEquals(new IeeeAddress("1234567890ABCDEF"), node.getIeeeAddress());
-        assertEquals(1, node.getEndpoints().size());
+        assertEquals(0, node.getEndpoints().size());
     }
 
     @Test
@@ -178,9 +117,17 @@ public class ZigBeeNetworkDiscovererTest {
         announce.setNwkAddrOfInterest(12345);
 
         ZigBeeNetworkDiscoverer discoverer = new ZigBeeNetworkDiscoverer(networkManager);
-        discoverer.commandReceived(announce);
+        discoverer.setRetryPeriod(0);
+        discoverer.setRequeryPeriod(0);
+        discoverer.setRetryCount(0);
 
+        discoverer.commandReceived(announce);
         Mockito.verify(node, Mockito.times(1)).setNetworkAddress(ArgumentMatchers.anyInt());
 
+        ZigBeeEndpointAddress address = Mockito.mock(ZigBeeEndpointAddress.class);
+        Mockito.when(address.getAddress()).thenReturn(12345);
+        ZclCommand zclCommand = Mockito.mock(ZclCommand.class);
+        Mockito.when(zclCommand.getSourceAddress()).thenReturn(address);
+        discoverer.commandReceived(zclCommand);
     }
 }

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeNodeServiceDiscovererTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeNodeServiceDiscovererTest.java
@@ -1,0 +1,220 @@
+/**
+ * Copyright (c) 2016-2018 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.app.discovery;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Future;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import com.zsmartsystems.zigbee.CommandResult;
+import com.zsmartsystems.zigbee.IeeeAddress;
+import com.zsmartsystems.zigbee.TestUtilities;
+import com.zsmartsystems.zigbee.ZigBeeCommand;
+import com.zsmartsystems.zigbee.ZigBeeEndpoint;
+import com.zsmartsystems.zigbee.ZigBeeEndpointAddress;
+import com.zsmartsystems.zigbee.ZigBeeNetworkManager;
+import com.zsmartsystems.zigbee.ZigBeeNode;
+import com.zsmartsystems.zigbee.transaction.ZigBeeTransactionFuture;
+import com.zsmartsystems.zigbee.transaction.ZigBeeTransactionMatcher;
+import com.zsmartsystems.zigbee.zdo.ZdoCommandType;
+import com.zsmartsystems.zigbee.zdo.ZdoStatus;
+import com.zsmartsystems.zigbee.zdo.command.ActiveEndpointsResponse;
+import com.zsmartsystems.zigbee.zdo.command.IeeeAddressResponse;
+import com.zsmartsystems.zigbee.zdo.command.ManagementLqiResponse;
+import com.zsmartsystems.zigbee.zdo.command.ManagementRoutingResponse;
+import com.zsmartsystems.zigbee.zdo.command.NetworkAddressResponse;
+import com.zsmartsystems.zigbee.zdo.command.NodeDescriptorResponse;
+import com.zsmartsystems.zigbee.zdo.command.PowerDescriptorResponse;
+import com.zsmartsystems.zigbee.zdo.command.SimpleDescriptorResponse;
+import com.zsmartsystems.zigbee.zdo.field.NeighborTable;
+import com.zsmartsystems.zigbee.zdo.field.NodeDescriptor;
+import com.zsmartsystems.zigbee.zdo.field.NodeDescriptor.LogicalType;
+import com.zsmartsystems.zigbee.zdo.field.PowerDescriptor;
+import com.zsmartsystems.zigbee.zdo.field.PowerDescriptor.CurrentPowerModeType;
+import com.zsmartsystems.zigbee.zdo.field.RoutingTable;
+import com.zsmartsystems.zigbee.zdo.field.SimpleDescriptor;
+
+/**
+ *
+ * @author Chris Jackson
+ *
+ */
+public class ZigBeeNodeServiceDiscovererTest {
+    static final int TIMEOUT = 5000;
+
+    ZigBeeNetworkManager networkManager;
+    ArgumentCaptor<ZigBeeNode> nodeCapture;
+    ArgumentCaptor<ZigBeeEndpoint> endpointCapture;
+    Map<Integer, ZigBeeCommand> responses = new HashMap<Integer, ZigBeeCommand>();
+
+    @Before
+    public void setupTest() {
+        networkManager = Mockito.mock(ZigBeeNetworkManager.class);
+        nodeCapture = ArgumentCaptor.forClass(ZigBeeNode.class);
+        endpointCapture = ArgumentCaptor.forClass(ZigBeeEndpoint.class);
+
+        Mockito.doAnswer(new Answer<Future<CommandResult>>() {
+            @Override
+            public Future<CommandResult> answer(InvocationOnMock invocation) {
+                ZigBeeCommand command = (ZigBeeCommand) invocation.getArguments()[0];
+
+                ZigBeeTransactionFuture commandFuture = new ZigBeeTransactionFuture();
+                CommandResult result = new CommandResult(responses.get(command.getClusterId()));
+                commandFuture.set(result);
+                return commandFuture;
+            }
+        }).when(networkManager).sendTransaction(ArgumentMatchers.any(ZigBeeCommand.class),
+                ArgumentMatchers.any(ZigBeeTransactionMatcher.class));
+
+        Mockito.doAnswer(new Answer<Void>() {
+            @Override
+            public Void answer(InvocationOnMock invocation) {
+                Runnable runnable = (Runnable) invocation.getArguments()[0];
+                new Thread(runnable).start();
+                return null;
+            }
+        }).when(networkManager).scheduleTask(ArgumentMatchers.any(Runnable.class), ArgumentMatchers.any(long.class));
+
+        Mockito.doAnswer(new Answer<Void>() {
+            @Override
+            public Void answer(InvocationOnMock invocation) {
+                Runnable runnable = (Runnable) invocation.getArguments()[1];
+                new Thread(runnable).start();
+                return null;
+            }
+        }).when(networkManager).rescheduleTask(ArgumentMatchers.any(), ArgumentMatchers.any(Runnable.class),
+                ArgumentMatchers.any(long.class));
+    }
+
+    @Test
+    public void test() throws Exception {
+        ZigBeeNode node = Mockito.mock(ZigBeeNode.class);
+        ZigBeeNodeServiceDiscoverer discoverer = new ZigBeeNodeServiceDiscoverer(networkManager, node);
+
+        TestUtilities.setField(ZigBeeNodeServiceDiscoverer.class, discoverer, "retryPeriod", 1);
+
+        NodeDescriptor initialNodeDescriptor = Mockito.mock(NodeDescriptor.class);
+        Mockito.when(initialNodeDescriptor.getLogicalType()).thenReturn(LogicalType.UNKNOWN);
+        Mockito.when(node.getNodeDescriptor()).thenReturn(initialNodeDescriptor);
+
+        PowerDescriptor initialPowerDescriptor = Mockito.mock(PowerDescriptor.class);
+        Mockito.when(initialPowerDescriptor.getCurrentPowerMode()).thenReturn(CurrentPowerModeType.UNKNOWN);
+        Mockito.when(node.getPowerDescriptor()).thenReturn(initialPowerDescriptor);
+
+        Mockito.when(node.getNetworkAddress()).thenReturn(123);
+
+        discoverer.setMaxBackoff(10);
+        assertEquals(10, discoverer.getMaxBackoff());
+
+        assertTrue(discoverer.getTasks().isEmpty());
+
+        assertEquals(node, discoverer.getNode());
+
+        // Add all the required responses to a list
+        NetworkAddressResponse nwkResponse = new NetworkAddressResponse();
+        nwkResponse.setStatus(ZdoStatus.SUCCESS);
+        nwkResponse.setSourceAddress(new ZigBeeEndpointAddress(123));
+        nwkResponse.setDestinationAddress(new ZigBeeEndpointAddress(0));
+        nwkResponse.setNwkAddrRemoteDev(123);
+        responses.put(ZdoCommandType.NETWORK_ADDRESS_REQUEST.getClusterId(), nwkResponse);
+
+        IeeeAddressResponse ieeeResponse = new IeeeAddressResponse();
+        ieeeResponse.setStatus(ZdoStatus.SUCCESS);
+        ieeeResponse.setSourceAddress(new ZigBeeEndpointAddress(123));
+        ieeeResponse.setDestinationAddress(new ZigBeeEndpointAddress(0));
+        ieeeResponse.setIeeeAddrRemoteDev(new IeeeAddress("1234567890ABCDEF"));
+        responses.put(ZdoCommandType.IEEE_ADDRESS_REQUEST.getClusterId(), ieeeResponse);
+
+        NodeDescriptorResponse nodeResponse = new NodeDescriptorResponse();
+        nodeResponse.setStatus(ZdoStatus.SUCCESS);
+        nodeResponse.setSourceAddress(new ZigBeeEndpointAddress(123));
+        nodeResponse.setDestinationAddress(new ZigBeeEndpointAddress(0));
+        nodeResponse.setNwkAddrOfInterest(0);
+        NodeDescriptor nodeDescriptor = new NodeDescriptor();
+        nodeResponse.setNodeDescriptor(nodeDescriptor);
+        responses.put(ZdoCommandType.NODE_DESCRIPTOR_REQUEST.getClusterId(), nodeResponse);
+
+        PowerDescriptorResponse powerResponse = new PowerDescriptorResponse();
+        powerResponse.setStatus(ZdoStatus.SUCCESS);
+        powerResponse.setSourceAddress(new ZigBeeEndpointAddress(123));
+        powerResponse.setDestinationAddress(new ZigBeeEndpointAddress(0));
+        powerResponse.setNwkAddrOfInterest(0);
+        PowerDescriptor powerDescriptor = new PowerDescriptor();
+        powerResponse.setPowerDescriptor(powerDescriptor);
+        responses.put(ZdoCommandType.POWER_DESCRIPTOR_REQUEST.getClusterId(), powerResponse);
+
+        ActiveEndpointsResponse endpointsResponse = new ActiveEndpointsResponse();
+        endpointsResponse.setStatus(ZdoStatus.SUCCESS);
+        endpointsResponse.setSourceAddress(new ZigBeeEndpointAddress(123));
+        endpointsResponse.setDestinationAddress(new ZigBeeEndpointAddress(0));
+        endpointsResponse.setNwkAddrOfInterest(0);
+        List<Integer> activeEpList = new ArrayList<Integer>();
+        activeEpList.add(1);
+        endpointsResponse.setActiveEpList(activeEpList);
+        responses.put(ZdoCommandType.ACTIVE_ENDPOINTS_REQUEST.getClusterId(), endpointsResponse);
+
+        SimpleDescriptorResponse simpleResponse = new SimpleDescriptorResponse();
+        simpleResponse.setStatus(ZdoStatus.SUCCESS);
+        simpleResponse.setSourceAddress(new ZigBeeEndpointAddress(123));
+        simpleResponse.setDestinationAddress(new ZigBeeEndpointAddress(0, 1));
+        simpleResponse.setNwkAddrOfInterest(0);
+        SimpleDescriptor simpleDescriptor = new SimpleDescriptor();
+        simpleDescriptor.setDeviceId(0);
+        simpleDescriptor.setDeviceVersion(0);
+        simpleDescriptor.setEndpoint(1);
+        simpleDescriptor.setProfileId(0x104);
+        List<Integer> inputClusterList = new ArrayList<Integer>();
+        List<Integer> outputClusterList = new ArrayList<Integer>();
+        simpleDescriptor.setInputClusterList(inputClusterList);
+        simpleDescriptor.setOutputClusterList(outputClusterList);
+        simpleResponse.setSimpleDescriptor(simpleDescriptor);
+        responses.put(ZdoCommandType.SIMPLE_DESCRIPTOR_REQUEST.getClusterId(), simpleResponse);
+
+        ManagementLqiResponse lqiRequest = new ManagementLqiResponse();
+        lqiRequest.setStatus(ZdoStatus.SUCCESS);
+        lqiRequest.setSourceAddress(new ZigBeeEndpointAddress(123));
+        lqiRequest.setDestinationAddress(new ZigBeeEndpointAddress(0));
+        lqiRequest.setStartIndex(0);
+        lqiRequest.setNeighborTableEntries(0);
+        lqiRequest.setNeighborTableList(new ArrayList<NeighborTable>());
+        responses.put(ZdoCommandType.MANAGEMENT_LQI_REQUEST.getClusterId(), lqiRequest);
+
+        ManagementRoutingResponse routingResponse = new ManagementRoutingResponse();
+        routingResponse.setStatus(ZdoStatus.SUCCESS);
+        routingResponse.setSourceAddress(new ZigBeeEndpointAddress(123));
+        routingResponse.setDestinationAddress(new ZigBeeEndpointAddress(0));
+        routingResponse.setStartIndex(0);
+        routingResponse.setRoutingTableList(new ArrayList<RoutingTable>());
+        routingResponse.setRoutingTableEntries(0);
+        responses.put(ZdoCommandType.MANAGEMENT_ROUTING_REQUEST.getClusterId(), routingResponse);
+
+        discoverer.startDiscovery();
+
+        Mockito.verify(node, Mockito.timeout(TIMEOUT).times(1)).addEndpoint(endpointCapture.capture());
+
+        // Then wait for the node to be updated
+        Mockito.verify(networkManager, Mockito.timeout(TIMEOUT).times(1)).updateNode(nodeCapture.capture());
+
+        ZigBeeEndpoint endpoint = endpointCapture.getValue();
+        assertEquals(1, endpoint.getEndpointId());
+        assertEquals(node, endpoint.getParentNode());
+    }
+}


### PR DESCRIPTION
The main change here is to start/stop discovery when the ```nodeUpdated``` call is made with the ```ONLINE``` or ```OFFLINE``` state changed.
This also improves the shutdown and adds more tests.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>