### PR TITLE
Wait only for EMBER_JOINED_NETWORK during initialisation

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
@@ -409,7 +409,7 @@ public class ZigBeeDongleEzsp implements ZigBeeTransportTransmit, ZigBeeTranspor
         long timer = System.currentTimeMillis() + WAIT_FOR_ONLINE;
         do {
             networkState = ncp.getNetworkState();
-            if (networkState != EmberNetworkStatus.EMBER_JOINING_NETWORK) {
+            if (networkState == EmberNetworkStatus.EMBER_JOINED_NETWORK) {
                 break;
             }
 


### PR DESCRIPTION
The state may change during initialisation, so we wait only for the EMBER_JOINED_NETWORK state.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>