### PR TITLE
Normalise attributes when restored via the data store

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/ZclAttributeNormalizer.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/ZclAttributeNormalizer.java
@@ -48,6 +48,28 @@ public class ZclAttributeNormalizer {
                         logger.debug("Normalizing data String {} to UNSIGNED_8_BIT_INTEGER", data);
                         return Integer.parseInt((String) data);
                     }
+                    if (data instanceof Double) {
+                        logger.debug("Normalizing data Double {} to UNSIGNED_8_BIT_INTEGER", data);
+                        return ((Double) data).intValue();
+                    }
+                    break;
+                case UNSIGNED_16_BIT_INTEGER:
+                    if (data instanceof Double) {
+                        logger.debug("Normalizing data Double {} to UNSIGNED_16_BIT_INTEGER", data);
+                        return ((Double) data).intValue();
+                    }
+                    break;
+                case SIGNED_8_BIT_INTEGER:
+                    if (data instanceof Double) {
+                        logger.debug("Normalizing data Double {} to SIGNED_8_BIT_INTEGER", data);
+                        return ((Double) data).intValue();
+                    }
+                    break;
+                case SIGNED_16_BIT_INTEGER:
+                    if (data instanceof Double) {
+                        logger.debug("Normalizing data Double {} to SIGNED_16_BIT_INTEGER", data);
+                        return ((Double) data).intValue();
+                    }
                     break;
                 default:
                     break;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/ZclCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/ZclCluster.java
@@ -1234,6 +1234,9 @@ public abstract class ZclCluster {
 
         Map<Integer, ZclAttribute> daoZclAttributes = new HashMap<>();
         for (ZclAttributeDao daoAttribute : dao.getAttributes().values()) {
+            // Normalize the data to protect against the users serialisation system restoring incorrect data classes
+            daoAttribute
+                    .setLastValue(normalizer.normalizeZclData(daoAttribute.getDataType(), daoAttribute.getLastValue()));
             ZclAttribute attribute = new ZclAttribute();
             attribute.setDao(this, daoAttribute);
             daoZclAttributes.put(daoAttribute.getId(), attribute);

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zcl/ZclAttributeNormalizerTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zcl/ZclAttributeNormalizerTest.java
@@ -35,5 +35,31 @@ public class ZclAttributeNormalizerTest {
         assertEquals(Integer.valueOf(123), normalizer.normalizeZclData(ZclDataType.UNSIGNED_8_BIT_INTEGER, "123"));
         assertEquals(Integer.valueOf(0), normalizer.normalizeZclData(ZclDataType.UNSIGNED_8_BIT_INTEGER,
                 String.valueOf(new char[] { 1, 2, 3 })));
+        assertEquals(Integer.valueOf(123),
+                normalizer.normalizeZclData(ZclDataType.UNSIGNED_8_BIT_INTEGER, Double.valueOf(123)));
+    }
+
+    @Test
+    public void testNormalizeSIGNED_8_BIT_INTEGER() {
+        ZclAttributeNormalizer normalizer = new ZclAttributeNormalizer();
+
+        assertEquals(Integer.valueOf(123),
+                normalizer.normalizeZclData(ZclDataType.SIGNED_8_BIT_INTEGER, Double.valueOf(123)));
+    }
+
+    @Test
+    public void testNormalizeUNSIGNED_16_BIT_INTEGER() {
+        ZclAttributeNormalizer normalizer = new ZclAttributeNormalizer();
+
+        assertEquals(Integer.valueOf(123),
+                normalizer.normalizeZclData(ZclDataType.UNSIGNED_16_BIT_INTEGER, Double.valueOf(123)));
+    }
+
+    @Test
+    public void testNormalizeSIGNED_16_BIT_INTEGER() {
+        ZclAttributeNormalizer normalizer = new ZclAttributeNormalizer();
+
+        assertEquals(Integer.valueOf(123),
+                normalizer.normalizeZclData(ZclDataType.SIGNED_16_BIT_INTEGER, Double.valueOf(123)));
     }
 }

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zcl/ZclClusterTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zcl/ZclClusterTest.java
@@ -15,8 +15,10 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Future;
 
@@ -31,6 +33,7 @@ import com.zsmartsystems.zigbee.ZigBeeCommand;
 import com.zsmartsystems.zigbee.ZigBeeEndpoint;
 import com.zsmartsystems.zigbee.ZigBeeEndpointAddress;
 import com.zsmartsystems.zigbee.ZigBeeNode;
+import com.zsmartsystems.zigbee.database.ZclAttributeDao;
 import com.zsmartsystems.zigbee.database.ZclClusterDao;
 import com.zsmartsystems.zigbee.transaction.ZigBeeTransactionMatcher;
 import com.zsmartsystems.zigbee.zcl.clusters.ZclLevelControlCluster;
@@ -434,5 +437,25 @@ public class ZclClusterTest {
         assertEquals(2, record.getAttributeIdentifier());
         assertEquals(ZclDataType.SIGNED_16_BIT_INTEGER, record.getAttributeDataType());
         assertEquals(Integer.valueOf(123), record.getAttributeValue());
+    }
+
+    @Test
+    public void setDao() {
+        createEndpoint();
+
+        ZclOnOffCluster cluster = new ZclOnOffCluster(endpoint);
+
+        ZclClusterDao clusterDao = cluster.getDao();
+        ZclAttributeDao attributeDao = new ZclAttributeDao();
+        attributeDao.setDataType(ZclDataType.SIGNED_16_BIT_INTEGER);
+        attributeDao.setId(1);
+        attributeDao.setLastValue(Double.valueOf(123));
+        Map<Integer, ZclAttributeDao> attributes = new HashMap<>();
+        attributes.put(1, attributeDao);
+        clusterDao.setAttributes(attributes);
+
+        cluster.setDao(clusterDao);
+        assertEquals(1, cluster.getAttributes().size());
+        assertEquals(Integer.class, cluster.getAttributes().iterator().next().getLastValue().getClass());
     }
 }


### PR DESCRIPTION
This uses the ```ZclAttributeNormalizer``` class to normalise data during the intialisation from a ```ZclAttributeDao```. This is designed to protect the framework from serialisation systems that may not restore the attribute data using the correct class.

Additionally, this adds normalisers to handle values passed in from the deserialiser as ```Double```, that should be ```Integer```. This can happen if ```Gson``` is used as the serialisation system.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>