### PR TITLE
Add manufacturer-specific infos when serializing ZCL frames

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/ZclHeader.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/ZclHeader.java
@@ -336,16 +336,23 @@ public class ZclHeader {
                 break;
         }
 
+        frameControl |= manufacturerSpecific ? MASK_MANUFACTURER_SPECIFIC : 0b00000000;
         frameControl |= direction == ZclCommandDirection.SERVER_TO_CLIENT ? MASK_DIRECTION : 0b00000000;
         frameControl |= disableDefaultResponse ? MASK_DEFAULT_RESPONSE : 0b00000000;
 
-        int[] zclFrame = new int[payload.length + 3];
+        int manufacturerCodeLength = manufacturerSpecific ? 2 : 0;
+
+        int[] zclFrame = new int[payload.length + 3 + manufacturerCodeLength];
         zclFrame[0] = frameControl;
-        zclFrame[1] = sequenceNumber;
-        zclFrame[2] = commandId;
+        if (manufacturerSpecific) {
+            zclFrame[1] = manufacturerCode & 0xFF; // low byte of manufacturer code
+            zclFrame[2] = (manufacturerCode >> 8) & 0xFF; // high byte of manufacturer code
+        }
+        zclFrame[1 + manufacturerCodeLength] = sequenceNumber;
+        zclFrame[2 + manufacturerCodeLength] = commandId;
 
         for (int cnt = 0; cnt < payload.length; cnt++) {
-            zclFrame[cnt + 3] = payload[cnt];
+            zclFrame[cnt + 3 + manufacturerCodeLength] = payload[cnt];
         }
         return zclFrame;
     }

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zcl/ZclHeaderTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zcl/ZclHeaderTest.java
@@ -63,4 +63,25 @@ public class ZclHeaderTest extends CommandTest {
         ZclFieldSerializer fieldSerializer = new ZclFieldSerializer(serializer);
         assertTrue(Arrays.equals(packet, zclHeader.serialize(fieldSerializer, new int[] {})));
     }
+
+    @Test
+    public void testDeserializeManufacturerSpecific() {
+        int[] packet = getPacketData("0C 4E 10 99 88");
+
+        DefaultDeserializer deserializer = new DefaultDeserializer(packet);
+        ZclFieldDeserializer fieldDeserializer = new ZclFieldDeserializer(deserializer);
+        ZclHeader zclHeader = new ZclHeader(fieldDeserializer);
+        System.out.println(zclHeader);
+
+        assertEquals(0x88, zclHeader.getCommandId());
+        assertEquals(ZclFrameType.ENTIRE_PROFILE_COMMAND, zclHeader.getFrameType());
+        assertEquals(true, zclHeader.isManufacturerSpecific());
+        assertEquals(false, zclHeader.isDisableDefaultResponse());
+        assertEquals(0x99, zclHeader.getSequenceNumber());
+        assertEquals(0x104E, zclHeader.getManufacturerCode());
+
+        DefaultSerializer serializer = new DefaultSerializer();
+        ZclFieldSerializer fieldSerializer = new ZclFieldSerializer(serializer);
+        assertTrue(Arrays.equals(packet, zclHeader.serialize(fieldSerializer, new int[] {})));
+    }
 }


### PR DESCRIPTION
The deserialization logic already processes the manufacturer-specific bits. This commit adds the logic for serializing ZCL frames, more specifically:

* Sets the manufacturer-specific bit in the frame control field for instances of `ZclHeader` that have the boolean value `manufacturerSpecific` set.
* Adds the manufacturer code to ZCL frames if the manufacturer-specific bit is set.