### PR TITLE
Move processing of attribute reports into ZclCluster

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeEndpoint.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeEndpoint.java
@@ -26,8 +26,6 @@ import com.zsmartsystems.zigbee.transaction.ZigBeeTransactionMatcher;
 import com.zsmartsystems.zigbee.zcl.ZclCluster;
 import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.clusters.ZclCustomCluster;
-import com.zsmartsystems.zigbee.zcl.clusters.general.ReadAttributesResponse;
-import com.zsmartsystems.zigbee.zcl.clusters.general.ReportAttributesCommand;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclClusterType;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 
@@ -446,26 +444,7 @@ public class ZigBeeEndpoint {
             return;
         }
 
-        if (command instanceof ReportAttributesCommand) {
-            ReportAttributesCommand attributeCommand = (ReportAttributesCommand) command;
-
-            // Pass the reports to the cluster
-            cluster.handleAttributeReport(attributeCommand.getReports());
-            return;
-        }
-
-        if (command instanceof ReadAttributesResponse) {
-            ReadAttributesResponse attributeCommand = (ReadAttributesResponse) command;
-
-            // Pass the reports to the cluster
-            cluster.handleAttributeStatus(attributeCommand.getRecords());
-            return;
-        }
-
-        // If this is a specific cluster command, pass the command to the cluster command handler
-        if (!command.isGenericCommand()) {
-            cluster.handleCommand(command);
-        }
+        cluster.handleCommand(command);
     }
 
     /**

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/TestUtilities.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/TestUtilities.java
@@ -70,7 +70,7 @@ public class TestUtilities {
 
     /**
      * Gets the value of the private field
-     * 
+     *
      * @param clazz the class where the field resides
      * @param object the object where the field resides
      * @param fieldName the field name


### PR DESCRIPTION
This moves the processing of the attribute handlers out of the ```ZclEndpoint``` class and into the ```ZclCluster``` class. This provides a more standard handling of these packets and allows a response to be sent.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>