### PR TITLE
Add ZclCluster method to read multiple attributes at once

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/ZclCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/ZclCluster.java
@@ -141,6 +141,13 @@ public abstract class ZclCluster {
      */
     protected abstract Map<Integer, ZclAttribute> initializeAttributes();
 
+    /**
+     * Creates a cluster
+     *
+     * @param zigbeeEndpoint the {@link ZigBeeEndpoint} to which the cluster belongs
+     * @param clusterId the 16 bit cluster identifier
+     * @param clusterName the cluster name
+     */
     public ZclCluster(ZigBeeEndpoint zigbeeEndpoint, int clusterId, String clusterName) {
         this.zigbeeEndpoint = zigbeeEndpoint;
         this.clusterId = clusterId;
@@ -148,6 +155,12 @@ public abstract class ZclCluster {
         this.normalizer = new ZclAttributeNormalizer();
     }
 
+    /**
+     * Sends a {@link ZclCommand}
+     *
+     * @param command the {@link ZclCommand} to send
+     * @return the command result future
+     */
     protected Future<CommandResult> send(ZclCommand command) {
         if (isClient()) {
             command.setCommandDirection(ZclCommandDirection.SERVER_TO_CLIENT);
@@ -159,19 +172,13 @@ public abstract class ZclCluster {
     }
 
     /**
-     * Read an attribute
+     * Read an attribute given the attribute ID
      *
-     * @param attribute the attribute to read
+     * @param attribute the integer attribute ID to read
      * @return command future
      */
     public Future<CommandResult> read(final int attribute) {
-        final ReadAttributesCommand command = new ReadAttributesCommand();
-
-        command.setClusterId(clusterId);
-        command.setIdentifiers(Collections.singletonList(attribute));
-        command.setDestinationAddress(zigbeeEndpoint.getEndpointAddress());
-
-        return send(command);
+        return read(Collections.singletonList(attribute));
     }
 
     /**
@@ -182,6 +189,23 @@ public abstract class ZclCluster {
      */
     public Future<CommandResult> read(final ZclAttribute attribute) {
         return read(attribute.getId());
+    }
+
+    /**
+     * Read a number of attributes given a list of attribute IDs. Care must be taken not to request too many attributes
+     * so as to exceed the allowable frame length
+     *
+     * @param attributes List of attribute identifiers to read
+     * @return command future
+     */
+    public Future<CommandResult> read(final List<Integer> attributes) {
+        final ReadAttributesCommand command = new ReadAttributesCommand();
+
+        command.setClusterId(clusterId);
+        command.setIdentifiers(attributes);
+        command.setDestinationAddress(zigbeeEndpoint.getEndpointAddress());
+
+        return send(command);
     }
 
     /**

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zcl/ZclClusterTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zcl/ZclClusterTest.java
@@ -31,6 +31,7 @@ import com.zsmartsystems.zigbee.transaction.ZigBeeTransactionMatcher;
 import com.zsmartsystems.zigbee.zcl.clusters.ZclLevelControlCluster;
 import com.zsmartsystems.zigbee.zcl.clusters.ZclOnOffCluster;
 import com.zsmartsystems.zigbee.zcl.clusters.general.ConfigureReportingCommand;
+import com.zsmartsystems.zigbee.zcl.clusters.general.ReadAttributesCommand;
 import com.zsmartsystems.zigbee.zcl.clusters.general.ReadReportingConfigurationCommand;
 import com.zsmartsystems.zigbee.zcl.clusters.onoff.OnCommand;
 import com.zsmartsystems.zigbee.zcl.field.AttributeRecord;
@@ -269,6 +270,42 @@ public class ZclClusterTest {
         onCommand = (OnCommand) command;
         assertEquals(false, onCommand.getApsSecurity());
         assertEquals(ZclCommandDirection.CLIENT_TO_SERVER, onCommand.getCommandDirection());
+    }
+
+    @Test
+    public void readAttribute() {
+        createEndpoint();
+
+        ZclOnOffCluster cluster = new ZclOnOffCluster(endpoint);
+
+        cluster.read(1);
+        assertEquals(1, commandCapture.getAllValues().size());
+        assertTrue(commandCapture.getValue() instanceof ReadAttributesCommand);
+        ReadAttributesCommand command = (ReadAttributesCommand) commandCapture.getValue();
+        System.out.println(command);
+        assertEquals(1, command.getIdentifiers().size());
+        assertEquals(Integer.valueOf(1), command.getIdentifiers().get(0));
+
+        ZclAttribute attribute = new ZclAttribute(null, 2, null, null, false, false, false, false);
+        cluster.read(attribute);
+        assertTrue(commandCapture.getValue() instanceof ReadAttributesCommand);
+        command = (ReadAttributesCommand) commandCapture.getValue();
+        System.out.println(command);
+        assertEquals(1, command.getIdentifiers().size());
+        assertEquals(Integer.valueOf(2), command.getIdentifiers().get(0));
+
+        List<Integer> attributeIds = new ArrayList<>();
+        attributeIds.add(4);
+        attributeIds.add(5);
+        attributeIds.add(6);
+        cluster.read(attributeIds);
+        assertTrue(commandCapture.getValue() instanceof ReadAttributesCommand);
+        command = (ReadAttributesCommand) commandCapture.getValue();
+        System.out.println(command);
+        assertEquals(3, command.getIdentifiers().size());
+        assertEquals(Integer.valueOf(4), command.getIdentifiers().get(0));
+        assertEquals(Integer.valueOf(5), command.getIdentifiers().get(1));
+        assertEquals(Integer.valueOf(6), command.getIdentifiers().get(2));
     }
 
 }


### PR DESCRIPTION
Adds a new implementation of the ```read``` method to read multiple attributes at once -:

```
    /**
     * Read a number of attributes given a list of attribute IDs. Care must be taken not to request too many attributes
     * so as to exceed the allowable frame length
     *
     * @param attributes List of attribute identifiers to read
     * @return command future
     */
    public Future<CommandResult> read(final List<Integer> attributes)
```

#529
Signed-off-by: Chris Jackson <chris@cd-jackson.com>