### PR TITLE
Allow late discovery of clusters on nodes for IAS

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/iasclient/ZigBeeIasCieExtension.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/iasclient/ZigBeeIasCieExtension.java
@@ -50,10 +50,23 @@ public class ZigBeeIasCieExtension implements ZigBeeNetworkExtension, ZigBeeNetw
 
     @Override
     public void nodeAdded(ZigBeeNode node) {
-        for (ZigBeeEndpoint endpoint : node.getEndpoints()) {
-            if (endpoint.getInputCluster(ZclIasZoneCluster.CLUSTER_ID) != null) {
-                endpoint.addApplication(new ZclIasZoneClient(networkManager, networkManager.getLocalIeeeAddress(), 0));
-                break;
+        if (node.isDiscovered()) {
+            for (ZigBeeEndpoint endpoint : node.getEndpoints()) {
+                if (endpoint.getInputCluster(ZclIasZoneCluster.CLUSTER_ID) != null && endpoint.getApplication(ZclIasZoneCluster.CLUSTER_ID) == null) {
+                    endpoint.addApplication(new ZclIasZoneClient(networkManager, networkManager.getLocalIeeeAddress(), 0));
+                    break;
+                }
+            }
+        }
+    }
+    @Override
+    public void nodeUpdated(ZigBeeNode node) {
+        if (node.isDiscovered()) {
+            for (ZigBeeEndpoint endpoint : node.getEndpoints()) {
+                if (endpoint.getInputCluster(ZclIasZoneCluster.CLUSTER_ID) != null && endpoint.getApplication(ZclIasZoneCluster.CLUSTER_ID) == null) {
+                    endpoint.addApplication(new ZclIasZoneClient(networkManager, networkManager.getLocalIeeeAddress(), 0));
+                    break;
+                }
             }
         }
     }


### PR DESCRIPTION
The node discovery extension can take longer than expected to get the node descriptor, leading to the IAS extension missing the cluster when the node is added and ignoring it when the cluster is finally discovered. This adds a nodeUpdated hook to the extension to allow these nodes to be discovered and registered in the application.