### PR TITLE
Updates to SPI Driver

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/spi/SpiFrameHandlerTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/spi/SpiFrameHandlerTest.java
@@ -139,9 +139,9 @@ public class SpiFrameHandlerTest {
 
     @Test
     public void testReceivePacket() {
-        int[] response = getPacket(new int[] { 0x01, 0x02, 0x03, 0x04, 0xA7 });
+        int[] response = getPacket(new int[] { 0x01, 0x02, 0xA7 });
         assertNotNull(response);
-        assertEquals(4, response.length);
+        assertEquals(2, response.length);
         assertEquals(0x01, response[0]);
     }
 
@@ -155,6 +155,15 @@ public class SpiFrameHandlerTest {
     }
 
     @Test
+    public void testReceivePacketReset() {
+        int[] response = getPacket(new int[] { 0x00, 0x02, 0xA7 });
+        assertNotNull(response);
+        assertEquals(2, response.length);
+        assertEquals(0x00, response[0]);
+        assertEquals(0x02, response[1]);
+    }
+
+    @Test
     public void testReceivePacketVersion() {
         int[] response = getPacket(new int[] { 0x82, 0xA7 });
         assertNotNull(response);
@@ -164,9 +173,9 @@ public class SpiFrameHandlerTest {
 
     @Test
     public void testReceivePacketNoData() {
-        int[] response = getPacket(new int[] { 0xFF, 0xFF, 0xA7, 0x01, 0x02, 0x03, 0x04, 0xA7 });
+        int[] response = getPacket(new int[] { 0xFF, 0xFF, 0xA7, 0x01, 0x02, 0xA7 });
         assertNotNull(response);
-        assertEquals(4, response.length);
+        assertEquals(2, response.length);
         assertEquals(0x01, response[0]);
     }
 


### PR DESCRIPTION
This tidies up the SPI Handler and adds a few features -:
* Ensures that the timer is stopped when the handler is closed.
* Adds support for frames such as RESET which are sent by the SPI NCP code during initialisation. This required some minor refactoring of the receive handler to allow these frames to be supported.

@triller-telekom it would be great if you could give this a test on your system.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>