### PR TITLE
Use value of -1 to bypass duplicate APS packet check

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/aps/ApsDataEntity.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/aps/ApsDataEntity.java
@@ -75,6 +75,8 @@ public class ApsDataEntity {
      * Processes a received {@link ZigBeeApsFrame}, and returns the frame that is to fed up the stack. The APS layer may
      * return null from this command if it should not be processed up the stack, or it may return a different frame if
      * defragmentation is performed.
+     * <p>
+     * If the APS frame counter is set to -1, then duplicate packet checks will not be performed.
      *
      * @param apsFrame the received {@link ZigBeeApsFrame}
      * @return the {@link ZigBeeApsFrame} to be used within the upper layers or null if the frame is not to be fed into
@@ -89,9 +91,10 @@ public class ApsDataEntity {
             return null;
         }
 
-        apsCounters.put(apsFrame.getSourceAddress(), apsFrame.getApsCounter());
-        lastFrameTimes.put(apsFrame.getSourceAddress(), System.currentTimeMillis());
-
+        if (apsFrame.getApsCounter() != -1) {
+            apsCounters.put(apsFrame.getSourceAddress(), apsFrame.getApsCounter());
+            lastFrameTimes.put(apsFrame.getSourceAddress(), System.currentTimeMillis());
+        }
         return apsFrame;
     }
 }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/aps/ZigBeeApsFrame.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/aps/ZigBeeApsFrame.java
@@ -260,6 +260,11 @@ public class ZigBeeApsFrame {
         return apsCounter;
     }
 
+    /**
+     * Sets the APS counter. This may be set to -1 to indicate no counter is available
+     * 
+     * @param apsCounter the APS counter for the frame
+     */
     public void setApsCounter(final int apsCounter) {
         this.apsCounter = apsCounter;
     }

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/aps/ApsDataEntityTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/aps/ApsDataEntityTest.java
@@ -39,5 +39,12 @@ public class ApsDataEntityTest {
         apsFrame.setApsCounter(2);
         response = aps.receive(apsFrame);
         assertEquals(apsFrame, response);
+
+        // -1 counter value is allowed - indicates no counter available and will always pass
+        apsFrame.setApsCounter(-1);
+        response = aps.receive(apsFrame);
+        assertEquals(apsFrame, response);
+        response = aps.receive(apsFrame);
+        assertEquals(apsFrame, response);
     }
 }


### PR DESCRIPTION
Allows working around buggy stacks such as the TI ZigBee 3.0.2 stack.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>