### PR TITLE
Remove unnecessary sync blocks when updating unmodifiable lists

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
@@ -898,15 +898,13 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
         }
 
         // Notify the listeners
-        synchronized (this) {
-            for (final ZigBeeAnnounceListener announceListener : announceListeners) {
-                NotificationService.execute(new Runnable() {
-                    @Override
-                    public void run() {
-                        announceListener.deviceStatusUpdate(deviceStatus, networkAddress, ieeeAddress);
-                    }
-                });
-            }
+        for (final ZigBeeAnnounceListener announceListener : announceListeners) {
+            NotificationService.execute(new Runnable() {
+                @Override
+                public void run() {
+                    announceListener.deviceStatusUpdate(deviceStatus, networkAddress, ieeeAddress);
+                }
+            });
         }
     }
 
@@ -1171,12 +1169,10 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
         if (networkNodeListener == null) {
             return;
         }
-        synchronized (this) {
-            final List<ZigBeeNetworkNodeListener> modifiedListeners = new ArrayList<ZigBeeNetworkNodeListener>(
-                    nodeListeners);
-            modifiedListeners.add(networkNodeListener);
-            nodeListeners = Collections.unmodifiableList(modifiedListeners);
-        }
+        final List<ZigBeeNetworkNodeListener> modifiedListeners = new ArrayList<ZigBeeNetworkNodeListener>(
+                nodeListeners);
+        modifiedListeners.add(networkNodeListener);
+        nodeListeners = Collections.unmodifiableList(modifiedListeners);
     }
 
     /**
@@ -1185,12 +1181,10 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
      * @param networkNodeListener the {@link ZigBeeNetworkNodeListener} to remove
      */
     public void removeNetworkNodeListener(final ZigBeeNetworkNodeListener networkNodeListener) {
-        synchronized (this) {
-            final List<ZigBeeNetworkNodeListener> modifiedListeners = new ArrayList<ZigBeeNetworkNodeListener>(
-                    nodeListeners);
-            modifiedListeners.remove(networkNodeListener);
-            nodeListeners = Collections.unmodifiableList(modifiedListeners);
-        }
+        final List<ZigBeeNetworkNodeListener> modifiedListeners = new ArrayList<ZigBeeNetworkNodeListener>(
+                nodeListeners);
+        modifiedListeners.remove(networkNodeListener);
+        nodeListeners = Collections.unmodifiableList(modifiedListeners);
     }
 
     /**


### PR DESCRIPTION
```announceListeners``` and ```nodeListeners``` use ```Collections.unmodifiableList``` so do not require the synchronisation. This can cause delays in processing serialisation as seen in #514.

@puzzle-star if you spot any other such examples, please provide a PR.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>