### PR TITLE
Add manufacturer and model information to the nodelist command

### DIFF
--- a/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleNodeListCommand.java
+++ b/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleNodeListCommand.java
@@ -59,21 +59,19 @@ public class ZigBeeConsoleNodeListCommand extends ZigBeeConsoleAbstractCommand {
         }
 
         Collections.sort(nodeIds);
-        String tableHeader = String.format("%7s | %4s | %17s | %13s | %3s | %25s | %15s | %15s | %15s", "Network",
-                "Addr", "IEEE Address", "Logical Type", "EP", "Profile", "Device Type", "Manufacturer", "Model");
+        String tableHeader = String.format("%7s  %4s  %17s  %13s  %3s  %25s  %15s  %15s  %15s", "Network", "Addr",
+                "IEEE Address", "Logical Type", "EP", "Profile", "Device Type", "Manufacturer", "Model");
         out.println(tableHeader);
-        out.println(createPadding(tableHeader.length(), '-'));
 
         for (Integer nodeId : nodeIds) {
             printNode(networkManager.getNode(nodeId), out);
-            out.println(createPadding(tableHeader.length(), '-'));
         }
     }
 
     private void printNode(ZigBeeNode node, PrintStream out) {
-        String nodeInfo = String.format("%7d | %04X | %17s | %13s |", node.getNetworkAddress(),
-                node.getNetworkAddress(), node.getIeeeAddress(), node.getLogicalType());
-        String nodeInfoPadding = String.format("%7s | %4s | %17s | %13s |", "", "", "", "");
+        String nodeInfo = String.format("%7d  %04X  %17s  %13s ", node.getNetworkAddress(), node.getNetworkAddress(),
+                node.getIeeeAddress(), node.getLogicalType());
+        String nodeInfoPadding = String.format("%7s  %4s  %17s  %13s ", "", "", "", "");
 
         List<ZigBeeEndpoint> endpoints = new ArrayList<>(node.getEndpoints());
         Collections.sort(endpoints, (ep1, ep2) -> ep1.getEndpointId() - ep2.getEndpointId());
@@ -81,7 +79,7 @@ public class ZigBeeConsoleNodeListCommand extends ZigBeeConsoleAbstractCommand {
         boolean first = true;
         for (ZigBeeEndpoint endpoint : endpoints) {
             boolean showManufacturerAndModel = endpoint.getParentNode().getNetworkAddress() != 0;
-            String endpointInfo = String.format("%3d | %25s | %15s | %15s | %15s", endpoint.getEndpointId(),
+            String endpointInfo = String.format("%3d  %25s  %15s  %15s  %15s", endpoint.getEndpointId(),
                     ZigBeeProfileType.getByValue(endpoint.getProfileId()),
                     ZigBeeDeviceType.getByValue(endpoint.getDeviceId()),
                     showManufacturerAndModel ? getManufacturer(endpoint) : "",
@@ -113,7 +111,4 @@ public class ZigBeeConsoleNodeListCommand extends ZigBeeConsoleAbstractCommand {
         }
     }
 
-    private String createPadding(int length, char padChar) {
-        return String.format("%0" + length + "d", 0).replace('0', padChar);
-    }
 }

--- a/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleNodeListCommand.java
+++ b/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleNodeListCommand.java
@@ -18,14 +18,17 @@ import com.zsmartsystems.zigbee.ZigBeeEndpoint;
 import com.zsmartsystems.zigbee.ZigBeeNetworkManager;
 import com.zsmartsystems.zigbee.ZigBeeNode;
 import com.zsmartsystems.zigbee.ZigBeeProfileType;
+import com.zsmartsystems.zigbee.zcl.ZclCluster;
+import com.zsmartsystems.zigbee.zcl.clusters.ZclBasicCluster;
 
 /**
  * Lists the devices in the network
  *
  * @author Chris Jackson
- *
+ * @author Henning Sudbrock - add manufacturer and model info
  */
 public class ZigBeeConsoleNodeListCommand extends ZigBeeConsoleAbstractCommand {
+
     @Override
     public String getCommand() {
         return "nodelist";
@@ -47,40 +50,70 @@ public class ZigBeeConsoleNodeListCommand extends ZigBeeConsoleAbstractCommand {
     }
 
     @Override
-    public void process(ZigBeeNetworkManager networkManager, String[] args, PrintStream out)
-            throws IllegalArgumentException {
+    public void process(ZigBeeNetworkManager networkManager, String[] args, PrintStream out) {
         final Set<ZigBeeNode> nodes = networkManager.getNodes();
-        final List<Integer> nodeIds = new ArrayList<Integer>();
+        final List<Integer> nodeIds = new ArrayList<>();
 
         for (ZigBeeNode node : nodes) {
             nodeIds.add(node.getNetworkAddress());
         }
 
         Collections.sort(nodeIds);
-        out.println("Network Addr  IEEE Address      Logical Type  EP   Profile                    Device Type");
+        String tableHeader = String.format("%7s | %4s | %17s | %13s | %3s | %25s | %15s | %15s | %15s", "Network",
+                "Addr", "IEEE Address", "Logical Type", "EP", "Profile", "Device Type", "Manufacturer", "Model");
+        out.println(tableHeader);
+        out.println(createPadding(tableHeader.length(), '-'));
+
         for (Integer nodeId : nodeIds) {
-            ZigBeeNode node = networkManager.getNode(nodeId);
-            out.print(String.format("%-6d  %04X  %s  %-12s  ", node.getNetworkAddress(), node.getNetworkAddress(),
-                    node.getIeeeAddress(), node.getLogicalType()));
-            List<Integer> endpointIds = new ArrayList<Integer>();
-            for (final ZigBeeEndpoint endpoint : node.getEndpoints()) {
-                endpointIds.add(endpoint.getEndpointId());
-            }
-            Collections.sort(endpointIds);
-            boolean first = true;
-            for (Integer endpointId : endpointIds) {
-                if (!first) {
-                    out.print("                                             ");
-                }
-                first = false;
-                ZigBeeEndpoint endpoint = node.getEndpoint(endpointId);
-                out.println(String.format("%-3d  %-25s  %s", endpoint.getEndpointId(),
-                        ZigBeeProfileType.getByValue(endpoint.getProfileId()),
-                        ZigBeeDeviceType.getByValue(endpoint.getDeviceId())));
-            }
-            if (first) {
-                out.println();
-            }
+            printNode(networkManager.getNode(nodeId), out);
+            out.println(createPadding(tableHeader.length(), '-'));
         }
+    }
+
+    private void printNode(ZigBeeNode node, PrintStream out) {
+        String nodeInfo = String.format("%7d | %04X | %17s | %13s |", node.getNetworkAddress(),
+                node.getNetworkAddress(), node.getIeeeAddress(), node.getLogicalType());
+        String nodeInfoPadding = String.format("%7s | %4s | %17s | %13s |", "", "", "", "");
+
+        List<ZigBeeEndpoint> endpoints = new ArrayList<>(node.getEndpoints());
+        Collections.sort(endpoints, (ep1, ep2) -> ep1.getEndpointId() - ep2.getEndpointId());
+
+        boolean first = true;
+        for (ZigBeeEndpoint endpoint : endpoints) {
+            boolean showManufacturerAndModel = endpoint.getParentNode().getNetworkAddress() != 0;
+            String endpointInfo = String.format("%3d | %25s | %15s | %15s | %15s", endpoint.getEndpointId(),
+                    ZigBeeProfileType.getByValue(endpoint.getProfileId()),
+                    ZigBeeDeviceType.getByValue(endpoint.getDeviceId()),
+                    showManufacturerAndModel ? getManufacturer(endpoint) : "",
+                    showManufacturerAndModel ? getModel(endpoint) : "");
+
+            String tableLine = String.format("%s %s", first ? nodeInfo : nodeInfoPadding, endpointInfo);
+            out.println(tableLine);
+
+            first = false;
+        }
+    }
+
+    private String getManufacturer(ZigBeeEndpoint endpoint) {
+        ZclBasicCluster cluster = getBasicCluster(endpoint);
+        return cluster != null ? cluster.getManufacturerName(Long.MAX_VALUE) : "";
+    }
+
+    private String getModel(ZigBeeEndpoint endpoint) {
+        ZclBasicCluster cluster = getBasicCluster(endpoint);
+        return cluster != null ? cluster.getModelIdentifier(Long.MAX_VALUE) : "";
+    }
+
+    private ZclBasicCluster getBasicCluster(ZigBeeEndpoint endpoint) {
+        ZclCluster cluster = endpoint.getInputCluster(0);
+        if (cluster instanceof ZclBasicCluster) {
+            return (ZclBasicCluster) cluster;
+        } else {
+            return null;
+        }
+    }
+
+    private String createPadding(int length, char padChar) {
+        return String.format("%0" + length + "d", 0).replace('0', padChar);
     }
 }


### PR DESCRIPTION
This PR is an attempt to improve the `nodelist` CLI command, so that it provides manufacturer and model ID from the basic cluster on the first endpoint, if available.

The reason for adding this is that I am quite often in the situation that I want to get information about or interact with a device using the console, for which I need the endpoint address (e.g., `1234/1`) - which I usually do not know by heart. I then call `nodelist`, which gives me a list of 10 or so nodes, and then I have to manually issue `endpoint <nodeaddress>/1` commands and check manufacturer/model in the basic cluster attributes until I found the correct node address. I found this somewhat tedious.

With this change to the `nodelist` command, the command attempts to read manufacturer and model ID from the basic cluster of the first endpoint; to make the output a little easier to read, I have also added bars as table line/column separators. The output looks like in the following example:

```
Network | Addr |      IEEE Address |  Logical Type |  EP |                   Profile |     Device Type |    Manufacturer |           Model
------------------------------------------------------------------------------------------------------------------------------------------
      0 | 0000 |  000D6F000DCFA37F |   COORDINATOR |   1 |    ZIGBEE_HOME_AUTOMATION |   ON_OFF_SWITCH |                 |                
------------------------------------------------------------------------------------------------------------------------------------------
  29750 | 7436 |  00124B0006233B7E |    END_DEVICE |   1 |    ZIGBEE_HOME_AUTOMATION |   ON_OFF_SWITCH |     Bitron Home |       902010/23
------------------------------------------------------------------------------------------------------------------------------------------
  40309 | 9D75 |  000D6F000E36AAE0 |        ROUTER |   1 |    ZIGBEE_HOME_AUTOMATION |   ON_OFF_SWITCH |      CentraLite |         3200-de
------------------------------------------------------------------------------------------------------------------------------------------
  60722 | ED32 |  00124B00028A1B7D |        ROUTER |   1 |    ZIGBEE_HOME_AUTOMATION |   ON_OFF_SWITCH |     Bitron Home |       902010/28
        |      |                   |               |   4 |    ZIGBEE_HOME_AUTOMATION |   ON_OFF_SWITCH |                 |                
------------------------------------------------------------------------------------------------------------------------------------------
```

What do you think about this, Chris? I am aware that adding infos from the basic cluster to the output of the `nodelist` command kind of breaks the barrier between the `ZigBee` and the `ZCL` layers - but I think that having this info in there would be really useful to console users.