### PR TITLE
Cancel scheduled task in service discovery before starting it again

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
@@ -760,14 +760,14 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
                 new ZigBeeEndpointAddress(apsFrame.getDestinationAddress(), apsFrame.getDestinationEndpoint()));
         command.setApsSecurity(apsFrame.getSecurityEnabled());
 
+        logger.debug("RX CMD: {}", command);
+
         // Pass the command to the transaction manager for processing
         // If the transaction manager wants to drop this command, it returns null
         command = transactionManager.receive(command);
         if (command == null) {
             return;
         }
-
-        logger.debug("RX CMD: {}", command);
 
         // Notify the listeners
         commandNotifier.notifyCommandListeners(command);

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeNodeServiceDiscoverer.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeNodeServiceDiscoverer.java
@@ -159,7 +159,7 @@ public class ZigBeeNodeServiceDiscoverer {
     private final Queue<NodeDiscoveryTask> discoveryTasks = new LinkedList<NodeDiscoveryTask>();
 
     /**
-     * Creates the discovery class
+     * Creates the discoverer
      *
      * @param networkManager the {@link ZigBeeNetworkManager} for the network
      * @param node the {@link ZigBeeNode} whose services we want to discover
@@ -169,6 +169,8 @@ public class ZigBeeNodeServiceDiscoverer {
         this.node = node;
 
         retryPeriod = DEFAULT_RETRY_PERIOD + new Random().nextInt(RETRY_RANDOM_TIME);
+
+        logger.debug("{}: Node SVC Discovery: created discoverer", node.getIeeeAddress());
     }
 
     /**
@@ -213,12 +215,15 @@ public class ZigBeeNodeServiceDiscoverer {
             } else {
                 lastDiscoveryStarted = Calendar.getInstance();
             }
+
+            logger.debug("{}: Node SVC Discovery: scheduled {}", node.getIeeeAddress(), discoveryTasks);
+            final Runnable runnable = new NodeServiceDiscoveryTask();
+
+            if (futureTask != null) {
+                futureTask.cancel(true);
+            }
+            futureTask = networkManager.scheduleTask(runnable, new Random().nextInt(retryPeriod));
         }
-
-        logger.debug("{}: Node SVC Discovery: scheduled {}", node.getIeeeAddress(), discoveryTasks);
-        final Runnable runnable = new NodeServiceDiscoveryTask();
-
-        futureTask = networkManager.scheduleTask(runnable, new Random().nextInt(retryPeriod));
     }
 
     /**

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeNodeServiceDiscovererTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeNodeServiceDiscovererTest.java
@@ -16,6 +16,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledFuture;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -242,7 +243,12 @@ public class ZigBeeNodeServiceDiscovererTest {
         // Use node 0 and we should not try and get the local endpoints
         Mockito.when(node.getNetworkAddress()).thenReturn(0);
 
+        ScheduledFuture<?> futureTask = Mockito.mock(ScheduledFuture.class);
+        TestUtilities.setField(ZigBeeNodeServiceDiscoverer.class, discoverer, "futureTask", futureTask);
+
         discoverer.startDiscovery();
+
+        Mockito.verify(futureTask, Mockito.times(1)).cancel(true);
 
         assertFalse(discoverer.getTasks().contains(NodeDiscoveryTask.ACTIVE_ENDPOINTS));
     }


### PR DESCRIPTION
This fixes a bug that was causing some duplicate packets to be sent during mesh updates and service discovery due to not stopping the scheduler before restarting.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>