### PR TITLE
Console: Add an option to remove a node after unsuccessful leave attempt

### DIFF
--- a/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleNetworkLeaveCommand.java
+++ b/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleNetworkLeaveCommand.java
@@ -30,7 +30,7 @@ public class ZigBeeConsoleNetworkLeaveCommand extends ZigBeeConsoleAbstractComma
 
     @Override
     public String getSyntax() {
-        return "NODE [PARENT]";
+        return "[forceNodeRemoval|fnr] NODE [PARENT]";
     }
 
     @Override
@@ -39,23 +39,28 @@ public class ZigBeeConsoleNetworkLeaveCommand extends ZigBeeConsoleAbstractComma
     }
 
     @Override
-    public void process(ZigBeeNetworkManager networkManager, String[] args, PrintStream out)
-            throws IllegalArgumentException {
-        if (args.length > 3) {
-            throw new IllegalArgumentException("Invalid number of arguments");
+    public void process(ZigBeeNetworkManager networkManager, String[] args, PrintStream out) {
+        if (args.length < 2) {
+            throw new IllegalArgumentException("Not enough arguments");
         }
 
-        ZigBeeNode leaver = getNode(networkManager, args[1]);
+        boolean forceNodeRemoval = args[1].equals("forceNodeRemoval") || args[1].equals("fnr");
 
-        if (args.length == 2) {
-            networkManager.leave(leaver.getNetworkAddress(), leaver.getIeeeAddress());
-            return;
+        if (args.length > (forceNodeRemoval ? 3 : 4)) {
+            throw new IllegalArgumentException("Too many arguments");
         }
 
-        if (args.length == 3) {
-            ZigBeeNode parent = getNode(networkManager, args[2]);
-            networkManager.leave(parent.getNetworkAddress(), leaver.getIeeeAddress());
-            return;
+        int leaverArgumentPosition = forceNodeRemoval ? 2 : 1;
+        int parentArgumentPosition = forceNodeRemoval ? 3 : 2;
+
+        ZigBeeNode leaver = getNode(networkManager, args[leaverArgumentPosition]);
+
+        if (args.length <= parentArgumentPosition) {
+            networkManager.leave(leaver.getNetworkAddress(), leaver.getIeeeAddress(), forceNodeRemoval);
+        } else {
+            ZigBeeNode parent = getNode(networkManager, args[parentArgumentPosition]);
+            networkManager.leave(parent.getNetworkAddress(), leaver.getIeeeAddress(), forceNodeRemoval);
         }
+
     }
 }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
@@ -1126,24 +1126,23 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
             public void run() {
                 try {
                     CommandResult response = sendTransaction(command, command).get();
-                    if (response.getStatusCode() == 0) {
-                        ZigBeeNode node = getNode(leaveAddress);
-                        if (node != null) {
+                    ZigBeeNode node = getNode(leaveAddress);
+
+                    if (node != null) {
+                        if (response.getStatusCode() == 0) {
                             removeNode(node);
                         } else {
-                            logger.debug("{}: No node found after successful leave command", leaveAddress);
-                        }
-                    } else {
-                        logger.debug("{}: No successful response received to leave command (status code {})",
-                                leaveAddress, response.getStatusCode());
-                        if (forceNodeRemoval) {
-                            ZigBeeNode node = getNode(leaveAddress);
-                            if (node != null) {
-                                logger.debug("{}: Force-removing node from the node list after unsuccessful leave request", 
+                            logger.debug("{}: No successful response received to leave command (status code {})",
+                                    leaveAddress, response.getStatusCode());
+                            if (forceNodeRemoval) {
+                                logger.debug(
+                                        "{}: Force-removing node from the node list after unsuccessful leave request",
                                         leaveAddress);
                                 removeNode(node);
                             }
                         }
+                    } else {
+                        logger.debug("{}: No node found after leave command", leaveAddress);
                     }
                 } catch (InterruptedException | ExecutionException e) {
                     logger.debug("Error sending leave command.", e);


### PR DESCRIPTION
Resolves #537 

As discussed in #537, I have added an option to the `Leave` CLI command that will first try to make a node leave the network, and, if the node does not respond to the leave request, removes the node from the list of nodes in the network manager.

I tried to implement this by first calling `networkManager.leave`, and , if this fails, calling `networkManager.removeNode`. But I did not see a way to find out whether the `leave` call succeeded, except setting a timeout and checking whether the node is still there after that timeout.

Hence, I have added a version of the `networkManager.leave` command that will remove the node if there is no successful response to the leave command.

Does that sound ok for you, Chris?