### PR TITLE
Ensure CC2531 receive uses the default APS counter

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.cc2531/src/main/java/com/zsmartsystems/zigbee/dongle/cc2531/ZigBeeDongleTiCc2531.java
+++ b/com.zsmartsystems.zigbee.dongle.cc2531/src/main/java/com/zsmartsystems/zigbee/dongle/cc2531/ZigBeeDongleTiCc2531.java
@@ -314,7 +314,6 @@ public class ZigBeeDongleTiCc2531
 
         // nwkHeader.setDestinationAddress(clusterMessage.geta);
         apsFrame.setSourceAddress(clusterMessage.getSrcAddr());
-        apsFrame.setApsCounter(clusterMessage.getTransId());
 
         apsFrame.setPayload(clusterMessage.getData());
 

--- a/com.zsmartsystems.zigbee.dongle.cc2531/src/main/java/com/zsmartsystems/zigbee/dongle/cc2531/frame/ZdoCallbackIncoming.java
+++ b/com.zsmartsystems.zigbee.dongle.cc2531/src/main/java/com/zsmartsystems/zigbee/dongle/cc2531/frame/ZdoCallbackIncoming.java
@@ -27,7 +27,6 @@ public class ZdoCallbackIncoming extends TiDongleReceivePacket {
         apsFrame.setSourceAddress(packet.getPacket()[4] + (packet.getPacket()[5] << 8));
         apsFrame.setSourceEndpoint(0);
         apsFrame.setProfile(0);
-        apsFrame.setApsCounter(packet.getPacket()[10]);
         apsFrame.setPayload(Arrays.copyOfRange(packet.getPacket(), 12, packet.getPacket().length - 1));
 
         return apsFrame;


### PR DESCRIPTION
The old ZStack firmware has the same bug as the new ZB3.0 firmware discovered while writing the new driver. This uses the default APS counter which avoids issues with duplicate packet detection.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>