### PR TITLE
Introduce ZigBeeNetworkState enum to separate transport and network states

### DIFF
--- a/com.zsmartsystems.zigbee.console.main/src/main/java/com/zsmartsystems/zigbee/console/main/ZigBeeConsole.java
+++ b/com.zsmartsystems.zigbee.console.main/src/main/java/com/zsmartsystems/zigbee/console/main/ZigBeeConsole.java
@@ -35,6 +35,7 @@ import com.zsmartsystems.zigbee.ZigBeeEndpoint;
 import com.zsmartsystems.zigbee.ZigBeeGroupAddress;
 import com.zsmartsystems.zigbee.ZigBeeNetworkManager;
 import com.zsmartsystems.zigbee.ZigBeeNetworkNodeListener;
+import com.zsmartsystems.zigbee.ZigBeeNetworkState;
 import com.zsmartsystems.zigbee.ZigBeeNetworkStateListener;
 import com.zsmartsystems.zigbee.ZigBeeNode;
 import com.zsmartsystems.zigbee.app.discovery.ZigBeeDiscoveryExtension;
@@ -74,7 +75,6 @@ import com.zsmartsystems.zigbee.transport.TrustCentreJoinMode;
 import com.zsmartsystems.zigbee.transport.ZigBeeTransportFirmwareCallback;
 import com.zsmartsystems.zigbee.transport.ZigBeeTransportFirmwareStatus;
 import com.zsmartsystems.zigbee.transport.ZigBeeTransportFirmwareUpdate;
-import com.zsmartsystems.zigbee.transport.ZigBeeTransportState;
 import com.zsmartsystems.zigbee.transport.ZigBeeTransportTransmit;
 import com.zsmartsystems.zigbee.zcl.ZclAttribute;
 import com.zsmartsystems.zigbee.zcl.ZclCluster;
