### PR TITLE
Change ZigBeeDongleEzsp to instantiate Executor in constructor

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
@@ -256,6 +256,12 @@ public class ZigBeeDongleEzsp implements ZigBeeTransportTransmit, ZigBeeTranspor
                 EzspDecisionId.EZSP_CHECK_BINDING_MODIFICATIONS_ARE_VALID_ENDPOINT_CLUSTERS);
 
         networkKey = new ZigBeeKey();
+
+        /*
+         * Create the scheduler with a single thread. This ensures that commands sent to the dongle, and the processing
+         * of responses is performed in order
+         */
+        executorService = Executors.newScheduledThreadPool(1);
     }
 
     /**
@@ -361,11 +367,6 @@ public class ZigBeeDongleEzsp implements ZigBeeTransportTransmit, ZigBeeTranspor
         // print current security state to debug logs
         ncp.getCurrentSecurityState();
 
-        /*
-         * Create the scheduler with a single thread. This ensures that commands sent to the dongle, and the processing
-         * of responses is performed in order
-         */
-        executorService = Executors.newScheduledThreadPool(1);
         scheduleNetworkStatePolling();
 
         logger.debug("EZSP dongle initialize done: Initialised {}", initResponse != EmberStatus.EMBER_NOT_JOINED);


### PR DESCRIPTION
Resolves #636

Allow me to speed up the fix of this issue.

The Executor is now instantiated in the constructor instead of the
initialise method. This prevents the variable from being accessed before
it is initialized.

Signed-off-by: Tommaso Travaglino <tommaso.travaglino@telekom.de>