### PR TITLE
Add methods to set device ID in NetworkManager and Transport interfaces

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
@@ -25,6 +25,7 @@ import com.zsmartsystems.zigbee.IeeeAddress;
 import com.zsmartsystems.zigbee.ZigBeeBroadcastDestination;
 import com.zsmartsystems.zigbee.ZigBeeChannel;
 import com.zsmartsystems.zigbee.ZigBeeChannelMask;
+import com.zsmartsystems.zigbee.ZigBeeDeviceType;
 import com.zsmartsystems.zigbee.ZigBeeExecutors;
 import com.zsmartsystems.zigbee.ZigBeeNetworkManager;
 import com.zsmartsystems.zigbee.ZigBeeNodeStatus;
@@ -192,6 +193,16 @@ public class ZigBeeDongleEzsp implements ZigBeeTransportTransmit, ZigBeeTranspor
      */
     private boolean passLoopbackMessages = true;
 
+    /**
+     * The default ProfileID to use
+     */
+    private int defaultProfileId = ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION.getKey();
+
+    /**
+     * The default DeviceID to use
+     */
+    private int defaultDeviceId = ZigBeeDeviceType.HOME_GATEWAY.getKey();
+
     private ScheduledExecutorService executorService;
     private ScheduledFuture<?> pollingTimer = null;
 
@@ -342,6 +353,16 @@ public class ZigBeeDongleEzsp implements ZigBeeTransportTransmit, ZigBeeTranspor
     }
 
     @Override
+    public void setDefaultProfileId(int defaultProfileId) {
+        this.defaultProfileId = defaultProfileId;
+    }
+
+    @Override
+    public void setDefaultDeviceId(int defaultDeviceId) {
+        this.defaultDeviceId = defaultDeviceId;
+    }
+
+    @Override
     public ZigBeeStatus initialize() {
         logger.debug("EZSP dongle initialize with protocol {}.", protocol);
 
@@ -382,7 +403,7 @@ public class ZigBeeDongleEzsp implements ZigBeeTransportTransmit, ZigBeeTranspor
         ncp.getNetworkParameters();
 
         // Add the endpoint
-        ncp.addEndpoint(1, 0, ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION.getKey(), new int[] { 0 }, new int[] { 0 });
+        ncp.addEndpoint(1, defaultDeviceId, defaultProfileId, new int[] { 0 }, new int[] { 0 });
 
         // Now initialise the network
         EmberStatus initResponse = ncp.networkInit();

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
@@ -468,10 +468,31 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
         return transport.setZigBeeExtendedPanId(panId);
     }
 
+    /**
+     * Sets the default profile ID to use. Standard profile IDs are defined in {@link ZigBeeProfileType}.
+     * <p>
+     * This should be set before calling the {@link #initialize} method.
+     *
+     * @param defaultProfileId the profile ID
+     */
     public void setDefaultProfileId(int defaultProfileId) {
-        logger.debug("Defuault profile set to {} [{}]", String.format("%04X", defaultProfileId),
+        logger.debug("Default profile ID set to {} [{}]", String.format("%04X", defaultProfileId),
                 ZigBeeProfileType.getByValue(defaultProfileId));
         this.defaultProfileId = defaultProfileId;
+        transport.setDefaultProfileId(defaultProfileId);
+    }
+
+    /**
+     * Sets the default device ID to use. Standard device IDs are defined in {@link ZigBeeDeviceType}.
+     * <p>
+     * This should be set before calling the {@link #initialize} method.
+     *
+     * @param defaultDeviceId the device ID
+     */
+    public void setDefaultDeviceId(int defaultDeviceId) {
+        logger.debug("Default device ID set to {} [{}]", String.format("%04X", defaultDeviceId),
+                ZigBeeDeviceType.getByValue(defaultDeviceId));
+        transport.setDefaultDeviceId(defaultDeviceId);
     }
 
     /**

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transport/ZigBeeTransportTransmit.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transport/ZigBeeTransportTransmit.java
@@ -201,4 +201,24 @@ public interface ZigBeeTransportTransmit {
      * @return {@link Map} of {@link TransportConfigOption} and {@link TransportConfigResult} values with the result
      */
     void updateTransportConfig(TransportConfig configuration);
+
+    /**
+     * Sets the default profile ID to use.
+     * <p>
+     * This should be set before calling the {@link #initialize} method.
+     *
+     * @param defaultProfileId the profile ID
+     */
+    default void setDefaultProfileId(int defaultProfileId) {
+    }
+
+    /**
+     * Sets the default device ID.
+     * <p>
+     * This should be set before calling the {@link #initialize} method.
+     *
+     * @param defaultDeviceId the device ID.
+     */
+    default void setDefaultDeviceId(int defaultDeviceId) {
+    }
 }

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeNetworkManagerTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeNetworkManagerTest.java
@@ -265,6 +265,18 @@ public class ZigBeeNetworkManagerTest
     }
 
     @Test
+    public void setDefaults() throws Exception {
+        ZigBeeNetworkManager networkManager = mockZigBeeNetworkManager();
+
+        networkManager.setDefaultProfileId(ZigBeeProfileType.ZIGBEE_SMART_ENERGY.getKey());
+        Mockito.verify(mockedTransport, Mockito.times(1))
+                .setDefaultProfileId(ZigBeeProfileType.ZIGBEE_SMART_ENERGY.getKey());
+
+        networkManager.setDefaultDeviceId(ZigBeeDeviceType.IN_HOME_DISPLAY.getKey());
+        Mockito.verify(mockedTransport, Mockito.times(1)).setDefaultDeviceId(ZigBeeDeviceType.IN_HOME_DISPLAY.getKey());
+    }
+
+    @Test
     public void testSendCommandZCL() throws Exception {
         ZigBeeNetworkManager networkManager = mockZigBeeNetworkManager();
         networkManager.setSerializer(DefaultSerializer.class, DefaultDeserializer.class);


### PR DESCRIPTION
This adds ```setDefaultProfileId``` and ```setDefaultDeviceId``` methods in the ```ZigBeeNetworkManager``` and also in the ```ZigBeeTransportTransmit``` interface.

The new methods in ```ZigBeeTransportTransmit``` interface have default implementations so are not required to be implemented in the dongle. However this is implemented for the Ember NCP to set both the profile and device id in the endpoint registered with the NCP.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>