### PR TITLE
Create a custom placeholder cluster if system does not know the cluster

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/ZclCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/ZclCluster.java
@@ -247,7 +247,7 @@ public abstract class ZclCluster {
      * @param clusterId the 16 bit cluster identifier
      * @param clusterName the cluster name
      */
-    public ZclCluster(ZigBeeEndpoint zigbeeEndpoint, int clusterId, String clusterName) {
+    protected ZclCluster(ZigBeeEndpoint zigbeeEndpoint, int clusterId, String clusterName) {
         this.zigbeeEndpoint = zigbeeEndpoint;
         this.clusterId = clusterId;
         this.clusterName = clusterName;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclCustomCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclCustomCluster.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2016-2019 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.zcl.clusters;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import com.zsmartsystems.zigbee.ZigBeeEndpoint;
+import com.zsmartsystems.zigbee.zcl.ZclAttribute;
+import com.zsmartsystems.zigbee.zcl.ZclCluster;
+import com.zsmartsystems.zigbee.zcl.ZclCommand;
+
+/**
+ * Custom cluster used as a placeholder for unknown clusters
+ *
+ * @author Chris Jackson
+ *
+ */
+public class ZclCustomCluster extends ZclCluster {
+
+    @Override
+    protected Map<Integer, ZclAttribute> initializeClientAttributes() {
+        return new ConcurrentHashMap<>(0);
+    }
+
+    @Override
+    protected Map<Integer, ZclAttribute> initializeServerAttributes() {
+        return new ConcurrentHashMap<>(0);
+    }
+
+    @Override
+    protected Map<Integer, Class<? extends ZclCommand>> initializeServerCommands() {
+        return new ConcurrentHashMap<>(0);
+    }
+
+    @Override
+    protected Map<Integer, Class<? extends ZclCommand>> initializeClientCommands() {
+        return new ConcurrentHashMap<>(0);
+    }
+
+    /**
+     * Default constructor to create a custom cluster.
+     *
+     * @param zigbeeEndpoint the {@link ZigBeeEndpoint} this cluster is contained within
+     * @param clusterId the cluster ID
+     * @param clusterName the cluster name
+     */
+    public ZclCustomCluster(final ZigBeeEndpoint zigbeeEndpoint, int clusterId, String clusterName) {
+        super(zigbeeEndpoint, clusterId, clusterName);
+    }
+
+}

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeEndpointTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeEndpointTest.java
@@ -27,6 +27,7 @@ import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.clusters.ZclAlarmsCluster;
 import com.zsmartsystems.zigbee.zcl.clusters.ZclBasicCluster;
 import com.zsmartsystems.zigbee.zcl.clusters.ZclColorControlCluster;
+import com.zsmartsystems.zigbee.zcl.clusters.ZclCustomCluster;
 import com.zsmartsystems.zigbee.zcl.clusters.ZclDoorLockCluster;
 import com.zsmartsystems.zigbee.zcl.clusters.ZclLevelControlCluster;
 import com.zsmartsystems.zigbee.zcl.clusters.ZclScenesCluster;
@@ -88,9 +89,10 @@ public class ZigBeeEndpointTest {
         clusterIdList.add(ZclColorControlCluster.CLUSTER_ID);
         clusterIdList.add(ZclDoorLockCluster.CLUSTER_ID);
         clusterIdList.add(ZclLevelControlCluster.CLUSTER_ID);
+        clusterIdList.add(0xEEEE);
         endpoint.setInputClusterIds(clusterIdList);
 
-        assertEquals(5, endpoint.getInputClusterIds().size());
+        assertEquals(6, endpoint.getInputClusterIds().size());
 
         assertNotNull(endpoint.getInputCluster(ZclAlarmsCluster.CLUSTER_ID));
         assertFalse(endpoint.getInputCluster(ZclAlarmsCluster.CLUSTER_ID).isClient());
@@ -103,6 +105,14 @@ public class ZigBeeEndpointTest {
         assertTrue(endpoint.addInputCluster(new ZclScenesCluster(endpoint)));
         assertFalse(endpoint.addInputCluster(new ZclScenesCluster(endpoint)));
         assertTrue(endpoint.getInputClusterIds().contains(ZclScenesCluster.CLUSTER_ID));
+
+        // Here we check that we can add a cluster if the current cluster is the
+        assertNotNull(endpoint.getInputCluster(0xEEEE));
+        assertTrue(endpoint.getInputCluster(0xEEEE) instanceof ZclCustomCluster);
+        ZclCluster cluster = Mockito.mock(ZclCluster.class);
+        Mockito.when(cluster.getClusterId()).thenReturn(0xEEEE);
+        assertTrue(endpoint.addInputCluster(cluster));
+        assertEquals(cluster, endpoint.getInputCluster(0xEEEE));
 
         assertTrue(endpoint.getOutputClusterIds().isEmpty());
     }


### PR DESCRIPTION
This adds a simple class ```ZclCustomCluster``` as a placeholder for any clusters that are unknown by the system. This ensures that the cluster will appear in the cluster lists for the endpoint and attributes may be read and written.

The system allows updating of the default cluster through the ```addInputCluster``` and ```addOutputCluster``` methods to allow the application to add a specific implementation.

@triller-telekom you might want to take a look at this to ensure it does not impact your implementation of manufacturer specific clusters - I don't think it should, but I welcome any feedback before I merge.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>