### PR TITLE
If ZigbeeNetworkManager is not ONLINE, don't inform listeners on node changes

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
@@ -1286,6 +1286,12 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
             networkNodes.remove(node.getIeeeAddress());
         }
 
+        synchronized (this) {
+            if (networkState != ZigBeeNetworkState.ONLINE) {
+                return;
+            }
+        }
+
         for (final ZigBeeNetworkNodeListener listener : nodeListeners) {
             NotificationService.execute(new Runnable() {
                 @Override
@@ -1366,6 +1372,12 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
         final boolean updated = nodeDiscoveryComplete.contains(node.getIeeeAddress());
         if (!updated && node.isDiscovered() || node.getIeeeAddress().equals(localIeeeAddress)) {
             nodeDiscoveryComplete.add(node.getIeeeAddress());
+        }
+
+        synchronized (this) {
+            if (networkState != ZigBeeNetworkState.ONLINE) {
+                return;
+            }
         }
 
         for (final ZigBeeNetworkNodeListener listener : nodeListeners) {


### PR DESCRIPTION
Similar to addNode(), do not inform the listeners if a node gets removed or updated.

Signed-off-by: Stefan Triller <stefan.triller@telekom.de>