@@ -215,7 +215,7 @@ public final class ZigBeeConsole {
 
         networkManager.addNetworkStateListener(new ZigBeeNetworkStateListener() {
             @Override
-            public void networkStateUpdated(ZigBeeTransportState state) {
+            public void networkStateUpdated(ZigBeeNetworkState state) {
                 print("ZigBee network state updated to " + state.toString(), System.out);
             }
         });

--- a/com.zsmartsystems.zigbee.dongle.conbee/src/main/java/com/zsmartsystems/zigbee/dongle/conbee/ZigBeeDongleConBee.java
+++ b/com.zsmartsystems.zigbee.dongle.conbee/src/main/java/com/zsmartsystems/zigbee/dongle/conbee/ZigBeeDongleConBee.java
@@ -102,7 +102,7 @@ public class ZigBeeDongleConBee implements ZigBeeTransportTransmit {
     public ZigBeeStatus initialize() {
         logger.debug("ConBee transport initialize");
 
-        zigbeeNetworkReceive.setNetworkState(ZigBeeTransportState.UNINITIALISED);
+        zigbeeNetworkReceive.setTransportState(ZigBeeTransportState.UNINITIALISED);
 
         if (!serialPort.open()) {
             logger.error("Unable to open ConBee serial port");
@@ -283,7 +283,7 @@ public class ZigBeeDongleConBee implements ZigBeeTransportTransmit {
             return;
         }
         conbeeHandler.setClosing();
-        zigbeeNetworkReceive.setNetworkState(ZigBeeTransportState.OFFLINE);
+        zigbeeNetworkReceive.setTransportState(ZigBeeTransportState.OFFLINE);
         serialPort.close();
         conbeeHandler.close();
         logger.debug("ConBee dongle shutdown.");
@@ -374,12 +374,12 @@ public class ZigBeeDongleConBee implements ZigBeeTransportTransmit {
             currentNetworkState = deviceState.getNetworkState();
             switch (deviceState.getNetworkState()) {
                 case NET_CONNECTED:
-                    zigbeeNetworkReceive.setNetworkState(ZigBeeTransportState.ONLINE);
+                    zigbeeNetworkReceive.setTransportState(ZigBeeTransportState.ONLINE);
                     break;
                 case NET_JOINING:
                 case NET_LEAVING:
                 case NET_OFFLINE:
-                    zigbeeNetworkReceive.setNetworkState(ZigBeeTransportState.OFFLINE);
+                    zigbeeNetworkReceive.setTransportState(ZigBeeTransportState.OFFLINE);
                     break;
                 default:
                     break;

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
@@ -733,7 +733,7 @@ public class ZigBeeDongleEzsp implements ZigBeeTransportTransmit, ZigBeeTranspor
                 }
                 // Handle link changes and notify framework
                 zigbeeTransportReceive
-                        .setNetworkState(linkState ? ZigBeeTransportState.ONLINE : ZigBeeTransportState.OFFLINE);
+                        .setTransportState(linkState ? ZigBeeTransportState.ONLINE : ZigBeeTransportState.OFFLINE);
             }
         }.start();
     }
@@ -961,7 +961,7 @@ public class ZigBeeDongleEzsp implements ZigBeeTransportTransmit, ZigBeeTranspor
             return false;
         }
 
-        zigbeeTransportReceive.setNetworkState(ZigBeeTransportState.OFFLINE);
+        zigbeeTransportReceive.setTransportState(ZigBeeTransportState.OFFLINE);
         callback.firmwareUpdateCallback(ZigBeeTransportFirmwareStatus.FIRMWARE_UPDATE_STARTED);
 
         // Initialise the EZSP protocol so we can start the bootloader

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzspTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzspTest.java
@@ -156,18 +156,18 @@ public class ZigBeeDongleEzspTest {
         EzspStackStatusHandler response = Mockito.mock(EzspStackStatusHandler.class);
         Mockito.when(response.getStatus()).thenReturn(EmberStatus.EMBER_NETWORK_BUSY);
         Mockito.verify(transport, Mockito.timeout(TIMEOUT).times(0))
-                .setNetworkState(ArgumentMatchers.any(ZigBeeTransportState.class));
+                .setTransportState(ArgumentMatchers.any(ZigBeeTransportState.class));
 
         response = Mockito.mock(EzspStackStatusHandler.class);
         Mockito.when(response.getStatus()).thenReturn(EmberStatus.EMBER_NETWORK_UP);
         dongle.handlePacket(response);
-        Mockito.verify(transport, Mockito.timeout(TIMEOUT)).setNetworkState(ZigBeeTransportState.ONLINE);
+        Mockito.verify(transport, Mockito.timeout(TIMEOUT)).setTransportState(ZigBeeTransportState.ONLINE);
         assertEquals(Integer.valueOf(1243), dongle.getNwkAddress());
 
         response = Mockito.mock(EzspStackStatusHandler.class);
         Mockito.when(response.getStatus()).thenReturn(EmberStatus.EMBER_NETWORK_DOWN);
         dongle.handlePacket(response);
-        Mockito.verify(transport, Mockito.timeout(TIMEOUT)).setNetworkState(ZigBeeTransportState.OFFLINE);
+        Mockito.verify(transport, Mockito.timeout(TIMEOUT)).setTransportState(ZigBeeTransportState.OFFLINE);
     }
 
     @Test

--- a/com.zsmartsystems.zigbee.dongle.telegesis/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/ZigBeeDongleTelegesis.java
+++ b/com.zsmartsystems.zigbee.dongle.telegesis/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/ZigBeeDongleTelegesis.java
@@ -471,7 +471,7 @@ public class ZigBeeDongleTelegesis
         }
         frameHandler.removeEventListener(this);
         frameHandler.setClosing();
-        zigbeeTransportReceive.setNetworkState(ZigBeeTransportState.OFFLINE);
+        zigbeeTransportReceive.setTransportState(ZigBeeTransportState.OFFLINE);
         serialPort.close();
         frameHandler.close();
         logger.debug("Telegesis dongle shutdown.");
@@ -760,11 +760,11 @@ public class ZigBeeDongleTelegesis
 
         // Handle link changes and notify framework or just reset link with dongle?
         if (event instanceof TelegesisNetworkLeftEvent | event instanceof TelegesisNetworkLostEvent) {
-            zigbeeTransportReceive.setNetworkState(ZigBeeTransportState.OFFLINE);
+            zigbeeTransportReceive.setTransportState(ZigBeeTransportState.OFFLINE);
             return;
         }
         if (event instanceof TelegesisNetworkJoinedEvent) {
-            zigbeeTransportReceive.setNetworkState(ZigBeeTransportState.ONLINE);
+            zigbeeTransportReceive.setTransportState(ZigBeeTransportState.ONLINE);
             return;
         }
 
@@ -885,7 +885,7 @@ public class ZigBeeDongleTelegesis
             return false;
         }
 
