### PR TITLE
Only disable join on startup if local node is coordinator

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/aps/ZigBeeApsFrame.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/aps/ZigBeeApsFrame.java
@@ -18,7 +18,7 @@ import com.zsmartsystems.zigbee.ZigBeeNwkAddressMode;
  * <p>
  * Note that not all APS header fields may be present in this class. The class is passed from the framework to the
  * hardware drivers where it is processed accordingly. Should data be missing that is required by a hardware
- * implemention, it will be added.
+ * implementation, it will be added.
  *
  * @author Chris Jackson
  *

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeNetworkManagerTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeNetworkManagerTest.java
@@ -295,7 +295,7 @@ public class ZigBeeNetworkManagerTest implements ZigBeeNetworkNodeListener, ZigB
         ZigBeeNetworkStateListener stateListener = Mockito.mock(ZigBeeNetworkStateListener.class);
         manager.addNetworkStateListener(stateListener);
 
-        Mockito.when(mockedTransport.getNwkAddress()).thenReturn(Integer.valueOf(123));
+        Mockito.when(mockedTransport.getNwkAddress()).thenReturn(Integer.valueOf(0));
         Mockito.when(mockedTransport.getIeeeAddress()).thenReturn(new IeeeAddress("1234567890ABCDEF"));
 
         // Default state is uninitialised
@@ -323,8 +323,7 @@ public class ZigBeeNetworkManagerTest implements ZigBeeNetworkNodeListener, ZigB
         ManagementPermitJoiningRequest joinRequest = (ManagementPermitJoiningRequest) mockedTransactionCaptor
                 .getValue();
         assertEquals(Integer.valueOf(0), joinRequest.getPermitDuration());
-
-        assertEquals(Integer.valueOf(123), manager.getLocalNwkAddress());
+        assertEquals(Integer.valueOf(0), manager.getLocalNwkAddress());
         assertEquals(new IeeeAddress("1234567890ABCDEF"), manager.getLocalIeeeAddress());
 
         manager.removeNetworkStateListener(mockedStateListener);


### PR DESCRIPTION
The disable join message is only sent on startup if the local node is coordinator. Detection of coordinator uses NWK == 0 which possibly isn't the 100% guaranteed to ensure that the local address is the trust centre.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>