### PR TITLE
Improve ZclCommand processing and handling of DefaultResponse

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,8 @@ Currently implemented extensions include -:
 
 These provide basic functionality and can be extended as required to meet the application needs.
 
+It should be noted that extensions to the framework should be performed by linking to the ```ZclCluster``` through the ```ZclCommandListener``` notifications. This ensures that processing of ```DefaultResponse``` commands is handled correctly as the framework will automatically handle sending of these responses if there is no response sent. Responses to incoming commands must be returned from the ```handleCommand``` method to ensure that the framework correctly handles the ```DefaultResponse``` notifications. If not handler returns a response, then the framework will return a ```DefaultResponse``` with ```UNSUP_CLUSTER_COMMAND```, ```UNSUP_GENERAL_COMMAND```, ```UNSUP_MANUF_CLUSTER_COMMAND``` or ```UNSUP_MANUF_GENERAL_COMMAND```, as appropriate.
+
 ## Overview
 
 Extensions may provide different levels of functionality - an extension may be as simple as configuring the framework to work with a specific feature, or could provide a detailed application.

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ Currently implemented extensions include -:
 
 These provide basic functionality and can be extended as required to meet the application needs.
 
-It should be noted that extensions to the framework should be performed by linking to the ```ZclCluster``` through the ```ZclCommandListener``` notifications. This ensures that processing of ```DefaultResponse``` commands is handled correctly as the framework will automatically handle sending of these responses if there is no response sent. Responses to incoming commands must be returned from the ```handleCommand``` method to ensure that the framework correctly handles the ```DefaultResponse``` notifications. If not handler returns a response, then the framework will return a ```DefaultResponse``` with ```UNSUP_CLUSTER_COMMAND```, ```UNSUP_GENERAL_COMMAND```, ```UNSUP_MANUF_CLUSTER_COMMAND``` or ```UNSUP_MANUF_GENERAL_COMMAND```, as appropriate.
+It should be noted that extensions to the framework should be performed by linking to the ```ZclCluster``` through the ```ZclCommandListener``` notifications. This ensures that processing of ```DefaultResponse``` commands is handled correctly as the framework will automatically handle sending of these responses if there is no response sent. Calls to the ```handleCommand``` method must return ```true``` if the method has sent a response, or ```false``` if no response is sent to ensure that the framework correctly handles the ```DefaultResponse``` notifications. If all handlers return a ```false``` response, then the framework will send a ```DefaultResponse``` with ```UNSUP_CLUSTER_COMMAND```, ```UNSUP_GENERAL_COMMAND```, ```UNSUP_MANUF_CLUSTER_COMMAND``` or ```UNSUP_MANUF_GENERAL_COMMAND```, as appropriate.
 
 ## Overview
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
@@ -924,6 +924,7 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
         command.deserialize(fieldDeserializer);
         command.setClusterId(apsFrame.getCluster());
         command.setTransactionId(zclHeader.getSequenceNumber());
+        command.setDisableDefaultResponse(zclHeader.isDisableDefaultResponse());
 
         return command;
     }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNode.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNode.java
@@ -28,7 +28,10 @@ import com.zsmartsystems.zigbee.database.ZigBeeEndpointDao;
 import com.zsmartsystems.zigbee.database.ZigBeeNodeDao;
 import com.zsmartsystems.zigbee.internal.NotificationService;
 import com.zsmartsystems.zigbee.transaction.ZigBeeTransactionMatcher;
+import com.zsmartsystems.zigbee.zcl.ZclCluster;
 import com.zsmartsystems.zigbee.zcl.ZclCommand;
+import com.zsmartsystems.zigbee.zcl.ZclStatus;
+import com.zsmartsystems.zigbee.zcl.clusters.general.DefaultResponse;
 import com.zsmartsystems.zigbee.zdo.ZdoStatus;
 import com.zsmartsystems.zigbee.zdo.command.ManagementBindRequest;
 import com.zsmartsystems.zigbee.zdo.command.ManagementBindResponse;
