### PR TITLE
Ensure that only the descriptors are requested during initial discovery

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeNodeServiceDiscoverer.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeNodeServiceDiscoverer.java
@@ -194,10 +194,12 @@ public class ZigBeeNodeServiceDiscoverer {
         // complete. When no tasks are left in the queue, the worker thread will exit.
         synchronized (discoveryTasks) {
             // Remove any tasks that we know are not supported by this device
-            if (!supportsManagementLqi && newTasks.contains(NodeDiscoveryTask.NEIGHBORS)) {
+            if ((!supportsManagementLqi || node.getNodeDescriptor().getLogicalType() == LogicalType.UNKNOWN)
+                    && newTasks.contains(NodeDiscoveryTask.NEIGHBORS)) {
                 newTasks.remove(NodeDiscoveryTask.NEIGHBORS);
             }
-            if ((!supportsManagementRouting || node.getNodeDescriptor().getLogicalType() == LogicalType.END_DEVICE)
+            if ((!supportsManagementRouting || node.getNodeDescriptor().getLogicalType() == LogicalType.UNKNOWN
+                    || node.getNodeDescriptor().getLogicalType() == LogicalType.END_DEVICE)
                     && newTasks.contains(NodeDiscoveryTask.ROUTES)) {
                 newTasks.remove(NodeDiscoveryTask.ROUTES);
             }
@@ -301,7 +303,7 @@ public class ZigBeeNodeServiceDiscoverer {
      * @throws InterruptedException
      */
     private boolean requestAssociatedNodes() throws InterruptedException, ExecutionException {
-        Integer startIndex = 0;
+        int startIndex = 0;
         int totalAssociatedDevices = 0;
         Set<Integer> associatedDevices = new HashSet<Integer>();
 
@@ -670,11 +672,9 @@ public class ZigBeeNodeServiceDiscoverer {
             tasks.add(NodeDiscoveryTask.POWER_DESCRIPTOR);
         }
 
-        if (node.getEndpoints().size() == 0 && node.getNetworkAddress() != networkManager.getLocalNwkAddress()) {
+        if (node.getEndpoints().size() == 0 && !networkManager.getLocalNwkAddress().equals(node.getNetworkAddress())) {
             tasks.add(NodeDiscoveryTask.ACTIVE_ENDPOINTS);
         }
-
-        tasks.add(NodeDiscoveryTask.NEIGHBORS);
 
         startDiscovery(tasks);
     }

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeNodeServiceDiscovererTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeNodeServiceDiscovererTest.java
@@ -10,7 +10,6 @@ package com.zsmartsystems.zigbee.app.discovery;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
@@ -216,8 +215,6 @@ public class ZigBeeNodeServiceDiscovererTest {
 
         discoverer.startDiscovery();
 
-        assertTrue(discoverer.getTasks().contains(NodeDiscoveryTask.ACTIVE_ENDPOINTS));
-
         Mockito.verify(node, Mockito.timeout(TIMEOUT).times(1)).addEndpoint(endpointCapture.capture());
 
         // Then wait for the node to be updated
@@ -253,10 +250,13 @@ public class ZigBeeNodeServiceDiscovererTest {
 
         Mockito.verify(futureTask, Mockito.times(1)).cancel(true);
 
-        assertFalse(discoverer.getTasks().contains(NodeDiscoveryTask.ACTIVE_ENDPOINTS));
+        Mockito.verify(networkManager, Mockito.timeout(TIMEOUT).times(1)).updateNode(nodeCapture.capture());
 
         assertNotNull(discoverer.getLastDiscoveryStarted());
-        assertNull(discoverer.getLastDiscoveryCompleted());
+        assertNotNull(discoverer.getLastDiscoveryCompleted());
+
+        TestUtilities.setField(ZigBeeNodeServiceDiscoverer.class, discoverer, "futureTask",
+                Mockito.mock(ScheduledFuture.class));
         discoverer.stopDiscovery();
     }
 
@@ -301,5 +301,7 @@ public class ZigBeeNodeServiceDiscovererTest {
         discoverer.updateMesh();
         assertFalse(discoverer.getTasks().contains(NodeDiscoveryTask.ROUTES));
         assertTrue(discoverer.getTasks().contains(NodeDiscoveryTask.NEIGHBORS));
+
+        discoverer.stopDiscovery();
     }
 }


### PR DESCRIPTION
In order to speed up the initial discovery, and not request the mesh data when we don't know if the device is a router or end device, only the node descriptors are requested during the initial discovery.

@puzzle-star FYI.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>