### PR TITLE
Clear the Ember NCP key table when reforming the network

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/EmberNcp.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/EmberNcp.java
@@ -27,6 +27,8 @@ import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspAddTransientLinkKe
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspAddTransientLinkKeyResponse;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspAesMmoHashRequest;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspAesMmoHashResponse;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspClearKeyTableRequest;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspClearKeyTableResponse;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspEnergyScanResultHandler;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspGetCertificate283k1Request;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspGetCertificate283k1Response;
@@ -330,6 +332,21 @@ public class EmberNcp {
         logger.debug(response.toString());
         lastStatus = null;
         return response.getValues();
+    }
+
+    /**
+     * Clears the key table on the NCP
+     *
+     * @return the {@link EmberStatus} or null on error
+     */
+    public EmberStatus clearKeyTable() {
+        EzspClearKeyTableRequest request = new EzspClearKeyTableRequest();
+        EzspTransaction transaction = protocolHandler
+                .sendEzspTransaction(new EzspSingleResponseTransaction(request, EzspClearKeyTableResponse.class));
+        EzspClearKeyTableResponse response = (EzspClearKeyTableResponse) transaction.getResponse();
+        logger.debug(response.toString());
+        lastStatus = response.getStatus();
+        return lastStatus;
     }
 
     /**

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/EmberNetworkInitialisation.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/EmberNetworkInitialisation.java
@@ -111,6 +111,8 @@ public class EmberNetworkInitialisation {
             ncp.leaveNetwork();
         }
 
+        ncp.clearKeyTable();
+
         // Perform an energy scan to find a clear channel
         int quietestChannel = doEnergyScan(ncp, scanDuration);
         logger.debug("Energy scan reports quietest channel is {}", quietestChannel);

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/EmberNcpTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/EmberNcpTest.java
@@ -21,6 +21,8 @@ import com.zsmartsystems.zigbee.IeeeAddress;
 import com.zsmartsystems.zigbee.ZigBeeChannelMask;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.EzspFrameRequest;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.EzspFrameResponse;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspClearKeyTableRequest;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspClearKeyTableResponse;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspGetEui64Request;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspGetEui64Response;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspGetNetworkParametersRequest;
@@ -209,6 +211,18 @@ public class EmberNcpTest {
         EzspFrameRequest request = ezspTransactionCapture.getValue().getRequest();
         assertTrue(request instanceof EzspStartScanRequest);
         assertEquals(ZigBeeChannelMask.CHANNEL_MASK_2GHZ, ((EzspStartScanRequest) request).getChannelMask());
+    }
+
+    @Test
+    public void clearKeyTable() {
+        EmberNcp ncp = getEmberNcp(Mockito.mock(EzspClearKeyTableResponse.class));
+
+        ncp.clearKeyTable();
+
+        Mockito.verify(handler, Mockito.times(1)).sendEzspTransaction(ezspTransactionCapture.capture());
+
+        EzspFrameRequest request = ezspTransactionCapture.getValue().getRequest();
+        assertTrue(request instanceof EzspClearKeyTableRequest);
     }
 
 }


### PR DESCRIPTION
Clear all keys from the Ember key table when reforming the network. Without this, APS link keys may remain that will prevent devices from joining the new network when uses the trust centre link key.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>