### PR TITLE
CC2531: get out of bootloader at every failed reset

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.cc2531/src/main/java/com/zsmartsystems/zigbee/dongle/cc2531/network/ZigBeeNetworkManager.java
+++ b/com.zsmartsystems.zigbee.dongle.cc2531/src/main/java/com/zsmartsystems/zigbee/dongle/cc2531/network/ZigBeeNetworkManager.java
@@ -262,13 +262,8 @@ public class ZigBeeNetworkManager {
         // Now reset the dongle
         setState(DriverStatus.HARDWARE_OPEN);
         if (!dongleReset()) {
-            logger.warn("Dongle reset failed. Assuming bootloader is running and sending magic byte {}.",
-                    String.format("0x%02x", BOOTLOADER_MAGIC_BYTE));
-            if (!bootloaderGetOut(BOOTLOADER_MAGIC_BYTE)) {
-                logger.warn("Attempt to get out from bootloader failed.");
-                shutdown();
-                return null;
-            }
+            shutdown();
+            return null;
         }
 
         setState(DriverStatus.HARDWARE_READY);
@@ -710,7 +705,16 @@ public class ZigBeeNetworkManager {
 
         SYS_RESET_RESPONSE response = (SYS_RESET_RESPONSE) waiter.getCommand(RESET_TIMEOUT);
 
-        return response != null;
+        if (response == null) {
+            logger.warn("Dongle reset failed. Assuming bootloader is running and sending magic byte {}.",
+                    String.format("0x%02x", BOOTLOADER_MAGIC_BYTE));
+            if (!bootloaderGetOut(BOOTLOADER_MAGIC_BYTE)) {
+                logger.warn("Attempt to get out from bootloader failed.");
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private boolean dongleSetStartupOption(int mask) {


### PR DESCRIPTION
As described [here](https://github.com/openhab/org.openhab.binding.zigbee/issues/2) some CC2531 dongles don't soft reset (always hard reset ending up in the bootloader). This PR adds getting out of the bootloader for post configuration reset (when reset flag = true). Extra benefit is a bit cleaner code as the dongleReset() method do reset and exits BL if necessary so you don't need to worry about sending magic byte outside of dongleReset().

Signed-off-by: Witold Sowa <witold.sowa@gmail.com>