### PR TITLE
Improve handling of incoming commands in node to avoid NPE if NWK address not known

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNode.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNode.java
@@ -652,11 +652,8 @@ public class ZigBeeNode implements ZigBeeCommandListener {
     public void commandReceived(ZigBeeCommand command) {
         // This gets called for all received commands
         // Check if it's our address
-        if (command.getSourceAddress().getAddress() != networkAddress) {
-            return;
-        }
-
-        if (!(command instanceof ZclCommand)) {
+        if (!(command instanceof ZclCommand) || networkAddress == null
+                || command.getSourceAddress().getAddress() != networkAddress) {
             return;
         }
 


### PR DESCRIPTION
Avoids an NPE if the NWK address is now known when a command is received in the node.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>