### PR TITLE
Add Ember NCP Reset Provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,10 @@ The library provide a standard set of configuration constants to configure the N
 
 The Ember dongle driver includes a public method ```getEmberNcp()``` which returns a ```EmberNcp``` class. This class provides high level methods for interacting directly with the NCP.
 
+#### Ember Reset
+
+By default the library uses the ASH Reset command to reset the NCP when the framework starts. Silabs have stated that this is not reliable due to possible communication problems between the NCP and the host. Where possible the user should implement a hardware reset to reset the NCP. Since this is application specific, the framework provides an interface for the application to implement this reset. The user should implement the ```EmberNcpResetProvider``` interface, and set this during NCP initialisation with the ```ZigBeeDongleEzsp.setEmberNcpResetProvider()``` method.
+
 #### Ember MfgLib use
 
 The library provides access to the ```mfglib``` functions in the NCP to facilitate device testing. To use this function, create the ```ZigBeeDongleEzsp``` and then call the ```getEmberMfglib(EmberMfglibListener)``` method to get the ```EmberMfglib``` class and also set the callback listener. The ```EmberMfglib``` class provides access to the ```mfglib``` functions.

--- a/com.zsmartsystems.zigbee.console.main/src/main/java/com/zsmartsystems/zigbee/console/main/EmberNcpHardwareReset.java
+++ b/com.zsmartsystems.zigbee.console.main/src/main/java/com/zsmartsystems/zigbee/console/main/EmberNcpHardwareReset.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2016-2019 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.console.main;
+
+import com.zsmartsystems.zigbee.dongle.ember.EmberNcpResetProvider;
+import com.zsmartsystems.zigbee.serial.ZigBeeSerialPort;
+import com.zsmartsystems.zigbee.transport.ZigBeePort;
+
+/**
+ * Class to perform reset using DTR
+ *
+ * @author Chris Jackson
+ *
+ */
+public class EmberNcpHardwareReset implements EmberNcpResetProvider {
+
+    @Override
+    public void emberNcpReset(ZigBeePort port) {
+        ZigBeeSerialPort serialPort = (ZigBeeSerialPort) port;
+
+        try {
+            serialPort.setRts(false);
+            serialPort.setDtr(false);
+            Thread.sleep(50);
+            serialPort.setRts(true);
+            serialPort.setDtr(true);
+        } catch (InterruptedException e) {
+        }
+    }
+
+}

--- a/com.zsmartsystems.zigbee.console.main/src/main/java/com/zsmartsystems/zigbee/console/main/ZigBeeConsoleMain.java
+++ b/com.zsmartsystems.zigbee.console.main/src/main/java/com/zsmartsystems/zigbee/console/main/ZigBeeConsoleMain.java
@@ -209,6 +209,8 @@ public class ZigBeeConsoleMain {
             commands.add(EmberConsoleNcpScanCommand.class);
             commands.add(EmberConsoleNcpMfglibCommand.class);
             commands.add(EmberConsoleNcpHandlerCommand.class);
+
+            ((ZigBeeDongleEzsp) dongle).setEmberNcpResetProvider(new EmberNcpHardwareReset());
         } else if (dongleName.toUpperCase().equals("XBEE")) {
             dongle = new ZigBeeDongleXBee(serialPort);
         } else if (dongleName.toUpperCase().equals("CONBEE")) {

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/EmberNcpResetProvider.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/EmberNcpResetProvider.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2016-2019 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.dongle.ember;
+
+import com.zsmartsystems.zigbee.transport.ZigBeePort;
+
+/**
+ * An interface to perform a reset on the Ember NCP.
+ *
+ * @author Chris Jackson
+ *
+ */
+public interface EmberNcpResetProvider {
+    /**
+     * A callback made by {@link ZigBeeDongleEzsp} to perform a hardware reset on the NCP
+     *
+     * @param port the {@link ZigBeePort} on which the dongle is connected
+     */
+    void emberNcpReset(ZigBeePort port);
+}

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzspTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzspTest.java
@@ -63,6 +63,13 @@ public class ZigBeeDongleEzspTest {
     private static int TIMEOUT = 5000;
 
     @Test
+    public void setEmberNcpResetProvider() {
+        ZigBeeDongleEzsp dongle = new ZigBeeDongleEzsp(null);
+
+        dongle.setEmberNcpResetProvider(Mockito.mock(EmberNcpResetProvider.class));
+    }
+
+    @Test
     public void setZigBeeExtendedPanId() {
         ZigBeeDongleEzsp dongle = new ZigBeeDongleEzsp(null);
 

--- a/com.zsmartsystems.zigbee.serial/src/main/java/com/zsmartsystems/zigbee/serial/ZigBeeSerialPort.java
+++ b/com.zsmartsystems.zigbee.serial/src/main/java/com/zsmartsystems/zigbee/serial/ZigBeeSerialPort.java
@@ -252,4 +252,20 @@ public class ZigBeeSerialPort implements ZigBeePort, SerialPortEventListener {
             end = 0;
         }
     }
+
+    public boolean setDtr(boolean state) {
+        try {
+            return serialPort.setDTR(state);
+        } catch (SerialPortException e) {
+            return false;
+        }
+    }
+
+    public boolean setRts(boolean state) {
+        try {
+            return serialPort.setRTS(state);
+        } catch (SerialPortException e) {
+            return false;
+        }
+    }
 }


### PR DESCRIPTION
By default the library uses the ASH Reset command to reset the NCP when the framework starts. Silabs have stated that this is not reliable due to possible communication problems between the NCP and the host. Where possible the user should implement a hardware reset to reset the NCP. Since this is application specific, the framework provides an interface for the application to implement this reset. The user should implement the ```EmberNcpResetProvider``` interface, and set this during NCP initialisation with the ```ZigBeeDongleEzsp.setEmberNcpResetProvider()``` method.

#663

Signed-off-by: Chris Jackson <chris@cd-jackson.com>