### PR TITLE
Add deviceId and deviceVersion to ZigBeeEndpointDao

### DIFF
--- a/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleNodeListCommand.java
+++ b/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleNodeListCommand.java
@@ -60,7 +60,7 @@ public class ZigBeeConsoleNodeListCommand extends ZigBeeConsoleAbstractCommand {
         }
 
         Collections.sort(nodeIds);
-        String tableHeader = String.format("%-7s  %-4s  %-17s  %-13s  %-3s  %-25s  %-15s  %-15s  %-15s", "Network",
+        String tableHeader = String.format("%-7s  %-4s  %-17s  %-13s  %-3s  %-25s  %-25s  %-15s  %-15s", "Network",
                 "Addr", "IEEE Address", "Logical Type", "EP", "Profile", "Device Type", "Manufacturer", "Model");
         out.println(tableHeader);
 
@@ -86,13 +86,13 @@ public class ZigBeeConsoleNodeListCommand extends ZigBeeConsoleAbstractCommand {
                 profileType = ZigBeeProfileType.getByValue(endpoint.getProfileId()).toString();
             }
             String deviceType;
-            if (ZigBeeProfileType.getByValue(endpoint.getProfileId()) == null) {
+            if (ZigBeeDeviceType.getByValue(endpoint.getDeviceId()) == null) {
                 deviceType = String.format("%04X", endpoint.getDeviceId());
             } else {
                 deviceType = ZigBeeDeviceType.getByValue(endpoint.getDeviceId()).toString();
             }
             boolean showManufacturerAndModel = endpoint.getParentNode().getNetworkAddress() != 0;
-            String endpointInfo = String.format("%3d  %-25s  %-15s  %-15s  %-15s", endpoint.getEndpointId(),
+            String endpointInfo = String.format("%3d  %-25s  %-25s  %-15s  %-15s", endpoint.getEndpointId(),
                     profileType, deviceType, showManufacturerAndModel ? getManufacturer(endpoint) : "",
                     showManufacturerAndModel ? getModel(endpoint) : "");
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeEndpoint.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeEndpoint.java
@@ -474,6 +474,8 @@ public class ZigBeeEndpoint {
 
         dao.setEndpointId(endpointId);
         dao.setProfileId(profileId);
+        dao.setDeviceId(deviceId);
+        dao.setDeviceVersion(deviceVersion);
 
         List<ZclClusterDao> clusters;
 
@@ -496,6 +498,12 @@ public class ZigBeeEndpoint {
         endpointId = dao.getEndpointId();
         if (dao.getProfileId() != null) {
             profileId = dao.getProfileId();
+        }
+        if (dao.getDeviceId() != null) {
+            deviceId = dao.getDeviceId();
+        }
+        if (dao.getDeviceVersion() != null) {
+            deviceVersion = dao.getDeviceVersion();
         }
 
         if (dao.getInputClusterIds() != null) {

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/database/ZigBeeEndpointDao.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/database/ZigBeeEndpointDao.java
@@ -20,9 +20,13 @@ import com.zsmartsystems.zigbee.ZigBeeEndpoint;
  *
  */
 public class ZigBeeEndpointDao {
+    private int endpointId;
+
     private Integer profileId;
 
-    private int endpointId;
+    private Integer deviceId;
+
+    private Integer deviceVersion;
 
     /**
      * Input cluster IDs
@@ -37,6 +41,14 @@ public class ZigBeeEndpointDao {
 
     private final List<ZclClusterDao> outputClusters = new ArrayList<ZclClusterDao>();
 
+    public int getEndpointId() {
+        return endpointId;
+    }
+
+    public void setEndpointId(int endpointId) {
+        this.endpointId = endpointId;
+    }
+
     public Integer getProfileId() {
         return profileId;
     }
@@ -45,12 +57,20 @@ public class ZigBeeEndpointDao {
         this.profileId = profileId;
     }
 
-    public int getEndpointId() {
-        return endpointId;
+    public Integer getDeviceId() {
+        return deviceId;
     }
 
-    public void setEndpointId(int endpointId) {
-        this.endpointId = endpointId;
+    public void setDeviceVersion(int deviceVersion) {
+        this.deviceVersion = deviceVersion;
+    }
+
+    public Integer getDeviceVersion() {
+        return deviceVersion;
+    }
+
+    public void setDeviceId(int deviceId) {
+        this.deviceId = deviceId;
     }
 
     public List<Integer> getInputClusterIds() {

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeEndpointTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeEndpointTest.java
@@ -171,7 +171,15 @@ public class ZigBeeEndpointTest {
         ZigBeeEndpoint endpoint = getEndpoint();
 
         ZigBeeEndpointDao dao = new ZigBeeEndpointDao();
+        dao.setEndpointId(1);
+        dao.setDeviceId(2);
+        dao.setDeviceVersion(3);
+        dao.setProfileId(4);
         endpoint.setDao(dao);
+        assertEquals(1, endpoint.getEndpointId());
+        assertEquals(2, endpoint.getDeviceId());
+        assertEquals(3, endpoint.getDeviceVersion());
+        assertEquals(4, endpoint.getProfileId());
     }
 
     private ZigBeeEndpoint getEndpoint() {


### PR DESCRIPTION
Also fixes the printing of deviceId in the ```nodes``` console command.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>