### PR TITLE
Updated handling of adding nodes and associated notifications

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
@@ -373,9 +373,7 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
             ZigBeeNode node = getNode(ieeeAddress);
             if (node == null) {
                 logger.debug("{}: Adding local node to network, NWK={}", ieeeAddress, nwkAddress);
-                node = new ZigBeeNode(this, ieeeAddress);
-                node.setNetworkAddress(nwkAddress);
-
+                node = new ZigBeeNode(this, ieeeAddress, nwkAddress);
                 updateNode(node);
             }
         }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
@@ -238,7 +238,12 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
     /**
      * Map of allowable transport state transitions
      */
-    private final Map<ZigBeeNetworkState, Set<ZigBeeTransportState>> validTransportStateTransitions;
+    private final Map<ZigBeeTransportState, Set<ZigBeeTransportState>> validTransportStateTransitions;
+
+    /**
+     * Current state of the transport layer
+     */
+    private ZigBeeTransportState transportState = ZigBeeTransportState.UNINITIALISED;
 
     /**
      * Our local {@link IeeeAddress}
@@ -258,13 +263,12 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
     public ZigBeeNetworkManager(final ZigBeeTransportTransmit transport) {
         databaseManager = new ZigBeeNetworkDatabaseManager(this);
 
-        Map<ZigBeeNetworkState, Set<ZigBeeTransportState>> transitions = new ConcurrentHashMap<>();
-        transitions.put(ZigBeeNetworkState.UNINITIALISED,
+        Map<ZigBeeTransportState, Set<ZigBeeTransportState>> transitions = new ConcurrentHashMap<>();
+        transitions.put(ZigBeeTransportState.UNINITIALISED,
                 new HashSet<>(Arrays.asList(ZigBeeTransportState.INITIALISING, ZigBeeTransportState.OFFLINE)));
-        transitions.put(ZigBeeNetworkState.INITIALISING, new HashSet<>(Arrays.asList(ZigBeeTransportState.ONLINE)));
-        transitions.put(ZigBeeNetworkState.ONLINE, new HashSet<>(Arrays.asList(ZigBeeTransportState.OFFLINE)));
-        transitions.put(ZigBeeNetworkState.OFFLINE, new HashSet<>(Arrays.asList(ZigBeeTransportState.ONLINE)));
-        transitions.put(ZigBeeNetworkState.SHUTDOWN, new HashSet<>());
+        transitions.put(ZigBeeTransportState.INITIALISING, new HashSet<>(Arrays.asList(ZigBeeTransportState.ONLINE)));
+        transitions.put(ZigBeeTransportState.ONLINE, new HashSet<>(Arrays.asList(ZigBeeTransportState.OFFLINE)));
+        transitions.put(ZigBeeTransportState.OFFLINE, new HashSet<>(Arrays.asList(ZigBeeTransportState.ONLINE)));
 
         validTransportStateTransitions = Collections.unmodifiableMap(new HashMap<>(transitions));
 
@@ -372,7 +376,7 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
                 node = new ZigBeeNode(this, ieeeAddress);
                 node.setNetworkAddress(nwkAddress);
 
-                addNode(node);
+                updateNode(node);
             }
         }
     }
@@ -596,6 +600,7 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
      */
     public void executeTask(Runnable runnableTask) {
         if (networkState != ZigBeeNetworkState.ONLINE) {
+            logger.debug("ZigBeeNetworkManager executeTask: not executing task while {}", networkState);
             return;
         }
         executorService.execute(runnableTask);
@@ -610,6 +615,7 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
      */
     public ScheduledFuture<?> scheduleTask(Runnable runnableTask, long delay) {
         if (networkState != ZigBeeNetworkState.ONLINE) {
+            logger.debug("ZigBeeNetworkManager scheduleTask: not scheduling task while {}", networkState);
             return null;
         }
         return executorService.schedule(runnableTask, delay, TimeUnit.MILLISECONDS);
@@ -627,6 +633,7 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
     public ScheduledFuture<?> rescheduleTask(ScheduledFuture<?> futureTask, Runnable runnableTask, long delay) {
         futureTask.cancel(false);
         if (networkState != ZigBeeNetworkState.ONLINE) {
+            logger.debug("ZigBeeNetworkManager rescheduleTask: not scheduling task while {}", networkState);
             return null;
         }
 
@@ -1011,15 +1018,19 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
     public synchronized void setTransportState(final ZigBeeTransportState state) {
         logger.debug("ZigBeeNetworkManager transport state updated to {}", state);
 
-        if (!validTransportStateTransitions.get(networkState).contains(state)) {
-            logger.debug(
-                    "Ignoring invalid transport state transition in ZigBeeNetworkState.{} by ZigBeeTransportState.{}",
-                    networkState, state);
-            return;
+        // Filter out unwanted transport state changes
+        synchronized (validTransportStateTransitions) {
+            if (!validTransportStateTransitions.get(transportState).contains(state)) {
+                logger.debug("Ignoring invalid transport state transition in {} to {}", transportState, state);
+                return;
+            }
+            transportState = state;
         }
 
         // Process the network state given the updated transport layer state
-        setNetworkState(ZigBeeNetworkState.valueOf(state.toString()));
+        if (networkState != ZigBeeNetworkState.INITIALISING) {
+            setNetworkState(ZigBeeNetworkState.valueOf(state.toString()));
+        }
     }
 
     private synchronized void setNetworkState(final ZigBeeNetworkState state) {
@@ -1087,7 +1098,6 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
                     public void run() {
                         stateListener.networkStateUpdated(state);
                     }
-
                 });
             }
         }
@@ -1358,11 +1368,16 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
     }
 
     /**
-     * Adds a {@link ZigBeeNode} to the network
+     * Adds or updates a {@link ZigBeeNode} to the network.
+     * <p>
+     * If the node is already known on the network (as uniquely identified by the {@link IeeeAddress} then registered
+     * {@link ZigBeeNetworkNodeListener} listeners will receive the
+     * {@link ZigBeeNetworkNodeListener#nodeUpdated(ZigBeeNode)} notification, otherwise the
+     * {@link ZigBeeNetworkNodeListener#nodeAdded(ZigBeeNode)} notification will be received.
      *
-     * @param node the {@link ZigBeeNode} to add
+     * @param node the {@link ZigBeeNode} to add or update
      */
