### PR TITLE
Display APS security en/disabled in cluster list

### DIFF
--- a/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleDescribeEndpointCommand.java
+++ b/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleDescribeEndpointCommand.java
@@ -92,6 +92,7 @@ public class ZigBeeConsoleDescribeEndpointCommand extends ZigBeeConsoleAbstractC
 
         for (ZclCluster cluster : clusterTree.values()) {
             out.println("   " + printClusterId(cluster.getClusterId()) + " " + cluster.getClusterName());
+            out.println("     - APS Security " + (cluster.getApsSecurityRequired() ? "en" : "dis") + "abled");
             printAttributes(cluster, out);
         }
     }


### PR DESCRIPTION
This adds the state of APS security to the endpoint cluster list in the CLI.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>