### PR TITLE
Avoid duplicate ZigBeeAnnounceListener registration

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
@@ -11,6 +11,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -135,10 +136,9 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
 
     /**
      * The announce listeners are notified whenever a new device is discovered.
-     * This can be called from the transport layer, or internally by methods watching
-     * the network state.
+     * This can be called from the transport layer, or internally by methods watching the network state.
      */
-    private List<ZigBeeAnnounceListener> announceListeners = Collections.unmodifiableList(new ArrayList<>());
+    private Collection<ZigBeeAnnounceListener> announceListeners = Collections.unmodifiableCollection(new HashSet<>());
 
     /**
      * {@link AtomicInteger} used to generate APS header counters
@@ -834,9 +834,12 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
      * @param announceListener the new {@link ZigBeeAnnounceListener} to add
      */
     public void addAnnounceListener(ZigBeeAnnounceListener announceListener) {
-        final List<ZigBeeAnnounceListener> modifiedStateListeners = new ArrayList<>(announceListeners);
+        if (announceListeners.contains(announceListener)) {
+            return;
+        }
+        final Collection<ZigBeeAnnounceListener> modifiedStateListeners = new HashSet<>(announceListeners);
         modifiedStateListeners.add(announceListener);
-        announceListeners = Collections.unmodifiableList(modifiedStateListeners);
+        announceListeners = Collections.unmodifiableCollection(modifiedStateListeners);
     }
 
     /**
@@ -845,9 +848,9 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
      * @param announceListener the new {@link ZigBeeAnnounceListener} to remove
      */
     public void removeAnnounceListener(ZigBeeAnnounceListener announceListener) {
-        final List<ZigBeeAnnounceListener> modifiedStateListeners = new ArrayList<>(announceListeners);
+        final Collection<ZigBeeAnnounceListener> modifiedStateListeners = new HashSet<>(announceListeners);
         modifiedStateListeners.remove(announceListener);
-        announceListeners = Collections.unmodifiableList(modifiedStateListeners);
+        announceListeners = Collections.unmodifiableCollection(modifiedStateListeners);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/ZigBeeNetworkExtension.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/ZigBeeNetworkExtension.java
@@ -53,7 +53,8 @@ public interface ZigBeeNetworkExtension {
      * not attempt to communicate on the network until after {@link #extensionStartup()} is called.
      *
      * @param networkManager The {@link ZigBeeNetworkManager} of the network
-     * @return {@link ZigBeeStatus#SUCCESS} if the extension initialized successfully
+     * @return {@link ZigBeeStatus#SUCCESS} if the extension initialized successfully,
+     *         {@link ZigBeeStatus#INVALID_STATE} if the extension was already started.
      */
     public ZigBeeStatus extensionInitialize(final ZigBeeNetworkManager networkManager);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeDiscoveryExtension.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeDiscoveryExtension.java
@@ -87,6 +87,10 @@ public class ZigBeeDiscoveryExtension
 
     @Override
     public ZigBeeStatus extensionStartup() {
+        if (extensionStarted) {
+            logger.debug("DISCOVERY Extension: Already started");
+            return ZigBeeStatus.INVALID_STATE;
+        }
         logger.debug("DISCOVERY Extension: Startup");
 
         networkManager.addNetworkNodeListener(this);

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/TestUtilities.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/TestUtilities.java
@@ -14,7 +14,7 @@ import java.lang.reflect.Modifier;
 
 /**
  * A class of helper methods for running tests.
- * 
+ *
  * @author Chris Jackson
  *
  */
@@ -22,7 +22,7 @@ public class TestUtilities {
 
     /**
      * Set the value of a private field in a class
-     * 
+     *
      * @param clazz the class where the field resides
      * @param object the object where the field resides
      * @param fieldName the field name
@@ -66,6 +66,24 @@ public class TestUtilities {
         method = clazz.getDeclaredMethod(methodName, classArray);
         method.setAccessible(true);
         return method.invoke(object, paramArray);
+    }
+
+    /**
+     * Gets the value of the private field
+     * 
+     * @param clazz the class where the field resides
+     * @param object the object where the field resides
+     * @param fieldName the field name
+     * @return the {@link Object} containing the field value
+     * @throws Exception
+     */
+    static public Object getField(Class clazz, Object object, String fieldName) throws Exception {
+        Field field = clazz.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        Field modifiersField = Field.class.getDeclaredField("modifiers");
+        modifiersField.setAccessible(true);
+        modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
+        return field.get(object);
     }
 
 }

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeNetworkManagerTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeNetworkManagerTest.java
@@ -21,6 +21,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.nio.file.FileSystems;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -638,7 +639,7 @@ public class ZigBeeNetworkManagerTest implements ZigBeeNetworkNodeListener, ZigB
     }
 
     @Test
-    public void nodeStatusUpdate() {
+    public void nodeStatusUpdate() throws Exception {
         ZigBeeNetworkManager manager = mockZigBeeNetworkManager();
 
         ZigBeeNode node = Mockito.mock(ZigBeeNode.class);
@@ -647,6 +648,11 @@ public class ZigBeeNetworkManagerTest implements ZigBeeNetworkNodeListener, ZigB
 
         ZigBeeAnnounceListener announceListener = Mockito.mock(ZigBeeAnnounceListener.class);
         manager.addAnnounceListener(announceListener);
+        assertEquals(1, ((Collection<ZigBeeAnnounceListener>) TestUtilities.getField(ZigBeeNetworkManager.class,
+                manager, "announceListeners")).size());
+        manager.addAnnounceListener(announceListener);
+        assertEquals(1, ((Collection<ZigBeeAnnounceListener>) TestUtilities.getField(ZigBeeNetworkManager.class,
+                manager, "announceListeners")).size());
 
         manager.nodeStatusUpdate(ZigBeeNodeStatus.DEVICE_LEFT, 1234, new IeeeAddress("123456789ABCDEF0"));
         Mockito.verify(node, Mockito.times(0)).setNodeState(ArgumentMatchers.any(ZigBeeNodeState.class));

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeDiscoveryExtensionTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeDiscoveryExtensionTest.java
@@ -54,7 +54,8 @@ public class ZigBeeDiscoveryExtensionTest {
         extension.setUpdatePeriod(0);
 
         assertEquals(ZigBeeStatus.SUCCESS, extension.extensionInitialize(networkManager));
-        extension.extensionStartup();
+        assertEquals(ZigBeeStatus.SUCCESS, extension.extensionStartup());
+        assertEquals(ZigBeeStatus.INVALID_STATE, extension.extensionStartup());
 
         extension.setUpdatePeriod(0);
         Mockito.verify(extension, Mockito.times(1)).stopScheduler();


### PR DESCRIPTION
This PR prevents the same ```ZigBeeAnnounceListener``` being registered more than once, and also ensures that the ```ZigBeeDiscoveryExtension``` cannot be started more than once to prevent multiple ```ZigBeeNetworkDiscoverer``` tasks being started.

FYI @triller-telekom

Closes #588 

Signed-off-by: Chris Jackson <chris@cd-jackson.com>