### PR TITLE
Process EmberIncomingMessageType and set ZigBeeApsFrame addressMode

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/aps/ZigBeeApsFrame.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/aps/ZigBeeApsFrame.java
@@ -12,6 +12,7 @@ import com.zsmartsystems.zigbee.ZigBeeNwkAddressMode;
 
 /**
  * Defines the APS layer frame along with some network layer elements that may be needed by the application.
+ * Fundamentally this defines the NLDE-DATA.request interface with some local extensions for internal use.
  * <p>
  * The APS frame format is composed of an APS header and an APS payload. The fields of the APS header appear in a fixed
  * order, however, the addressing fields may not be included in all frames.


### PR DESCRIPTION
This processes the EmberIncomingMessageType on a received frame from the Ember NCP and sets the ZigBeeApsFrame appropriately. It also adds an option to drop LOOPBACK frames - ie those that were sent from the application. This can be set by the application using the ```passLoopbackMessages``` method.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>