### PR TITLE
Create Jar with dependencies for console

### DIFF
--- a/com.zsmartsystems.zigbee.console.main/pom.xml
+++ b/com.zsmartsystems.zigbee.console.main/pom.xml
@@ -142,6 +142,27 @@
 					</archive>
 				</configuration>
 			</plugin>
+			<plugin>
+				<artifactId>maven-assembly-plugin</artifactId>
+				<configuration>
+					<archive>
+						<manifest>
+							<addClasspath>true</addClasspath>
+							<classpathPrefix>lib/</classpathPrefix>
+							<mainClass>com.zsmartsystems.zigbee.console.main.ZigBeeConsoleMain</mainClass>
+						</manifest>
+					</archive>
+					<descriptorRefs><descriptorRef>jar-with-dependencies</descriptorRef></descriptorRefs>
+				</configuration>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>single</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 


### PR DESCRIPTION
This makes it easier to execute the console on non-development devices.
(It still needs the `log4j.xml` in the current working dir)

Signed-off-by: Thomas Weißschuh <thomas@weissschuh.net>