### PR TITLE
Add missing license to ZclIasZoneClientTest.java

### DIFF
--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/app/iasclient/ZclIasZoneClientTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/app/iasclient/ZclIasZoneClientTest.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2016-2019 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
 package com.zsmartsystems.zigbee.app.iasclient;
 
 import static org.junit.Assert.assertEquals;


### PR DESCRIPTION
Fixes the license check.

Signed-off-by: Stefan Triller <stefan.triller@telekom.de>