### PR TITLE
Add notification when unknown device is heard on network

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeAnnounceListener.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeAnnounceListener.java
@@ -8,10 +8,11 @@
 package com.zsmartsystems.zigbee;
 
 /**
- * Device status listener.
+ * Device status listener. This provides a notification of devices joining or leaving the network to aid discovery
+ * handlers.
  * <p>
  * Listeners are called when the device status on the network is updated. Normally this occurs when a device joins or
- * leaves.
+ * leaves. Unknown devices are also notified through this interface.
  *
  * @author Chris Jackson
  */
@@ -24,6 +25,18 @@ public interface ZigBeeAnnounceListener {
      * @param networkAddress the network address of the newly announced device
      * @param ieeeAddress the {@link IeeeAddress} of the newly announced device
      */
-    void deviceStatusUpdate(final ZigBeeNodeStatus deviceStatus, final Integer networkAddress,
-            final IeeeAddress ieeeAddress);
+    default void deviceStatusUpdate(final ZigBeeNodeStatus deviceStatus, final Integer networkAddress,
+            final IeeeAddress ieeeAddress) {
+        // Default implementation
+    }
+
+    /**
+     * Called when a device is heard that is unknown to the system. This will generally mean that the device is not
+     * known to the Network Manager, however it is joined to the network and should be rediscovered.
+     *
+     * @param networkAddress the network address of the unknown device
+     */
+    default void announceUnknownDevice(final Integer networkAddress) {
+        // Default implementation
+    }
 }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
@@ -820,7 +820,19 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
         }
 
         if (command == null) {
-            logger.debug("Incoming message did not translate to command.");
+            logger.debug("Incoming message from node {} did not translate to command",
+                    String.format("%04X", apsFrame.getSourceAddress()));
+
+            // Notify the listeners that we have heard a device that was unknown to us
+            for (final ZigBeeAnnounceListener announceListener : announceListeners) {
+                NotificationService.execute(new Runnable() {
+                    @Override
+                    public void run() {
+                        announceListener.announceUnknownDevice(apsFrame.getSourceAddress());
+                    }
+                });
+            }
+
             return;
         }
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeNetworkDiscoverer.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeNetworkDiscoverer.java
@@ -28,7 +28,6 @@ import com.zsmartsystems.zigbee.ZigBeeNetworkManager;
 import com.zsmartsystems.zigbee.ZigBeeNode;
 import com.zsmartsystems.zigbee.ZigBeeNode.ZigBeeNodeState;
 import com.zsmartsystems.zigbee.ZigBeeNodeStatus;
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zdo.ZdoStatus;
 import com.zsmartsystems.zigbee.zdo.command.DeviceAnnounce;
 import com.zsmartsystems.zigbee.zdo.command.IeeeAddressRequest;
@@ -177,19 +176,12 @@ public class ZigBeeNetworkDiscoverer implements ZigBeeCommandListener, ZigBeeAnn
     }
 
     @Override
+    public void announceUnknownDevice(final Integer networkAddress) {
+        startNodeDiscovery(networkAddress);
+    }
+
+    @Override
     public void commandReceived(final ZigBeeCommand command) {
-        // ZCL command received from remote node. Perform discovery if it is not yet known.
-        if (command instanceof ZclCommand) {
-            final ZclCommand zclCommand = (ZclCommand) command;
-            if (networkManager.getNode(zclCommand.getSourceAddress().getAddress()) == null) {
-                // TODO: Protect against group address?
-                ZigBeeEndpointAddress address = (ZigBeeEndpointAddress) zclCommand.getSourceAddress();
-                startNodeDiscovery(address.getAddress());
-            }
-
-            return;
-        }
-
         // Node has been announced.
         if (command instanceof DeviceAnnounce) {
             final DeviceAnnounce announce = (DeviceAnnounce) command;

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeNetworkManagerTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeNetworkManagerTest.java
@@ -339,6 +339,13 @@ public class ZigBeeNetworkManagerTest
         assertEquals(0, (int) response.getCommandId());
         assertEquals(1, (int) response.getTransactionId());
         assertEquals(new ZigBeeEndpointAddress(1234, 5), response.getSourceAddress());
+
+        ZigBeeAnnounceListener announceListener = Mockito.mock(ZigBeeAnnounceListener.class);
+        networkManager.addAnnounceListener(announceListener);
+
+        apsFrame.setSourceAddress(4321);
+        networkManager.receiveCommand(apsFrame);
+        Mockito.verify(announceListener, Mockito.timeout(TIMEOUT).times(1)).announceUnknownDevice(4321);
     }
 
     @Test


### PR DESCRIPTION
Following the restructuring to add the manufacturer specific cluster handling, commands from unknown devices are not processed as the commands are instantiated through the endpoint and the clusters supported by each endpoint.

To allow discovery of devices that are sending commands this PR removes the incoming command handler in the ```ZigBeeNetworkDiscoverer``` class, and adds a new new method to ```ZigBeeAnnounceListener```. This method, ```announceUnknownDevice``` is called when the ```ZigBeeNetworkManager``` receives a message from an unknown device - discovery classes can use this to discovery nodes and this is implemented in ```ZigBeeNetworkDiscoverer```.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>