### PR TITLE
Fix error sending no response transaction

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeEndpoint.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeEndpoint.java
@@ -537,6 +537,7 @@ public class ZigBeeEndpoint {
      */
     public void sendTransaction(ZigBeeCommand command) {
         command.setDestinationAddress(getEndpointAddress());
+        node.sendTransaction(command);
     }
 
     /**


### PR DESCRIPTION
```ZigBeeEndpoint.sendTransaction(ZigBeeCommand)``` does not do anything. This fixes this bug and adds a test to verify this.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>