### PR TITLE
532 Disable join not working properly

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
@@ -1034,7 +1034,7 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
      * @return {@link ZigBeeStatus} with the status of function
      */
     public ZigBeeStatus permitJoin(final ZigBeeEndpointAddress destination, final int duration) {
-        if (duration < 0 || duration >= 255) {
+        if (duration <= 0 || duration >= 255) {
             logger.debug("Permit join to {} invalid period of {} seconds.", destination, duration);
             return ZigBeeStatus.INVALID_ARGUMENTS;
         }


### PR DESCRIPTION
Regarding this comment, disable joining was not working properly.

`/**
     * Enables or disables devices to join the network.
     * <p>
     * Devices can only join the network when joining is enabled. It is not advised to leave joining enabled permanently
     * since it allows devices to join the network without the installer knowing.
     *
     * @param destination the {@link ZigBeeEndpointAddress} to send the join request to
     * @param duration sets the duration of the join enable. Setting this to 0 disables joining. As per ZigBee 3, a
     *            value of 255 is not permitted and will be ignored.
     * @return {@link ZigBeeStatus} with the status of function
     */`