### PR TITLE
Fix handling of SPI transaction sequence following retries

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.ember.autocode/src/main/java/com/zsmartsystems/zigbee/dongle/ember/autocode/CommandGenerator.java
+++ b/com.zsmartsystems.zigbee.dongle.ember.autocode/src/main/java/com/zsmartsystems/zigbee/dongle/ember/autocode/CommandGenerator.java
@@ -1042,10 +1042,16 @@ public class CommandGenerator extends ClassGenerator {
         out.println("     */");
         out.println("    public static EzspFrameResponse createHandler(int[] data) {");
         out.println("        Class<?> ezspClass;");
-        out.println("        if (data[2] != 0xFF) {");
-        out.println("            ezspClass = ezspHandlerMap.get(data[2]);");
-        out.println("        } else {");
-        out.println("            ezspClass = ezspHandlerMap.get(data[4]);");
+
+        out.println("        try {");
+        out.println("            if (data[2] != 0xFF) {");
+        out.println("                ezspClass = ezspHandlerMap.get(data[2]);");
+        out.println("            } else {");
+        out.println("                ezspClass = ezspHandlerMap.get(data[4]);");
+        out.println("            }");
+        out.println("        } catch (ArrayIndexOutOfBoundsException e) {");
+        out.println("            logger.debug(\"Error creating instance of EzspFrame: Too short.\");");
+        out.println("            return null;");
         out.println("        }");
         out.println();
         out.println("        if (ezspClass == null) {");

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/EzspFrame.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/EzspFrame.java
@@ -391,16 +391,16 @@ public abstract class EzspFrame {
      * @return the {@link EzspFrameResponse} or null if the response can't be created.
      */
     public static EzspFrameResponse createHandler(int[] data) {
-        Class<?> ezspClass = null;
-        
+        Class<?> ezspClass;
         try {
-            if (data[2] != 0xFF) {
-                ezspClass = ezspHandlerMap.get(data[2]);
-            } else {
-                ezspClass = ezspHandlerMap.get(data[4]);
-            }
+        if (data[2] != 0xFF) {
+            ezspClass = ezspHandlerMap.get(data[2]);
+        } else {
+            ezspClass = ezspHandlerMap.get(data[4]);
+        }
         } catch (ArrayIndexOutOfBoundsException e) {
-            logger.debug("Error detecting the Ezsp frame type", e);
+            logger.debug("Error creating instance of EzspFrame: Too short.");
+            return null;
         }
 
         if (ezspClass == null) {


### PR DESCRIPTION
This is an attempt to fix the issue in #604. It doesn't now reset the transaction unless the response correlates with the last SPI request.
This also improves some of the SPI tests by adding some mocks to avoid null pointer issues.

@triller-telekom  it would be appreciated if you could give this a test to at least make sure it at least works ok.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>