### PR TITLE
Add Ember mfglib console command

### DIFF
--- a/com.zsmartsystems.zigbee.console.ember/src/main/java/com/zsmartsystems/zigbee/console/ember/EmberConsoleNcpMfglibCommand.java
+++ b/com.zsmartsystems.zigbee.console.ember/src/main/java/com/zsmartsystems/zigbee/console/ember/EmberConsoleNcpMfglibCommand.java
@@ -1,0 +1,121 @@
+/**
+ * Copyright (c) 2016-2019 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.console.ember;
+
+import java.io.PrintStream;
+
+import com.zsmartsystems.zigbee.ZigBeeNetworkManager;
+import com.zsmartsystems.zigbee.dongle.ember.EmberMfglib;
+import com.zsmartsystems.zigbee.dongle.ember.ZigBeeDongleEzsp;
+
+/**
+ *
+ * @author Chris Jackson
+ *
+ */
+public class EmberConsoleNcpMfglibCommand extends EmberConsoleAbstractCommand {
+    @Override
+    public String getCommand() {
+        return "ncpmfglib";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Uses the mfglib test features of the NCP. Note that these commands should not be used without understanding MfgLib";
+    }
+
+    @Override
+    public String getSyntax() {
+        return "[]";
+    }
+
+    @Override
+    public String getHelp() {
+        return "";
+    }
+
+    @Override
+    public void process(ZigBeeNetworkManager networkManager, String[] args, PrintStream out)
+            throws IllegalArgumentException {
+        if (args.length > 3) {
+            throw new IllegalArgumentException("Incorrect number of arguments.");
+        }
+
+        switch (args[1].toLowerCase()) {
+            case "start":
+                start(networkManager, out);
+                break;
+            case "end":
+                end(networkManager, out);
+                break;
+            case "tone":
+                switch (args[2].toLowerCase()) {
+                    case "start":
+                        toneStart(networkManager, out);
+                        break;
+                    case "stop":
+                        toneStop(networkManager, out);
+                        break;
+                    default:
+                        throw new IllegalArgumentException("Unknown option specified: tone " + args[2].toUpperCase());
+                }
+                break;
+            default:
+                throw new IllegalArgumentException("Unknown option specified: " + args[1].toUpperCase());
+        }
+    }
+
+    private void start(ZigBeeNetworkManager networkManager, PrintStream out) {
+        EmberMfglib mfglib = getMfglib(networkManager);
+        if (!mfglib.doMfglibStart()) {
+            throw new IllegalStateException("NCP MfgLib start failed");
+        }
+
+        out.println("NCP MfgLib started.");
+    }
+
+    private void end(ZigBeeNetworkManager networkManager, PrintStream out) {
+        EmberMfglib mfglib = getMfglib(networkManager);
+        if (!mfglib.doMfglibEnd()) {
+            throw new IllegalStateException("NCP MfgLib start failed");
+        }
+
+        out.println("NCP MfgLib started.");
+    }
+
+    private void toneStart(ZigBeeNetworkManager networkManager, PrintStream out) {
+        EmberMfglib mfglib = getMfglib(networkManager);
+        if (!mfglib.doMfglibStartTone()) {
+            throw new IllegalStateException("NCP MfgLib start tone failed");
+        }
+
+        out.println("NCP MfgLib tone stopped.");
+    }
+
+    private void toneStop(ZigBeeNetworkManager networkManager, PrintStream out) {
+        EmberMfglib mfglib = getMfglib(networkManager);
+        if (!mfglib.doMfglibStopTone()) {
+            throw new IllegalStateException("NCP MfgLib stop tone failed");
+        }
+
+        out.println("NCP MfgLib tone stopped.");
+    }
+
+    private EmberMfglib getMfglib(ZigBeeNetworkManager networkManager) {
+        if (!(networkManager.getZigBeeTransport() instanceof ZigBeeDongleEzsp)) {
+            throw new IllegalArgumentException("Dongle is not an Ember NCP.");
+        }
+        ZigBeeDongleEzsp dongle = (ZigBeeDongleEzsp) networkManager.getZigBeeTransport();
+        if (dongle == null) {
+            throw new IllegalStateException("Dongle is not an Ember NCP.");
+        }
+        EmberMfglib mfglib = dongle.getEmberMfglib(null);
+
+        return mfglib;
+    }
+}

--- a/com.zsmartsystems.zigbee.console.main/src/main/java/com/zsmartsystems/zigbee/console/main/ZigBeeConsoleMain.java
+++ b/com.zsmartsystems.zigbee.console.main/src/main/java/com/zsmartsystems/zigbee/console/main/ZigBeeConsoleMain.java
@@ -31,6 +31,7 @@ import com.zsmartsystems.zigbee.console.ember.EmberConsoleMmoHashCommand;
 import com.zsmartsystems.zigbee.console.ember.EmberConsoleNcpChildrenCommand;
 import com.zsmartsystems.zigbee.console.ember.EmberConsoleNcpConfigurationCommand;
 import com.zsmartsystems.zigbee.console.ember.EmberConsoleNcpCountersCommand;
+import com.zsmartsystems.zigbee.console.ember.EmberConsoleNcpMfglibCommand;
 import com.zsmartsystems.zigbee.console.ember.EmberConsoleNcpScanCommand;
 import com.zsmartsystems.zigbee.console.ember.EmberConsoleNcpStateCommand;
 import com.zsmartsystems.zigbee.console.ember.EmberConsoleNcpValueCommand;
@@ -205,6 +206,7 @@ public class ZigBeeConsoleMain {
             commands.add(EmberConsoleNcpVersionCommand.class);
             commands.add(EmberConsoleSecurityStateCommand.class);
             commands.add(EmberConsoleNcpScanCommand.class);
+            commands.add(EmberConsoleNcpMfglibCommand.class);
         } else if (dongleName.toUpperCase().equals("XBEE")) {
             dongle = new ZigBeeDongleXBee(serialPort);
         } else if (dongleName.toUpperCase().equals("CONBEE")) {

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
@@ -298,10 +298,11 @@ public class ZigBeeDongleEzsp implements ZigBeeTransportTransmit, ZigBeeTranspor
      * <p>
      * This may only be used if the {@link ZigBeeDongleEmber} instance has not been initialized on a ZigBee network.
      *
+     * @param mfglibListener a {@link EmberMfglibListener} to receive packets received. May be null.
      * @return the {@link EmberMfglib} instance, or null on error
      */
     public EmberMfglib getEmberMfglib(EmberMfglibListener mfglibListener) {
-        if (!initialiseEzspProtocol()) {
+        if (frameHandler == null && !initialiseEzspProtocol()) {
             return null;
         }
 


### PR DESCRIPTION
Adds initial ```ncpmfglib``` commands to support Ember NCP FCC certification.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>