### PR TITLE
Improve Ember bootloader to allow recovery from situation where bootloader is already running

### DIFF
--- a/com.zsmartsystems.zigbee.console.main/src/main/java/com/zsmartsystems/zigbee/console/main/ZigBeeConsoleMain.java
+++ b/com.zsmartsystems.zigbee.console.main/src/main/java/com/zsmartsystems/zigbee/console/main/ZigBeeConsoleMain.java
@@ -236,7 +236,13 @@ public class ZigBeeConsoleMain {
         final ZigBeeConsole console = new ZigBeeConsole(networkManager, dongle, commands);
 
         // Initialise the network
-        networkManager.initialize();
+        ZigBeeStatus initResponse = networkManager.initialize();
+        System.out.println("networkManager.initialize returned " + initResponse);
+        if (initResponse != ZigBeeStatus.SUCCESS) {
+            console.start();
+            System.out.println("Console closed.");
+            return;
+        }
 
         System.out.println("PAN ID          = " + networkManager.getZigBeePanId());
         System.out.println("Extended PAN ID = " + networkManager.getZigBeeExtendedPanId());

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/EmberNcp.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/EmberNcp.java
@@ -145,6 +145,10 @@ public class EmberNcp {
         EzspTransaction transaction = protocolHandler
                 .sendEzspTransaction(new EzspSingleResponseTransaction(request, EzspVersionResponse.class));
         EzspVersionResponse response = (EzspVersionResponse) transaction.getResponse();
+        if (response == null) {
+            logger.debug("No response from ezspVersion command");
+            return null;
+        }
         logger.debug(response.toString());
         lastStatus = null;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/ash/AshFrameHandler.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/ash/AshFrameHandler.java
@@ -506,7 +506,6 @@ public class AshFrameHandler implements EzspProtocolHandler {
     @Override
     public synchronized void connect() {
         stateConnected = false;
-        AshFrame reset = new AshFrameRst();
 
         ackNum = 0;
         frmNum = 0;
@@ -515,7 +514,7 @@ public class AshFrameHandler implements EzspProtocolHandler {
 
         receiveTimeout = T_RX_ACK_INIT;
 
-        sendFrame(reset);
+        sendFrame(new AshFrameRst());
     }
 
     private void disconnect() {
@@ -590,6 +589,12 @@ public class AshFrameHandler implements EzspProtocolHandler {
                 // Too many retries.
                 // We should alert the upper layer so they can reset the link?
                 disconnect();
+                return;
+            }
+
+            // If we're not connected, then try the reset again
+            if (!stateConnected) {
+                sendFrame(new AshFrameRst());
                 return;
             }
 

--- a/com.zsmartsystems.zigbee.serial/src/main/java/com/zsmartsystems/zigbee/serial/ZigBeeSerialPort.java
+++ b/com.zsmartsystems.zigbee.serial/src/main/java/com/zsmartsystems/zigbee/serial/ZigBeeSerialPort.java
@@ -214,7 +214,6 @@ public class ZigBeeSerialPort implements ZigBeePort, SerialPortEventListener {
             }
             return -1;
         } catch (InterruptedException e) {
-            e.printStackTrace();
         }
         return -1;
     }


### PR DESCRIPTION
This allows recovery if an Ember NCP is already in the bootloader (eg because a previous firmware load failed, leaving the NCP without valid firmware).  This simply assumes that if the bootloader can't be entered, that the bootloader may already be running so tries the bootloader commands.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>