### PR TITLE
Improve scheduler shutdown when ZigBeeNetworkManager closes

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
@@ -471,6 +471,11 @@ public class ZigBeeDongleEzsp implements ZigBeeTransportTransmit, ZigBeeTranspor
         if (frameHandler == null) {
             return;
         }
+        logger.debug("Ember NCP Shutdown");
+        frameHandler.setClosing();
+        frameHandler.close();
+        serialPort.close();
+        frameHandler = null;
 
         if (mfglibListener != null) {
             mfglibListener = null;
@@ -481,13 +486,8 @@ public class ZigBeeDongleEzsp implements ZigBeeTransportTransmit, ZigBeeTranspor
         }
 
         if (executorService != null) {
-            executorService.shutdown();
+            executorService.shutdownNow();
         }
-
-        frameHandler.setClosing();
-        serialPort.close();
-        frameHandler.close();
-        frameHandler = null;
     }
 
     /**

--- a/com.zsmartsystems.zigbee.dongle.telegesis/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/ZigBeeDongleTelegesis.java
+++ b/com.zsmartsystems.zigbee.dongle.telegesis/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/ZigBeeDongleTelegesis.java
@@ -503,8 +503,10 @@ public class ZigBeeDongleTelegesis
             pollingTimer.cancel(true);
         }
         if (executorService != null) {
-            executorService.shutdown();
+            executorService.shutdownNow();
         }
+
+        commandScheduler.shutdownNow();
 
         frameHandler.removeEventListener(this);
         frameHandler.setClosing();

--- a/com.zsmartsystems.zigbee.dongle.telegesis/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/internal/TelegesisFrameHandler.java
+++ b/com.zsmartsystems.zigbee.dongle.telegesis/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/internal/TelegesisFrameHandler.java
@@ -318,7 +318,8 @@ public class TelegesisFrameHandler {
     public void close() {
         setClosing();
 
-        timeoutScheduler.shutdown();
+        timeoutScheduler.shutdownNow();
+        executor.shutdownNow();
 
         try {
             parserThread.interrupt();

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/database/ZigBeeNetworkDatabaseManager.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/database/ZigBeeNetworkDatabaseManager.java
@@ -186,6 +186,7 @@ public class ZigBeeNetworkDatabaseManager implements ZigBeeNetworkNodeListener {
         } catch (InterruptedException e) {
             logger.debug("Data store: shutdown did not complete all tasks.");
         }
+        executorService.shutdownNow();
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransactionManager.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransactionManager.java
@@ -188,7 +188,7 @@ public class ZigBeeTransactionManager implements ZigBeeNetworkNodeListener {
 
         networkManager.removeNetworkNodeListener(this);
 
-        executorService.shutdown();
+        executorService.shutdownNow();
 
         if (timeoutTask != null) {
             timeoutTask.cancel(false);

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeNodeTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeNodeTest.java
@@ -20,8 +20,10 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
@@ -29,6 +31,7 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 import com.zsmartsystems.zigbee.ZigBeeNode.ZigBeeNodeState;
+import com.zsmartsystems.zigbee.internal.NotificationService;
 import com.zsmartsystems.zigbee.serialization.DefaultDeserializer;
 import com.zsmartsystems.zigbee.transaction.ZigBeeTransactionFuture;
 import com.zsmartsystems.zigbee.transaction.ZigBeeTransactionMatcher;
@@ -50,6 +53,12 @@ import com.zsmartsystems.zigbee.zdo.field.RoutingTable.DiscoveryState;
 
 public class ZigBeeNodeTest {
     static final int TIMEOUT = 5000;
+
+    @Before
+    public void resetNotificationService() throws Exception {
+        TestUtilities.setField(NotificationService.class, NotificationService.class, "executorService",
+                Executors.newCachedThreadPool());
+    }
 
     @Test
     public void testAddDescriptors() {
@@ -439,7 +448,7 @@ public class ZigBeeNodeTest {
     }
 
     @Test
-    public void isDiscovered() {
+    public void isDiscovered() throws Exception {
         ZigBeeNode node = new ZigBeeNode(Mockito.mock(ZigBeeNetworkManager.class), new IeeeAddress("1234567890"));
         ZigBeeNetworkEndpointListener listener = Mockito.mock(ZigBeeNetworkEndpointListener.class);
         node.addNetworkEndpointListener(listener);

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/app/otaupgrade/ZclOtaUpgradeServerTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/app/otaupgrade/ZclOtaUpgradeServerTest.java
@@ -17,10 +17,12 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Callable;
+import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 import org.awaitility.Awaitility;
+import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
@@ -30,6 +32,7 @@ import org.mockito.stubbing.Answer;
 
 import com.zsmartsystems.zigbee.CommandResult;
 import com.zsmartsystems.zigbee.IeeeAddress;
+import com.zsmartsystems.zigbee.TestUtilities;
 import com.zsmartsystems.zigbee.ZigBeeCommand;
 import com.zsmartsystems.zigbee.ZigBeeEndpoint;
 import com.zsmartsystems.zigbee.ZigBeeEndpointAddress;
@@ -40,6 +43,7 @@ import com.zsmartsystems.zigbee.app.otaserver.ZclOtaUpgradeServer;
 import com.zsmartsystems.zigbee.app.otaserver.ZigBeeOtaFile;
 import com.zsmartsystems.zigbee.app.otaserver.ZigBeeOtaServerStatus;
 import com.zsmartsystems.zigbee.app.otaserver.ZigBeeOtaStatusCallback;
+import com.zsmartsystems.zigbee.internal.NotificationService;
 import com.zsmartsystems.zigbee.transaction.ZigBeeTransactionMatcher;
 import com.zsmartsystems.zigbee.zcl.ZclAttribute;
 import com.zsmartsystems.zigbee.zcl.clusters.ZclOtaUpgradeCluster;
@@ -55,8 +59,14 @@ import com.zsmartsystems.zigbee.zdo.field.NodeDescriptor;
 public class ZclOtaUpgradeServerTest implements ZigBeeOtaStatusCallback {
     private List<ZigBeeOtaServerStatus> otaStatusCapture;
 
+    @Before
+    public void resetNotificationService() throws Exception {
+        TestUtilities.setField(NotificationService.class, NotificationService.class, "executorService",
+                Executors.newCachedThreadPool());
+    }
+
     @Test
-    public void testNotify() {
+    public void testNotify() throws Exception {
         ArgumentCaptor<ZigBeeCommand> mockedCommandCaptor = ArgumentCaptor.forClass(ZigBeeCommand.class);
 
         NodeDescriptor nodeDescriptor = new NodeDescriptor();
@@ -151,7 +161,7 @@ public class ZclOtaUpgradeServerTest implements ZigBeeOtaStatusCallback {
     }
 
     @Test
-    public void cancelUpgrade() {
+    public void cancelUpgrade() throws Exception {
         otaStatusCapture = new ArrayList<ZigBeeOtaServerStatus>();
 
         ZclOtaUpgradeCluster cluster = Mockito.mock(ZclOtaUpgradeCluster.class);

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransactionManagerTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransactionManagerTest.java
@@ -23,9 +23,11 @@ import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledFuture;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
@@ -38,6 +40,7 @@ import com.zsmartsystems.zigbee.ZigBeeCommand;
 import com.zsmartsystems.zigbee.ZigBeeEndpointAddress;
 import com.zsmartsystems.zigbee.ZigBeeNetworkManager;
 import com.zsmartsystems.zigbee.ZigBeeNode;
+import com.zsmartsystems.zigbee.internal.NotificationService;
 import com.zsmartsystems.zigbee.transaction.ZigBeeTransaction.TransactionState;
 import com.zsmartsystems.zigbee.transport.ZigBeeTransportProgressState;
 import com.zsmartsystems.zigbee.zdo.field.NodeDescriptor;
@@ -51,6 +54,12 @@ import com.zsmartsystems.zigbee.zdo.field.NodeDescriptor.MacCapabilitiesType;
  */
 public class ZigBeeTransactionManagerTest {
     private static int TIMEOUT = 5000;
+
+    @Before
+    public void resetNotificationService() throws Exception {
+        TestUtilities.setField(NotificationService.class, NotificationService.class, "executorService",
+                Executors.newCachedThreadPool());
+    }
 
     @Test
     public void sendTransaction() {
@@ -164,7 +173,7 @@ public class ZigBeeTransactionManagerTest {
     }
 
     @Test
-    public void shutdown() {
+    public void shutdown() throws Exception {
         ZigBeeNetworkManager networkManager = Mockito.mock(ZigBeeNetworkManager.class);
         ZigBeeTransactionManager transactionManager = new ZigBeeTransactionManager(networkManager);
         ZigBeeTransactionMatcher responseMatcher = Mockito.mock(ZigBeeTransactionMatcher.class);
@@ -325,7 +334,7 @@ public class ZigBeeTransactionManagerTest {
     }
 
     @Test
-    public void testSleepyManagement() {
+    public void testSleepyManagement() throws Exception {
         // This test sets the max sleepy transactions to 2, then fills the queue with 3 frames and makes sure only 2 are
         // sent
         ZigBeeNetworkManager networkManager = Mockito.mock(ZigBeeNetworkManager.class);


### PR DESCRIPTION
This ensures that all schedulers are shutdown when the stack is closed, thus ensuring that any applications are not stuck waiting on a thread/scheduler/timer.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>