### PR TITLE
Fix notifyAll error waiting for notification responses

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/ZclCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/ZclCluster.java
@@ -1120,16 +1120,13 @@ public abstract class ZclCluster {
                             latch.countDown();
                             response.set(true);
                         }
-                        latch.notifyAll();
                     }
                     latch.countDown();
                 }
             });
         }
 
-        try
-
-        {
+        try {
             // TODO: Set the timer properly
             latch.await(1, TimeUnit.SECONDS);
             return response.get();


### PR DESCRIPTION
```notifyAll``` is not required and causes ```IllegalMonitorStateException``` as it's not synchronised. The code already counts down the ```CountDownLatch``` so will trigger waiters.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>