### PR TITLE
CLI nodelist: Do not force read of modelId/manufacturer

### DIFF
--- a/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleNodeListCommand.java
+++ b/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleNodeListCommand.java
@@ -7,6 +7,8 @@
  */
 package com.zsmartsystems.zigbee.console;
 
+import static com.zsmartsystems.zigbee.zcl.clusters.ZclBasicCluster.*;
+
 import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -18,6 +20,7 @@ import com.zsmartsystems.zigbee.ZigBeeEndpoint;
 import com.zsmartsystems.zigbee.ZigBeeNetworkManager;
 import com.zsmartsystems.zigbee.ZigBeeNode;
 import com.zsmartsystems.zigbee.ZigBeeProfileType;
+import com.zsmartsystems.zigbee.zcl.ZclAttribute;
 import com.zsmartsystems.zigbee.zcl.ZclCluster;
 import com.zsmartsystems.zigbee.zcl.clusters.ZclBasicCluster;
 
@@ -94,12 +97,16 @@ public class ZigBeeConsoleNodeListCommand extends ZigBeeConsoleAbstractCommand {
 
     private String getManufacturer(ZigBeeEndpoint endpoint) {
         ZclBasicCluster cluster = getBasicCluster(endpoint);
-        return cluster != null ? cluster.getManufacturerName(Long.MAX_VALUE) : "";
+        ZclAttribute attribute = cluster != null ? cluster.getAttribute(ATTR_MANUFACTURERNAME) : null;
+        Object lastValue = attribute != null ? attribute.getLastValue() : null;
+        return lastValue != null ? lastValue.toString() : "";
     }
 
     private String getModel(ZigBeeEndpoint endpoint) {
         ZclBasicCluster cluster = getBasicCluster(endpoint);
-        return cluster != null ? cluster.getModelIdentifier(Long.MAX_VALUE) : "";
+        ZclAttribute attribute = cluster != null ? cluster.getAttribute(ATTR_MODELIDENTIFIER) : null;
+        Object lastValue = attribute != null ? attribute.getLastValue() : null;
+        return lastValue != null ? lastValue.toString() : "";
     }
 
     private ZclBasicCluster getBasicCluster(ZigBeeEndpoint endpoint) {


### PR DESCRIPTION
This resolves #553.

Unlike what I wrote in #553, I did not introduce a flag for the command; instead, the command now displays the last value of the model ID and the manufacturer (unless these values were never read from the device, in which no model ID / manufacturer is displayed in the node list for the device).

If one wants to have model ID and manufacturer in the nodelist output, and they have not yet been read, one simply has to execute a `read <endpoint> 0 4 5` command to read both attributes once.