### PR TITLE
Don't poll ASH state when ASH layer is OFFLINE

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
@@ -432,6 +432,10 @@ public class ZigBeeDongleEzsp implements ZigBeeTransportTransmit, ZigBeeTranspor
         pollingTimer = pollingScheduler.scheduleWithFixedDelay(new Runnable() {
             @Override
             public void run() {
+                // Don't poll the state if the network is down
+                if (!networkStateUp) {
+                    return;
+                }
                 frameHandler.queueFrame(new EzspNetworkStateRequest());
             }
         }, pollRate, pollRate, TimeUnit.MILLISECONDS);


### PR DESCRIPTION
This makes two changes relating to the polling of the ASH layer.

1) It doesn't poll the state if the ESZP layer is OFFLINE. This avoids any polling during startup, and also when the ASH layer has closed.
2) If there is an error in the ASH layer, the ASH layer is closed and no further transactions are accepted. Once there is an error, the upper layers need to reinitialise the NCP, so this should have no negative impact.

Closes #494 

Signed-off-by: Chris Jackson <chris@cd-jackson.com>