### PR TITLE
Manage broadcast addresses in cluster matcher

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/internal/ClusterMatcher.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/internal/ClusterMatcher.java
@@ -16,6 +16,7 @@ import java.util.concurrent.CopyOnWriteArraySet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.zsmartsystems.zigbee.ZigBeeBroadcastDestination;
 import com.zsmartsystems.zigbee.ZigBeeCommand;
 import com.zsmartsystems.zigbee.ZigBeeCommandListener;
 import com.zsmartsystems.zigbee.ZigBeeNetworkManager;
@@ -80,6 +81,10 @@ public class ClusterMatcher implements ZigBeeCommandListener {
                 // TODO: Do we need to restrict the profile? Remove this check?
                 return;
             }
+            if (matchRequest.getNwkAddrOfInterest() != networkManager.getLocalNwkAddress()
+                    && !ZigBeeBroadcastDestination.isBroadcast(matchRequest.getNwkAddrOfInterest())) {
+                return;
+            }
 
             // We want to match any of our local servers (ie our input clusters) with any
             // requested clusters in the requests cluster list
@@ -96,7 +101,7 @@ public class ClusterMatcher implements ZigBeeCommandListener {
             matchResponse.setMatchList(matchList);
 
             matchResponse.setDestinationAddress(command.getSourceAddress());
-            matchResponse.setNwkAddrOfInterest(matchRequest.getNwkAddrOfInterest());
+            matchResponse.setNwkAddrOfInterest(networkManager.getLocalNwkAddress());
             logger.debug("{}: ClusterMatcher sending match {}", networkManager.getZigBeeExtendedPanId(), matchResponse);
             networkManager.sendTransaction(matchResponse);
         }

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/internal/ClusterMatcherTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/internal/ClusterMatcherTest.java
@@ -54,6 +54,7 @@ public class ClusterMatcherTest {
         List<Integer> clusterListIn = new ArrayList<Integer>();
         List<Integer> clusterListOut = new ArrayList<Integer>();
         MatchDescriptorRequest request = new MatchDescriptorRequest();
+        request.setNwkAddrOfInterest(0);
         request.setSourceAddress(new ZigBeeEndpointAddress(1234, 5));
         request.setProfileId(0x104);
         request.setInClusterList(clusterListIn);
@@ -61,6 +62,45 @@ public class ClusterMatcherTest {
 
         matcher.commandReceived(request);
         assertEquals(0, mockedCommandCaptor.getAllValues().size());
+    }
+
+    @Test
+    public void testMatcherNoAddressMatch() {
+        ClusterMatcher matcher = getMatcher();
+        matcher.addCluster(0x500);
+
+        List<Integer> clusterListIn = new ArrayList<Integer>();
+        List<Integer> clusterListOut = new ArrayList<Integer>();
+        MatchDescriptorRequest request = new MatchDescriptorRequest();
+        request.setNwkAddrOfInterest(1);
+        request.setSourceAddress(new ZigBeeEndpointAddress(1234, 5));
+        request.setProfileId(0x104);
+        request.setInClusterList(clusterListIn);
+        request.setOutClusterList(clusterListOut);
+
+        matcher.commandReceived(request);
+        assertEquals(0, mockedCommandCaptor.getAllValues().size());
+    }
+
+    @Test
+    public void testMatcherBroadcast() {
+        ClusterMatcher matcher = getMatcher();
+        matcher.addCluster(0x500);
+
+        List<Integer> clusterListIn = new ArrayList<Integer>();
+        List<Integer> clusterListOut = new ArrayList<Integer>();
+        clusterListIn.add(0x500);
+        MatchDescriptorRequest request = new MatchDescriptorRequest();
+        request.setNwkAddrOfInterest(0xFFFF);
+        request.setSourceAddress(new ZigBeeEndpointAddress(1234, 5));
+        request.setProfileId(0x104);
+        request.setInClusterList(clusterListIn);
+        request.setOutClusterList(clusterListOut);
+
+        matcher.commandReceived(request);
+        assertEquals(1, mockedCommandCaptor.getAllValues().size());
+        MatchDescriptorResponse response = (MatchDescriptorResponse) mockedCommandCaptor.getValue();
+        assertEquals(1234, response.getDestinationAddress().getAddress());
     }
 
     @Test
@@ -73,6 +113,7 @@ public class ClusterMatcherTest {
         List<Integer> clusterListOut = new ArrayList<Integer>();
         clusterListIn.add(0x500);
         MatchDescriptorRequest request = new MatchDescriptorRequest();
+        request.setNwkAddrOfInterest(0);
         request.setSourceAddress(new ZigBeeEndpointAddress(1234, 5));
         request.setProfileId(0x104);
         request.setInClusterList(clusterListIn);
@@ -92,6 +133,7 @@ public class ClusterMatcherTest {
         List<Integer> clusterListOut = new ArrayList<Integer>();
         clusterListOut.add(0x500);
         MatchDescriptorRequest request = new MatchDescriptorRequest();
+        request.setNwkAddrOfInterest(0);
         request.setSourceAddress(new ZigBeeEndpointAddress(1234, 5));
         request.setProfileId(0x104);
         request.setInClusterList(clusterListIn);
@@ -112,8 +154,8 @@ public class ClusterMatcherTest {
         clusterListIn.add(0x500);
         clusterListOut.add(0x500);
         MatchDescriptorRequest request = new MatchDescriptorRequest();
+        request.setNwkAddrOfInterest(0);
         request.setSourceAddress(new ZigBeeEndpointAddress(1234, 5));
-        request.setNwkAddrOfInterest(4321);
         request.setProfileId(0x104);
         request.setInClusterList(clusterListIn);
         request.setOutClusterList(clusterListOut);
@@ -122,6 +164,6 @@ public class ClusterMatcherTest {
         assertEquals(1, mockedCommandCaptor.getAllValues().size());
         MatchDescriptorResponse response = (MatchDescriptorResponse) mockedCommandCaptor.getValue();
         assertEquals(1234, response.getDestinationAddress().getAddress());
-        assertEquals(Integer.valueOf(4321), response.getNwkAddrOfInterest());
+        assertEquals(Integer.valueOf(0), response.getNwkAddrOfInterest());
     }
 }


### PR DESCRIPTION
This adds address checking to the cluster matcher to ensure that the request is addressed to our local address or a broadcast address, and then ensures that the response uses the local address.
Fixes #731 
@TomTravaglino this should solve the issue you reported - as mentioned though this will not be related to the issue you report in #712. 
Signed-off-by: Chris Jackson <chris@cd-jackson.com>