### PR TITLE
Add NCP Scan command and minor refactoring

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,10 @@ deploy:
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)
+
+global:
+  - CODECOV_TOKEN=:uuid-repo-token
+
+branches:
+  only:
+    - master

--- a/com.zsmartsystems.zigbee.console.ember/src/main/java/com/zsmartsystems/zigbee/console/ember/EmberConsoleNcpScanCommand.java
+++ b/com.zsmartsystems.zigbee.console.ember/src/main/java/com/zsmartsystems/zigbee/console/ember/EmberConsoleNcpScanCommand.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) 2016-2018 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.console.ember;
+
+import java.io.PrintStream;
+import java.util.List;
+
+import com.zsmartsystems.zigbee.ExtendedPanId;
+import com.zsmartsystems.zigbee.ZigBeeChannelMask;
+import com.zsmartsystems.zigbee.ZigBeeNetworkManager;
+import com.zsmartsystems.zigbee.dongle.ember.EmberNcp;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspEnergyScanResultHandler;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspNetworkFoundHandler;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EmberZigbeeNetwork;
+
+/**
+ * Performs a scan on the Ember NCP
+ *
+ * @author Chris Jackson
+ *
+ */
+public class EmberConsoleNcpScanCommand extends EmberConsoleAbstractCommand {
+    @Override
+    public String getCommand() {
+        return "ncpscan";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Performs a scan on the Ember NCP";
+    }
+
+    @Override
+    public String getSyntax() {
+        return "";
+    }
+
+    @Override
+    public String getHelp() {
+        return "";
+    }
+
+    @Override
+    public void process(ZigBeeNetworkManager networkManager, String[] args, PrintStream out)
+            throws IllegalArgumentException {
+        EmberNcp ncp = getEmberNcp(networkManager);
+
+        List<EzspNetworkFoundHandler> networksFound = ncp.doActiveScan(ZigBeeChannelMask.CHANNEL_MASK_2GHZ, 6);
+        List<EzspEnergyScanResultHandler> channels = ncp.doEnergyScan(ZigBeeChannelMask.CHANNEL_MASK_2GHZ, 6);
+
+        if (networksFound == null) {
+            out.println("Error performing active scan");
+        } else {
+            out.println("Ember NCP active scan found " + networksFound.size() + " networks");
+            out.println();
+
+            if (!networksFound.isEmpty()) {
+                outputNetworksFound(out, networksFound);
+                out.println();
+            }
+        }
+
+        if (channels == null) {
+            out.println("Error performing energy scan");
+        } else {
+            outputChannelEnergy(out, channels);
+        }
+    }
+
+    private void outputNetworksFound(PrintStream out, List<EzspNetworkFoundHandler> networksFound) {
+        out.println("CH  PAN   Extended PAN      Stk  Join   Upd");
+        for (EzspNetworkFoundHandler network : networksFound) {
+            EmberZigbeeNetwork params = network.getNetworkFound();
+            ExtendedPanId epanId = new ExtendedPanId(params.getExtendedPanId());
+            out.println(String.format("%-2d  %04X  %s  %d    %s  %d", params.getChannel(), params.getPanId(), epanId,
+                    params.getStackProfile(), params.getAllowingJoin() ? "True " : "False", params.getNwkUpdateId()));
+        }
+    }
+
+    private void outputChannelEnergy(PrintStream out, List<EzspEnergyScanResultHandler> channels) {
+        out.println("CH  RSSI");
+        for (EzspEnergyScanResultHandler channel : channels) {
+            out.println(String.format("%-2d  %d", channel.getChannel(), channel.getMaxRssiValue()));
+        }
+    }
+}

--- a/com.zsmartsystems.zigbee.console.main/src/main/java/com/zsmartsystems/zigbee/console/main/ZigBeeConsoleMain.java
+++ b/com.zsmartsystems.zigbee.console.main/src/main/java/com/zsmartsystems/zigbee/console/main/ZigBeeConsoleMain.java
@@ -31,6 +31,7 @@ import com.zsmartsystems.zigbee.console.ember.EmberConsoleMmoHashCommand;
 import com.zsmartsystems.zigbee.console.ember.EmberConsoleNcpChildrenCommand;
 import com.zsmartsystems.zigbee.console.ember.EmberConsoleNcpConfigurationCommand;
 import com.zsmartsystems.zigbee.console.ember.EmberConsoleNcpCountersCommand;
