### PR TITLE
Improve PowerDescriptor.toString and fix ZDO tests

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/field/NodeDescriptor.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/field/NodeDescriptor.java
@@ -9,6 +9,7 @@ package com.zsmartsystems.zigbee.zdo.field;
 
 import java.util.HashSet;
 import java.util.Set;
+import java.util.TreeSet;
 
 import com.zsmartsystems.zigbee.serialization.ZigBeeDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
@@ -26,12 +27,12 @@ public class NodeDescriptor {
     private boolean complexDescriptorAvailable;
     private int manufacturerCode;
     private LogicalType logicalType = LogicalType.UNKNOWN;
-    private Set<ServerCapabilitiesType> serverCapabilities = new HashSet<>();
+    private Set<ServerCapabilitiesType> serverCapabilities = new TreeSet<>();
     private int incomingTransferSize;
     private int outgoingTransferSize;
     private boolean userDescriptorAvailable;
     private Set<FrequencyBandType> frequencyBands = new HashSet<FrequencyBandType>();
-    private final Set<MacCapabilitiesType> macCapabilities = new HashSet<>();
+    private final Set<MacCapabilitiesType> macCapabilities = new TreeSet<>();
     private boolean extendedEndpointListAvailable;
     private boolean extendedSimpleDescriptorListAvailable;
     private int stackCompliance;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/field/PowerDescriptor.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/field/PowerDescriptor.java
@@ -9,6 +9,7 @@ package com.zsmartsystems.zigbee.zdo.field;
 
 import java.util.HashSet;
 import java.util.Set;
+import java.util.TreeSet;
 
 import com.zsmartsystems.zigbee.serialization.ZigBeeDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
@@ -92,7 +93,7 @@ public class PowerDescriptor {
     }
 
     private CurrentPowerModeType currentPowerMode = CurrentPowerModeType.UNKNOWN;
-    private Set<PowerSourceType> availablePowerSources = new HashSet<PowerSourceType>();
+    private Set<PowerSourceType> availablePowerSources = new TreeSet<>();
     private PowerSourceType currentPowerSource = PowerSourceType.UNKNOWN;
     private PowerLevelType powerLevel = PowerLevelType.UNKNOWN;
 
@@ -310,6 +311,8 @@ public class PowerDescriptor {
 
     @Override
     public String toString() {
-        return currentPowerMode + ", " + availablePowerSources + ", " + currentPowerSource + ", " + powerLevel;
+        return "PowerDescriptor [currentPowerMode=" + currentPowerMode + ", availablePowerSources="
+                + availablePowerSources + ", currentPowerSource=" + currentPowerSource + ", powerLevel=" + powerLevel
+                + "]";
     }
 }

--- a/com.zsmartsystems.zigbee/src/test/resource/logs/zdo.txt
+++ b/com.zsmartsystems.zigbee/src/test/resource/logs/zdo.txt
@@ -22,23 +22,26 @@ ManagementPermitJoiningRequest [0/0 -> 65532/0, cluster=0036, TID=0A, permitDura
 ZigBeeApsFrame [sourceAddress=0/0, destinationAddress=0/0, profile=0000, cluster=8036, addressMode=null, radius=0, apsSecurity=false, apsCounter=00, payload=00 00]
 ManagementPermitJoiningResponse [0/0 -> 0/0, cluster=8036, TID=NULL, status=SUCCESS]
 
-ZigBeeApsFrame [sourceAddress=0/0, destinationAddress=31259/0, profile=0000, cluster=0003, addressMode=DEVICE, radius=31, apsSecurity=false, apsCounter=1C, payload=00 1B 7A]
-PowerDescriptorRequest [0/0 -> 31259/0, cluster=0003, TID=1C, nwkAddrOfInterest=31259]
+ZigBeeApsFrame [sourceAddress=61585/0, destinationAddress=0/0, profile=0000, cluster=8003, addressMode=null, radius=0, apsSecurity=false, apsCounter=6C, payload=84 84]
+PowerDescriptorResponse [61585/0 -> 0/0, cluster=8003, TID=--, status=NOT_SUPPORTED, nwkAddrOfInterest=null, powerDescriptor=null]
 
-#ZigBeeApsFrame [sourceAddress=31259/0, destinationAddress=0/0, profile=0000, cluster=8003, addressMode=DEVICE, radius=0, apsSecurity=false, apsCounter=00, payload=00 00 1B 7A 70 C1]
-#PowerDescriptorResponse [31259/0 -> 0/0, cluster=8003, TID=NULL, status=SUCCESS, nwkAddrOfInterest=31259, powerDescriptor=RECEIVER_ON_IDLE, [MAINS, RECHARGABLE_BATTERY, DISPOSABLE_BATTERY], MAINS, FULL]
+ZigBeeApsFrame [sourceAddress=31259/0, destinationAddress=0/0, profile=0000, cluster=8003, addressMode=DEVICE, radius=0, apsSecurity=false, apsCounter=00, payload=00 00 1B 7A 70 C1]
+PowerDescriptorResponse [31259/0 -> 0/0, cluster=8003, TID=--, status=SUCCESS, nwkAddrOfInterest=31259, powerDescriptor=PowerDescriptor [currentPowerMode=RECEIVER_ON_IDLE, availablePowerSources=[RECHARGABLE_BATTERY, MAINS, DISPOSABLE_BATTERY], currentPowerSource=MAINS, powerLevel=FULL]]
+
+ZigBeeApsFrame [sourceAddress=61585/0, destinationAddress=0/0, profile=0000, cluster=8003, addressMode=null, radius=0, apsSecurity=false, apsCounter=6C, payload=84 84]
+PowerDescriptorResponse [61585/0 -> 0/0, cluster=8003, TID=--, status=NOT_SUPPORTED, nwkAddrOfInterest=null, powerDescriptor=null]
 
 ZigBeeApsFrame [sourceAddress=0/0, destinationAddress=31259/0, profile=0000, cluster=0002, addressMode=DEVICE, radius=31, apsSecurity=false, apsCounter=1B, payload=00 1B 7A]
 NodeDescriptorRequest [0/0 -> 31259/0, cluster=0002, TID=1B, nwkAddrOfInterest=31259]
 
-#ZigBeeApsFrame [sourceAddress=0/0, destinationAddress=0/0, profile=0000, cluster=8002, addressMode=DEVICE, radius=0, apsSecurity=false, apsCounter=00, payload=00 00 1B 7A 01 40 8E AA BB 40 00 00 00 00 00 00 03]
-#NodeDescriptorResponse [0/0 -> 0/0, cluster=8002, TID=NULL, status=SUCCESS, nwkAddrOfInterest=31259, nodeDescriptor=NodeDescriptor [apsFlags=0, bufferSize=64, complexDescriptorAvailable=false, manufacturerCode=48042, logicalType=ROUTER, serverCapabilities=[], incomingTransferSize=0, outgoingTransferSize=0, userDescriptorAvailable=false, frequencyBands=[FREQ_2400_MHZ], macCapabilities=[FULL_FUNCTION_DEVICE, RECEIVER_ON_WHEN_IDLE, MAINS_POWER], extendedEndpointListAvailable=true, extendedSimpleDescriptorListAvailable=true, stackCompliance=0]]
+ZigBeeApsFrame [sourceAddress=0/0, destinationAddress=0/0, profile=0000, cluster=8002, addressMode=DEVICE, radius=0, apsSecurity=false, apsCounter=00, payload=00 00 1B 7A 01 40 8E AA BB 40 00 00 00 00 00 00 03]
+NodeDescriptorResponse [0/0 -> 0/0, cluster=8002, TID=NULL, status=SUCCESS, nwkAddrOfInterest=31259, nodeDescriptor=NodeDescriptor [apsFlags=0, bufferSize=64, complexDescriptorAvailable=false, manufacturerCode=48042, logicalType=ROUTER, serverCapabilities=[], incomingTransferSize=0, outgoingTransferSize=0, userDescriptorAvailable=false, frequencyBands=[FREQ_2400_MHZ], macCapabilities=[FULL_FUNCTION_DEVICE, MAINS_POWER, RECEIVER_ON_WHEN_IDLE], extendedEndpointListAvailable=true, extendedSimpleDescriptorListAvailable=true, stackCompliance=0]]
 
 ZigBeeApsFrame [sourceAddress=0/0, destinationAddress=31259/0, profile=0000, cluster=0005, addressMode=DEVICE, radius=31, apsSecurity=false, apsCounter=1D, payload=00 1B 7A]
 ActiveEndpointsRequest [0/0 -> 31259/0, cluster=0005, TID=1D, nwkAddrOfInterest=31259]
 
-#ZigBeeApsFrame [sourceAddress=0/0, destinationAddress=0/0, profile=0000, cluster=8002, addressMode=DEVICE, radius=0, apsSecurity=false, apsCounter=00, payload=00 00 1B 7A 01 03]
-#ActiveEndpointsResponse [0/0 -> 0/0, cluster=8005, TID=NULL, status=SUCCESS, nwkAddrOfInterest=31259, activeEpList=[3]]
+ZigBeeApsFrame [sourceAddress=61585/0, destinationAddress=0/0, profile=0000, cluster=8005, addressMode=null, radius=0, apsSecurity=false, apsCounter=3F, payload=00 00 91 F0 07 01 02 03 04 05 C8 E8]
+ActiveEndpointsResponse [61585/0 -> 0/0, cluster=8005, TID=--, status=SUCCESS, nwkAddrOfInterest=61585, activeEpList=[1, 2, 3, 4, 5, 200, 232]]
 
 ZigBeeApsFrame [sourceAddress=0/0, destinationAddress=31259/0, profile=0000, cluster=0004, addressMode=DEVICE, radius=31, apsSecurity=false, apsCounter=1E, payload=00 1B 7A 03]
 SimpleDescriptorRequest [0/0 -> 31259/0, cluster=0004, TID=1E, nwkAddrOfInterest=31259, endpoint=3]


### PR DESCRIPTION
This changes the ```toString()``` method in ```PowerDescriptor``` to use the standard format used throughout the framework.  It also fixes some ZDO tests.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>