-        zigbeeTransportReceive.setNetworkState(ZigBeeTransportState.OFFLINE);
+        zigbeeTransportReceive.setTransportState(ZigBeeTransportState.OFFLINE);
         callback.firmwareUpdateCallback(ZigBeeTransportFirmwareStatus.FIRMWARE_UPDATE_STARTED);
 
         // Send the bootload command, but ignore the response since there doesn't seem to be one
@@ -1060,7 +1060,7 @@ public class ZigBeeDongleTelegesis
         if (!startupComplete) {
             return;
         }
-        zigbeeTransportReceive.setNetworkState(state ? ZigBeeTransportState.ONLINE : ZigBeeTransportState.OFFLINE);
+        zigbeeTransportReceive.setTransportState(state ? ZigBeeTransportState.ONLINE : ZigBeeTransportState.OFFLINE);
     }
 
 }

--- a/com.zsmartsystems.zigbee.dongle.telegesis/src/test/java/com/zsmartsystems/zigbee/dongle/telegesis/ZigBeeDongleTelegesisTest.java
+++ b/com.zsmartsystems.zigbee.dongle.telegesis/src/test/java/com/zsmartsystems/zigbee/dongle/telegesis/ZigBeeDongleTelegesisTest.java
@@ -177,7 +177,7 @@ public class ZigBeeDongleTelegesisTest {
         TelegesisNetworkLeftEvent response = Mockito.mock(TelegesisNetworkLeftEvent.class);
         dongle.telegesisEventReceived(response);
 
-        Mockito.verify(transport, Mockito.timeout(TIMEOUT)).setNetworkState(ZigBeeTransportState.OFFLINE);
+        Mockito.verify(transport, Mockito.timeout(TIMEOUT)).setTransportState(ZigBeeTransportState.OFFLINE);
     }
 
     @Test
@@ -192,7 +192,7 @@ public class ZigBeeDongleTelegesisTest {
         TelegesisNetworkLostEvent response = Mockito.mock(TelegesisNetworkLostEvent.class);
         dongle.telegesisEventReceived(response);
 
-        Mockito.verify(transport, Mockito.timeout(TIMEOUT)).setNetworkState(ZigBeeTransportState.OFFLINE);
+        Mockito.verify(transport, Mockito.timeout(TIMEOUT)).setTransportState(ZigBeeTransportState.OFFLINE);
     }
 
     @Test
@@ -207,7 +207,7 @@ public class ZigBeeDongleTelegesisTest {
         TelegesisNetworkJoinedEvent response = Mockito.mock(TelegesisNetworkJoinedEvent.class);
         dongle.telegesisEventReceived(response);
 
-        Mockito.verify(transport, Mockito.timeout(TIMEOUT)).setNetworkState(ZigBeeTransportState.ONLINE);
+        Mockito.verify(transport, Mockito.timeout(TIMEOUT)).setTransportState(ZigBeeTransportState.ONLINE);
     }
 
     @Test

--- a/com.zsmartsystems.zigbee.dongle.xbee/src/main/java/com/zsmartsystems/zigbee/dongle/xbee/ZigBeeDongleXBee.java
+++ b/com.zsmartsystems.zigbee.dongle.xbee/src/main/java/com/zsmartsystems/zigbee/dongle/xbee/ZigBeeDongleXBee.java
@@ -284,7 +284,7 @@ public class ZigBeeDongleXBee implements ZigBeeTransportTransmit, XBeeEventListe
             return;
         }
         frameHandler.setClosing();
-        zigbeeTransportReceive.setNetworkState(ZigBeeTransportState.OFFLINE);
+        zigbeeTransportReceive.setTransportState(ZigBeeTransportState.OFFLINE);
         serialPort.close();
         frameHandler.close();
         logger.debug("XBee dongle shutdown.");
@@ -398,7 +398,7 @@ public class ZigBeeDongleXBee implements ZigBeeTransportTransmit, XBeeEventListe
 
     private void setNetworkState(ZigBeeTransportState state) {
         if (initialisationComplete) {
-            zigbeeTransportReceive.setNetworkState(state);
+            zigbeeTransportReceive.setTransportState(state);
         }
     }
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
@@ -208,14 +208,14 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
     private ClusterMatcher clusterMatcher = null;
 
     /**
-     * The current {@link ZigBeeTransportState}
+     * The current {@link ZigBeeNetworkState}
      */