+import com.zsmartsystems.zigbee.console.ember.EmberConsoleNcpScanCommand;
 import com.zsmartsystems.zigbee.console.ember.EmberConsoleNcpStateCommand;
 import com.zsmartsystems.zigbee.console.ember.EmberConsoleNcpValueCommand;
 import com.zsmartsystems.zigbee.console.ember.EmberConsoleNcpVersionCommand;
@@ -202,6 +203,7 @@ public class ZigBeeConsoleMain {
             commands.add(EmberConsoleNcpValueCommand.class);
             commands.add(EmberConsoleNcpVersionCommand.class);
             commands.add(EmberConsoleSecurityStateCommand.class);
+            commands.add(EmberConsoleNcpScanCommand.class);
         } else if (dongleName.toUpperCase().equals("XBEE")) {
             dongle = new ZigBeeDongleXBee(serialPort);
         } else if (dongleName.toUpperCase().equals("CONBEE")) {
@@ -321,7 +323,6 @@ public class ZigBeeConsoleMain {
 
         if (networkManager.startup(resetNetwork) != ZigBeeStatus.SUCCESS) {
             System.out.println("ZigBee console starting up ... [FAIL]");
-            return;
         } else {
             System.out.println("ZigBee console starting up ... [OK]");
         }

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/EmberNcpTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/EmberNcpTest.java
@@ -1,0 +1,214 @@
+/**
+ * Copyright (c) 2016-2018 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.dongle.ember;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import com.zsmartsystems.zigbee.IeeeAddress;
+import com.zsmartsystems.zigbee.ZigBeeChannelMask;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.EzspFrameRequest;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.EzspFrameResponse;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspGetEui64Request;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspGetEui64Response;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspGetNetworkParametersRequest;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspGetNetworkParametersResponse;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspGetNodeIdRequest;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspGetNodeIdResponse;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspGetParentChildParametersRequest;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspGetParentChildParametersResponse;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspLeaveNetworkRequest;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspLeaveNetworkResponse;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspNetworkInitRequest;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspNetworkInitResponse;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspNetworkStateRequest;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspNetworkStateResponse;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspReadCountersRequest;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspReadCountersResponse;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspScanCompleteHandler;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspSetRadioPowerRequest;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspSetRadioPowerResponse;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspStartScanRequest;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EmberStatus;
+import com.zsmartsystems.zigbee.dongle.ember.internal.EzspProtocolHandler;
+import com.zsmartsystems.zigbee.dongle.ember.internal.transaction.EzspTransaction;
+
+/**
+ *
+ * @author Chris Jackson
+ *
+ */
+public class EmberNcpTest {
+    private ArgumentCaptor<EzspTransaction> ezspTransactionCapture = ArgumentCaptor.forClass(EzspTransaction.class);
+    private EzspProtocolHandler handler;
+
+    private EmberNcp getEmberNcp(EzspFrameResponse response) {
+        handler = Mockito.mock(EzspProtocolHandler.class);
+        EmberNcp ncp = new EmberNcp(handler);
+
+        EzspTransaction transaction = Mockito.mock(EzspTransaction.class);
+        Mockito.when(transaction.getResponse()).thenReturn(response);
+        Mockito.doAnswer(new Answer<EzspTransaction>() {
+            @Override
+            public EzspTransaction answer(InvocationOnMock invocation) {
+                return transaction;
+            }
+        }).when(handler).sendEzspTransaction(ArgumentMatchers.any(EzspTransaction.class));
+
+        return ncp;
+    }
+
+    @Test
+    public void networkInit() {
+        EmberNcp ncp = getEmberNcp(Mockito.mock(EzspNetworkInitResponse.class));
+
+        ncp.networkInit();
+
+        Mockito.verify(handler, Mockito.times(1)).sendEzspTransaction(ezspTransactionCapture.capture());
+
+        EzspFrameRequest request = ezspTransactionCapture.getValue().getRequest();
+        assertTrue(request instanceof EzspNetworkInitRequest);
+    }
+
+    @Test
+    public void leaveNetwork() {
+        EmberNcp ncp = getEmberNcp(Mockito.mock(EzspLeaveNetworkResponse.class));
+
+        ncp.leaveNetwork();
+
+        Mockito.verify(handler, Mockito.times(1)).sendEzspTransaction(ezspTransactionCapture.capture());
+
+        EzspFrameRequest request = ezspTransactionCapture.getValue().getRequest();
+        assertTrue(request instanceof EzspLeaveNetworkRequest);
+    }
+
+    @Test
+    public void getNetworkParameters() {
+        EmberNcp ncp = getEmberNcp(Mockito.mock(EzspGetNetworkParametersResponse.class));
+
+        ncp.getNetworkParameters();
+
+        Mockito.verify(handler, Mockito.times(1)).sendEzspTransaction(ezspTransactionCapture.capture());
+
+        EzspFrameRequest request = ezspTransactionCapture.getValue().getRequest();
+        assertTrue(request instanceof EzspGetNetworkParametersRequest);
+    }
+
+    @Test
+    public void getNetworkState() {
+        EmberNcp ncp = getEmberNcp(Mockito.mock(EzspNetworkStateResponse.class));
+
+        ncp.getNetworkState();
+
+        Mockito.verify(handler, Mockito.times(1)).sendEzspTransaction(ezspTransactionCapture.capture());
+
+        EzspFrameRequest request = ezspTransactionCapture.getValue().getRequest();
+        assertTrue(request instanceof EzspNetworkStateRequest);
+    }
+
+    @Test
+    public void getChildParameters() {
+        EmberNcp ncp = getEmberNcp(Mockito.mock(EzspGetParentChildParametersResponse.class));
+
+        ncp.getChildParameters();
+
+        Mockito.verify(handler, Mockito.times(1)).sendEzspTransaction(ezspTransactionCapture.capture());
+
+        EzspFrameRequest request = ezspTransactionCapture.getValue().getRequest();
+        assertTrue(request instanceof EzspGetParentChildParametersRequest);
+    }
+
+    @Test
+    public void getCounters() {
+        EmberNcp ncp = getEmberNcp(Mockito.mock(EzspReadCountersResponse.class));
+
+        ncp.getCounters();
+
+        Mockito.verify(handler, Mockito.times(1)).sendEzspTransaction(ezspTransactionCapture.capture());
+
+        EzspFrameRequest request = ezspTransactionCapture.getValue().getRequest();
+        assertTrue(request instanceof EzspReadCountersRequest);
+    }
+
+    @Test
+    public void getIeeeAddress() {
+        EzspGetEui64Response response = Mockito.mock(EzspGetEui64Response.class);
+        Mockito.when(response.getEui64()).thenReturn(new IeeeAddress("1234567890ABCDEF"));
+        EmberNcp ncp = getEmberNcp(response);
+
+        ncp.getIeeeAddress();
+
+        Mockito.verify(handler, Mockito.times(1)).sendEzspTransaction(ezspTransactionCapture.capture());
+
+        EzspFrameRequest request = ezspTransactionCapture.getValue().getRequest();
+        assertTrue(request instanceof EzspGetEui64Request);
+    }
+
+    @Test
+    public void getNwkAddress() {
+        EmberNcp ncp = getEmberNcp(Mockito.mock(EzspGetNodeIdResponse.class));
+
+        ncp.getNwkAddress();
+
+        Mockito.verify(handler, Mockito.times(1)).sendEzspTransaction(ezspTransactionCapture.capture());
+
+        EzspFrameRequest request = ezspTransactionCapture.getValue().getRequest();
+        assertTrue(request instanceof EzspGetNodeIdRequest);
+    }
+
+    @Test
+    public void setRadioPower() {
+        EmberNcp ncp = getEmberNcp(Mockito.mock(EzspSetRadioPowerResponse.class));
+
+        ncp.setRadioPower(6);
+
+        Mockito.verify(handler, Mockito.times(1)).sendEzspTransaction(ezspTransactionCapture.capture());
+
+        EzspFrameRequest request = ezspTransactionCapture.getValue().getRequest();
+        assertTrue(request instanceof EzspSetRadioPowerRequest);
+        assertEquals(6, ((EzspSetRadioPowerRequest) request).getPower());
+    }
+
+    @Test
+    public void doActiveScan() {
+        EzspScanCompleteHandler scanComplete = Mockito.mock(EzspScanCompleteHandler.class);
+        Mockito.when(scanComplete.getStatus()).thenReturn(EmberStatus.EMBER_SUCCESS);
+        EmberNcp ncp = getEmberNcp(scanComplete);
+
+        ncp.doActiveScan(ZigBeeChannelMask.CHANNEL_MASK_2GHZ, 123);
+
+        Mockito.verify(handler, Mockito.times(1)).sendEzspTransaction(ezspTransactionCapture.capture());
+
+        EzspFrameRequest request = ezspTransactionCapture.getValue().getRequest();
+        assertTrue(request instanceof EzspStartScanRequest);
+        assertEquals(ZigBeeChannelMask.CHANNEL_MASK_2GHZ, ((EzspStartScanRequest) request).getChannelMask());
+    }
+
+    @Test
+    public void doEnergyScan() {
+        EzspScanCompleteHandler scanComplete = Mockito.mock(EzspScanCompleteHandler.class);
+        Mockito.when(scanComplete.getStatus()).thenReturn(EmberStatus.EMBER_SUCCESS);
+        EmberNcp ncp = getEmberNcp(scanComplete);
+
+        ncp.doEnergyScan(ZigBeeChannelMask.CHANNEL_MASK_2GHZ, 123);
+
+        Mockito.verify(handler, Mockito.times(1)).sendEzspTransaction(ezspTransactionCapture.capture());
+
+        EzspFrameRequest request = ezspTransactionCapture.getValue().getRequest();
+        assertTrue(request instanceof EzspStartScanRequest);
+        assertEquals(ZigBeeChannelMask.CHANNEL_MASK_2GHZ, ((EzspStartScanRequest) request).getChannelMask());
+    }
+
+}

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspNetworkFoundHandlerTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspNetworkFoundHandlerTest.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2016-2018 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.dongle.ember.ezsp.command;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.EzspFrame;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.EzspFrameTest;
+
+/**
+ *
+ * @author Chris Jackson
+ *
+ */
+public class EzspNetworkFoundHandlerTest extends EzspFrameTest {
+    @Test
+    public void testReceive() {
+        EzspFrame.setEzspVersion(4);
+
+        EzspNetworkFoundHandler handler = new EzspNetworkFoundHandler(
+                getPacketData("56 90 FF 00 1B 11 8B D9 63 08 1D DC 2D C4 F2 46 00 02 01 FF C3"));
+        System.out.println(handler);
+
+        assertEquals(0x1B, handler.getFrameId());
+        assertTrue(handler.isResponse());
+        assertEquals(255, handler.getLastHopLqi());
+        assertEquals(-61, handler.getLastHopRssi());
+        assertEquals(false, handler.getNetworkFound().getAllowingJoin());
+        assertEquals(2, handler.getNetworkFound().getStackProfile());
+        assertEquals(1, handler.getNetworkFound().getNwkUpdateId());
+        assertEquals(55691, handler.getNetworkFound().getPanId());
+        assertTrue(Arrays.equals(new int[] { 0x63, 0x08, 0x1D, 0xDC, 0x2D, 0xC4, 0xF2, 0x46 },
+                handler.getNetworkFound().getExtendedPanId()));
+    }
+
+}

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspScanCompleteHandlerTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspScanCompleteHandlerTest.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2016-2018 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.dongle.ember.ezsp.command;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.EzspFrame;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.EzspFrameTest;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EmberStatus;
+
+/**
+ *
+ * @author Chris Jackson
+ *
+ */
+public class EzspScanCompleteHandlerTest extends EzspFrameTest {
+    @Test
+    public void testReceive() {
+        EzspFrame.setEzspVersion(4);
+
+        EzspScanCompleteHandler handler = new EzspScanCompleteHandler(getPacketData("4E 90 FF 00 1C FF 00"));
+        System.out.println(handler);
+
+        assertEquals(0x1C, handler.getFrameId());
+        assertTrue(handler.isResponse());
+        assertEquals(255, handler.getChannel());
+        assertEquals(EmberStatus.EMBER_SUCCESS, handler.getStatus());
+    }
+
+}

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeNodeServiceDiscoverer.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeNodeServiceDiscoverer.java
@@ -658,7 +658,7 @@ public class ZigBeeNodeServiceDiscoverer {
             tasks.add(NodeDiscoveryTask.POWER_DESCRIPTOR);
         }
 
-        if (node.getEndpoints().size() == 0 && node.getNetworkAddress() != 0) {
+        if (node.getEndpoints().size() == 0 && node.getNetworkAddress() != networkManager.getLocalNwkAddress()) {
             tasks.add(NodeDiscoveryTask.ACTIVE_ENDPOINTS);
         }
 


### PR DESCRIPTION
This refactors the Ember initialisation class to move the scan methods into the common ```EmberNcp``` utility class. A new ```ncpscan``` command has then been added to the CLI package.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>