### PR TITLE
Provide ability to configure tasks to be completed during mesh update

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeNodeServiceDiscoverer.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeNodeServiceDiscoverer.java
@@ -10,6 +10,7 @@ package com.zsmartsystems.zigbee.app.discovery;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -140,6 +141,11 @@ public class ZigBeeNodeServiceDiscoverer {
     private Calendar lastDiscoveryCompleted;
 
     /**
+     * List of tasks to be completed during a mesh update
+     */
+    private List<NodeDiscoveryTask> meshUpdateTasks = Collections.emptyList();
+
+    /**
      *
      *
      */
@@ -191,7 +197,8 @@ public class ZigBeeNodeServiceDiscoverer {
             if (!supportsManagementLqi && newTasks.contains(NodeDiscoveryTask.NEIGHBORS)) {
                 newTasks.remove(NodeDiscoveryTask.NEIGHBORS);
             }
-            if (!supportsManagementRouting && newTasks.contains(NodeDiscoveryTask.ROUTES)) {
+            if ((!supportsManagementRouting || node.getNodeDescriptor().getLogicalType() == LogicalType.END_DEVICE)
+                    && newTasks.contains(NodeDiscoveryTask.ROUTES)) {
                 newTasks.remove(NodeDiscoveryTask.ROUTES);
             }
 
@@ -682,11 +689,7 @@ public class ZigBeeNodeServiceDiscoverer {
         logger.debug("{}: Node SVC Discovery: Update mesh", node.getIeeeAddress());
         Set<NodeDiscoveryTask> tasks = new HashSet<NodeDiscoveryTask>();
 
-        tasks.add(NodeDiscoveryTask.NEIGHBORS);
-
-        if (node.getNodeDescriptor().getLogicalType() != LogicalType.END_DEVICE) {
-            tasks.add(NodeDiscoveryTask.ROUTES);
-        }
+        tasks.addAll(meshUpdateTasks);
 
         startDiscovery(tasks);
     }
@@ -725,5 +728,14 @@ public class ZigBeeNodeServiceDiscoverer {
      */
     public Calendar getLastDiscoveryCompleted() {
         return lastDiscoveryCompleted;
+    }
+
+    /**
+     * Updates the list of tasks to be completed with the mesh update is executed
+     *
+     * @param tasks a List of {@link NodeDiscoveryTask}s to execute as part of the mesh update
+     */
+    public void setUpdateMeshTasks(List<NodeDiscoveryTask> tasks) {
+        meshUpdateTasks = tasks;
     }
 }

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeDiscoveryExtensionTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeDiscoveryExtensionTest.java
@@ -9,6 +9,7 @@ package com.zsmartsystems.zigbee.app.discovery;
 
 import static org.junit.Assert.assertEquals;
 
+import java.util.Arrays;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -24,6 +25,7 @@ import com.zsmartsystems.zigbee.ZigBeeNetworkNodeListener;
 import com.zsmartsystems.zigbee.ZigBeeNode;
 import com.zsmartsystems.zigbee.ZigBeeNode.ZigBeeNodeState;
 import com.zsmartsystems.zigbee.ZigBeeStatus;
+import com.zsmartsystems.zigbee.app.discovery.ZigBeeNodeServiceDiscoverer.NodeDiscoveryTask;
 import com.zsmartsystems.zigbee.zdo.command.DeviceAnnounce;
 import com.zsmartsystems.zigbee.zdo.command.ManagementLeaveResponse;
 
@@ -45,6 +47,9 @@ public class ZigBeeDiscoveryExtensionTest {
         Mockito.doNothing().when(extension).startDiscovery(node);
         Mockito.doNothing().when(extension).stopDiscovery(node);
         Mockito.doNothing().when(extension).startScheduler(ArgumentMatchers.any(int.class));
+
+        extension.setUpdateMeshTasks(
+                Arrays.asList(new NodeDiscoveryTask[] { NodeDiscoveryTask.ROUTES, NodeDiscoveryTask.NEIGHBORS }));
 
         extension.setUpdatePeriod(0);
 


### PR DESCRIPTION
This allows the mesh update tasks to be configured using the ```ZigBeeDiscoveryExtension.setUpdateMeshTasks()``` method. By default it will perform ```ROUTES``` and ```NEIGHBORS``` updates, but this could be configured differently if desired.

FYI @Shyamranny
Signed-off-by: Chris Jackson <chris@cd-jackson.com>