### PR TITLE
Fixed handling of ReadReportingConfigurationResponse

### DIFF
--- a/com.zsmartsystems.zigbee.autocode/src/main/java/com/zsmartsystems/zigbee/autocode/ZclDataType.java
+++ b/com.zsmartsystems.zigbee.autocode/src/main/java/com/zsmartsystems/zigbee/autocode/ZclDataType.java
@@ -73,6 +73,8 @@ public class ZclDataType {
                 new DataTypeMap("List<WriteAttributeStatusRecord>", 0, 0, false));
         dataTypeMapping.put("N_X_ATTRIBUTE_REPORTING_CONFIGURATION_RECORD",
                 new DataTypeMap("List<AttributeReportingConfigurationRecord>", 0, 0, false));
+        dataTypeMapping.put("N_X_ATTRIBUTE_REPORTING_STATUS_RECORD",
+                new DataTypeMap("List<AttributeReportingStatusRecord>", 0, 0, false));
         dataTypeMapping.put("N_X_ATTRIBUTE_STATUS_RECORD", new DataTypeMap("List<AttributeStatusRecord>", 0, 0, false));
         dataTypeMapping.put("N_X_ATTRIBUTE_RECORD", new DataTypeMap("List<AttributeRecord>", 0, 0, false));
         dataTypeMapping.put("N_X_ATTRIBUTE_REPORT", new DataTypeMap("List<AttributeReport>", 0, 0, false));

--- a/com.zsmartsystems.zigbee.autocode/src/main/resources/XXXX_General.xml
+++ b/com.zsmartsystems.zigbee.autocode/src/main/resources/XXXX_General.xml
@@ -75,7 +75,7 @@
     <command code="0x09" source="client">
         <name>Read Reporting Configuration Response</name>
         <description>The Read Reporting Configuration Response command is used to respond to a Read Reporting Configuration command.</description>
