### PR TITLE
Add status return to ZigBeeEndpoint.addApplication

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeEndpoint.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeEndpoint.java
@@ -398,29 +398,34 @@ public class ZigBeeEndpoint {
      * {@link ZclApplication#serverStartup()) method to start the application.
      *
      * @param application the new {@link ZigBeeApplication}
+     * @return the {@link ZigBeeStatus} of the call. {@link ZigBeeStatus.SUCCESS} if the application was registered and
+     *         started, and {@link ZigBeeStatus.INVALID_STATE} if an application is already registered to the cluster
      */
-    public void addApplication(ZigBeeApplication application) {
+    public ZigBeeStatus addApplication(ZigBeeApplication application) {
+        if (applications.get(application.getClusterId()) != null) {
+            return ZigBeeStatus.INVALID_STATE;
+        }
         applications.put(application.getClusterId(), application);
         ZclCluster cluster = outputClusters.get(application.getClusterId());
         if (cluster == null) {
             cluster = inputClusters.get(application.getClusterId());
         }
-        application.appStartup(cluster);
+        return application.appStartup(cluster);
     }
 
     /**
      * Gets the application associated with the clusterId. Returns null if there is no server linked to the requested
      * cluster
      *
-     * @param clusterId
-     * @return the {@link ZigBeeApplication}
+     * @param clusterId the cluster ID of the application to retrieve
+     * @return the {@link ZigBeeApplication} registered to the clusterId or null if no application is registered
      */
     public ZigBeeApplication getApplication(int clusterId) {
         return applications.get(clusterId);
     }
 
     /**
-     * Incoming command handler. The endpoint will process any commands addressed to this endpoint ID and pass o
+     * Incoming command handler. The endpoint will process any commands addressed to this endpoint ID and pass to
      * clusters and applications
      *
      * @param command the {@link ZclCommand} received

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeEndpointTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeEndpointTest.java
@@ -171,9 +171,12 @@ public class ZigBeeEndpointTest {
         assertEquals(Integer.valueOf(123), defaultResponse.getTransactionId());
 
         ZigBeeApplication application = Mockito.mock(ZigBeeApplication.class);
+        Mockito.when(application.appStartup(cluster)).thenReturn(ZigBeeStatus.SUCCESS);
         Mockito.when(application.getClusterId()).thenReturn(0);
-        endpoint.addApplication(application);
+        assertEquals(ZigBeeStatus.SUCCESS, endpoint.addApplication(application));
+        assertEquals(ZigBeeStatus.INVALID_STATE, endpoint.addApplication(application));
         Mockito.verify(application, Mockito.times(1)).appStartup(ArgumentMatchers.any(ZclCluster.class));
+        assertEquals(application, endpoint.getApplication(0));
     }
 
     private ZclCommand mockZclCommand(Class<?> clazz) {


### PR DESCRIPTION
As discussed in #740 the ```ZigBeeEndpoint.addApplication``` method currently will add an application even if one is already registered. This would loose the reference to any previously registered application.

This PR adds a check to ensure that this doesn't happen, and adds a ```ZigBeeStatus``` return to the method to indicate success or failure.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>