### PR TITLE
Print clusters in hex in binding table

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/field/BindingTable.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/field/BindingTable.java
@@ -212,9 +212,7 @@ public class BindingTable {
                 builder.append(", Unknown destination mode");
                 break;
         }
-        builder.append(", clusterId=");
-        builder.append(clusterId);
-        builder.append(']');
+        builder.append(String.format(", clusterId=%04X]", clusterId));
         return builder.toString();
     }
 }

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zdo/field/BindingTableTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zdo/field/BindingTableTest.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2016-2019 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.zdo.field;
+
+import org.junit.Test;
+
+/**
+ *
+ * @author Chris Jackson
+ *
+ */
+public class BindingTableTest {
+
+    @Test
+    public void test() {
+        BindingTable table = new BindingTable();
+
+        System.out.println(table);
+    }
+}


### PR DESCRIPTION
Trying to standardise printing cluster IDs in hex.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>