### PR TITLE
Add FLOAT_32_BIT type handling

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/serialization/DefaultDeserializer.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/serialization/DefaultDeserializer.java
@@ -267,6 +267,11 @@ public class DefaultDeserializer implements ZigBeeDeserializer {
                 }
                 value[0] = new ByteArray(arrayB8);
                 break;
+            case FLOAT_32_BIT:
+                Float float32 = Float.intBitsToFloat(payload[index++] + (payload[index++] << 8)
+                        + (payload[index++] << 16) + (payload[index++] << 24));
+                value[0] = float32.doubleValue();
+                break;
             default:
                 throw new IllegalArgumentException("No reader defined in " + ZigBeeDeserializer.class.getSimpleName()
                         + " for " + type.toString() + " (" + type.getId() + ")");

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/serialization/DefaultSerializer.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/serialization/DefaultSerializer.java
@@ -202,6 +202,14 @@ public class DefaultSerializer implements ZigBeeSerializer {
             case ZIGBEE_DATA_TYPE:
                 buffer[length++] = ((ZclDataType) data).getId();
                 break;
+            case FLOAT_32_BIT:
+                final Float float32 = ((Double) data).floatValue();
+                final int float32Value = Float.floatToRawIntBits(float32);
+                buffer[length++] = float32Value & 0xFF;
+                buffer[length++] = (float32Value >> 8) & 0xFF;
+                buffer[length++] = (float32Value >> 16) & 0xFF;
+                buffer[length++] = (float32Value >> 24) & 0xFF;
+                break;
             default:
                 throw new IllegalArgumentException("No writer defined in " + ZigBeeDeserializer.class.getSimpleName()
                         + " for " + type.toString() + " (" + type.getId() + ")");

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/protocol/ZclDataType.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/protocol/ZclDataType.java
@@ -12,12 +12,31 @@ import java.util.HashMap;
 import java.util.Map;
 
 import javax.annotation.Generated;
-import com.zsmartsystems.zigbee.zcl.field.*;
-import com.zsmartsystems.zigbee.zcl.ZclStatus;
-import com.zsmartsystems.zigbee.zdo.ZdoStatus;
-import com.zsmartsystems.zigbee.zdo.field.*;
-import com.zsmartsystems.zigbee.IeeeAddress;
+
 import com.zsmartsystems.zigbee.ExtendedPanId;
+import com.zsmartsystems.zigbee.IeeeAddress;
+import com.zsmartsystems.zigbee.zcl.ZclStatus;
+import com.zsmartsystems.zigbee.zcl.field.AttributeInformation;
+import com.zsmartsystems.zigbee.zcl.field.AttributeRecord;
+import com.zsmartsystems.zigbee.zcl.field.AttributeReport;
+import com.zsmartsystems.zigbee.zcl.field.AttributeReportingConfigurationRecord;
+import com.zsmartsystems.zigbee.zcl.field.AttributeStatusRecord;
+import com.zsmartsystems.zigbee.zcl.field.ByteArray;
+import com.zsmartsystems.zigbee.zcl.field.ExtendedAttributeInformation;
+import com.zsmartsystems.zigbee.zcl.field.ExtensionFieldSet;
+import com.zsmartsystems.zigbee.zcl.field.NeighborInformation;
+import com.zsmartsystems.zigbee.zcl.field.ReadAttributeStatusRecord;
+import com.zsmartsystems.zigbee.zcl.field.WriteAttributeRecord;
+import com.zsmartsystems.zigbee.zcl.field.WriteAttributeStatusRecord;
+import com.zsmartsystems.zigbee.zdo.ZdoStatus;
+import com.zsmartsystems.zigbee.zdo.field.BindingTable;
+import com.zsmartsystems.zigbee.zdo.field.ComplexDescriptor;
+import com.zsmartsystems.zigbee.zdo.field.NeighborTable;
+import com.zsmartsystems.zigbee.zdo.field.NodeDescriptor;
+import com.zsmartsystems.zigbee.zdo.field.PowerDescriptor;
+import com.zsmartsystems.zigbee.zdo.field.RoutingTable;
+import com.zsmartsystems.zigbee.zdo.field.SimpleDescriptor;
+import com.zsmartsystems.zigbee.zdo.field.UserDescriptor;
 
 /**
  * Enumeration of the ZCL data types
@@ -37,22 +56,26 @@ public enum ZclDataType {
     DATA_8_BIT("8-bit data", Integer.class, 0x08, false),
     ENUMERATION_16_BIT("16-bit enumeration", Integer.class, 0x31, false),
     ENUMERATION_8_BIT("8-bit Enumeration", Integer.class, 0x30, false),
+    FLOAT_32_BIT("Single precision float", Double.class, 0x39, true),
     IEEE_ADDRESS("IEEE Address", IeeeAddress.class, 0xF0, false),
     N_X_ATTRIBUTE_IDENTIFIER("N X Attribute identifier", Integer.class, 0x00, false),
     N_X_ATTRIBUTE_INFORMATION("N X Attribute information", AttributeInformation.class, 0x00, false),
     N_X_ATTRIBUTE_RECORD("N X Attribute record", AttributeRecord.class, 0x00, false),
     N_X_ATTRIBUTE_REPORT("N X Attribute report", AttributeReport.class, 0x00, false),
-    N_X_ATTRIBUTE_REPORTING_CONFIGURATION_RECORD("N X Attribute reporting configuration record", AttributeReportingConfigurationRecord.class, 0x00, false),
+    N_X_ATTRIBUTE_REPORTING_CONFIGURATION_RECORD("N X Attribute reporting configuration record",
+            AttributeReportingConfigurationRecord.class, 0x00, false),
     N_X_ATTRIBUTE_SELECTOR("N X Attribute selector", Object.class, 0x00, false),
     N_X_ATTRIBUTE_STATUS_RECORD("N X Attribute status record", AttributeStatusRecord.class, 0x00, false),
-    N_X_EXTENDED_ATTRIBUTE_INFORMATION("N x Extended Attribute Information", ExtendedAttributeInformation.class, 0x00, false),
+    N_X_EXTENDED_ATTRIBUTE_INFORMATION("N x Extended Attribute Information", ExtendedAttributeInformation.class, 0x00,
+            false),
     N_X_EXTENSION_FIELD_SET("N X Extension field set", ExtensionFieldSet.class, 0x00, false),
     N_X_NEIGHBORS_INFORMATION("N X Neighbors information", NeighborInformation.class, 0x00, false),
     N_X_READ_ATTRIBUTE_STATUS_RECORD("N X Read attribute status record", ReadAttributeStatusRecord.class, 0x00, false),
     N_X_UNSIGNED_16_BIT_INTEGER("N X Unsigned 16-bit integer", Integer.class, 0x00, false),
     N_X_UNSIGNED_8_BIT_INTEGER("N x Unsigned 8-bit Integer", Integer.class, 0x00, false),
     N_X_WRITE_ATTRIBUTE_RECORD("N X Write attribute record", WriteAttributeRecord.class, 0x00, false),
-    N_X_WRITE_ATTRIBUTE_STATUS_RECORD("N X Write attribute status record", WriteAttributeStatusRecord.class, 0x00, false),
+    N_X_WRITE_ATTRIBUTE_STATUS_RECORD("N X Write attribute status record", WriteAttributeStatusRecord.class, 0x00,
+            false),
     OCTET_STRING("Octet string", ByteArray.class, 0x41, false),
     SIGNED_16_BIT_INTEGER("Signed 16-bit Integer", Integer.class, 0x29, true),
     SIGNED_32_BIT_INTEGER("Signed 32-bit Integer", Integer.class, 0x2B, true),

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/serialization/SerializerIntegrationTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/serialization/SerializerIntegrationTest.java
@@ -30,6 +30,12 @@ import com.zsmartsystems.zigbee.zdo.ZdoStatus;
  */
 public class SerializerIntegrationTest {
     @Test
+    public void testDeserialize_FLOAT_32_BIT() {
+        Double valIn = 1234.56e9;
+        testSerializer(valIn, ZclDataType.FLOAT_32_BIT);
+    }
+
+    @Test
     public void testDeserialize_ZDO_STATUS() {
         ZdoStatus valIn = ZdoStatus.NO_DESCRIPTOR;
         testSerializer(valIn, ZclDataType.ZDO_STATUS);
@@ -231,6 +237,8 @@ public class SerializerIntegrationTest {
             assertTrue(Arrays.equals((int[]) objectIn, (int[]) objectOut));
         } else if (objectIn instanceof byte[]) {
             assertTrue(Arrays.equals((byte[]) objectIn, (byte[]) objectOut));
+        } else if (objectIn instanceof Double) {
+            assertTrue(Math.abs((Double) objectOut - (Double) objectIn) < 50000);
         } else {
             assertEquals(objectIn, objectOut);
         }

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zcl/clusters/general/ReportAttributesCommandTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zcl/clusters/general/ReportAttributesCommandTest.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2016-2019 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.zcl.clusters.general;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import com.zsmartsystems.zigbee.CommandTest;
+import com.zsmartsystems.zigbee.serialization.DefaultDeserializer;
+import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
+import com.zsmartsystems.zigbee.zcl.field.AttributeReport;
+import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
+
+/**
+ *
+ * @author Chris Jackson
+ *
+ */
+public class ReportAttributesCommandTest extends CommandTest {
+
+    @Test
+    public void testSingle() {
+        int[] packet = getPacketData("05 FF 21 5C 03 55 00 39 FF BF 38 43");
+        // 0x4338BFFF =
+        ReportAttributesCommand response = new ReportAttributesCommand();
+
+        DefaultDeserializer deserializer = new DefaultDeserializer(packet);
+        ZclFieldDeserializer fieldDeserializer = new ZclFieldDeserializer(deserializer);
+
+        response.deserialize(fieldDeserializer);
+
+        System.out.println(response);
+
+        List<AttributeReport> reports = response.getReports();
+        AttributeReport record = reports.get(0);
+        assertEquals(ZclDataType.UNSIGNED_16_BIT_INTEGER, record.getAttributeDataType());
+        assertEquals(65285, record.getAttributeIdentifier());
+        assertEquals(860, record.getAttributeValue());
+
+        record = reports.get(1);
+        assertEquals(ZclDataType.FLOAT_32_BIT, record.getAttributeDataType());
+        assertEquals(85, record.getAttributeIdentifier());
+        assertTrue(Math.abs((Double) record.getAttributeValue() - 184.74998) < 0.0001);
+    }
+
+}


### PR DESCRIPTION
Adds handling for 32 bit single precision floats.
https://github.com/openhab/org.openhab.binding.zigbee/issues/406
Signed-off-by: Chris Jackson <chris@cd-jackson.com>