### PR TITLE
Rename Stop2Command to StopWithOnOffCommand

### DIFF
--- a/com.zsmartsystems.zigbee.autocode/src/main/resources/0008_LevelControl.xml
+++ b/com.zsmartsystems.zigbee.autocode/src/main/resources/0008_LevelControl.xml
@@ -72,7 +72,7 @@
         </field>
     </command>
     <command code="0x07" source="client">
-        <name>Stop 2 Command</name>
+        <name>Stop (with On/Off) Command</name>
     </command>
 
     <attribute code="0x0000" type="UNSIGNED_8_BIT_INTEGER" side="server" optional="false" writable="false" reportable="true">

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclLevelControlCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclLevelControlCluster.java
@@ -24,8 +24,8 @@ import com.zsmartsystems.zigbee.zcl.clusters.levelcontrol.MoveToLevelWithOnOffCo
 import com.zsmartsystems.zigbee.zcl.clusters.levelcontrol.MoveWithOnOffCommand;
 import com.zsmartsystems.zigbee.zcl.clusters.levelcontrol.StepCommand;
 import com.zsmartsystems.zigbee.zcl.clusters.levelcontrol.StepWithOnOffCommand;
-import com.zsmartsystems.zigbee.zcl.clusters.levelcontrol.Stop2Command;
 import com.zsmartsystems.zigbee.zcl.clusters.levelcontrol.StopCommand;
+import com.zsmartsystems.zigbee.zcl.clusters.levelcontrol.StopWithOnOffCommand;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
 /**
@@ -51,7 +51,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-10-04T18:21:10Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T17:34:01Z")
 public class ZclLevelControlCluster extends ZclCluster {
     /**
      * The ZigBee Cluster Library Cluster ID
@@ -149,7 +149,7 @@ public class ZclLevelControlCluster extends ZclCluster {
         commandMap.put(0x0004, MoveToLevelWithOnOffCommand.class);
         commandMap.put(0x0005, MoveWithOnOffCommand.class);
         commandMap.put(0x0006, StepWithOnOffCommand.class);
-        commandMap.put(0x0007, Stop2Command.class);
+        commandMap.put(0x0007, StopWithOnOffCommand.class);
 
         return commandMap;
     }
@@ -892,11 +892,11 @@ public class ZclLevelControlCluster extends ZclCluster {
     }
 
     /**
-     * The Stop 2 Command
+     * The Stop (with On/Off) Command
      *
      * @return the {@link Future<CommandResult>} command result future
      */
-    public Future<CommandResult> stop2Command() {
-        return send(new Stop2Command());
+    public Future<CommandResult> stopWithOnOffCommand() {
+        return send(new StopWithOnOffCommand());
     }
 }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/levelcontrol/StopWithOnOffCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/levelcontrol/StopWithOnOffCommand.java
@@ -13,15 +13,15 @@ import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 
 /**
- * Stop 2 Command value object class.
+ * Stop (with On/Off) Command value object class.
  * <p>
  * Cluster: <b>Level Control</b>. Command ID 0x07 is sent <b>TO</b> the server.
  * This command is a <b>specific</b> command used for the Level Control cluster.
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class Stop2Command extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-09-24T18:34:07Z")
+public class StopWithOnOffCommand extends ZclCommand {
     /**
      * The cluster ID to which this command belongs.
      */
@@ -35,7 +35,7 @@ public class Stop2Command extends ZclCommand {
     /**
      * Default constructor.
      */
-    public Stop2Command() {
+    public StopWithOnOffCommand() {
         clusterId = CLUSTER_ID;
         commandId = COMMAND_ID;
         genericCommand = false;
@@ -44,8 +44,8 @@ public class Stop2Command extends ZclCommand {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(15);
-        builder.append("Stop2Command [");
+        final StringBuilder builder = new StringBuilder(23);
+        builder.append("StopWithOnOffCommand [");
         builder.append(super.toString());
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee/src/test/resource/logs/cluster-0008-LevelControl.txt
+++ b/com.zsmartsystems.zigbee/src/test/resource/logs/cluster-0008-LevelControl.txt
@@ -6,7 +6,7 @@ ZigBeeApsFrame [sourceAddress=0000/1, destinationAddress=0000/1, profile=0104, c
 MoveToLevelWithOnOffCommand [Level Control: 0000/1 -> 0000/1, cluster=0008, TID=71, level=254, transitionTime=10]
 
 ZigBeeApsFrame [sourceAddress=0000/1, destinationAddress=0000/1, profile=0104, cluster=0008, addressMode=DEVICE, radius=0, apsSecurity=false, apsCounter=7E, payload=01 21 07]
-Stop2Command [Level Control: 0000/1 -> 0000/1, cluster=0008, TID=21]
+StopWithOnOffCommand [Level Control: 0000/1 -> 0000/1, cluster=0008, TID=21]
 
 ZigBeeApsFrame [sourceAddress=0000/1, destinationAddress=0000/1, profile=0104, cluster=0008, addressMode=DEVICE, radius=0, apsSecurity=false, apsCounter=7D, payload=01 20 05 01 C8]
 MoveWithOnOffCommand [Level Control: 0000/1 -> 0000/1, cluster=0008, TID=20, moveMode=1, rate=200]


### PR DESCRIPTION
ZCL states the following -:

> This command has two entries in Table 3-5, one for the Move to Level, Move and Set commands, and one for their 'with On/Off' counterparts. This is solely for symmetry, to allow easy choice of one or other set of commands – the Stop commands are identical.

Therefore, renaming this to be consistent.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>