### PR TITLE
Catch invalid Ezsp frame when detecting the frame type

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/EzspFrame.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/EzspFrame.java
@@ -391,11 +391,16 @@ public abstract class EzspFrame {
      * @return the {@link EzspFrameResponse} or null if the response can't be created.
      */
     public static EzspFrameResponse createHandler(int[] data) {
-        Class<?> ezspClass;
-        if (data[2] != 0xFF) {
-            ezspClass = ezspHandlerMap.get(data[2]);
-        } else {
-            ezspClass = ezspHandlerMap.get(data[4]);
+        Class<?> ezspClass = null;
+        
+        try {
+            if (data[2] != 0xFF) {
+                ezspClass = ezspHandlerMap.get(data[2]);
+            } else {
+                ezspClass = ezspHandlerMap.get(data[4]);
+            }
+        } catch (ArrayIndexOutOfBoundsException e) {
+            logger.debug("Error detecting the Ezsp frame type", e);
         }
 
         if (ezspClass == null) {

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/spi/SpiFrameHandlerTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/spi/SpiFrameHandlerTest.java
@@ -199,6 +199,12 @@ public class SpiFrameHandlerTest {
     }
 
     @Test
+    public void testReceiveInvalidEzsp() {
+        processSpiCommand(new int[] { 0xFE }, new int[] { 0xFE, 0x04, 0x02, 0x80, 0xFF, 0x00 });
+        assertTrue(responseCaptor.getAllValues().size() == 0);
+    }
+
+    @Test
     public void testReceiveErrors() {
         SpiFrameHandler handler;
 


### PR DESCRIPTION
Fixes #586 

In this PR `EzspFrame.createHandler(int[] data)` catches the `ArrayIndexOutOfBoundsException` thrown when an invalid frame is received . Now when the Exception occurs a null object is returned.

Signed-off-by: Tommaso Travaglino <tommaso.travaglino@telekom.de>