### PR TITLE
Close the Node Service Discovery if the thread is running

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeNodeServiceDiscoverer.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeNodeServiceDiscoverer.java
@@ -164,6 +164,8 @@ public class ZigBeeNodeServiceDiscoverer {
      */
     private final Queue<NodeDiscoveryTask> discoveryTasks = new LinkedList<NodeDiscoveryTask>();
 
+    private boolean closed = false;
+
     /**
      * Creates the discoverer
      *
@@ -239,6 +241,10 @@ public class ZigBeeNodeServiceDiscoverer {
      * Stops service discovery and removes any scheduled tasks
      */
     public void stopDiscovery() {
+        closed = true;
+        synchronized (discoveryTasks) {
+            discoveryTasks.clear();
+        }
         if (futureTask != null) {
             futureTask.cancel(true);
         }
@@ -616,6 +622,11 @@ public class ZigBeeNodeServiceDiscoverer {
                     default:
                         logger.debug("{}: Node SVC Discovery: unknown task: {}", node.getIeeeAddress(), discoveryTask);
                         break;
+                }
+
+                if (closed) {
+                    logger.debug("{}: Node SVC Discovery: closing scheduler thread", node.getIeeeAddress());
+                    return;
                 }
 
                 retryCnt++;


### PR DESCRIPTION
@triller-telekom this relates to issue #651. There is code in place to stop the discovery when a node is removed, however I see a corner case in that if a task is running when the node is removed, then it will be rescheduled.  Here I've added a flag to try and avoid this.

Maybe there's a better approach here so please feel free to comment.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>