### PR TITLE
Improve data store performance and add serialise method to network manager

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
@@ -288,6 +288,23 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
     }
 
     /**
+     * Serializes a node to the {@link ZigBeeNetworkDataStore}.
+     * <p>
+     * Note that the data will not be serialized instantly, but will be handled by the
+     * {@link ZigBeeNetworkDatabaseManager} as per a standard node update.
+     *
+     * @param nodeAddress the {@link IeeeAddress} of the node to serialize
+     */
+    public void serializeNetworkDataStore(IeeeAddress nodeAddress) {
+        ZigBeeNode node = getNode(nodeAddress);
+        if (node == null) {
+            return;
+        }
+
+        databaseManager.nodeUpdated(node);
+    }
+
+    /**
      * Set the serializer class to be used to convert commands and fields into data to be sent to the dongle.
      * The system instantiates a new serializer for each command.
      *
@@ -561,11 +578,11 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
                 node.shutdown();
             }
 
-            databaseManager.shutdown();
-
             for (ZigBeeNetworkExtension extension : extensions) {
                 extension.extensionShutdown();
             }
+
+            databaseManager.shutdown();
         }
 
         transport.shutdown();

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/database/ZigBeeNetworkDatabaseManagerTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/database/ZigBeeNetworkDatabaseManagerTest.java
@@ -97,7 +97,7 @@ public class ZigBeeNetworkDatabaseManagerTest {
         databaseManager.setMaxDeferredWriteTime(1000);
 
         databaseManager.nodeAdded(node);
-        Mockito.verify(dataStore, Mockito.times(1)).writeNode(nodeDao);
+        Mockito.verify(dataStore, Mockito.timeout(TIMEOUT).times(1)).writeNode(nodeDao);
 
         databaseManager.setDeferredWriteTime(1);
 
@@ -121,12 +121,12 @@ public class ZigBeeNetworkDatabaseManagerTest {
                 .thenReturn(Mockito.mock(ScheduledFuture.class));
 
         databaseManager.nodeUpdated(node);
-        Mockito.verify(dataStore, Mockito.times(3)).writeNode(nodeDao);
+        Mockito.verify(dataStore, Mockito.timeout(TIMEOUT).times(3)).writeNode(nodeDao);
 
         databaseManager.nodeRemoved(node);
-        Mockito.verify(dataStore, Mockito.times(1)).removeNode(new IeeeAddress("1234567890ABCDEF"));
+        Mockito.verify(dataStore, Mockito.timeout(TIMEOUT).times(1)).removeNode(new IeeeAddress("1234567890ABCDEF"));
 
         databaseManager.shutdown();
-        Mockito.verify(networkManager, Mockito.times(1)).removeNetworkNodeListener(databaseManager);
+        Mockito.verify(networkManager, Mockito.timeout(TIMEOUT).times(1)).removeNetworkNodeListener(databaseManager);
     }
 }


### PR DESCRIPTION
This adds a new ```serializeNetworkDataStore``` method to the ```ZigBeeNetworkManager```. This allows applications to force the update of a node within the store without having to resort to directly manipulating the store. Doing so may breach the threading restrictions in the store which could cause blocks.

In addition, this makes a few changes to the database manager that should improve performance.

1. Only creates the DAO when the data is to be written to the store rather than when the deferred thread is created. This previously meant the DAO may be created multiple times before the data is eventually written.
1. Uses a local scheduler to ensure that only a single call to the data store will happen at once.
1. Immediate writes to the data store are still scheduled through the scheduler to ensure we only make a single write to the data store at once.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>