### PR TITLE
Fix handling of ZigBeeNode Command Listener to only register nodes in the network

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
@@ -1372,6 +1372,7 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
                 return;
             }
             networkNodes.remove(node.getIeeeAddress());
+            removeCommandListener(node);
         }
 
         synchronized (this) {
@@ -1415,6 +1416,7 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
                 return;
             }
             networkNodes.put(node.getIeeeAddress(), node);
+            addCommandListener(node);
         }
 
         synchronized (this) {

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNode.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNode.java
@@ -154,8 +154,6 @@ public class ZigBeeNode implements ZigBeeCommandListener {
 
         this.network = network;
         this.ieeeAddress = ieeeAddress;
-
-        network.addCommandListener(this);
     }
 
     /**

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeNetworkManagerTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeNetworkManagerTest.java
@@ -92,8 +92,7 @@ public class ZigBeeNetworkManagerTest
 
     @Before
     public void resetNotificationService() throws Exception {
-        TestUtilities.setField(NotificationService.class, NotificationService.class, "executorService",
-                Executors.newCachedThreadPool());
+        NotificationService.initialize();
     }
 
     @Test
@@ -626,6 +625,7 @@ public class ZigBeeNetworkManagerTest
 
         TestUtilities.setField(ZigBeeNetworkManager.class, networkManager, "networkState", ZigBeeNetworkState.ONLINE);
         networkManager.receiveCommand(apsFrame);
+        Mockito.verify(node, Mockito.timeout(TIMEOUT).times(1)).commandReceived(Mockito.any(ZigBeeCommand.class));
         Awaitility.await().until(() -> commandListenerUpdated());
         if (commandListenerCapture.size() == 0) {
             return null;

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeNodeTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeNodeTest.java
@@ -20,7 +20,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
 import org.junit.Before;
@@ -56,8 +55,7 @@ public class ZigBeeNodeTest {
 
     @Before
     public void resetNotificationService() throws Exception {
-        TestUtilities.setField(NotificationService.class, NotificationService.class, "executorService",
-                Executors.newCachedThreadPool());
+        NotificationService.initialize();
     }
 
     @Test

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransactionManagerTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransactionManagerTest.java
@@ -57,8 +57,7 @@ public class ZigBeeTransactionManagerTest {
 
     @Before
     public void resetNotificationService() throws Exception {
-        TestUtilities.setField(NotificationService.class, NotificationService.class, "executorService",
-                Executors.newCachedThreadPool());
+        NotificationService.initialize();
     }
 
     @Test


### PR DESCRIPTION
This removes the registration of the ```ZigBeeCommandListener``` from the ```ZigBeeNode``` constructor and adds it to be consistent with nodes being added to the ```networkNodes``` map in ```ZigBeeNetworkManager```.

Fixes #735 

Signed-off-by: Chris Jackson <chris@cd-jackson.com>