### PR TITLE
Remove getLabel method from ZclDataType

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/protocol/ZclDataType.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/protocol/ZclDataType.java
@@ -29,7 +29,6 @@ import com.zsmartsystems.zigbee.zcl.field.NeighborInformation;
 import com.zsmartsystems.zigbee.zcl.field.ReadAttributeStatusRecord;
 import com.zsmartsystems.zigbee.zcl.field.WriteAttributeRecord;
 import com.zsmartsystems.zigbee.zcl.field.WriteAttributeStatusRecord;
-import com.zsmartsystems.zigbee.zcl.field.ZclArrayList;
 import com.zsmartsystems.zigbee.zdo.ZdoStatus;
 import com.zsmartsystems.zigbee.zdo.field.BindingTable;
 import com.zsmartsystems.zigbee.zdo.field.ComplexDescriptor;
@@ -46,145 +45,151 @@ import com.zsmartsystems.zigbee.zdo.field.UserDescriptor;
  * @author Chris Jackson
  */
 public enum ZclDataType {
-    DATA_8_BIT("8-bit data", Integer.class, 0x08, false),
-    DATA_16_BIT("16-bit data", null, 0x09, false),
-    DATA_24_BIT("24-bit data", null, 0x0A, false),
-    DATA_32_BIT("32-bit data", null, 0x0B, false),
-    DATA_40_BIT("40-bit data", null, 0x0C, false),
-    DATA_48_BIT("48-bit data", null, 0x0D, false),
-    DATA_56_BIT("56-bit data", null, 0x0E, false),
-    DATA_64_BIT("64-bit data", null, 0x0F, false),
-    BOOLEAN("Boolean", Boolean.class, 0x10, false),
-    BITMAP_8_BIT("8-bit Bitmap", Integer.class, 0x18, false),
-    BITMAP_16_BIT("16-bit Bitmap", Integer.class, 0x19, false),
-    BITMAP_24_BIT("24-bit Bitmap", Integer.class, 0x1A, false),
-    BITMAP_32_BIT("32-bit Bitmap", Integer.class, 0x1B, false),
-    BITMAP_40_BIT("40-bit Bitmap", Long.class, 0x1C, false),
-    BITMAP_48_BIT("48-bit Bitmap", Long.class, 0x1D, false),
-    BITMAP_56_BIT("56-bit Bitmap", Long.class, 0x1E, false),
-    BITMAP_64_BIT("64-bit Bitmap", Long.class, 0x1F, false),
-    UNSIGNED_8_BIT_INTEGER("Unsigned 8-bit integer", Integer.class, 0x20, true),
-    UNSIGNED_16_BIT_INTEGER("Unsigned 16-bit integer", Integer.class, 0x21, true),
-    UNSIGNED_24_BIT_INTEGER("Unsigned 24-bit integer", Integer.class, 0x22, true),
-    UNSIGNED_32_BIT_INTEGER("Unsigned 32-bit integer", Integer.class, 0x23, true),
-    UNSIGNED_40_BIT_INTEGER("Unsigned 40-bit integer", Long.class, 0x24, true),
-    UNSIGNED_48_BIT_INTEGER("Unsigned 48-bit integer", Long.class, 0x25, true),
-    UNSIGNED_56_BIT_INTEGER("Unsigned 56-bit integer", Long.class, 0x26, true),
-    UNSIGNED_64_BIT_INTEGER("Unsigned 64-bit integer", Long.class, 0x27, true),
-    SIGNED_8_BIT_INTEGER("Signed 8-bit Integer", Integer.class, 0x28, true),
-    SIGNED_16_BIT_INTEGER("Signed 16-bit Integer", Integer.class, 0x29, true),
-    SIGNED_24_BIT_INTEGER("Signed 24-bit Integer", Integer.class, 0x2A, true),
-    SIGNED_32_BIT_INTEGER("Signed 32-bit Integer", Integer.class, 0x2B, true),
-    SIGNED_40_BIT_INTEGER("Signed 40-bit Integer", null, 0x2C, true),
-    SIGNED_48_BIT_INTEGER("Signed 48-bit Integer", null, 0x2D, true),
-    SIGNED_56_BIT_INTEGER("Signed 56-bit Integer", null, 0x2E, true),
-    SIGNED_64_BIT_INTEGER("Signed 64-bit Integer", null, 0x2F, true),
-    ENUMERATION_8_BIT("8-bit Enumeration", Integer.class, 0x30, false),
-    ENUMERATION_16_BIT("16-bit enumeration", Integer.class, 0x31, false),
-    ENUMERATION_32_BIT("32-bit enumeration", Integer.class, 0x33, false),
-    FLOAT_16_BIT("Semi precision float", null, 0x38, true),
-    FLOAT_32_BIT("Single precision float", Double.class, 0x39, true),
-    FLOAT_64_BIT("Double precision float", null, 0x3A, true),
-    OCTET_STRING("Octet string", ByteArray.class, 0x41, false),
-    CHARACTER_STRING("Character String", String.class, 0x42, false),
-    LONG_OCTET_STRING("Long Octet string", ByteArray.class, 0x43, false),
-    LONG_CHARACTER_STRING("Long Character String", null, 0x44, false),
-    ORDERED_SEQUENCE_ARRAY("ARRAY", ZclArrayList.class, 0x48, false),
-    ORDERED_SEQUENCE_STRUCTURE("ORDERED_SEQUENCE_STRUCTURE", List.class, 0x4C, false),
-    COLLECTION_SET("SET", null, 0x50, false),
-    COLLECTION_BAG("BAG", null, 0x51, false),
-    TIME_OF_DAY("Time", null, 0xE0, true),
-    DATE("Date", null, 0xE1, true),
-    UTCTIME("UTCTime", Calendar.class, 0xE2, true),
-    CLUSTERID("ClusterId", Integer.class, 0xE8, false),
-    ATTRIBUTEID("AttributeId", null, 0xE9, false),
-    BACNET_OID("BACNetId", null, 0xEA, false),
-    IEEE_ADDRESS("IEEE Address", IeeeAddress.class, 0xF0, false),
-    SECURITY_KEY("ZigBee Key", ZigBeeKey.class, 0xF1, false),
-    BYTE_ARRAY("Byte array", ByteArray.class, 0x00, false),
-    N_X_ATTRIBUTE_IDENTIFIER("N X Attribute identifier", Integer.class, 0x00, false),
-    N_X_ATTRIBUTE_INFORMATION("N X Attribute information", AttributeInformation.class, 0x00, false),
-    N_X_ATTRIBUTE_RECORD("N X Attribute record", AttributeRecord.class, 0x00, false),
-    N_X_ATTRIBUTE_REPORT("N X Attribute report", AttributeReport.class, 0x00, false),
-    N_X_ATTRIBUTE_REPORTING_STATUS_RECORD("N X Attribute reporting configuration record",
-            AttributeReportingStatusRecord.class, 0x00, false),
-    N_X_ATTRIBUTE_REPORTING_CONFIGURATION_RECORD("N X Attribute reporting configuration record",
-            AttributeReportingConfigurationRecord.class, 0x00, false),
-    N_X_ATTRIBUTE_SELECTOR("N X Attribute selector", Object.class, 0x00, false),
-    N_X_ATTRIBUTE_STATUS_RECORD("N X Attribute status record", AttributeStatusRecord.class, 0x00, false),
-    N_X_EXTENDED_ATTRIBUTE_INFORMATION("N x Extended Attribute Information", ExtendedAttributeInformation.class, 0x00,
-            false),
-    N_X_EXTENSION_FIELD_SET("N X Extension field set", ExtensionFieldSet.class, 0x00, false),
-    N_X_NEIGHBORS_INFORMATION("N X Neighbors information", NeighborInformation.class, 0x00, false),
-    N_X_READ_ATTRIBUTE_STATUS_RECORD("N X Read attribute status record", ReadAttributeStatusRecord.class, 0x00, false),
-    N_X_UNSIGNED_8_BIT_INTEGER("N x Unsigned 8-bit Integer", Integer.class, 0x00, false),
-    N_X_UNSIGNED_16_BIT_INTEGER("N X Unsigned 16-bit integer", Integer.class, 0x00, false),
-    N_X_WRITE_ATTRIBUTE_RECORD("N X Write attribute record", WriteAttributeRecord.class, 0x00, false),
-    N_X_WRITE_ATTRIBUTE_STATUS_RECORD("N X Write attribute status record", WriteAttributeStatusRecord.class, 0x00,
-            false),
-    X_UNSIGNED_8_BIT_INTEGER("X Unsigned 8-bit integer", Integer.class, 0x00, false),
-    ZCL_STATUS("ZCL Status", ZclStatus.class, 0x00, false),
-    EXTENDED_PANID("EXTENDED_PANID", ExtendedPanId.class, 0x00, false),
-    BINDING_TABLE("Binding Table", BindingTable.class, 0x00, false),
-    COMPLEX_DESCRIPTOR("Complex Descriptor", ComplexDescriptor.class, 0x00, false),
-    ENDPOINT("Endpoint", Integer.class, 0x00, false),
-    NEIGHBOR_TABLE("Neighbor Table", NeighborTable.class, 0x00, false),
-    NODE_DESCRIPTOR("Node Descriptor", NodeDescriptor.class, 0x00, false),
-    NWK_ADDRESS("NWK address", Integer.class, 0x00, false),
-    N_X_BINDING_TABLE("N x Binding Table", BindingTable.class, 0x00, false),
-    N_X_IEEE_ADDRESS("N X IEEE Address", IeeeAddress.class, 0x00, false),
-    POWER_DESCRIPTOR("Power Descriptor", PowerDescriptor.class, 0x00, false),
-    ROUTING_TABLE("Routing Table", RoutingTable.class, 0x00, false),
-    SIMPLE_DESCRIPTOR("Simple Descriptor", SimpleDescriptor.class, 0x00, false),
-    USER_DESCRIPTOR("User Descriptor", UserDescriptor.class, 0x00, false),
-    ZDO_STATUS("ZDO Status", ZdoStatus.class, 0x00, false),
-    UNSIGNED_8_BIT_INTEGER_ARRAY("Unsigned 8 bit Integer Array", int[].class, 0x00, false),
-    RAW_OCTET("RAW_OCTET", ByteArray.class, 0x00, false),
-    ZIGBEE_DATA_TYPE("ZigBee Data Type", ZclDataType.class, 0x00, false);
+    DATA_8_BIT(Integer.class, 0x08, false),
+    DATA_16_BIT(null, 0x09, false),
+    DATA_24_BIT(null, 0x0A, false),
+    DATA_32_BIT(null, 0x0B, false),
+    DATA_40_BIT(null, 0x0C, false),
+    DATA_48_BIT(null, 0x0D, false),
+    DATA_56_BIT(null, 0x0E, false),
+    DATA_64_BIT(null, 0x0F, false),
+    BOOLEAN(Boolean.class, 0x10, false),
+    BITMAP_8_BIT(Integer.class, 0x18, false),
+    BITMAP_16_BIT(Integer.class, 0x19, false),
+    BITMAP_24_BIT(Integer.class, 0x1A, false),
+    BITMAP_32_BIT(Integer.class, 0x1B, false),
+    BITMAP_40_BIT(Long.class, 0x1C, false),
+    BITMAP_48_BIT(Long.class, 0x1D, false),
+    BITMAP_56_BIT(Long.class, 0x1E, false),
+    BITMAP_64_BIT(Long.class, 0x1F, false),
+    UNSIGNED_8_BIT_INTEGER(Integer.class, 0x20, true),
+    UNSIGNED_16_BIT_INTEGER(Integer.class, 0x21, true),
+    UNSIGNED_24_BIT_INTEGER(Integer.class, 0x22, true),
+    UNSIGNED_32_BIT_INTEGER(Integer.class, 0x23, true),
+    UNSIGNED_40_BIT_INTEGER(Long.class, 0x24, true),
+    UNSIGNED_48_BIT_INTEGER(Long.class, 0x25, true),
+    UNSIGNED_56_BIT_INTEGER(Long.class, 0x26, true),
+    UNSIGNED_64_BIT_INTEGER(Long.class, 0x27, true),
+    SIGNED_8_BIT_INTEGER(Integer.class, 0x28, true),
+    SIGNED_16_BIT_INTEGER(Integer.class, 0x29, true),
+    SIGNED_24_BIT_INTEGER(Integer.class, 0x2A, true),
+    SIGNED_32_BIT_INTEGER(Integer.class, 0x2B, true),
+    SIGNED_40_BIT_INTEGER(null, 0x2C, true),
+    SIGNED_48_BIT_INTEGER(null, 0x2D, true),
+    SIGNED_56_BIT_INTEGER(null, 0x2E, true),
+    SIGNED_64_BIT_INTEGER(null, 0x2F, true),
+    ENUMERATION_8_BIT(Integer.class, 0x30, false),
+    ENUMERATION_16_BIT(Integer.class, 0x31, false),
+    ENUMERATION_32_BIT(Integer.class, 0x33, false),
+    FLOAT_16_BIT(null, 0x38, true),
+    FLOAT_32_BIT(Double.class, 0x39, true),
+    FLOAT_64_BIT(null, 0x3A, true),
+    OCTET_STRING(ByteArray.class, 0x41, false),
+    CHARACTER_STRING(String.class, 0x42, false),
+    LONG_OCTET_STRING(ByteArray.class, 0x43, false),
+    LONG_CHARACTER_STRING(null, 0x44, false),
+    ORDERED_SEQUENCE_ARRAY(null, 0x48, false),
+    ORDERED_SEQUENCE_STRUCTURE(List.class, 0x4C, false),
+    COLLECTION_SET(null, 0x50, false),
+    COLLECTION_BAG(null, 0x51, false),
+    TIME_OF_DAY(null, 0xE0, true),
+    DATE(null, 0xE1, true),
+    UTCTIME(Calendar.class, 0xE2, true),
+    CLUSTERID(Integer.class, 0xE8, false),
+    ATTRIBUTEID(null, 0xE9, false),
+    BACNET_OID(null, 0xEA, false),
+    IEEE_ADDRESS(IeeeAddress.class, 0xF0, false),
+    SECURITY_KEY(ZigBeeKey.class, 0xF1, false),
 
-    private final String label;
+    BYTE_ARRAY(ByteArray.class, 0x00, false),
+    N_X_ATTRIBUTE_IDENTIFIER(Integer.class, 0x00, false),
+    N_X_ATTRIBUTE_INFORMATION(AttributeInformation.class, 0x00, false),
+    N_X_ATTRIBUTE_RECORD(AttributeRecord.class, 0x00, false),
+    N_X_ATTRIBUTE_REPORT(AttributeReport.class, 0x00, false),
+    N_X_ATTRIBUTE_REPORTING_STATUS_RECORD(AttributeReportingStatusRecord.class, 0x00, false),
+    N_X_ATTRIBUTE_REPORTING_CONFIGURATION_RECORD(AttributeReportingConfigurationRecord.class, 0x00, false),
+    N_X_ATTRIBUTE_SELECTOR(Object.class, 0x00, false),
+    N_X_ATTRIBUTE_STATUS_RECORD(AttributeStatusRecord.class, 0x00, false),
+    N_X_EXTENDED_ATTRIBUTE_INFORMATION(ExtendedAttributeInformation.class, 0x00, false),
+    N_X_EXTENSION_FIELD_SET(ExtensionFieldSet.class, 0x00, false),
+    N_X_NEIGHBORS_INFORMATION(NeighborInformation.class, 0x00, false),
+    N_X_READ_ATTRIBUTE_STATUS_RECORD(ReadAttributeStatusRecord.class, 0x00, false),
+    N_X_UNSIGNED_8_BIT_INTEGER(Integer.class, 0x00, false),
+    N_X_UNSIGNED_16_BIT_INTEGER(Integer.class, 0x00, false),
+    N_X_WRITE_ATTRIBUTE_RECORD(WriteAttributeRecord.class, 0x00, false),
+    N_X_WRITE_ATTRIBUTE_STATUS_RECORD(WriteAttributeStatusRecord.class, 0x00, false),
+    X_UNSIGNED_8_BIT_INTEGER(Integer.class, 0x00, false),
+    ZCL_STATUS(ZclStatus.class, 0x00, false),
+    EXTENDED_PANID(ExtendedPanId.class, 0x00, false),
+    BINDING_TABLE(BindingTable.class, 0x00, false),
+    COMPLEX_DESCRIPTOR(ComplexDescriptor.class, 0x00, false),
+    ENDPOINT(Integer.class, 0x00, false),
+    NEIGHBOR_TABLE(NeighborTable.class, 0x00, false),
+    NODE_DESCRIPTOR(NodeDescriptor.class, 0x00, false),
+    NWK_ADDRESS(Integer.class, 0x00, false),
+    N_X_BINDING_TABLE(BindingTable.class, 0x00, false),
+    N_X_IEEE_ADDRESS(IeeeAddress.class, 0x00, false),
+    POWER_DESCRIPTOR(PowerDescriptor.class, 0x00, false),
+    ROUTING_TABLE(RoutingTable.class, 0x00, false),
+    SIMPLE_DESCRIPTOR(SimpleDescriptor.class, 0x00, false),
+    USER_DESCRIPTOR(UserDescriptor.class, 0x00, false),
+    ZDO_STATUS(ZdoStatus.class, 0x00, false),
+    UNSIGNED_8_BIT_INTEGER_ARRAY(int[].class, 0x00, false),
+    RAW_OCTET(ByteArray.class, 0x00, false),
+    ZIGBEE_DATA_TYPE(ZclDataType.class, 0x00, false);
+
     private final Class<?> dataClass;
-    private final int id;
+    private final int typeId;
     private final boolean analogue;
     private static Map<Integer, ZclDataType> codeTypeMapping;
 
     static {
         codeTypeMapping = new HashMap<Integer, ZclDataType>();
-        for (ZclDataType s : values()) {
-            codeTypeMapping.put(s.id, s);
+        for (ZclDataType dataType : values()) {
+            codeTypeMapping.put(dataType.typeId, dataType);
         }
     }
 
-    ZclDataType(final String label, final Class<?> dataClass, final int id, final boolean analogue) {
-        this.label = label;
+    private ZclDataType(final Class<?> dataClass, final int typeId, final boolean analogue) {
         this.dataClass = dataClass;
-        this.id = id;
+        this.typeId = typeId;
         this.analogue = analogue;
     }
 
-    public static ZclDataType getType(int id) {
-        return codeTypeMapping.get(id);
+    /**
+     * Gets the {@link ZclDataType} given the ZCL defined type ID
+     *
+     * @param typeId the ZCL defined type ID
+     * @return the {@link ZclDataType} corresponding to the type ID
+     */
+    public static ZclDataType getType(int typeId) {
+        return codeTypeMapping.get(typeId);
     }
 
     /**
-     * Gets the label for the data type
+     * Gets the Java class used in the framework for this data type
      *
-     * @return
-     * @deprecated use the enumeration
+     * @return the Java class used for this data type in the framework
      */
-    @Deprecated
-    public String getLabel() {
-        return label;
-    }
-
     public Class<?> getDataClass() {
         return dataClass;
     }
 
+    /**
+     * Gets the ZCL data type as defined in the ZigBee Standard
+     *
+     * @return the ZCL data type
+     */
     public int getId() {
-        return id;
+        return typeId;
     }
 
+    /**
+     * Returns true if this data type is considered analogue, or false if it is discrete.
+     * Analogue data types may set the change value when configuring reporting.
+     *
+     * @return true if this is an analogue data type
+     */
     public boolean isAnalog() {
         return analogue;
     }


### PR DESCRIPTION
Method was deprecated in 1.1 and is not used in the framework. The enumeration itself should be used.

Closes #706

Signed-off-by: Chris Jackson <chris@cd-jackson.com>