### PR TITLE
Update Ember TC link policy to not generate new keys

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.ember.autocode/src/main/resources/ezsp_protocol.xml
+++ b/com.zsmartsystems.zigbee.dongle.ember.autocode/src/main/resources/ezsp_protocol.xml
@@ -4194,6 +4194,11 @@
 				<description>Admit joins only if there is an entry in the transient key table. This corresponds to the Base Device Behavior specification where a Trust Center enforces all devices to join with an install code-derived link key.</description>
 			</value>
 			<value>
+				<name>EZSP_DEFER_JOINS_REJOINS_HAVE_LINK_KEY</name>
+				<enum_value>0x07</enum_value>
+				<description>Delay sending the network key to a new joining device.</description>
+			</value>
+			<value>
 				<name>EZSP_DISALLOW_BINDING_MODIFICATION</name>
 				<enum_value>0x10</enum_value>
 				<description>EZSP_BINDING_MODIFICATION_POLICY default decision. Do not allow the local binding table to be changed by remote nodes.</description>
@@ -4244,12 +4249,12 @@
 				<description>EZSP_TC_KEY_REQUEST_POLICY decision. When the Trust Center receives a request for a Trust Center link key, it will be ignored.</description>
 			</value>
 			<value>
-				<name>EZSP_ALLOW_TC_KEY_REQUESTS</name>
+				<name>EZSP_ALLOW_TC_KEY_REQUESTS_AND_SEND_CURRENT_KEY</name>
 				<enum_value>0x51</enum_value>
-				<description>EZSP_TC_KEY_REQUEST_POLICY decision. When the Trust Center receives a request for a Trust Center link key, it will reply to it with the corresponding key.</description>
+				<description>EZSP_TC_KEY_REQUEST_POLICY decision. When the Trust Center receives a request for a Trust Center link key, it will reply to it with the current key. If not key is currently in the key table for this device, a new key will be generated and sent to the device.</description>
 			</value>
 			<value>
-				<name>EZSP_GENERATE_NEW_TC_LINK_KEY</name>
+				<name>EZSP_ALLOW_TC_KEY_REQUEST_AND_GENERATE_NEW_KEY</name>
 				<enum_value>0x52</enum_value>
 				<description>EZSP_TC_KEY_REQUEST_POLICY decision. When the Trust Center receives a request for a Trust Center link key, it will generate a key to send to the joiner.</description>
 			</value>
@@ -6168,7 +6173,7 @@
 			</value>
 			<value>
 				<name>EMBER_TC_TIMEOUT_WAITING_FOR_SECOND_APP_KEY_REQUEST</name>
-				<enum_value>0x000C</enum_value>
+				<enum_value>0x000D</enum_value>
 				<description></description>
 			</value>
 			<value>
@@ -6451,8 +6456,38 @@
 				<description>The number of times a NWK broadcast was dropped because the the broadcast table was full.</description>
 			</value>
 			<value>
-				<name>EMBER_COUNTER_TYPE_COUNT</name>
+				<name>EMBER_COUNTER_PTA_LO_PRI_REQUESTED</name>
 				<enum_value>34</enum_value>
+				<description>The number of low priority packet traffic arbitration requests.</description>
+			</value>
+			<value>
+				<name>EMBER_COUNTER_PTA_HI_PRI_REQUESTED</name>
+				<enum_value>35</enum_value>
+				<description>The number of high priority packet traffic arbitration requests.</description>
+			</value>
+			<value>
+				<name>EMBER_COUNTER_PTA_LO_PRI_DENIED</name>
+				<enum_value>36</enum_value>
+				<description>The number of low priority packet traffic arbitration requests denied.</description>
+			</value>
+			<value>
+				<name>EMBER_COUNTER_PTA_HI_PRI_DENIED</name>
+				<enum_value>37</enum_value>
+				<description>The number of high priority packet traffic arbitration requests denied.</description>
+			</value>
+			<value>
+				<name>EMBER_COUNTER_PTA_LO_PRI_TX_ABORTED</name>
+				<enum_value>38</enum_value>
+				<description>The number of aborted low priority packet traffic arbitration transmissions.</description>
+			</value>
+			<value>
+				<name>EMBER_COUNTER_PTA_HI_PRI_TX_ABORTED</name>
+				<enum_value>39</enum_value>
+				<description>The number of aborted high priority packet traffic arbitration transmissions.</description>
+			</value>
+			<value>
+				<name>EMBER_COUNTER_TYPE_COUNT</name>
+				<enum_value>40</enum_value>
 				<description>A placeholder giving the number of Ember counter types.</description>
 			</value>
 		</values>
