### PR TITLE
Remove global dependency on logging implementation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,11 @@ allprojects {
  version = '1.1.10-SNAPSHOT'
 }
 
+ext {
+ slf4jVersion = '1.7.2'
+ log4jVersion = '1.2.17'
+}
+
 subprojects {
  apply plugin: 'java'
  sourceCompatibility = 1.8
@@ -29,9 +34,7 @@ subprojects {
 
 
  dependencies {
-  compile group: 'log4j', name: 'log4j', version: '1.2.17'
-  compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.2'
-  compile group: 'org.slf4j', name: 'slf4j-log4j12', version: '1.7.2'
+  compile group: 'org.slf4j', name: 'slf4j-api', version: rootProject.slf4jVersion
   testCompile group: 'junit', name: 'junit', version: '4.12'
   testCompile group: 'org.mockito', name: 'mockito-core', version: '2.19.1'
   testCompile group: 'org.awaitility', name: 'awaitility', version: '2.0.0'

--- a/com.zsmartsystems.zigbee.console/build.gradle
+++ b/com.zsmartsystems.zigbee.console/build.gradle
@@ -2,4 +2,6 @@ group = 'com.zsmartsystems.zigbee'
 description = ''
 dependencies {
   compile project(':com.zsmartsystems.zigbee')
+  compile group: 'log4j', name: 'log4j', version: rootProject.log4jVersion
+  compile group: 'org.slf4j', name: 'slf4j-log4j12', version: rootProject.slf4jVersion
 }

--- a/com.zsmartsystems.zigbee.console/pom.xml
+++ b/com.zsmartsystems.zigbee.console/pom.xml
@@ -19,6 +19,18 @@
             <artifactId>com.zsmartsystems.zigbee</artifactId>
             <version>1.1.11-SNAPSHOT</version>
         </dependency>
+
+        <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+            <version>${log4j.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
         
     </dependencies>
     

--- a/com.zsmartsystems.zigbee/build.gradle
+++ b/com.zsmartsystems.zigbee/build.gradle
@@ -1,2 +1,7 @@
 group = 'com.zsmartsystems.zigbee'
 description = ''
+
+dependencies {
+  testCompile group: 'log4j', name: 'log4j', version: rootProject.log4jVersion
+  testCompile group: 'org.slf4j', name: 'slf4j-log4j12', version: rootProject.slf4jVersion
+}

--- a/com.zsmartsystems.zigbee/pom.xml
+++ b/com.zsmartsystems.zigbee/pom.xml
@@ -12,6 +12,22 @@
 		<version>1.1.11-SNAPSHOT</version>
 	</parent>
 
+	<dependencies>
+		<dependency>
+			<groupId>log4j</groupId>
+			<artifactId>log4j</artifactId>
+			<version>${log4j.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-log4j12</artifactId>
+			<version>${slf4j.version}</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
 	<build>
 		<plugins>
 			<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,8 @@
         <license.year>2019</license.year>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+		<slf4j.version>1.7.2</slf4j.version>
+		<log4j.version>1.2.17</log4j.version>
 	</properties>
 
 	<scm>
@@ -221,20 +223,8 @@
 	<dependencies>
 
 		<dependency>
-			<groupId>log4j</groupId>
-			<artifactId>log4j</artifactId>
-			<version>1.2.17</version>
-		</dependency>
-
-		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>1.7.2</version>
-		</dependency>
-
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-log4j12</artifactId>
 			<version>1.7.2</version>
 		</dependency>
 


### PR DESCRIPTION
Currently the library pulls in a dependency on log4j and slf4j-log4j12
although they are not used.
Also libraries should not pull in logging implementations as it will
conflict with other logging implementations on the classpath.