### PR TITLE
Ensure serialisation of RAW_OCTET results in unsigned values

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/serialization/DefaultSerializer.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/serialization/DefaultSerializer.java
@@ -143,7 +143,7 @@ public class DefaultSerializer implements ZigBeeSerializer {
             case RAW_OCTET:
                 final ByteArray rawArray = (ByteArray) data;
                 for (byte arrayByte : rawArray.get()) {
-                    buffer[length++] = arrayByte;
+                    buffer[length++] = arrayByte & 0xFF;
                 }
                 break;
             case OCTET_STRING:

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/serialization/DefaultDeserializerTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/serialization/DefaultDeserializerTest.java
@@ -13,6 +13,7 @@ import org.junit.Test;
 
 import com.zsmartsystems.zigbee.ExtendedPanId;
 import com.zsmartsystems.zigbee.IeeeAddress;
+import com.zsmartsystems.zigbee.zcl.field.ByteArray;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
 /**
@@ -26,6 +27,13 @@ public class DefaultDeserializerTest {
         int[] valIn = { 0x9 };
         int valOut = 0x9;
         testDeserialize(valIn, valOut, ZclDataType.DATA_8_BIT);
+    }
+
+    @Test
+    public void testDeserialize_RAW_OCTET() {
+        int[] valIn = { 0x00, 0x11, 0x22, 0x44, 0x88, 0xCC, 0xFF };
+        ByteArray valOut = new ByteArray(new int[] { 0x00, 0x11, 0x22, 0x44, 0x88, 0xCC, 0xFF });
+        testDeserialize(valIn, valOut, ZclDataType.RAW_OCTET);
     }
 
     @Test

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/serialization/DefaultSerializerTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/serialization/DefaultSerializerTest.java
@@ -17,6 +17,7 @@ import org.junit.Test;
 
 import com.zsmartsystems.zigbee.ExtendedPanId;
 import com.zsmartsystems.zigbee.IeeeAddress;
+import com.zsmartsystems.zigbee.zcl.field.ByteArray;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
 /**
@@ -42,6 +43,13 @@ public class DefaultSerializerTest {
         int valIn = 0x9;
         int[] valOut = { 0x9 };
         testSerializedData(valIn, valOut, ZclDataType.DATA_8_BIT);
+    }
+
+    @Test
+    public void testSerialize_RAW_OCTET() {
+        ByteArray valIn = new ByteArray(new int[] { 0x00, 0x11, 0x22, 0x44, 0x88, 0xCC, 0xFF });
+        int[] valOut = { 0x00, 0x11, 0x22, 0x44, 0x88, 0xCC, 0xFF };
+        testSerializedData(valIn, valOut, ZclDataType.RAW_OCTET);
     }
 
     @Test
@@ -81,6 +89,24 @@ public class DefaultSerializerTest {
         DefaultSerializer serializer = new DefaultSerializer();
         serializer.appendZigBeeType(object, type);
         int[] data = serializer.getPayload();
+        System.out.println("Serialize: " + type + " >> " + object + " = " + arrayToString(data) + ", expect "
+                + arrayToString(output));
         assertTrue(Arrays.equals(output, data));
+    }
+
+    private String arrayToString(int[] value) {
+        StringBuilder builder = new StringBuilder(120);
+        builder.append('[');
+        boolean first = true;
+        for (int val : value) {
+            if (!first) {
+                builder.append(' ');
+            }
+            first = false;
+            builder.append(String.format("%02X", val & 0xFF));
+        }
+        builder.append(']');
+
+        return builder.toString();
     }
 }


### PR DESCRIPTION
This doesn't impact data sent over the air (at least with Ember) since data is converted to bytes, but printing of RAW_OCTETs with values >128 results in them being printed as unsigned values. This PR fixes this.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>