@@ -6769,6 +6804,41 @@
 				<name>EZSP_VALUE_PTA_DIRECTIONAL_PRIORITY_PULSE_WIDTH</name>
 				<enum_value>0x36</enum_value>
 				<description>Set packet traffic arbitration directional priority pulse width in microseconds.</description>
+			</value>
+			<value>
+				<name>EZSP_VALUE_PTA_PHY_SELECT_TIMEOUT</name>
+				<enum_value>0x37</enum_value>
+				<description>Set packet traffic arbitration phy select timeout(ms).</description>
+			</value>
+			<value>
+				<name>EZSP_VALUE_ANTENNA_RX_MODE</name>
+				<enum_value>0x38</enum_value>
+				<description>Configure the RX antenna mode: (0-do not switch; 1-primary; 2-secondary; 3-RX antenna diversity).</description>
+			</value>
+			<value>
+				<name>EZSP_VALUE_NWK_KEY_TIMEOUT</name>
+				<enum_value>0x39</enum_value>
+				<description>Configure the timeout to wait for the network key before failing a join</description>
+			</value>
+			<value>
+				<name>EZSP_VALUE_FORCE_TX_AFTER_FAILED_CCA_ATTEMPTS</name>
+				<enum_value>0x3A</enum_value>
+				<description>The number of failed CSMA attempts due to failed CCA made by the MAC before continuing transmission with CCA disabled. This is the same as calling the emberForceTxAfterFailedCca(uint8_t csmaAttempts) API. A value of 0 disables the feature.</description>
+			</value>
+			<value>
+				<name>EZSP_VALUE_TRANSIENT_KEY_TIMEOUT_S</name>
+				<enum_value>0x3B</enum_value>
+				<description>The length of time, in seconds, that a trust center will store a transient link key that a device can use to join its network. A transient key is added with a call to emberAddTransientLinkKey. After the transient key is added, it will be removed once this amount of time has passed. A joining device will not be able to use that key to join until it is added again on the trust center. The default value is 300 seconds (5 minutes).</description>
+			</value>
+			<value>
+				<name>EZSP_VALUE_COULOMB_COUNTER_USAGE</name>
+				<enum_value>0x3C</enum_value>
+				<description>Cumulative energy usage metric since the last value reset of the coulomb counter plugin. Setting this value will reset the coulomb counter.</description>
+			</value>
+			<value>
+				<name>EZSP_VALUE_MAX_BEACONS_TO_STORE</name>
+				<enum_value>0x3D</enum_value>
+				<description>When scanning, configure the maximum number of beacons to store in cache. Each beacon consumes one packet buffer in RAM.</description>
 			</value>
 		</values>
 	</enum>

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
@@ -246,11 +246,11 @@ public class ZigBeeDongleEzsp implements ZigBeeTransportTransmit, ZigBeeTranspor
 
         // Define the default policies
         stackPolicies = new TreeMap<EzspPolicyId, EzspDecisionId>();
