### PR TITLE
Defaults the APS counter to -1 to indicate that it is not being used

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/aps/ZigBeeApsFrame.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/aps/ZigBeeApsFrame.java
@@ -126,8 +126,10 @@ public class ZigBeeApsFrame {
     /**
      * This field is eight bits in length and is used to prevent the reception of duplicate frames. This value shall be
      * incremented by one for each new transmission.
+     * <p>
+     * A value of -1 indicates that the counter is invalid
      */
-    private int apsCounter;
+    private int apsCounter = -1;
 
     /**
      * The APS payload.


### PR DESCRIPTION
@triller-telekom FYI this should resolve the issue we saw in your logs relating to Telegesis messages being dropped due to duplicate APS counters.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>