-    public void addNode(final ZigBeeNode node) {
+    public void updateNode(final ZigBeeNode node) {
         if (node == null) {
             return;
         }
@@ -1373,7 +1388,7 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
             // Don't add if the node is already known
             // We especially don't want to notify listeners
             if (networkNodes.containsKey(node.getIeeeAddress())) {
-                updateNode(node);
+                refreshNode(node);
                 return;
             }
             networkNodes.put(node.getIeeeAddress(), node);
@@ -1389,6 +1404,7 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
             NotificationService.execute(new Runnable() {
                 @Override
                 public void run() {
+                    logger.debug("{}: Node sending added", node.getIeeeAddress());
                     listener.nodeAdded(node);
                 }
             });
@@ -1400,7 +1416,7 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
      *
      * @param node the {@link ZigBeeNode} to update
      */
-    public void updateNode(final ZigBeeNode node) {
+    private void refreshNode(final ZigBeeNode node) {
         if (node == null) {
             return;
         }
@@ -1419,13 +1435,13 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
 
             // Return if there were no updates
             if (!currentNode.updateNode(node)) {
-                // logger.debug("{}: Node {} is not updated", node.getIeeeAddress(), node.getNetworkAddress());
-                // return;
+                logger.debug("{}: Node {} is not updated", node.getIeeeAddress(), node.getNetworkAddress());
+                return;
             }
         }
 
-        final boolean updated = nodeDiscoveryComplete.contains(node.getIeeeAddress());
-        if (!updated && node.isDiscovered() || node.getIeeeAddress().equals(localIeeeAddress)) {
+        if (!nodeDiscoveryComplete.contains(node.getIeeeAddress()) && node.isDiscovered()
+                || node.getIeeeAddress().equals(localIeeeAddress)) {
             nodeDiscoveryComplete.add(node.getIeeeAddress());
         }
 
@@ -1439,11 +1455,7 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
             NotificationService.execute(new Runnable() {
                 @Override
                 public void run() {
-                    if (updated) {
-                        listener.nodeUpdated(currentNode);
-                    } else {
-                        listener.nodeAdded(currentNode);
-                    }
+                    listener.nodeUpdated(currentNode);
                 }
             });
         }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNode.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNode.java
@@ -71,12 +71,12 @@ public class ZigBeeNode implements ZigBeeCommandListener {
     /**
      * The {@link NodeDescriptor} for the node.
      */
-    private NodeDescriptor nodeDescriptor = new NodeDescriptor();
+    private NodeDescriptor nodeDescriptor;
 
     /**
      * The {@link PowerDescriptor} for the node.
      */
-    private PowerDescriptor powerDescriptor = new PowerDescriptor();
+    private PowerDescriptor powerDescriptor;
 
     /**
      * The time the node information was last updated. This is set from the mesh update class when it the
@@ -200,9 +200,7 @@ public class ZigBeeNode implements ZigBeeCommandListener {
      * @param nodeDescriptor the new {@link NodeDescriptor}
      */
     public void setNodeDescriptor(NodeDescriptor nodeDescriptor) {
-        synchronized (this.nodeDescriptor) {
-            this.nodeDescriptor = nodeDescriptor;
-        }
+        this.nodeDescriptor = nodeDescriptor;
     }
 
     /**
@@ -328,6 +326,7 @@ public class ZigBeeNode implements ZigBeeCommandListener {
      * <li>{@link LogicalType#COORDINATOR}
      * <li>{@link LogicalType#ROUTER}
      * <li>{@link LogicalType#END_DEVICE}
+     * <li>{@link LogicalType#UNKNOWN}
      * <ul>
      *
      * @return the {@link LogicalType} of the node
@@ -683,9 +682,8 @@ public class ZigBeeNode implements ZigBeeCommandListener {
      * @return true if basic device information is known
      */
     public boolean isDiscovered() {
-        synchronized (nodeDescriptor) {
-            return nodeDescriptor.getLogicalType() != LogicalType.UNKNOWN && endpoints.size() != 0;
-        }
+        return nodeDescriptor != null && nodeDescriptor.getLogicalType() != LogicalType.UNKNOWN
+                && endpoints.size() != 0;
     }
 
     /**
@@ -703,20 +701,23 @@ public class ZigBeeNode implements ZigBeeCommandListener {
 
         boolean updated = false;
 
-        if (node.getNetworkAddress() != null && !networkAddress.equals(node.getNetworkAddress())) {
+        if (node.getNetworkAddress() != null
+                && (networkAddress == null || !networkAddress.equals(node.getNetworkAddress()))) {
             logger.debug("{}: Network address updated from {} to {}", ieeeAddress, networkAddress,
                     node.getNetworkAddress());
             updated = true;
             networkAddress = node.getNetworkAddress();
         }
 
-        if (!nodeDescriptor.equals(node.getNodeDescriptor())) {
+        if (node.getNodeDescriptor() != null
+                && (nodeDescriptor == null || !nodeDescriptor.equals(node.getNodeDescriptor()))) {
             logger.debug("{}: Node descriptor updated", ieeeAddress);
             updated = true;
             nodeDescriptor = node.getNodeDescriptor();
         }
 
-        if (!powerDescriptor.equals(node.getPowerDescriptor())) {
+        if (node.getPowerDescriptor() != null
+                && (powerDescriptor == null || !powerDescriptor.equals(node.getPowerDescriptor()))) {
             logger.debug("{}: Power descriptor updated", ieeeAddress);
             updated = true;
             powerDescriptor = node.getPowerDescriptor();

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNode.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNode.java
@@ -159,6 +159,20 @@ public class ZigBeeNode implements ZigBeeCommandListener {
     }
 
     /**
+     * Constructor
+     *
+     * @param network the {@link ZigBeeNetwork}
+     * @param ieeeAddress the {@link IeeeAddress} of the node
+     * @param networkAddress the network address of the node
+     * @throws {@link IllegalArgumentException} if ieeeAddress is null
+     */
+    public ZigBeeNode(ZigBeeNetwork network, IeeeAddress ieeeAddress, Integer networkAddress) {
+        this(network, ieeeAddress);
+
+        this.networkAddress = networkAddress;
+    }
+
+    /**
      * Called when the node is removed from the network.
      */
     public void shutdown() {

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNode.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNode.java
@@ -176,16 +176,19 @@ public class ZigBeeNode implements ZigBeeCommandListener {
     /**
      * Sets the 16 bit network address of the node.
      *
-     * @param networkAddress
+     * @param networkAddress the new NWK address for the node
+     * @return true if the new NWK address is different from the original value
      */
-    public void setNetworkAddress(Integer networkAddress) {
+    public boolean setNetworkAddress(Integer networkAddress) {
+        boolean changed = this.networkAddress == null || (!this.networkAddress.equals(networkAddress));
         this.networkAddress = networkAddress;
+        return changed;
     }
 
     /**
      * Gets the 16 bit network address of the node.
      *
-     * @return networkAddress
+     * @return networkAddress the current NWK address for the node
      */
     public Integer getNetworkAddress() {
         return networkAddress;
@@ -197,7 +200,9 @@ public class ZigBeeNode implements ZigBeeCommandListener {
      * @param nodeDescriptor the new {@link NodeDescriptor}
      */
     public void setNodeDescriptor(NodeDescriptor nodeDescriptor) {
-        this.nodeDescriptor = nodeDescriptor;
+        synchronized (this.nodeDescriptor) {
+            this.nodeDescriptor = nodeDescriptor;
+        }
     }
 
     /**
@@ -328,6 +333,9 @@ public class ZigBeeNode implements ZigBeeCommandListener {
      * @return the {@link LogicalType} of the node
      */
     public LogicalType getLogicalType() {
+        if (nodeDescriptor == null) {
+            return LogicalType.UNKNOWN;
+        }
         return nodeDescriptor.getLogicalType();
     }
 
@@ -371,7 +379,7 @@ public class ZigBeeNode implements ZigBeeCommandListener {
 
                 do {
                     ManagementBindRequest bindingRequest = new ManagementBindRequest();
-                    bindingRequest.setDestinationAddress(new ZigBeeEndpointAddress(networkAddress));
+                    bindingRequest.setDestinationAddress(new ZigBeeEndpointAddress(getNetworkAddress()));
                     bindingRequest.setStartIndex(index);
 
                     CommandResult result = network.sendTransaction(bindingRequest, new ManagementBindRequest()).get();
@@ -675,7 +683,9 @@ public class ZigBeeNode implements ZigBeeCommandListener {
      * @return true if basic device information is known
      */
     public boolean isDiscovered() {
-        return nodeDescriptor.getLogicalType() != LogicalType.UNKNOWN && endpoints.size() != 0;
+        synchronized (nodeDescriptor) {
+            return nodeDescriptor.getLogicalType() != LogicalType.UNKNOWN && endpoints.size() != 0;
+        }
     }
 
     /**
@@ -687,12 +697,13 @@ public class ZigBeeNode implements ZigBeeCommandListener {
      */
     protected boolean updateNode(ZigBeeNode node) {
         if (!node.getIeeeAddress().equals(ieeeAddress)) {
+            logger.debug("{}: Ieee address inconsistent during update <>{}", ieeeAddress, node.getIeeeAddress());
             return false;
         }
 
         boolean updated = false;
 
-        if (!networkAddress.equals(node.getNetworkAddress())) {
+        if (node.getNetworkAddress() != null && !networkAddress.equals(node.getNetworkAddress())) {
             logger.debug("{}: Network address updated from {} to {}", ieeeAddress, networkAddress,
                     node.getNetworkAddress());
             updated = true;
@@ -700,17 +711,20 @@ public class ZigBeeNode implements ZigBeeCommandListener {
         }
 
         if (!nodeDescriptor.equals(node.getNodeDescriptor())) {
+            logger.debug("{}: Node descriptor updated", ieeeAddress);
             updated = true;
             nodeDescriptor = node.getNodeDescriptor();
         }
 
         if (!powerDescriptor.equals(node.getPowerDescriptor())) {
+            logger.debug("{}: Power descriptor updated", ieeeAddress);
             updated = true;
             powerDescriptor = node.getPowerDescriptor();
         }
 
         synchronized (associatedDevices) {
             if (!associatedDevices.equals(node.getAssociatedDevices())) {
+                logger.debug("{}: Associated devices updated", ieeeAddress);
                 updated = true;
                 associatedDevices.clear();
                 associatedDevices.addAll(node.getAssociatedDevices());
@@ -719,6 +733,7 @@ public class ZigBeeNode implements ZigBeeCommandListener {
 
         synchronized (bindingTable) {
             if (!bindingTable.equals(node.getBindingTable())) {
+                logger.debug("{}: Binding table updated", ieeeAddress);
                 updated = true;
                 bindingTable.clear();
                 bindingTable.addAll(node.getBindingTable());
@@ -727,6 +742,7 @@ public class ZigBeeNode implements ZigBeeCommandListener {
 
         synchronized (neighbors) {
             if (!neighbors.equals(node.getNeighbors())) {
+                logger.debug("{}: Neighbors updated", ieeeAddress);
                 updated = true;
                 neighbors.clear();
                 neighbors.addAll(node.getNeighbors());
@@ -735,13 +751,25 @@ public class ZigBeeNode implements ZigBeeCommandListener {
 
         synchronized (routes) {
             if (!routes.equals(node.getRoutes())) {
+                logger.debug("{}: Routes updated", ieeeAddress);
                 updated = true;
                 routes.clear();
                 routes.addAll(node.getRoutes());
             }
         }
 
-        // TODO: How to deal with endpoints
+        // Endpoints are only copied over if they don't exist in the node
+        // The assumption here is that endpoints are only set once, and not changed.
+        // This should be valid as they are set through the SimpleDescriptor.
+        for (ZigBeeEndpoint endpoint : node.getEndpoints()) {
+            if (endpoints.containsKey(endpoint.getEndpointId())) {
+                continue;
+            }
+
+            logger.debug("{}: Endpoint {} added", ieeeAddress, endpoint.getEndpointId());
+            updated = true;
+            endpoints.put(endpoint.getEndpointId(), endpoint);
+        }
 
         return updated;
     }
@@ -755,7 +783,7 @@ public class ZigBeeNode implements ZigBeeCommandListener {
         ZigBeeNodeDao dao = new ZigBeeNodeDao();
 
         dao.setIeeeAddress(ieeeAddress);
-        dao.setNetworkAddress(networkAddress);
+        dao.setNetworkAddress(getNetworkAddress());
         dao.setNodeDescriptor(nodeDescriptor);
         dao.setPowerDescriptor(powerDescriptor);
         dao.setBindingTable(bindingTable);
@@ -771,9 +799,9 @@ public class ZigBeeNode implements ZigBeeCommandListener {
 
     public void setDao(ZigBeeNodeDao dao) {
         ieeeAddress = dao.getIeeeAddress();
-        networkAddress = dao.getNetworkAddress();
-        nodeDescriptor = dao.getNodeDescriptor();
-        powerDescriptor = dao.getPowerDescriptor();
+        setNetworkAddress(dao.getNetworkAddress());
+        setNodeDescriptor(dao.getNodeDescriptor());
+        setPowerDescriptor(dao.getPowerDescriptor());
         if (dao.getBindingTable() != null) {
             bindingTable.addAll(dao.getBindingTable());
         }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeNetworkDiscoverer.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeNetworkDiscoverer.java
@@ -459,9 +459,8 @@ public class ZigBeeNetworkDiscoverer implements ZigBeeCommandListener, ZigBeeAnn
      */
     private void addNode(final IeeeAddress ieeeAddress, int networkAddress) {
         logger.debug("{}: NWK Discovery add node {}", ieeeAddress, networkAddress);
-        ZigBeeNode node = new ZigBeeNode(networkManager, ieeeAddress);
+        ZigBeeNode node = new ZigBeeNode(networkManager, ieeeAddress, networkAddress);
         node.setNodeState(ZigBeeNodeState.ONLINE);
-        node.setNetworkAddress(networkAddress);
         networkManager.updateNode(node);
     }
 }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeNetworkDiscoverer.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeNetworkDiscoverer.java
@@ -459,21 +459,9 @@ public class ZigBeeNetworkDiscoverer implements ZigBeeCommandListener, ZigBeeAnn
      */
     private void addNode(final IeeeAddress ieeeAddress, int networkAddress) {
         logger.debug("{}: NWK Discovery add node {}", ieeeAddress, networkAddress);
-        ZigBeeNode node = networkManager.getNode(ieeeAddress);
-        if (node != null) {
-            if (node.getNetworkAddress() != networkAddress) {
-                logger.debug("{}: NWK Discovery updated network address to {}", ieeeAddress, networkAddress);
-            }
-            node.setNodeState(ZigBeeNodeState.ONLINE);
-            node.setNetworkAddress(networkAddress);
-            networkManager.updateNode(node);
-            return;
-        }
-
-        node = new ZigBeeNode(networkManager, ieeeAddress);
+        ZigBeeNode node = new ZigBeeNode(networkManager, ieeeAddress);
+        node.setNodeState(ZigBeeNodeState.ONLINE);
         node.setNetworkAddress(networkAddress);
-
-        // Add the node to the network...
-        networkManager.addNode(node);
+        networkManager.updateNode(node);
     }
 }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeNodeServiceDiscoverer.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeNodeServiceDiscoverer.java
@@ -224,7 +224,7 @@ public class ZigBeeNodeServiceDiscoverer {
 
             // Check the current list of tasks to decide if we need to start the worker
             // This prevents restarting if we didn't add new tasks, which might overload the system
-            boolean startWorker = discoveryTasks.isEmpty() | (futureTask == null);
+            boolean startWorker = discoveryTasks.isEmpty() || (futureTask == null);
 
             // Add new tasks, avoiding any duplication
             for (NodeDiscoveryTask newTask : newTasks) {
@@ -238,8 +238,7 @@ public class ZigBeeNodeServiceDiscoverer {
             } else {
                 // Create a new node to store the data from this update.
                 // We set the network address so that we can detect the change later if needed.
-                updatedNode = new ZigBeeNode(networkManager, node.getIeeeAddress());
-                updatedNode.setNetworkAddress(node.getNetworkAddress());
+                updatedNode = new ZigBeeNode(networkManager, node.getIeeeAddress(), node.getNetworkAddress());
                 lastDiscoveryStarted = Calendar.getInstance();
             }
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeNodeServiceDiscoverer.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeNodeServiceDiscoverer.java
@@ -204,12 +204,14 @@ public class ZigBeeNodeServiceDiscoverer {
             logger.debug("{}: Node SVC Discovery: starting new tasks {}", node.getIeeeAddress(), newTasks);
 
             // Remove any tasks that we know are not supported by this device
-            if ((!supportsManagementLqi || node.getNodeDescriptor().getLogicalType() == LogicalType.UNKNOWN)
+            if ((!supportsManagementLqi || node.getNodeDescriptor() != null
+                    && node.getNodeDescriptor().getLogicalType() == LogicalType.UNKNOWN)
                     && newTasks.contains(NodeDiscoveryTask.NEIGHBORS)) {
                 newTasks.remove(NodeDiscoveryTask.NEIGHBORS);
             }
-            if ((!supportsManagementRouting || node.getNodeDescriptor().getLogicalType() == LogicalType.UNKNOWN
-                    || node.getNodeDescriptor().getLogicalType() == LogicalType.END_DEVICE)
+            if ((!supportsManagementRouting || node.getNodeDescriptor() != null
+                    && (node.getNodeDescriptor().getLogicalType() == LogicalType.UNKNOWN
+                            || node.getNodeDescriptor().getLogicalType() == LogicalType.END_DEVICE))
                     && newTasks.contains(NodeDiscoveryTask.ROUTES)) {
                 newTasks.remove(NodeDiscoveryTask.ROUTES);
             }
@@ -693,11 +695,12 @@ public class ZigBeeNodeServiceDiscoverer {
             tasks.add(NodeDiscoveryTask.NWK_ADDRESS);
         }
 
-        if (node.getNodeDescriptor().getLogicalType() == LogicalType.UNKNOWN) {
+        if (node.getNodeDescriptor() == null || node.getNodeDescriptor().getLogicalType() == LogicalType.UNKNOWN) {
             tasks.add(NodeDiscoveryTask.NODE_DESCRIPTOR);
         }
 
-        if (node.getPowerDescriptor().getCurrentPowerMode() == CurrentPowerModeType.UNKNOWN) {
+        if (node.getPowerDescriptor() == null
+                || node.getPowerDescriptor().getCurrentPowerMode() == CurrentPowerModeType.UNKNOWN) {
             tasks.add(NodeDiscoveryTask.POWER_DESCRIPTOR);
         }
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/database/ZigBeeNetworkDatabaseManager.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/database/ZigBeeNetworkDatabaseManager.java
@@ -166,7 +166,8 @@ public class ZigBeeNetworkDatabaseManager implements ZigBeeNetworkNodeListener {
                 continue;
             }
             node.setDao(nodeDao);
-            networkManager.addNode(node);
+            logger.debug("{}: Data store: Node was restored.", nodeAddress);
+            networkManager.updateNode(node);
         }
 
         networkManager.addNetworkNodeListener(this);

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransactionManager.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransactionManager.java
@@ -417,7 +417,8 @@ public class ZigBeeTransactionManager implements ZigBeeNetworkNodeListener {
      */
     private boolean setQueueType(ZigBeeNode node, ZigBeeTransactionQueue queue) {
         boolean sleepy;
-        if (!node.getNodeDescriptor().getMacCapabilities().contains(MacCapabilitiesType.RECEIVER_ON_WHEN_IDLE)) {
+        if (node.getNodeDescriptor() != null
+                && !node.getNodeDescriptor().getMacCapabilities().contains(MacCapabilitiesType.RECEIVER_ON_WHEN_IDLE)) {
             queue.setProfile(defaultSleepyProfile);
             sleepy = true;
         } else {

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeNodeTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeNodeTest.java
@@ -9,6 +9,7 @@ package com.zsmartsystems.zigbee;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -316,14 +317,16 @@ public class ZigBeeNodeTest {
         ZigBeeNode newNode = new ZigBeeNode(Mockito.mock(ZigBeeNetworkManager.class), new IeeeAddress("1234567890"));
         ZigBeeNode invalidNode = new ZigBeeNode(Mockito.mock(ZigBeeNetworkManager.class),
                 new IeeeAddress("ABCDEF1234567890"));
-        node.setNetworkAddress(1234);
-        newNode.setNetworkAddress(1234);
+        assertTrue(node.setNetworkAddress(1234));
+        assertTrue(newNode.setNetworkAddress(1234));
 
         assertFalse(node.updateNode(invalidNode));
 
         assertFalse(node.updateNode(newNode));
 
-        newNode.setNetworkAddress(5678);
+        Integer oldNwkAddress = newNode.getNetworkAddress();
+        assertTrue(newNode.setNetworkAddress(5678));
+        assertNotEquals(oldNwkAddress, newNode.getNetworkAddress());
         assertTrue(node.updateNode(newNode));
 
         Set<Integer> associated = new HashSet<Integer>();
@@ -384,6 +387,19 @@ public class ZigBeeNodeTest {
         assertEquals(2, node.getNeighbors().size());
         assertTrue(node.setNeighbors(null));
         assertEquals(0, node.getNeighbors().size());
+
+        newNode = new ZigBeeNode(Mockito.mock(ZigBeeNetworkManager.class), node.getIeeeAddress());
+        ZigBeeEndpoint endpoint = new ZigBeeEndpoint(newNode, 1);
+        newNode.addEndpoint(endpoint);
+        assertTrue(node.updateNode(newNode));
+        assertFalse(node.updateNode(newNode));
+        assertEquals(1, node.getEndpoints().size());
+
+        endpoint = new ZigBeeEndpoint(newNode, 2);
+        newNode.addEndpoint(endpoint);
+        assertTrue(node.updateNode(newNode));
+        assertFalse(node.updateNode(newNode));
+        assertEquals(2, node.getEndpoints().size());
     }
 
     @Test
@@ -417,7 +433,7 @@ public class ZigBeeNodeTest {
     @Test
     public void commandReceived() {
         ZigBeeNode node = new ZigBeeNode(Mockito.mock(ZigBeeNetworkManager.class), new IeeeAddress("1234567890"));
-        node.setNetworkAddress(12345);
+        assertTrue(node.setNetworkAddress(12345));
 
         ZigBeeEndpoint endpoint1 = Mockito.mock(ZigBeeEndpoint.class);
         Mockito.when(endpoint1.getEndpointId()).thenReturn(1);
@@ -497,7 +513,7 @@ public class ZigBeeNodeTest {
                 ArgumentMatchers.any(ZigBeeTransactionMatcher.class));
 
         ZigBeeNode node = new ZigBeeNode(networkManager, new IeeeAddress("1234567890"));
-        node.setNetworkAddress(1);
+        assertTrue(node.setNetworkAddress(1));
 
         ManagementBindResponse nodeResponse = new ManagementBindResponse();
         nodeResponse.setStatus(ZdoStatus.NOT_SUPPORTED);

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeNodeTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeNodeTest.java
@@ -53,7 +53,9 @@ public class ZigBeeNodeTest {
 
     @Test
     public void testAddDescriptors() {
-        ZigBeeNode node = new ZigBeeNode(Mockito.mock(ZigBeeNetworkManager.class), new IeeeAddress());
+        ZigBeeNode node = new ZigBeeNode(Mockito.mock(ZigBeeNetworkManager.class), new IeeeAddress(), 1);
+
+        assertEquals(Integer.valueOf(1), node.getNetworkAddress());
 
         // Null by default
         assertNull(node.getNodeDescriptor());

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeNetworkDiscovererTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeNetworkDiscovererTest.java
@@ -31,7 +31,6 @@ import com.zsmartsystems.zigbee.ZigBeeCommand;
 import com.zsmartsystems.zigbee.ZigBeeEndpointAddress;
 import com.zsmartsystems.zigbee.ZigBeeNetworkManager;
 import com.zsmartsystems.zigbee.ZigBeeNode;
-import com.zsmartsystems.zigbee.ZigBeeNode.ZigBeeNodeState;
 import com.zsmartsystems.zigbee.ZigBeeNodeStatus;
 import com.zsmartsystems.zigbee.transaction.ZigBeeTransactionFuture;
 import com.zsmartsystems.zigbee.transaction.ZigBeeTransactionMatcher;
@@ -148,7 +147,7 @@ public class ZigBeeNetworkDiscovererTest {
         Mockito.verify(networkManager).addAnnounceListener(discoverer);
 
         // Then wait for the nodes to be added
-        Mockito.verify(networkManager, Mockito.timeout(TIMEOUT).times(2)).addNode(nodeCapture.capture());
+        Mockito.verify(networkManager, Mockito.timeout(TIMEOUT).times(2)).updateNode(nodeCapture.capture());
 
         ZigBeeNode node = nodeCapture.getValue();
         assertNotNull(node);
@@ -165,10 +164,6 @@ public class ZigBeeNetworkDiscovererTest {
     public void testNodeAddressUpdate() {
         IeeeAddress ieeeAddress = new IeeeAddress("123456890ABCDEF");
 
-        ZigBeeNode node = Mockito.mock(ZigBeeNode.class);
-        Mockito.doReturn(node).when(networkManager).getNode(ArgumentMatchers.any(IeeeAddress.class));
-        Mockito.when(node.getNetworkAddress()).thenReturn(11111);
-
         DeviceAnnounce announce = new DeviceAnnounce();
         announce.setIeeeAddr(ieeeAddress);
         announce.setNwkAddrOfInterest(12345);
@@ -179,8 +174,7 @@ public class ZigBeeNetworkDiscovererTest {
         discoverer.setRetryCount(0);
 
         discoverer.commandReceived(announce);
-        Mockito.verify(node, Mockito.times(1)).setNetworkAddress(12345);
-        Mockito.verify(node, Mockito.times(1)).setNodeState(ZigBeeNodeState.ONLINE);
+        Mockito.verify(networkManager, Mockito.times(1)).updateNode(ArgumentMatchers.any());
 
         ZigBeeEndpointAddress address = Mockito.mock(ZigBeeEndpointAddress.class);
         Mockito.when(address.getAddress()).thenReturn(12345);
@@ -191,18 +185,14 @@ public class ZigBeeNetworkDiscovererTest {
 
     @Test
     public void deviceStatusUpdate() {
-        ZigBeeNode node = Mockito.mock(ZigBeeNode.class);
-        Mockito.doReturn(node).when(networkManager).getNode(ArgumentMatchers.any(IeeeAddress.class));
-        Mockito.when(node.getNetworkAddress()).thenReturn(1111);
-
         ZigBeeNetworkDiscoverer discoverer = new ZigBeeNetworkDiscoverer(networkManager);
         discoverer.setRetryPeriod(0);
         discoverer.setRequeryPeriod(0);
         discoverer.setRetryCount(0);
 
         discoverer.deviceStatusUpdate(ZigBeeNodeStatus.UNSECURED_JOIN, 2222, new IeeeAddress("1111111111111111"));
-        Mockito.verify(node, Mockito.times(1)).setNetworkAddress(2222);
-        Mockito.verify(node, Mockito.times(1)).setNodeState(ZigBeeNodeState.ONLINE);
+
+        Mockito.verify(networkManager, Mockito.times(1)).updateNode(ArgumentMatchers.any());
     }
 
     @Test
@@ -223,7 +213,7 @@ public class ZigBeeNetworkDiscovererTest {
         TestUtilities.setField(ZigBeeNetworkDiscoverer.class, discoverer, "discoveryStartTime", discoveryStartTime);
         discoverer.rediscoverNode(1111);
 
-        Mockito.verify(networkManager, Mockito.timeout(TIMEOUT).times(1)).addNode(nodeCapture.capture());
+        Mockito.verify(networkManager, Mockito.timeout(TIMEOUT).times(1)).updateNode(nodeCapture.capture());
 
         ZigBeeNode node = nodeCapture.getValue();
         assertNotNull(node);
@@ -250,7 +240,7 @@ public class ZigBeeNetworkDiscovererTest {
         TestUtilities.setField(ZigBeeNetworkDiscoverer.class, discoverer, "discoveryStartTime", discoveryStartTime);
         discoverer.rediscoverNode(new IeeeAddress("1111111111111111"));
 
-        Mockito.verify(networkManager, Mockito.timeout(TIMEOUT).times(1)).addNode(nodeCapture.capture());
+        Mockito.verify(networkManager, Mockito.timeout(TIMEOUT).times(1)).updateNode(nodeCapture.capture());
 
         ZigBeeNode node = nodeCapture.getValue();
         assertNotNull(node);

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/database/ZigBeeNetworkDatabaseManagerTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/database/ZigBeeNetworkDatabaseManagerTest.java
@@ -89,7 +89,7 @@ public class ZigBeeNetworkDatabaseManagerTest {
 
         databaseManager.startup();
         Mockito.verify(networkManager, Mockito.times(1)).addNetworkNodeListener(databaseManager);
-        Mockito.verify(networkManager, Mockito.times(1)).addNode(ArgumentMatchers.any(ZigBeeNode.class));
+        Mockito.verify(networkManager, Mockito.times(1)).updateNode(ArgumentMatchers.any(ZigBeeNode.class));
 
         databaseManager.setDeferredWriteTime(0);
 


### PR DESCRIPTION
This is a change to the way that nodes are added to the network manager, and the associated notifications are sent to consumers. This should make the notifications clearer and cleaner, but please note that this may require changes in the ```nodeAdded``` or ```nodeUpdated``` listeners in application code.

Nodes are now added to the network through the ```updateNode``` method. This will send a ```nodeAdded``` on initial addition, or a ```nodeUpdated``` notification for subsequent updates.

The ```nodeAdded``` will not be sent immediately if the network is not ```ONLINE``` - it will be deferred until the network comes up.

This also fixes the sending of the ```nodeUpdated``` notification so that it is only sent if the node data has really changed. As part of this, we ensure that there are no changes to existing clusters, so that currently installed listeners are not lost, meaning that applications fail to receive notifications.

This change required numerous changes throughout the code to better allow this change detection and consolidation of the ```ZigBeeNode``` fields.

There has also been some small changes to the startup state detection when the ```ZigBeeTransportState``` is updated - again this is all related to the node initialisation and update notifications.

Closes #184
Closes #649 

Signed-off-by: Chris Jackson <chris@cd-jackson.com>