-        stackPolicies.put(EzspPolicyId.EZSP_TC_KEY_REQUEST_POLICY, EzspDecisionId.EZSP_GENERATE_NEW_TC_LINK_KEY);
+        stackPolicies.put(EzspPolicyId.EZSP_TC_KEY_REQUEST_POLICY, EzspDecisionId.EZSP_DENY_TC_KEY_REQUESTS);
         stackPolicies.put(EzspPolicyId.EZSP_TRUST_CENTER_POLICY, EzspDecisionId.EZSP_ALLOW_PRECONFIGURED_KEY_JOINS);
         stackPolicies.put(EzspPolicyId.EZSP_MESSAGE_CONTENTS_IN_CALLBACK_POLICY,
                 EzspDecisionId.EZSP_MESSAGE_TAG_ONLY_IN_CALLBACK);
-        // stackPolicies.put(EzspPolicyId.EZSP_APP_KEY_REQUEST_POLICY, value)
+        stackPolicies.put(EzspPolicyId.EZSP_APP_KEY_REQUEST_POLICY, EzspDecisionId.EZSP_DENY_APP_KEY_REQUESTS);
 
         // stackPolicies.put(EzspPolicyId.EZSP_POLL_HANDLER_POLICY, EzspDecisionId.EZSP_POLL_HANDLER_CALLBACK);
         stackPolicies.put(EzspPolicyId.EZSP_BINDING_MODIFICATION_POLICY,

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/structure/EmberCounterType.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/structure/EmberCounterType.java
@@ -209,9 +209,39 @@ public enum EmberCounterType {
     EMBER_COUNTER_BROADCAST_TABLE_FULL(0x0021),
 
     /**
+     * The number of low priority packet traffic arbitration requests.
+     */
+    EMBER_COUNTER_PTA_LO_PRI_REQUESTED(0x0022),
+
+    /**
+     * The number of high priority packet traffic arbitration requests.
+     */
+    EMBER_COUNTER_PTA_HI_PRI_REQUESTED(0x0023),
+
+    /**
+     * The number of low priority packet traffic arbitration requests denied.
+     */
+    EMBER_COUNTER_PTA_LO_PRI_DENIED(0x0024),
+
+    /**
+     * The number of high priority packet traffic arbitration requests denied.
+     */
+    EMBER_COUNTER_PTA_HI_PRI_DENIED(0x0025),
+
+    /**
+     * The number of aborted low priority packet traffic arbitration transmissions.
+     */
+    EMBER_COUNTER_PTA_LO_PRI_TX_ABORTED(0x0026),
+
+    /**
+     * The number of aborted high priority packet traffic arbitration transmissions.
+     */
+    EMBER_COUNTER_PTA_HI_PRI_TX_ABORTED(0x0027),
+
+    /**
      * A placeholder giving the number of Ember counter types.
      */
-    EMBER_COUNTER_TYPE_COUNT(0x0022);
+    EMBER_COUNTER_TYPE_COUNT(0x0028);
 
     /**
      * A mapping between the integer code and its corresponding type to

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/structure/EmberKeyStatus.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/structure/EmberKeyStatus.java
@@ -77,7 +77,7 @@ public enum EmberKeyStatus {
 
     /**
      */
-    EMBER_TC_TIMEOUT_WAITING_FOR_SECOND_APP_KEY_REQUEST(0x000C),
+    EMBER_TC_TIMEOUT_WAITING_FOR_SECOND_APP_KEY_REQUEST(0x000D),
 
     /**
      */

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/structure/EzspDecisionId.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/structure/EzspDecisionId.java
@@ -69,6 +69,11 @@ public enum EzspDecisionId {
     EZSP_BDB_JOIN_USES_INSTALL_CODE_KEY(0x0006),
 
     /**
+     * Delay sending the network key to a new joining device.
+     */
+    EZSP_DEFER_JOINS_REJOINS_HAVE_LINK_KEY(0x0007),
+
+    /**
      * EZSP_BINDING_MODIFICATION_POLICY default decision. Do not allow the local binding table
      * to be changed by remote nodes.
      */
@@ -131,13 +136,13 @@ public enum EzspDecisionId {
      * EZSP_TC_KEY_REQUEST_POLICY decision. When the Trust Center receives a request for a Trust
      * Center link key, it will reply to it with the corresponding key.
      */
-    EZSP_ALLOW_TC_KEY_REQUESTS(0x0051),
+    EZSP_ALLOW_TC_KEY_REQUEST_AND_GENERATE_NEW_KEY(0x0051),
 
     /**
      * EZSP_TC_KEY_REQUEST_POLICY decision. When the Trust Center receives a request for a Trust
      * Center link key, it will generate a key to send to the joiner.
      */
-    EZSP_GENERATE_NEW_TC_LINK_KEY(0x0052),
+    EZSP_ALLOW_TC_KEY_REQUESTS_AND_SEND_CURRENT_KEY(0x0052),
 
     /**
      * EZSP_APP_KEY_REQUEST_POLICY decision. When the Trust Center receives a request for an

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/structure/EzspValueId.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/structure/EzspValueId.java
@@ -230,7 +230,52 @@ public enum EzspValueId {
     /**
      * Set packet traffic arbitration directional priority pulse width in microseconds.
      */
-    EZSP_VALUE_PTA_DIRECTIONAL_PRIORITY_PULSE_WIDTH(0x0036);
+    EZSP_VALUE_PTA_DIRECTIONAL_PRIORITY_PULSE_WIDTH(0x0036),
+
+    /**
+     * Set packet traffic arbitration phy select timeout(ms).
+     */
+    EZSP_VALUE_PTA_PHY_SELECT_TIMEOUT(0x0037),
+
+    /**
+     * Configure the RX antenna mode: (0-do not switch; 1-primary; 2-secondary; 3-RX antenna
+     * diversity).
+     */
+    EZSP_VALUE_ANTENNA_RX_MODE(0x0038),
+
+    /**
+     * Configure the timeout to wait for the network key before failing a join
+     */
+    EZSP_VALUE_NWK_KEY_TIMEOUT(0x0039),
+
+    /**
+     * The number of failed CSMA attempts due to failed CCA made by the MAC before continuing
+     * transmission with CCA disabled. This is the same as calling the
+     * emberForceTxAfterFailedCca(uint8_t csmaAttempts) API. A value of 0 disables the
+     * feature.
+     */
+    EZSP_VALUE_FORCE_TX_AFTER_FAILED_CCA_ATTEMPTS(0x003A),
+
+    /**
+     * The length of time, in seconds, that a trust center will store a transient link key that a
+     * device can use to join its network. A transient key is added with a call to
+     * emberAddTransientLinkKey. After the transient key is added, it will be removed once this
+     * amount of time has passed. A joining device will not be able to use that key to join until it is
+     * added again on the trust center. The default value is 300 seconds (5 minutes).
+     */
+    EZSP_VALUE_TRANSIENT_KEY_TIMEOUT_S(0x003B),
+
+    /**
+     * Cumulative energy usage metric since the last value reset of the coulomb counter plugin.
+     * Setting this value will reset the coulomb counter.
+     */
+    EZSP_VALUE_COULOMB_COUNTER_USAGE(0x003C),
+
+    /**
+     * When scanning, configure the maximum number of beacons to store in cache. Each beacon
+     * consumes one packet buffer in RAM.
+     */
+    EZSP_VALUE_MAX_BEACONS_TO_STORE(0x003D);
 
     /**
      * A mapping between the integer code and its corresponding type to


### PR DESCRIPTION
This prevents the Ember dongle generating a new key and adding it to the key table when a device requests the key. If this is allowed, then the application must ensure that when the device leaves and rejoins, a new transient key is used, or the keytable has this entry removed or the device will not rejoin.

#701 

Signed-off-by: Chris Jackson <chris@cd-jackson.com>