### PR TITLE
Do not set link state to true after SPI connect

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/spi/SpiFrameHandler.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/spi/SpiFrameHandler.java
@@ -368,9 +368,7 @@ public class SpiFrameHandler implements EzspProtocolHandler {
                         spiTransactionComplete();
                         stateConnected = (packetData[0] & SPI_MASK_READY) == SPI_MASK_READY;
                         logger.debug("SPI Protocol Ready: {}", stateConnected);
-                        if (stateConnected) {
-                            frameHandler.handleLinkStateChange(true);
-                        } else {
+                        if (!stateConnected) {
                             outputFrame(requestSpiStatus);
                         }
                         break;

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/spi/SpiFrameHandlerTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/spi/SpiFrameHandlerTest.java
@@ -7,10 +7,7 @@
  */
 package com.zsmartsystems.zigbee.dongle.ember.internal.spi;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -246,10 +243,6 @@ public class SpiFrameHandlerTest {
         assertEquals(2, portOutData.size());
         assertEquals(Integer.valueOf(0x0B), portOutData.get(0));
         assertEquals(Integer.valueOf(0xA7), portOutData.get(1));
-
-        // If we process the status and it is ready, then we get the online notification
-        processSpiCommand(new int[] { 0x0B }, new int[] { 0xC1 });
-        assertTrue(stateCaptor.getValue());
     }
 
     @Test


### PR DESCRIPTION
This resolves #578 

Currently, for SPI the link state is set to `true` if (a) a SPI Status command with status bit set is received, or if (b) an `EzspStackStatusHandler` callback with status `EMBER_NETWORK_UP` is received. (For ASH, only (b) is the case.)

However, if the library handles a link state change to `true`, it assumes that it can read the network address from the chip. This is, however, not possible if only the SPI connection is ready, but the network is not yet up on the chip.

Hence, the link status should only be set to `true` if the `EMBER_NETWORK_UP` status is received.