### PR TITLE
Support multiple attribute updates per report

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/ZclAttributeListener.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/ZclAttributeListener.java
@@ -18,6 +18,7 @@ public interface ZclAttributeListener {
      * Called when an attribute is updated
      *
      * @param attribute the {@link ZclAttribute} that has been updated
+     * @param value the new value of the attribute
      */
-    void attributeUpdated(ZclAttribute attribute);
+    void attributeUpdated(ZclAttribute attribute, Object value);
 }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/ZclCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/ZclCluster.java
@@ -826,13 +826,14 @@ public abstract class ZclCluster {
      * Notify attribute listeners of an updated {@link ZclAttribute}.
      *
      * @param attribute the {@link ZclAttribute} to notify
+     * @param value the current value of the attribute
      */
-    private void notifyAttributeListener(final ZclAttribute attribute) {
+    private void notifyAttributeListener(final ZclAttribute attribute, final Object value) {
         for (final ZclAttributeListener listener : attributeListeners) {
             NotificationService.execute(new Runnable() {
                 @Override
                 public void run() {
-                    listener.attributeUpdated(attribute);
+                    listener.attributeUpdated(attribute, value);
                 }
             });
         }
@@ -912,8 +913,9 @@ public abstract class ZclCluster {
             logger.debug("{}: Unknown attribute {} in cluster {}", zigbeeEndpoint.getEndpointAddress(), attributeId,
                     clusterId);
         } else {
-            attribute.updateValue(normalizer.normalizeZclData(attribute.getDataType(), attributeValue));
-            notifyAttributeListener(attribute);
+            Object value = normalizer.normalizeZclData(attribute.getDataType(), attributeValue);
+            attribute.updateValue(value);
+            notifyAttributeListener(attribute, value);
         }
     }
 

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zcl/ZclClusterTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zcl/ZclClusterTest.java
@@ -175,6 +175,7 @@ public class ZclClusterTest {
 
         ZclAttributeListener listenerMock = Mockito.mock(ZclAttributeListener.class);
         ArgumentCaptor<ZclAttribute> attributeCapture = ArgumentCaptor.forClass(ZclAttribute.class);
+        ArgumentCaptor<Object> valueCaptor = ArgumentCaptor.forClass(Object.class);
         cluster.addAttributeListener(listenerMock);
         cluster.addAttributeListener(listenerMock);
         List<AttributeReport> attributeList = new ArrayList<AttributeReport>();
@@ -185,17 +186,37 @@ public class ZclClusterTest {
         report.setAttributeValue(Integer.valueOf(1));
         System.out.println(report);
         attributeList.add(report);
+
+        AttributeReport report2;
+        report2 = new AttributeReport();
+        report2.setAttributeDataType(ZclDataType.SIGNED_8_BIT_INTEGER);
+        report2.setAttributeIdentifier(0);
+        report2.setAttributeValue(0);
+        System.out.println(report2);
+        attributeList.add(report2);
         cluster.handleAttributeReport(attributeList);
         ZclAttribute attribute = cluster.getAttribute(0);
         assertTrue(attribute.getLastValue() instanceof Boolean);
 
-        Mockito.verify(listenerMock, Mockito.timeout(1000).times(1)).attributeUpdated(attributeCapture.capture());
+        Mockito.verify(listenerMock, Mockito.timeout(1000).times(2)).attributeUpdated(attributeCapture.capture(), valueCaptor.capture());
 
-        attribute = attributeCapture.getValue();
+        List<ZclAttribute> updatedAttributes = attributeCapture.getAllValues();
+        assertEquals(2, updatedAttributes.size());
+        List<Object> values = valueCaptor.getAllValues();
+
+        attribute = updatedAttributes.get(0);
         assertTrue(attribute.getLastValue() instanceof Boolean);
         assertEquals(ZclDataType.BOOLEAN, attribute.getDataType());
         assertEquals(0, attribute.getId());
-        assertEquals(true, attribute.getLastValue());
+        assertEquals(false, attribute.getLastValue());
+        assertEquals(true, values.get(0));
+
+        attribute = updatedAttributes.get(1);
+        assertTrue(attribute.getLastValue() instanceof Boolean);
+        assertEquals(ZclDataType.BOOLEAN, attribute.getDataType());
+        assertEquals(0, attribute.getId());
+        assertEquals(false, attribute.getLastValue());
+        assertEquals(false, values.get(1));
 
         cluster.removeAttributeListener(listenerMock);
     }


### PR DESCRIPTION
# Description

As the listeners are executed asynchronously all parts of the report
will have been processed when the listeners are called.
Attribute.getLastValue() will be the same for all listeners.

# Usecase

I want to add support for a Xiami Mini Wireless switch to the openhab binding.
On each press the switch sends a single attributereport command with two reports in it.
One for pressed, one for released. Unfortunately the attribute listener inside the binding can't match on the different values, as it only receives a reference to the attribute and has to fetch the last value out of it, which is always the last one.

# Comments

Currently this changes the AttributeListener interface.
If it is preferred to be fully backwards compatible we could add `default` variants for both interface methods and new users of the interface could use the new method.