### PR TITLE
Use custom ThreadFactory for all Executors to provide named threads

### DIFF
--- a/com.zsmartsystems.zigbee.console.main/pom.xml
+++ b/com.zsmartsystems.zigbee.console.main/pom.xml
@@ -75,18 +75,6 @@
 		</dependency>
 
 		<dependency>
-			<groupId>commons-lang</groupId>
-			<artifactId>commons-lang</artifactId>
-			<version>2.6</version>
-		</dependency>
-
-		<dependency>
-			<groupId>commons-io</groupId>
-			<artifactId>commons-io</artifactId>
-			<version>2.4</version>
-		</dependency>
-
-		<dependency>
 			<groupId>commons-cli</groupId>
 			<artifactId>commons-cli</artifactId>
 			<version>1.4</version>
@@ -96,12 +84,6 @@
 			<groupId>com.thoughtworks.xstream</groupId>
 			<artifactId>xstream</artifactId>
 			<version>1.4.9</version>
-		</dependency>
-
-		<dependency>
-			<groupId>org.bouncycastle</groupId>
-			<artifactId>bcprov-jdk15on</artifactId>
-			<version>1.49</version>
 		</dependency>
 
 	</dependencies>

--- a/com.zsmartsystems.zigbee.dongle.conbee/src/main/java/com/zsmartsystems/zigbee/dongle/conbee/internal/ConBeeFrameHandler.java
+++ b/com.zsmartsystems.zigbee.dongle.conbee/src/main/java/com/zsmartsystems/zigbee/dongle/conbee/internal/ConBeeFrameHandler.java
@@ -17,13 +17,13 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.zsmartsystems.zigbee.ZigBeeExecutors;
 import com.zsmartsystems.zigbee.dongle.conbee.ZigBeeDongleConBee;
 import com.zsmartsystems.zigbee.dongle.conbee.internal.frame.ConBeeDeviceState;
 import com.zsmartsystems.zigbee.dongle.conbee.internal.frame.ConBeeDeviceStateRequest;
@@ -68,7 +68,7 @@ public class ConBeeFrameHandler {
      */
     private final BlockingQueue<ConBeeFrameRequest> sendQueue = new ArrayBlockingQueue<ConBeeFrameRequest>(20);
 
-    private ExecutorService executor = Executors.newCachedThreadPool();
+    private ExecutorService executor = ZigBeeExecutors.newCachedThreadPool("ConBeeDongle");
     private final List<ConBeeListener> transactionListeners = new ArrayList<ConBeeListener>();
 
     /**

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
@@ -13,7 +13,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -26,6 +25,7 @@ import com.zsmartsystems.zigbee.IeeeAddress;
 import com.zsmartsystems.zigbee.ZigBeeBroadcastDestination;
 import com.zsmartsystems.zigbee.ZigBeeChannel;
 import com.zsmartsystems.zigbee.ZigBeeChannelMask;
+import com.zsmartsystems.zigbee.ZigBeeExecutors;
 import com.zsmartsystems.zigbee.ZigBeeNetworkManager;
 import com.zsmartsystems.zigbee.ZigBeeNodeStatus;
 import com.zsmartsystems.zigbee.ZigBeeNwkAddressMode;
@@ -262,7 +262,7 @@ public class ZigBeeDongleEzsp implements ZigBeeTransportTransmit, ZigBeeTranspor
          * Create the scheduler with a single thread. This ensures that commands sent to the dongle, and the processing
          * of responses is performed in order
          */
-        executorService = Executors.newScheduledThreadPool(1);
+        executorService = ZigBeeExecutors.newScheduledThreadPool(1, "EmberDongle");
     }
 
     /**
@@ -747,7 +747,7 @@ public class ZigBeeDongleEzsp implements ZigBeeTransportTransmit, ZigBeeTranspor
         }
         networkStateUp = linkState;
 
-        new Thread() {
+        new Thread("EmberLinkStateChange") {
             @Override
             public void run() {
                 if (linkState) {

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/EzspNeighborTable.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/EzspNeighborTable.java
@@ -7,13 +7,13 @@
  */
 package com.zsmartsystems.zigbee.dongle.ember.internal;
 