-        <field type="N_X_ATTRIBUTE_REPORTING_CONFIGURATION_RECORD">
+        <field type="N_X_ATTRIBUTE_REPORTING_STATUS_RECORD">
             <name>Records</name>
         </field>
     </command>

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeProfileType.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeProfileType.java
@@ -17,7 +17,7 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-06-15T20:20:47Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-08-15T18:28:04Z")
 public enum ZigBeeProfileType {
 
     /**
@@ -33,7 +33,7 @@ public enum ZigBeeProfileType {
     /**
      * ZigBee Green Power
      */
-    ZIGBEE_GREEN_POWER(0xA1E0),
+    ZIGBEE_GREEN_POWER(0xA10E),
 
     /**
      * Manufacturer Telegesis

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/ReadReportingConfigurationResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/ReadReportingConfigurationResponse.java
@@ -14,7 +14,7 @@ import javax.annotation.Generated;
 import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
-import com.zsmartsystems.zigbee.zcl.field.AttributeReportingConfigurationRecord;
+import com.zsmartsystems.zigbee.zcl.field.AttributeReportingStatusRecord;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
@@ -29,7 +29,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-08-15T18:28:04Z")
 public class ReadReportingConfigurationResponse extends ZclCommand {
     /**
      * The command ID.
@@ -39,7 +39,7 @@ public class ReadReportingConfigurationResponse extends ZclCommand {
     /**
      * Records command message field.
      */
-    private List<AttributeReportingConfigurationRecord> records;
+    private List<AttributeReportingStatusRecord> records;
 
     /**
      * Default constructor.
@@ -68,7 +68,7 @@ public class ReadReportingConfigurationResponse extends ZclCommand {
      *
      * @return the Records
      */
-    public List<AttributeReportingConfigurationRecord> getRecords() {
+    public List<AttributeReportingStatusRecord> getRecords() {
         return records;
     }
 
@@ -77,18 +77,18 @@ public class ReadReportingConfigurationResponse extends ZclCommand {
      *
      * @param records the Records
      */
-    public void setRecords(final List<AttributeReportingConfigurationRecord> records) {
+    public void setRecords(final List<AttributeReportingStatusRecord> records) {
         this.records = records;
     }
 
     @Override
     public void serialize(final ZclFieldSerializer serializer) {
-        serializer.serialize(records, ZclDataType.N_X_ATTRIBUTE_REPORTING_CONFIGURATION_RECORD);
+        serializer.serialize(records, ZclDataType.N_X_ATTRIBUTE_REPORTING_STATUS_RECORD);
     }
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        records = (List<AttributeReportingConfigurationRecord>) deserializer.deserialize(ZclDataType.N_X_ATTRIBUTE_REPORTING_CONFIGURATION_RECORD);
+        records = (List<AttributeReportingStatusRecord>) deserializer.deserialize(ZclDataType.N_X_ATTRIBUTE_REPORTING_STATUS_RECORD);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/protocol/ZclDataType.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/protocol/ZclDataType.java
@@ -20,6 +20,7 @@ import com.zsmartsystems.zigbee.zcl.field.AttributeInformation;
 import com.zsmartsystems.zigbee.zcl.field.AttributeRecord;
 import com.zsmartsystems.zigbee.zcl.field.AttributeReport;
 import com.zsmartsystems.zigbee.zcl.field.AttributeReportingConfigurationRecord;
+import com.zsmartsystems.zigbee.zcl.field.AttributeReportingStatusRecord;
 import com.zsmartsystems.zigbee.zcl.field.AttributeStatusRecord;
 import com.zsmartsystems.zigbee.zcl.field.ByteArray;
 import com.zsmartsystems.zigbee.zcl.field.ExtendedAttributeInformation;
@@ -105,6 +106,8 @@ public enum ZclDataType {
     N_X_ATTRIBUTE_INFORMATION("N X Attribute information", AttributeInformation.class, 0x00, false),
     N_X_ATTRIBUTE_RECORD("N X Attribute record", AttributeRecord.class, 0x00, false),
     N_X_ATTRIBUTE_REPORT("N X Attribute report", AttributeReport.class, 0x00, false),
+    N_X_ATTRIBUTE_REPORTING_STATUS_RECORD("N X Attribute reporting configuration record",
+            AttributeReportingStatusRecord.class, 0x00, false),
     N_X_ATTRIBUTE_REPORTING_CONFIGURATION_RECORD("N X Attribute reporting configuration record",
             AttributeReportingConfigurationRecord.class, 0x00, false),
     N_X_ATTRIBUTE_SELECTOR("N X Attribute selector", Object.class, 0x00, false),

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zcl/clusters/general/ReadReportingConfigurationResponseTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zcl/clusters/general/ReadReportingConfigurationResponseTest.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2016-2019 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.zcl.clusters.general;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import com.zsmartsystems.zigbee.CommandTest;
+import com.zsmartsystems.zigbee.serialization.DefaultDeserializer;
+import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
+import com.zsmartsystems.zigbee.zcl.ZclStatus;
+import com.zsmartsystems.zigbee.zcl.field.AttributeReportingStatusRecord;
+import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
+
+/**
+ *
+ * @author Chris Jackson
+ *
+ */
+public class ReadReportingConfigurationResponseTest extends CommandTest {
+
+    @Test
+    public void testReceive_SUCCESS() {
+        int[] packet = getPacketData("00 00 00 00 10 01 00 2C 01");
+
+        ReadReportingConfigurationResponse response = new ReadReportingConfigurationResponse();
+
+        DefaultDeserializer deserializer = new DefaultDeserializer(packet);
+        ZclFieldDeserializer fieldDeserializer = new ZclFieldDeserializer(deserializer);
+
+        response.deserialize(fieldDeserializer);
+
+        System.out.println(response);
+
+        List<AttributeReportingStatusRecord> records = response.getRecords();
+        AttributeReportingStatusRecord record = records.get(0);
+        assertEquals(ZclDataType.BOOLEAN, record.getAttributeDataType());
+        assertEquals(0, record.getAttributeIdentifier());
+        assertEquals(ZclStatus.SUCCESS, record.getStatus());
+        assertEquals(1, record.getMinimumReportingInterval());
+        assertEquals(300, record.getMaximumReportingInterval());
+    }
+
+    @Test
+    public void testReceive_UNSUPPORTED_ATTRIBUTE() {
+        int[] packet = getPacketData("86 00 00 00");
+
+        ReadReportingConfigurationResponse response = new ReadReportingConfigurationResponse();
+
+        DefaultDeserializer deserializer = new DefaultDeserializer(packet);
+        ZclFieldDeserializer fieldDeserializer = new ZclFieldDeserializer(deserializer);
+
+        response.deserialize(fieldDeserializer);
+
+        System.out.println(response);
+
+        List<AttributeReportingStatusRecord> records = response.getRecords();
+        AttributeReportingStatusRecord record = records.get(0);
+        assertEquals(0, record.getAttributeIdentifier());
+        assertEquals(ZclStatus.UNSUPPORTED_ATTRIBUTE, record.getStatus());
+    }
+
+}

--- a/com.zsmartsystems.zigbee/src/test/resource/logs/cluster-FFFF-General.txt
+++ b/com.zsmartsystems.zigbee/src/test/resource/logs/cluster-FFFF-General.txt
@@ -28,3 +28,6 @@ DefaultResponse [Metering: 0/1 -> 0/1, cluster=0702, TID=7A, commandIdentifier=1
 
 ZigBeeApsFrame [sourceAddress=0/1, destinationAddress=0/1, profile=0104, cluster=0702, addressMode=DEVICE, radius=0, apsSecurity=false, apsCounter=2A, payload=18 3E 01 00 00 00 48 08 02 00 00 00]
 ReadAttributesResponse [Metering: 0/1 -> 0/1, cluster=0702, TID=3E, records=[ReadAttributeStatusRecord [attributeDataType=ORDERED_SEQUENCE_ARRAY, attributeIdentifier=0, status=SUCCESS, attributeValue=ZclArrayList [dataType=DATA_8_BIT, values=[0, 0]]]]]
+
+ZigBeeApsFrame [sourceAddress=0/1, destinationAddress=0/1, profile=0104, cluster=0006, addressMode=null, radius=0, apsSecurity=false, apsCounter=17, payload=08 25 09 00 00 00 00 10 01 00 2C 01]
+ReadReportingConfigurationResponse [On/Off: 0/1 -> 0/1, cluster=0006, TID=25, records=[AttributeReportingStatusRecord: [status=SUCCESS, attributeIdentifier=0, direction=0, attributeDataType=BOOLEAN, minimumReportingInterval=1, maximumReportingInterval=300]]]


### PR DESCRIPTION
Fixes a bug in the processing of the ```ReadReportingConfigurationResponse```. This previously used the same response as the ```ConfigureReportingResponse``` however this is actually slightly different as it includes a ```status``` member in ```ReadReportingConfigurationResponse```.
 
Signed-off-by: Chris Jackson <chris@cd-jackson.com>