### PR TITLE
Add default implementation to ZigBeeNetworkNodeListener interface

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkNodeListener.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkNodeListener.java
@@ -18,24 +18,27 @@ public interface ZigBeeNetworkNodeListener {
     /**
      * Node was added
      *
-     * @param node
-     *            the new {@link ZigBeeNode}
+     * @param node the new {@link ZigBeeNode}
      */
-    void nodeAdded(final ZigBeeNode node);
+    default void nodeAdded(final ZigBeeNode node) {
+        // Default implementation does nothing
+    }
 
     /**
      * Node was updated
      *
-     * @param node
-     *            the updated {@link ZigBeeNode}
+     * @param node the updated {@link ZigBeeNode}
      */
-    void nodeUpdated(final ZigBeeNode node);
+    default void nodeUpdated(final ZigBeeNode node) {
+        // Default implementation does nothing
+    }
 
     /**
      * Node was removed
      *
-     * @param node
-     *            the removed {@link ZigBeeNode}
+     * @param node the removed {@link ZigBeeNode}
      */
-    void nodeRemoved(final ZigBeeNode node);
+    default void nodeRemoved(final ZigBeeNode node) {
+        // Default implementation does nothing
+    }
 }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/iasclient/ZigBeeIasCieExtension.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/iasclient/ZigBeeIasCieExtension.java
@@ -57,15 +57,4 @@ public class ZigBeeIasCieExtension implements ZigBeeNetworkExtension, ZigBeeNetw
             }
         }
     }
-
-    @Override
-    public void nodeUpdated(ZigBeeNode node) {
-        // Not used
-    }
-
-    @Override
-    public void nodeRemoved(ZigBeeNode node) {
-        // Not used
-    }
-
 }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/otaserver/ZigBeeOtaUpgradeExtension.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/otaserver/ZigBeeOtaUpgradeExtension.java
@@ -55,15 +55,4 @@ public class ZigBeeOtaUpgradeExtension implements ZigBeeNetworkExtension, ZigBee
             }
         }
     }
-
-    @Override
-    public void nodeUpdated(ZigBeeNode node) {
-        // Not used
-    }
-
-    @Override
-    public void nodeRemoved(ZigBeeNode node) {
-        // Not used
-    }
-
 }


### PR DESCRIPTION
This PR adds default implementations to the ```ZigBeeNetworkNodeListener``` interface methods so that implementors don't need to implement empty methods if they don't use one or more of the notifications.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>