### PR TITLE
Allow empty list of supported attributes

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/database/ZclClusterDao.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/database/ZclClusterDao.java
@@ -75,6 +75,12 @@ public class ZclClusterDao {
         return isClient;
     }
 
+    /**
+     * Gets the list of supported attributes.
+     *
+     * @return the list of supported attributes if known, and empty list if the attributes are known, but there are non
+     *         supported by the cluster, or null if the list of supported attributes is unknown
+     */
     public Set<Integer> getSupportedAttributes() {
         return supportedAttributes;
     }


### PR DESCRIPTION
This adds a flag to the ```ZclCluster``` class to remember if we have recovered the list of supported attributes from the device.

During serialisation, the ```ZclClusterDao``` will set the ```supportedAttributes``` field to null if the supported attributes is unknown. **NOTE** that this does require persistence implementations to correctly differentiate between empty lists and null lists - for this reason, this is marked as a **BREAKING CHANGE**.

This allows an empty list of supported attributes to be stored/restored in the event that a cluster supports no attributes.

Closes #569 

Signed-off-by: Chris Jackson <chris@cd-jackson.com>