@@ -682,9 +685,17 @@ public class ZigBeeNode implements ZigBeeCommandListener {
         ZigBeeEndpointAddress endpointAddress = (ZigBeeEndpointAddress) zclCommand.getSourceAddress();
 
         ZigBeeEndpoint endpoint = endpoints.get(endpointAddress.getEndpoint());
-        if (endpoint != null) {
-            endpoint.commandReceived(zclCommand);
+        if (endpoint == null) {
+            logger.debug("{}: Endpoint {} not found for received node command", ieeeAddress,
+                    endpointAddress.getEndpoint());
+            DefaultResponse response = ZclCluster.createDefaultResponse(zclCommand, ZclStatus.UNSUPPORTED_CLUSTER);
+            if (response != null) {
+                sendTransaction(response);
+            }
+            return;
         }
+
+        endpoint.commandReceived(zclCommand);
     }
 
     /**

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/ZigBeeApplication.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/ZigBeeApplication.java
@@ -7,9 +7,7 @@
  */
 package com.zsmartsystems.zigbee.app;
 
-import com.zsmartsystems.zigbee.ZigBeeCommand;
 import com.zsmartsystems.zigbee.ZigBeeEndpoint;
-import com.zsmartsystems.zigbee.ZigBeeNode;
 import com.zsmartsystems.zigbee.ZigBeeStatus;
 import com.zsmartsystems.zigbee.zcl.ZclCluster;
 
@@ -48,12 +46,4 @@ public interface ZigBeeApplication {
      * @return the cluster ID
      */
     public int getClusterId();
-
-    /**
-     * Called when a command has been received. This is called by the {@link ZigBeeNode} when a command for this node is
-     * received.
-     *
-     * @param command the received {@link ZigBeeCommand}
-     */
-    void commandReceived(final ZigBeeCommand command);
 }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/otaserver/ZclOtaUpgradeServer.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/otaserver/ZclOtaUpgradeServer.java
@@ -253,6 +253,7 @@ public class ZclOtaUpgradeServer implements ZigBeeApplication, ZclCommandListene
 
     @Override
     public void appShutdown() {
+        cluster.removeCommandListener(this);
         stopTransferTimer();
         timer.shutdownNow();
     }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/ZclCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/ZclCommand.java
@@ -14,7 +14,6 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 /**
  * Base class for value object classes holding ZCL commands, extended from {@link ZigBeeCommand}.
  *
- * @author Tommi S.E. Laukkanen
  * @author Chris Jackson
  */
 public abstract class ZclCommand extends ZigBeeCommand {
@@ -28,6 +27,11 @@ public abstract class ZclCommand extends ZigBeeCommand {
      * The command ID
      */
     protected int commandId;
+
+    /**
+     * True if the default response is disabled
+     */
+    protected boolean disableDefaultResponse;
 
     /**
      * The command direction for this command.
@@ -49,10 +53,6 @@ public abstract class ZclCommand extends ZigBeeCommand {
      * </ul>
      */
     private Integer manufacturerCode = null;
-
-    protected void setManufacturerCode(int manufacturerCode) {
-        this.manufacturerCode = manufacturerCode;
-    }
 
     /**
      * Sets the cluster ID for <i>generic</i> commands.
@@ -122,10 +122,37 @@ public abstract class ZclCommand extends ZigBeeCommand {
         return manufacturerCode;
     }
 
+    /**
+     * Sets the manufacturer code
+     *
+     * @param manufacturerCode the manufacturer code
+     */
+    protected void setManufacturerCode(int manufacturerCode) {
+        this.manufacturerCode = manufacturerCode;
+    }
+
+    /**
+     * When set to true, the default response message will not be generated
+     * 
+     * @return the disableDefaultResponse flag - when set to true, the default response message will not be generated
+     */
+    public boolean isDisableDefaultResponse() {
+        return disableDefaultResponse;
+    }
+
+    /**
+     * When set to true, the default response message will not be generated
+     *
+     * @param disableDefaultResponse true if the default response is not required
+     */
+    public void setDisableDefaultResponse(boolean disableDefaultResponse) {
+        this.disableDefaultResponse = disableDefaultResponse;
+    }
+
     @Override
     public String toString() {
         Integer resolvedClusterId = getClusterId();
-        final StringBuilder builder = new StringBuilder();
+        final StringBuilder builder = new StringBuilder(50);
         ZclClusterType clusterType = ZclClusterType.getValueById(resolvedClusterId);
         builder.append(clusterType != null ? clusterType.getLabel() : Integer.toHexString(resolvedClusterId));
         builder.append(": ");

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/ZclCommandListener.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/ZclCommandListener.java
@@ -18,7 +18,7 @@ public interface ZclCommandListener {
      * Called when a {@link ZclCommand} is received for this cluster
      *
      * @param command the {@link ZclCommand} that has been received
+     * @return true if the handler has, or will send a response to this command
      */
-    void commandReceived(ZclCommand command);
-
+    boolean commandReceived(ZclCommand command);
 }

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/internal/ZigBeeCommandNotifierTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/internal/ZigBeeCommandNotifierTest.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2016-2019 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.internal;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Set;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.zsmartsystems.zigbee.TestUtilities;
+import com.zsmartsystems.zigbee.ZigBeeCommand;
+import com.zsmartsystems.zigbee.ZigBeeCommandListener;
+import com.zsmartsystems.zigbee.zcl.ZclCommand;
+
+/**
+ *
+ * @author Chris Jackson
+ *
+ */
+public class ZigBeeCommandNotifierTest {
+    private static final int TIMEOUT = 5000;
+
+    @Test
+    public void addCommandListener() throws Exception {
+        ZigBeeCommandNotifier notifier = new ZigBeeCommandNotifier();
+
+        ZigBeeCommandListener commandListener = Mockito.mock(ZigBeeCommandListener.class);
+        notifier.addCommandListener(commandListener);
+
+        Set<ZigBeeCommandListener> commandListeners = (Set<ZigBeeCommandListener>) TestUtilities
+                .getField(ZigBeeCommandNotifier.class, notifier, "commandListeners");
+        assertEquals(1, commandListeners.size());
+        assertEquals(commandListener, commandListeners.iterator().next());
+
+        notifier.addCommandListener(commandListener);
+        assertEquals(1, commandListeners.size());
+
+        notifier.addCommandListener(Mockito.mock(ZigBeeCommandListener.class));
+        assertEquals(2, commandListeners.size());
+
+        ZigBeeCommand command = Mockito.mock(ZigBeeCommand.class);
+        notifier.notifyCommandListeners(command);
+        Mockito.verify(commandListener, Mockito.timeout(TIMEOUT).times(1)).commandReceived(command);
+
+        ZclCommand zclCommand = Mockito.mock(ZclCommand.class);
+        Mockito.when(zclCommand.isDisableDefaultResponse()).thenReturn(true);
+        notifier.notifyCommandListeners(zclCommand);
+
+        Mockito.when(zclCommand.isDisableDefaultResponse()).thenReturn(false);
+        notifier.notifyCommandListeners(zclCommand);
+
+        notifier.removeCommandListener(commandListener);
+        assertEquals(1, commandListeners.size());
+    }
+}


### PR DESCRIPTION
This PR resolves a major non-compliance of the framework to the ZigBee standards in relation to the ```DefaultResponse```. It does present some small breaking changes in the way that commands are processed in ```ZclCluster``` and ```ZigBeeApplication``` in order to get consistent processing of ```DefaultResponse``` frames.

**ZigBee Requirement from ZCL Specification**

The Default Response command SHALL be generated when all 4 of these criteria are met: 
1. A device receives a unicast command that is not a Default Response command. 
2. No other command is sent in response to the received command, using the same Transaction sequence number as the received command. 
3. The Disable Default Response bit of its Frame control field is set to 0 (see 2.4.1.1.4) or when an error results. 
4. The “Effect on Receipt” clause for the received command does not override the behavior of when a Default Response command is sent. 

If a device receives a command in error through a broadcast or multicast transmission, the command SHALL be discarded and the Default Response command SHALL not be generated.

If the identifier of the received command is not supported on the device, it SHALL set the command identifier field to the value of the identifier of the command received in error. The status code field SHALL be set to the either ```UNSUP_CLUSTER_COMMAND```, ```UNSUP_GENERAL_COMMAND```, ```UNSUP_MANUF_CLUSTER_COMMAND``` or ```UNSUP_MANUF_GENERAL_COMMAND```, as appropriate.
If the device receives a unicast cluster command to a particular endpoint, and the cluster does not exist on the endpoint, the status code field SHALL be set to ```UNSUPPORTED_CLUSTER```.
The Default Response command SHALL be generated in response to reception of all commands, including response commands (such as the Write Attributes Response command), under the conditions specified above. However, the Default Response command SHALL not be generated in response to reception of another Default Response command. 

**Framework Response Processing**

Each ZCL command that is processed in the framework must be responded to within the command handler thread by returning either true if the handler has, or will, send a response, or false if it has not processed the command. If all handlers return false, the ```ZclCluster``` handler will respond with a ```DefaultResponse``` with an UNSUPPORTED error. Note that handlers do not need to check if the Disable default Response flag is set - the ```ZclCluster``` handler will manage this.


**Implementation**

Commands are sent from ```ZigBeeNetworkManager``` to the ```ZigBeeNode```, then to the ```ZigBeeEndpoint``` and on to the ```ZclCluster```.

* ```ZigBeeNode``` will send a ```DefaultResponse``` with ```UNSUPPORTED_CLUSTER``` if the endpoint is not supported.
* ```ZigBeeEndpoint``` will send a ```DefaultResponse``` with ```UNSUPPORTED_CLUSTER``` if the cluster is not supported.
* ```ZclCluster``` will send a ```DefaultResponse``` with ```UNSUP_CLUSTER_COMMAND```, ```UNSUP_GENERAL_COMMAND```, ```UNSUP_MANUF_CLUSTER_COMMAND``` or ```UNSUP_MANUF_GENERAL_COMMAND```, as appropriate if there are no listeners registered, if the command is not processed within a set time, or no listeners send a response (ie return ```true```).

When ```ZclCluster``` calls each ```ZclCommandListener``` it waits for each handler to complete. Once all handlers have completed, if none of them sent a response (as determined by the handler returning ```true```) the above action is taken to send a ```DefaultResponse```.

The static helper method ```ZclCluster.createDefaultResponse()``` is added to allow a consistent response from different parts of the framework (ie the ```ZclNode``` and ```ZclEndpoint```.

To ensure that all cluster commands are handled consistently with respect to the ```DefaultResponse```, the application command handler ```ZigBeeApplication. commandReceived ()``` has been removed. Implementations of  ```ZigBeeApplication``` should register to receive commands via the command listeners in the respective clusters.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>