### PR TITLE
Add default transaction queue to handle unknown nodes

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransactionManager.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransactionManager.java
@@ -149,6 +149,7 @@ public class ZigBeeTransactionManager implements ZigBeeNetworkNodeListener {
      */
     private final List<ZigBeeTransactionQueue> outstandingQueues = new ArrayList<>();
 
+    private final ZigBeeTransactionQueue defaultQueue;
     private final ZigBeeTransactionQueue broadcastQueue;
     private final ZigBeeTransactionQueue multicastQueue;
 
@@ -165,6 +166,10 @@ public class ZigBeeTransactionManager implements ZigBeeNetworkNodeListener {
 
         defaultProfile = new ZigBeeTransactionProfile(NODE_RETRIES, NODE_TRANSACTIONS, NODE_DELAY);
         defaultSleepyProfile = new ZigBeeTransactionProfile(SLEEPY_RETRIES, SLEEPY_TRANSACTIONS, SLEEPY_DELAY);
+
+        defaultQueue = new ZigBeeTransactionQueue("Default");
+        defaultQueue.setProfile(defaultProfile);
+        defaultQueue.setSleepy(false);
 
         broadcastQueue = new ZigBeeTransactionQueue("Broadcast");
         broadcastQueue.setProfile(new ZigBeeTransactionProfile(BCAST_RETRIES, BCAST_TRANSACTIONS, BCAST_DELAY));
@@ -383,7 +388,7 @@ public class ZigBeeTransactionManager implements ZigBeeNetworkNodeListener {
             ZigBeeNode node = networkManager.getNode(address.getAddress());
             if (node == null) {
                 logger.debug("Attempt to send command with unknown destination: {}", transaction);
-                return null;
+                return defaultQueue;
             }
             // Add the transaction to the device queue - if it doesn't currently exist, create it
             ZigBeeTransactionQueue queue = nodeQueue.get(node.getIeeeAddress());

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransactionManagerTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransactionManagerTest.java
@@ -133,16 +133,20 @@ public class ZigBeeTransactionManagerTest {
         assertNotNull(transactionManager.getQueue(new IeeeAddress("1111111111111111")));
         assertTrue(transactionManager.getQueue(new IeeeAddress("1111111111111111")).isSleepy());
 
-        // Send a transaction to a node that is unknown by the transaction manager. This will not be sent.
-        ZigBeeCommand unknownCommand = Mockito.mock(ZigBeeCommand.class);
-        Mockito.when(unknownCommand.getDestinationAddress()).thenReturn(new ZigBeeEndpointAddress(789));
-        cmdResult = transactionManager.sendTransaction(unknownCommand, responseMatcher);
-        assertNull(cmdResult);
+        // Send a transaction to a node that is unknown by the transaction manager.
+        // This will be sent with the default queue.
+        command = Mockito.mock(ZigBeeCommand.class);
+        Mockito.when(command.getDestinationAddress()).thenReturn(new ZigBeeEndpointAddress(789));
+        cmdResult = transactionManager.sendTransaction(command, responseMatcher);
+        assertNotNull(cmdResult);
+        Mockito.verify(networkManager, Mockito.timeout(TIMEOUT).times(1)).sendCommand(command);
 
         // Send a transaction without matcher
         command = getCommand(123);
         transactionManager.sendTransaction(command);
         Mockito.verify(networkManager, Mockito.timeout(TIMEOUT).times(1)).sendCommand(command);
+
+        transactionManager.setMaxOutstandingTransactions(10);
 
         // Send a broadcast transaction
         command = Mockito.mock(ZigBeeCommand.class);


### PR DESCRIPTION
Transactions for nodes that aren't known are now sent via a default queue.

Closes #589 

Signed-off-by: Chris Jackson <chris@cd-jackson.com>