### PR TITLE
Handle EzspChildJoinHandler joined=false

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
@@ -723,8 +723,9 @@ public class ZigBeeDongleEzsp implements ZigBeeTransportTransmit, ZigBeeTranspor
 
         if (response instanceof EzspChildJoinHandler) {
             EzspChildJoinHandler joinHandler = (EzspChildJoinHandler) response;
-            zigbeeTransportReceive.nodeStatusUpdate(ZigBeeNodeStatus.UNSECURED_JOIN, joinHandler.getChildId(),
-                    joinHandler.getChildEui64());
+            zigbeeTransportReceive.nodeStatusUpdate(
+                    joinHandler.getJoining() ? ZigBeeNodeStatus.UNSECURED_JOIN : ZigBeeNodeStatus.DEVICE_LEFT,
+                    joinHandler.getChildId(), joinHandler.getChildEui64());
             return;
         }
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzspTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzspTest.java
@@ -245,10 +245,19 @@ public class ZigBeeDongleEzspTest {
 
         EzspChildJoinHandler response = Mockito.mock(EzspChildJoinHandler.class);
         Mockito.when(response.getChildId()).thenReturn(123);
+        Mockito.when(response.getJoining()).thenReturn(true);
         Mockito.when(response.getChildEui64()).thenReturn(new IeeeAddress("1234567890ABCDEF"));
         dongle.handlePacket(response);
         Mockito.verify(transport, Mockito.timeout(TIMEOUT).times(1)).nodeStatusUpdate(ZigBeeNodeStatus.UNSECURED_JOIN,
                 123, new IeeeAddress("1234567890ABCDEF"));
+
+        response = Mockito.mock(EzspChildJoinHandler.class);
+        Mockito.when(response.getChildId()).thenReturn(123);
+        Mockito.when(response.getJoining()).thenReturn(false);
+        Mockito.when(response.getChildEui64()).thenReturn(new IeeeAddress("1234567890ABCDEF"));
+        dongle.handlePacket(response);
+        Mockito.verify(transport, Mockito.timeout(TIMEOUT).times(1)).nodeStatusUpdate(ZigBeeNodeStatus.DEVICE_LEFT, 123,
+                new IeeeAddress("1234567890ABCDEF"));
     }
 
     @Test


### PR DESCRIPTION
Handles the ```joining``` flag in ```EzspChildJoinHandler``` to signal ```UNSECURED_JOIN``` or ```DEVICE_LEFT```.
Closes #715 
Signed-off-by: Chris Jackson <chris@cd-jackson.com>