-import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.zsmartsystems.zigbee.ZigBeeExecutors;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspGetConfigurationValueRequest;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspGetConfigurationValueResponse;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspGetNeighborRequest;
@@ -43,7 +43,7 @@ public class EzspNeighborTable {
     /**
      * Scheduler to run the service
      */
-    private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
+    private final ScheduledExecutorService scheduler = ZigBeeExecutors.newScheduledThreadPool(1, "EzspNeighborTable");
 
     private AshFrameHandler ashHandler;
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/ash/AshFrameHandler.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/ash/AshFrameHandler.java
@@ -18,7 +18,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -28,6 +27,7 @@ import java.util.concurrent.TimeoutException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.zsmartsystems.zigbee.ZigBeeExecutors;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.EzspFrame;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.EzspFrameRequest;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.EzspFrameResponse;
@@ -110,12 +110,12 @@ public class AshFrameHandler implements EzspProtocolHandler {
      */
     private final Queue<AshFrameData> sentQueue = new ConcurrentLinkedQueue<AshFrameData>();
 
-    private ScheduledExecutorService timer = Executors.newScheduledThreadPool(1);
+    private ScheduledExecutorService timer = ZigBeeExecutors.newScheduledThreadPool(1, "AshTimer");
     private ScheduledFuture<?> timerFuture;
 
     private boolean stateConnected = false;
 
-    private ExecutorService executor = Executors.newCachedThreadPool();
+    private ExecutorService executor = ZigBeeExecutors.newCachedThreadPool("AshExecutor");
     private final List<AshListener> transactionListeners = new ArrayList<AshListener>();
 
     /**

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/spi/SpiFrameHandler.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/spi/SpiFrameHandler.java
@@ -18,7 +18,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -29,6 +28,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.zsmartsystems.zigbee.ZigBeeExecutors;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.EzspFrame;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.EzspFrameRequest;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.EzspFrameResponse;
@@ -109,7 +109,7 @@ public class SpiFrameHandler implements EzspProtocolHandler {
      */
     private int pollRate = DEFAULT_POLL_RATE;
 
-    private ScheduledExecutorService timer = Executors.newScheduledThreadPool(1);
+    private ScheduledExecutorService timer = ZigBeeExecutors.newScheduledThreadPool(1, "SpiTimer");
     private ScheduledFuture<?> timerFuture;
 
     /**
@@ -121,7 +121,7 @@ public class SpiFrameHandler implements EzspProtocolHandler {
 
     private int[] lastFrameSent = null;
 
-    private ExecutorService executor = Executors.newCachedThreadPool();
+    private ExecutorService executor = ZigBeeExecutors.newCachedThreadPool("SpiExecutor");
     private final List<SpiListener> transactionListeners = new ArrayList<SpiListener>();
 
     private final Map<Integer, String> errorMessages = new ConcurrentHashMap<Integer, String>();
@@ -192,7 +192,7 @@ public class SpiFrameHandler implements EzspProtocolHandler {
     public void start(final ZigBeePort port) {
         this.port = port;
 
-        pollingScheduler = Executors.newSingleThreadScheduledExecutor();
+        pollingScheduler = ZigBeeExecutors.newSingleThreadScheduledExecutor("SpiPollingExecutor");
 
         parserThread = new Thread("SpiFrameHandler") {
             @Override

--- a/com.zsmartsystems.zigbee.dongle.telegesis/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/ZigBeeDongleTelegesis.java
+++ b/com.zsmartsystems.zigbee.dongle.telegesis/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/ZigBeeDongleTelegesis.java
@@ -12,7 +12,6 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -25,6 +24,7 @@ import com.zsmartsystems.zigbee.IeeeAddress;
 import com.zsmartsystems.zigbee.ZigBeeBroadcastDestination;
 import com.zsmartsystems.zigbee.ZigBeeChannel;
 import com.zsmartsystems.zigbee.ZigBeeChannelMask;
+import com.zsmartsystems.zigbee.ZigBeeExecutors;
 import com.zsmartsystems.zigbee.ZigBeeNetworkManager;
 import com.zsmartsystems.zigbee.ZigBeeNodeStatus;
 import com.zsmartsystems.zigbee.ZigBeeNwkAddressMode;
@@ -350,7 +350,7 @@ public class ZigBeeDongleTelegesis
      * We need to put all received events in a "pipeline" to make sure we process "SEQ/OK/ERROR" responses
      * from the dongle before "ACK/NAK" responses, or even before the command response arrives from the remote device
      */
-    private ExecutorService commandScheduler = Executors.newFixedThreadPool(1);
+    private ExecutorService commandScheduler = ZigBeeExecutors.newFixedThreadPool(1, "TelegesisCommands");
 
     /**
      * Constructor for Telegesis dongle.
@@ -360,7 +360,7 @@ public class ZigBeeDongleTelegesis
     public ZigBeeDongleTelegesis(final ZigBeePort serialPort) {
         this.serialPort = serialPort;
 
-        executorService = Executors.newScheduledThreadPool(1);
+        executorService = ZigBeeExecutors.newScheduledThreadPool(1, "TelegesisDongle");
     }
 
     /**

--- a/com.zsmartsystems.zigbee.dongle.telegesis/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/internal/TelegesisFrameHandler.java
+++ b/com.zsmartsystems.zigbee.dongle.telegesis/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/internal/TelegesisFrameHandler.java
@@ -15,7 +15,6 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -25,6 +24,7 @@ import java.util.concurrent.TimeoutException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.zsmartsystems.zigbee.ZigBeeExecutors;
 import com.zsmartsystems.zigbee.dongle.telegesis.ZigBeeDongleTelegesis;
 import com.zsmartsystems.zigbee.dongle.telegesis.internal.protocol.TelegesisCommand;
 import com.zsmartsystems.zigbee.dongle.telegesis.internal.protocol.TelegesisEvent;
@@ -49,7 +49,7 @@ public class TelegesisFrameHandler {
      */
     private final Queue<TelegesisCommand> sendQueue = new ConcurrentLinkedQueue<TelegesisCommand>();
 
-    private ExecutorService executor = Executors.newCachedThreadPool();
+    private ExecutorService executor = ZigBeeExecutors.newCachedThreadPool("TelegesisFrameExecutor");
 
     /**
      * List of listeners waiting for commands to complete
@@ -154,7 +154,7 @@ public class TelegesisFrameHandler {
 
         this.serialPort = serialPort;
 
-        timeoutScheduler = Executors.newSingleThreadScheduledExecutor();
+        timeoutScheduler = ZigBeeExecutors.newSingleThreadScheduledExecutor("TelegesisTimer");
 
         parserThread = new Thread("TelegesisFrameHandler") {
             @Override

--- a/com.zsmartsystems.zigbee.dongle.xbee/src/main/java/com/zsmartsystems/zigbee/dongle/xbee/internal/XBeeFrameHandler.java
+++ b/com.zsmartsystems.zigbee.dongle.xbee/src/main/java/com/zsmartsystems/zigbee/dongle/xbee/internal/XBeeFrameHandler.java
@@ -15,7 +15,6 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -26,6 +25,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.zsmartsystems.zigbee.ZigBeeExecutors;
 import com.zsmartsystems.zigbee.dongle.xbee.internal.protocol.XBeeCommand;
 import com.zsmartsystems.zigbee.dongle.xbee.internal.protocol.XBeeEvent;
 import com.zsmartsystems.zigbee.dongle.xbee.internal.protocol.XBeeFrame;
@@ -49,7 +49,7 @@ public class XBeeFrameHandler {
      */
     private final Queue<XBeeCommand> sendQueue = new ConcurrentLinkedQueue<XBeeCommand>();
 
-    private ExecutorService executor = Executors.newCachedThreadPool();
+    private ExecutorService executor = ZigBeeExecutors.newCachedThreadPool("XBeeFrameExecutor");
 
     /**
      * List of listeners waiting for commands to complete
@@ -147,7 +147,7 @@ public class XBeeFrameHandler {
         frameId.set(1);
 
         this.serialPort = serialPort;
-        this.timeoutScheduler = Executors.newSingleThreadScheduledExecutor();
+        this.timeoutScheduler = ZigBeeExecutors.newSingleThreadScheduledExecutor("XBeeTimer");
 
         // Clear anything in the receive buffer before we start
         emptyRxBuffer();

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeExecutors.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeExecutors.java
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) 2016-2019 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Extension of the {@link Executors} class to create threads with custom names. This allows better profiling of the
+ * system as the source of all threads can be determined.
+ *
+ * @author Chris Jackson
+ *
+ */
+public class ZigBeeExecutors {
+
+    /**
+     * Creates a thread pool that creates new threads as needed, but will reuse previously constructed threads when they
+     * are available, and uses the provided ThreadFactory to create new threads when needed.
+     *
+     * @param name the thread pool name
+     * @return the newly created thread pool
+     */
+    public static ExecutorService newCachedThreadPool(String name) {
+        return Executors.newCachedThreadPool(new ThreadFactoryWithNamePrefix(name));
+    }
+
+    /**
+     * Creates a thread pool that can schedule commands to run after a given delay, or to execute periodically.
+     *
+     * @param corePoolSize the number of threads to keep in the pool, even if they are idle
+     * @param name the thread pool name
+     * @return a newly created scheduled thread pool
+     */
+    public static ScheduledExecutorService newScheduledThreadPool(int corePoolSize, String name) {
+        return Executors.newScheduledThreadPool(corePoolSize, new ThreadFactoryWithNamePrefix(name));
+    }
+
+    /**
+     * Creates a single-threaded executor that can schedule commands to run after a given delay, or to execute
+     * periodically. (Note however that if this single thread terminates due to a failure during execution prior to
+     * shutdown, a new one will take its place if needed to execute subsequent tasks.) Tasks are guaranteed to execute
+     * sequentially, and no more than one task will be active at any given time. Unlike the otherwise equivalent
+     * newScheduledThreadPool(1, threadFactory) the returned executor is guaranteed not to be reconfigurable to use
+     * additional threads.
+     *
+     * @param name the thread pool name
+     * @return a newly created scheduled executor
+     */
+    public static ScheduledExecutorService newSingleThreadScheduledExecutor(String name) {
+        return Executors.newSingleThreadScheduledExecutor(new ThreadFactoryWithNamePrefix(name));
+    }
+
+    /**
+     * Creates a thread pool that reuses a fixed number of threads operating off a shared unbounded queue, using the
+     * provided ThreadFactory to create new threads when needed. At any point, at most nThreads threads will be active
+     * processing tasks. If additional tasks are submitted when all threads are active, they will wait in the queue
+     * until a thread is available. If any thread terminates due to a failure during execution prior to shutdown, a new
+     * one will take its place if needed to execute subsequent tasks. The threads in the pool will exist until it is
+     * explicitly shutdown.
+     *
+     * @param nThreads the number of threads in the pool
+     * @param name the thread pool name
+     * @return the newly created thread pool
+     */
+    public static ExecutorService newFixedThreadPool(int nThreads, String name) {
+        return Executors.newFixedThreadPool(nThreads, new ThreadFactoryWithNamePrefix(name));
+    }
+
+    /**
+     * ThreadFactory with the ability to set the thread name prefix. This class is the same as
+     * {@link java.util.concurrent.Executors#defaultThreadFactory()} from JDK8, except for the thread naming feature.
+     * <p>
+     * The factory creates threads that have names on the form <i>prefix-thread-M</i>, where <i>prefix</i> is a string
+     * provided in the constructor and <i>M</i> is the sequence number of the thread created by this factory.
+     */
+    private static class ThreadFactoryWithNamePrefix implements ThreadFactory {
+        private final ThreadGroup group;
+        private final AtomicInteger threadNumber = new AtomicInteger(1);
+        private final String namePrefix;
+
+        /**
+         * Creates a new ThreadFactory where threads are created with a name prefix
+         * of <code>prefix</code>.
+         *
+         * @param prefix Thread name prefix.
+         */
+        public ThreadFactoryWithNamePrefix(String prefix) {
+            SecurityManager secMac = System.getSecurityManager();
+            group = (secMac != null) ? secMac.getThreadGroup() : Thread.currentThread().getThreadGroup();
+            namePrefix = prefix + "-thread-";
+        }
+
+        @Override
+        public Thread newThread(Runnable runnable) {
+            Thread thread = new Thread(group, runnable, namePrefix + threadNumber.getAndIncrement(), 0);
+            if (thread.isDaemon()) {
+                thread.setDaemon(false);
+            }
+            if (thread.getPriority() != Thread.NORM_PRIORITY) {
+                thread.setPriority(Thread.NORM_PRIORITY);
+            }
+            return thread;
+        }
+    }
+
+}

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
@@ -22,7 +22,6 @@ import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -172,10 +171,11 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
 
     /**
      * Executor service to execute update threads for discovery or mesh updates etc.
-     * We use a {@link Executors.newScheduledThreadPool} to provide a fixed number of threads as otherwise this could
-     * result in a large number of simultaneous threads in large networks.
+     * We use a {@link ZigBeeExecutors.newScheduledThreadPool} to provide a fixed number of threads as otherwise this
+     * could result in a large number of simultaneous threads in large networks.
      */
-    private final ScheduledExecutorService executorService = Executors.newScheduledThreadPool(6);
+    private final ScheduledExecutorService executorService = ZigBeeExecutors.newScheduledThreadPool(6,
+            "NetworkManager");
 
     /**
      * The {@link ZigBeeTransportTransmit} implementation. This provides the interface
@@ -1201,7 +1201,7 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
 
         // Start a thread to wait for the response
         // When we receive the response, if it's successful, we assume the device left.
-        new Thread() {
+        new Thread("NetworkLeave") {
             @Override
             public void run() {
                 try {

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNode.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNode.java
@@ -420,7 +420,7 @@ public class ZigBeeNode implements ZigBeeCommandListener {
         });
 
         // start the thread to execute it
-        new Thread(future).start();
+        new Thread(future, "UpdateBindingTable" + getIeeeAddress()).start();
         return future;
     }
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/otaserver/ZclOtaUpgradeServer.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/otaserver/ZclOtaUpgradeServer.java
@@ -12,7 +12,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -22,6 +21,7 @@ import org.slf4j.LoggerFactory;
 
 import com.zsmartsystems.zigbee.CommandResult;
 import com.zsmartsystems.zigbee.ZigBeeCommand;
+import com.zsmartsystems.zigbee.ZigBeeExecutors;
 import com.zsmartsystems.zigbee.ZigBeeStatus;
 import com.zsmartsystems.zigbee.app.ZigBeeApplication;
 import com.zsmartsystems.zigbee.internal.NotificationService;
@@ -110,7 +110,8 @@ public class ZclOtaUpgradeServer implements ZigBeeApplication {
      * spawning multiple threads. This should ensure a level of pacing if we had a lot of devices on the network that
      * suddenly wanted to upgrade using page requests at the same time.
      */
-    private static ScheduledExecutorService pageScheduledExecutor = Executors.newScheduledThreadPool(1);
+    private static ScheduledExecutorService pageScheduledExecutor = ZigBeeExecutors.newScheduledThreadPool(1,
+            "OtaUpgradeServer");
 
     /**
      * The logger.
@@ -181,7 +182,7 @@ public class ZclOtaUpgradeServer implements ZigBeeApplication {
     /**
      * Timer used to handle transfer timeout
      */
-    private ScheduledExecutorService timer = Executors.newScheduledThreadPool(1);
+    private ScheduledExecutorService timer = ZigBeeExecutors.newScheduledThreadPool(1, "OtaUpgradeTimer");
 
     /**
      * Current timer task
@@ -402,7 +403,7 @@ public class ZclOtaUpgradeServer implements ZigBeeApplication {
      */
     public boolean completeUpgrade() {
         // TODO: Handle the time?
-        new Thread() {
+        new Thread("OtaCompleteUpgrade") {
             @Override
             public void run() {
                 try {

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/database/ZigBeeNetworkDatabaseManager.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/database/ZigBeeNetworkDatabaseManager.java
@@ -10,7 +10,6 @@ package com.zsmartsystems.zigbee.database;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -19,6 +18,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.zsmartsystems.zigbee.IeeeAddress;
+import com.zsmartsystems.zigbee.ZigBeeExecutors;
 import com.zsmartsystems.zigbee.ZigBeeNetworkManager;
 import com.zsmartsystems.zigbee.ZigBeeNetworkNodeListener;
 import com.zsmartsystems.zigbee.ZigBeeNode;
@@ -98,7 +98,7 @@ public class ZigBeeNetworkDatabaseManager implements ZigBeeNetworkNodeListener {
     /**
      * Single thread scheduler to ensure single writes within the data store
      */
-    private ScheduledExecutorService executorService = Executors.newScheduledThreadPool(1);
+    private ScheduledExecutorService executorService = ZigBeeExecutors.newScheduledThreadPool(1, "DatabaseManager");
 
     /**
      * Creates the database manager

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/internal/NotificationService.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/internal/NotificationService.java
@@ -8,11 +8,12 @@
 package com.zsmartsystems.zigbee.internal;
 
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.zsmartsystems.zigbee.ZigBeeExecutors;
 
 /**
  * {@link NotificationService} is used to provide notifications to our listeners "safely". A separate
@@ -28,14 +29,14 @@ public class NotificationService {
      */
     private static Logger logger = LoggerFactory.getLogger(NotificationService.class);
 
-    private static ExecutorService executorService = Executors.newCachedThreadPool();
+    private static ExecutorService executorService = ZigBeeExecutors.newCachedThreadPool("NotificationService");
 
     /**
      * Initializes the notification service
      */
     public static void initialize() {
         if (executorService.isShutdown()) {
-            executorService = Executors.newCachedThreadPool();
+            executorService = ZigBeeExecutors.newCachedThreadPool("NotificationService");
         }
     }
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransactionManager.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransactionManager.java
@@ -14,7 +14,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -30,6 +29,7 @@ import com.zsmartsystems.zigbee.ZigBeeAddress;
 import com.zsmartsystems.zigbee.ZigBeeBroadcastDestination;
 import com.zsmartsystems.zigbee.ZigBeeCommand;
 import com.zsmartsystems.zigbee.ZigBeeEndpointAddress;
+import com.zsmartsystems.zigbee.ZigBeeExecutors;
 import com.zsmartsystems.zigbee.ZigBeeNetworkManager;
 import com.zsmartsystems.zigbee.ZigBeeNetworkNodeListener;
 import com.zsmartsystems.zigbee.ZigBeeNode;
@@ -127,11 +127,12 @@ public class ZigBeeTransactionManager implements ZigBeeNetworkNodeListener {
 
     /**
      * Executor service to execute update threads for discovery or mesh updates etc.
-     * We use a {@link Executors.newScheduledThreadPool} to provide a fixed number of threads as otherwise this could
-     * result in a large number of simultaneous threads in large networks. The threads are only used to time out a
+     * We use a {@link ZigBeeExecutors.newScheduledThreadPool} to provide a fixed number of threads as otherwise this
+     * could result in a large number of simultaneous threads in large networks. The threads are only used to time out a
      * transaction which is a short running event so should not block other threads from running in any practical sense.
      */
-    private final ScheduledExecutorService executorService = Executors.newScheduledThreadPool(6);
+    private final ScheduledExecutorService executorService = ZigBeeExecutors.newScheduledThreadPool(6,
+            "TransactionManager");
 
     /**
      * A Map containing the queue for each node. This provides quick access when adding commands to queue, or performing

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/ZclCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/ZclCluster.java
@@ -787,7 +787,7 @@ public abstract class ZclCluster {
         });
 
         // Create the thread to execute it
-        new Thread(future, "DiscoverAttributes" + zigbeeEndpoint.getIeeeAddress()).start();
+        new Thread(future, "DiscoverAttributes-" + zigbeeEndpoint.getIeeeAddress()).start();
         return future;
     }
 
@@ -897,7 +897,7 @@ public abstract class ZclCluster {
         });
 
         // start the thread to execute it
-        new Thread(future, "DiscoverCommandsReceived" + zigbeeEndpoint.getIeeeAddress()).start();
+        new Thread(future, "DiscoverCommandsReceived-" + zigbeeEndpoint.getIeeeAddress()).start();
         return future;
     }
 
@@ -1007,7 +1007,7 @@ public abstract class ZclCluster {
         });
 
         // start the thread to execute it
-        new Thread(future, "DiscoverCommandsGenerated" + zigbeeEndpoint.getIeeeAddress()).start();
+        new Thread(future, "DiscoverCommandsGenerated-" + zigbeeEndpoint.getIeeeAddress()).start();
         return future;
     }
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/ZclCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/ZclCluster.java
@@ -787,7 +787,7 @@ public abstract class ZclCluster {
         });
 
         // Create the thread to execute it
-        new Thread(future).start();
+        new Thread(future, "DiscoverAttributes" + zigbeeEndpoint.getIeeeAddress()).start();
         return future;
     }
 
@@ -897,7 +897,7 @@ public abstract class ZclCluster {
         });
 
         // start the thread to execute it
-        new Thread(future).start();
+        new Thread(future, "DiscoverCommandsReceived" + zigbeeEndpoint.getIeeeAddress()).start();
         return future;
     }
 
@@ -1007,7 +1007,7 @@ public abstract class ZclCluster {
         });
 
         // start the thread to execute it
-        new Thread(future).start();
+        new Thread(future, "DiscoverCommandsGenerated" + zigbeeEndpoint.getIeeeAddress()).start();
         return future;
     }
 


### PR DESCRIPTION
This creates a custom ```ZigBeeExecutors``` that uses a custom ```ThreadFactory``` so that all threads have more useful names.  All threads created explicitly have also been named.

This makes profiling and thread dumps more useful as all threads will now have a name that at least allows its source to be identified.

@triller-telekom any thoughts on this?

Signed-off-by: Chris Jackson <chris@cd-jackson.com>