-    private ZigBeeTransportState networkState = ZigBeeTransportState.UNINITIALISED;
+    private ZigBeeNetworkState networkState = ZigBeeNetworkState.UNINITIALISED;
 
     /**
-     * Map of allowable state transitions
+     * Map of allowable transport state transitions
      */
-    private final Map<ZigBeeTransportState, Set<ZigBeeTransportState>> validStateTransitions;
+    private final Map<ZigBeeNetworkState, Set<ZigBeeTransportState>> validTransportStateTransitions;
 
     /**
      * Our local {@link IeeeAddress}
@@ -227,39 +227,22 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
      */
     private int localNwkAddress = 0;
 
-    public enum ZigBeeInitializeResponse {
-        /**
-         * Device is initialized successfully and is currently joined to a network
-         */
-        JOINED,
-        /**
-         * Device initialization failed
-         */
-        FAILED,
-        /**
-         * Device is initialized successfully and is currently not joined to a network
-         */
-        NOT_JOINED
-    }
-
     /**
      * Constructor which configures serial port and ZigBee network.
      *
-     * @param transport the dongle
+     * @param transport the dongle providing the {@link ZigBeeTransportTransmit}
      */
     public ZigBeeNetworkManager(final ZigBeeTransportTransmit transport) {
         databaseManager = new ZigBeeNetworkDatabaseManager(this);
-        Map<ZigBeeTransportState, Set<ZigBeeTransportState>> transitions = new HashMap<>();
 
-        transitions.put(null, new HashSet<>(Arrays.asList(ZigBeeTransportState.UNINITIALISED)));
-        transitions.put(ZigBeeTransportState.UNINITIALISED,
+        Map<ZigBeeNetworkState, Set<ZigBeeTransportState>> transitions = new ConcurrentHashMap<>();
+        transitions.put(ZigBeeNetworkState.UNINITIALISED,
                 new HashSet<>(Arrays.asList(ZigBeeTransportState.INITIALISING, ZigBeeTransportState.OFFLINE)));
-        transitions.put(ZigBeeTransportState.INITIALISING,
-                new HashSet<>(Arrays.asList(ZigBeeTransportState.ONLINE, ZigBeeTransportState.OFFLINE)));
-        transitions.put(ZigBeeTransportState.ONLINE, new HashSet<>(Arrays.asList(ZigBeeTransportState.OFFLINE)));
-        transitions.put(ZigBeeTransportState.OFFLINE, new HashSet<>(Arrays.asList(ZigBeeTransportState.ONLINE)));
+        transitions.put(ZigBeeNetworkState.INITIALISING, new HashSet<>(Arrays.asList(ZigBeeTransportState.ONLINE)));
+        transitions.put(ZigBeeNetworkState.ONLINE, new HashSet<>(Arrays.asList(ZigBeeTransportState.OFFLINE)));
+        transitions.put(ZigBeeNetworkState.OFFLINE, new HashSet<>(Arrays.asList(ZigBeeTransportState.ONLINE)));
 
-        validStateTransitions = Collections.unmodifiableMap(new HashMap<>(transitions));
+        validTransportStateTransitions = Collections.unmodifiableMap(new HashMap<>(transitions));
 
         this.transport = transport;
 
@@ -316,20 +299,20 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
      */
     public ZigBeeStatus initialize() {
         synchronized (this) {
-            if (networkState != ZigBeeTransportState.UNINITIALISED) {
+            if (networkState != ZigBeeNetworkState.UNINITIALISED) {
                 return ZigBeeStatus.INVALID_STATE;
             }
-            setNetworkState(ZigBeeTransportState.INITIALISING);
+            setNetworkState(ZigBeeNetworkState.INITIALISING);
         }
 
         databaseManager.startup();
 
         ZigBeeStatus transportResponse = transport.initialize();
         if (transportResponse != ZigBeeStatus.SUCCESS) {
-            setNetworkState(ZigBeeTransportState.OFFLINE);
+            setNetworkState(ZigBeeNetworkState.OFFLINE);
             return transportResponse;
         }
-        setNetworkState(ZigBeeTransportState.INITIALISING);
+        setNetworkState(ZigBeeNetworkState.INITIALISING);
 
         addLocalNode();
 
@@ -501,16 +484,16 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
      * @return {@link ZigBeeStatus} with the status of function
      */
     public ZigBeeStatus startup(boolean reinitialize) {
-        if (networkState == ZigBeeTransportState.UNINITIALISED) {
+        if (networkState == ZigBeeNetworkState.UNINITIALISED) {
             return ZigBeeStatus.INVALID_STATE;
         }
 
         ZigBeeStatus status = transport.startup(reinitialize);
         if (status != ZigBeeStatus.SUCCESS) {
-            setNetworkState(ZigBeeTransportState.OFFLINE);
+            setNetworkState(ZigBeeNetworkState.OFFLINE);
             return status;
         }
-        setNetworkState(ZigBeeTransportState.ONLINE);
+        setNetworkState(ZigBeeNetworkState.ONLINE);
         return ZigBeeStatus.SUCCESS;
     }
 
@@ -542,7 +525,7 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
      * @param runnableTask the {@link Runnable} to execute
      */
     public void executeTask(Runnable runnableTask) {
-        if (networkState != ZigBeeTransportState.ONLINE) {
+        if (networkState != ZigBeeNetworkState.ONLINE) {
             return;
         }
         executorService.execute(runnableTask);
@@ -556,7 +539,7 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
      * @return the {@link ScheduledFuture} for the scheduled task
      */
     public ScheduledFuture<?> scheduleTask(Runnable runnableTask, long delay) {
-        if (networkState != ZigBeeTransportState.ONLINE) {
+        if (networkState != ZigBeeNetworkState.ONLINE) {
             return null;
         }
         return executorService.schedule(runnableTask, delay, TimeUnit.MILLISECONDS);
@@ -573,7 +556,7 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
      */
     public ScheduledFuture<?> rescheduleTask(ScheduledFuture<?> futureTask, Runnable runnableTask, long delay) {
         futureTask.cancel(false);
-        if (networkState != ZigBeeTransportState.ONLINE) {
+        if (networkState != ZigBeeNetworkState.ONLINE) {
             return null;
         }
 
@@ -921,14 +904,21 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
     }
 
     @Override
-    public void setNetworkState(final ZigBeeTransportState state) {
-        // Only notify users of state changes
-        if (state.equals(networkState)) {
+    public synchronized void setTransportState(final ZigBeeTransportState state) {
+        if (!validTransportStateTransitions.get(networkState).contains(state)) {
+            logger.debug(
+                    "Ignoring invalid transport state transition in ZigBeeNetworkState.{} by ZigBeeTransportState.{}",
+                    networkState, state);
             return;
         }
 
-        if (!validStateTransitions.get(networkState).contains(state)) {
-            logger.debug("Ignoring invalid network state transition from {} to {}", networkState, state);
+        // Process the network state given the updated transport layer state
+        setNetworkState(ZigBeeNetworkState.valueOf(state.toString()));
+    }
+
+    private synchronized void setNetworkState(final ZigBeeNetworkState state) {
+        // Only notify users of state changes
+        if (state.equals(networkState)) {
             return;
         }
 
@@ -940,7 +930,7 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
         });
     }
 
-    private void setNetworkStateRunnable(final ZigBeeTransportState state) {
+    private void setNetworkStateRunnable(final ZigBeeNetworkState state) {
         synchronized (this) {
             networkState = state;
 
@@ -948,7 +938,7 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
 
             // If the state has changed to online, then we need to add any pending nodes,
             // and ensure that the local node is added
-            if (state == ZigBeeTransportState.ONLINE) {
+            if (state == ZigBeeNetworkState.ONLINE) {
                 localNwkAddress = transport.getNwkAddress();
                 localIeeeAddress = transport.getIeeeAddress();
 
@@ -978,10 +968,12 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
             // Now that everything is added and started, notify the listeners that the state has updated
             for (final ZigBeeNetworkStateListener stateListener : stateListeners) {
                 NotificationService.execute(new Runnable() {
+
                     @Override
                     public void run() {
                         stateListener.networkStateUpdated(state);
                     }
+
                 });
             }
         }
@@ -1267,8 +1259,10 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
             networkNodes.put(node.getIeeeAddress(), node);
         }
 
-        if (networkState != ZigBeeTransportState.ONLINE) {
-            return;
+        synchronized (this) {
+            if (networkState != ZigBeeNetworkState.ONLINE) {
+                return;
+            }
         }
 
         for (final ZigBeeNetworkNodeListener listener : nodeListeners) {
@@ -1355,7 +1349,7 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
         extension.extensionInitialize(this);
 
         // If the network is online, start the extension
-        if (networkState == ZigBeeTransportState.ONLINE) {
+        if (networkState == ZigBeeNetworkState.ONLINE) {
             extension.extensionStartup();
         }
     }
@@ -1363,7 +1357,6 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
     /**
      * Gets a functional extension that has been registered with the network.
      *
-     * @param <T> {@link ZigBeeNetworkExtension}
      * @param requestedExtension the {@link ZigBeeNetworkExtension} to get
      * @return the requested {@link ZigBeeNetworkExtension} if it exists, or null
      */
@@ -1379,11 +1372,11 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
     }
 
     /**
-     * Gets the current {@link ZigBeeTransportState}
+     * Gets the current {@link ZigBeeNetworkState}
      *
-     * @return the current {@link ZigBeeTransportState}
+     * @return the current {@link ZigBeeNetworkState}
      */
-    public ZigBeeTransportState getNetworkState() {
+    public ZigBeeNetworkState getNetworkState() {
         return networkState;
     }
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkState.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkState.java
@@ -5,29 +5,29 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  */
-package com.zsmartsystems.zigbee.transport;
+package com.zsmartsystems.zigbee;
 
 /**
- * An enumeration of the current state of the transport layer.
+ * An enumeration of possible network states
  *
  * @author Chris Jackson
  *
  */
-public enum ZigBeeTransportState {
+public enum ZigBeeNetworkState {
     /**
-     * Transport has not yet been initialised
+     * Network has not yet been initialised
      */
     UNINITIALISED,
     /**
-     * Transport is currently initialising
+     * Network is currently initialising
      */
     INITIALISING,
     /**
-     * Transport is online and able to be used
+     * Network is online and able to be used
      */
     ONLINE,
     /**
-     * Transport is offline and not able to be used
+     * Network is offline and not able to be used
      */
     OFFLINE
 }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkStateListener.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkStateListener.java
@@ -7,10 +7,19 @@
  */
 package com.zsmartsystems.zigbee;
 
-import com.zsmartsystems.zigbee.transport.ZigBeeTransportState;
-
 /**
  * ZigBee network listener. Provides notifications on updates to the network state
+ * <p>
+ * This is used to provide status updates to higher layer listeners registered through the
+ * {@link ZigBeeNetworkStateListener} interface.
+ * <p>
+ * Valid state transitions are -:
+ * <ul>
+ * <li>UNITIALISED to INITIALISING or OFFLINE
+ * <li>INITIALISING to ONLINE or OFFLINE
+ * <li>ONLINE to OFFLINE
+ * <li>OFFLINE to ONLINE
+ * </ul
  *
  * @author Chris Jackson
  */
@@ -19,8 +28,7 @@ public interface ZigBeeNetworkStateListener {
     /**
      * Network state has been updated.
      *
-     * @param state
-     *            the updated {@link TransportState}
+     * @param state the updated {@link ZigBeeNetworkState}
      */
-    void networkStateUpdated(final ZigBeeTransportState state);
+    void networkStateUpdated(final ZigBeeNetworkState state);
 }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transport/ZigBeeTransportReceive.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transport/ZigBeeTransportReceive.java
@@ -55,7 +55,7 @@ public interface ZigBeeTransportReceive {
      *
      * @param state the updated {@link ZigBeeTransportState}
      */
-    void setNetworkState(final ZigBeeTransportState state);
+    void setTransportState(final ZigBeeTransportState state);
 
     /**
      * Announce a node has joined or left the network.


### PR DESCRIPTION
This separates the state of the transport layer from the network state. It introduces a new ```ZigBeeNetworkState``` enum, and the ```ZigBeeNetworkStateListener``` now receives updates with this new enum and not the ```ZigBeeTransportState```.

When refactoring it is noted that state names remain the same between the two - just the class name changes.

Closes #548 
Closes #554

Signed-off-by: Chris Jackson <chris@cd-jackson.com>