### PR TITLE
Don't send a DefaultResponse to a DefaultResponse

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
@@ -58,6 +58,7 @@ import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.ZclFrameType;
 import com.zsmartsystems.zigbee.zcl.ZclHeader;
+import com.zsmartsystems.zigbee.zcl.clusters.general.DefaultResponse;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 import com.zsmartsystems.zigbee.zdo.ZdoCommand;
 import com.zsmartsystems.zigbee.zdo.ZdoCommandType;
@@ -883,6 +884,11 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
         // If the transaction manager wants to drop this command, it returns null
         command = transactionManager.receive(command);
         if (command == null) {
+            return;
+        }
+
+        // Ignore the DefaultResponse
+        if (command instanceof DefaultResponse) {
             return;
         }
 

--- a/com.zsmartsystems.zigbee/src/test/resource/logs/cluster-FFFF-General.txt
+++ b/com.zsmartsystems.zigbee/src/test/resource/logs/cluster-FFFF-General.txt
@@ -23,9 +23,6 @@ ConfigureReportingCommand [Electrical Measurement: 0/1 -> 37410/1, cluster=0B04,
 ZigBeeApsFrame [sourceAddress=0/1, destinationAddress=0/0, profile=0104, cluster=0B04, addressMode=DEVICE, radius=0, sequence=0, payload=08 28 07 00]
 ConfigureReportingResponse [Electrical Measurement: 0/1 -> 0/0, cluster=0B04, TID=28, status=SUCCESS, records=null]
 
-ZigBeeApsFrame [sourceAddress=0/1, destinationAddress=0/1, profile=0104, cluster=0702, addressMode=DEVICE, radius=0, apsSecurity=false, apsCounter=4C, payload=08 7A 0B 0C 01]
-DefaultResponse [Metering: 0/1 -> 0/1, cluster=0702, TID=7A, commandIdentifier=12, statusCode=FAILURE]
-
 ZigBeeApsFrame [sourceAddress=0/1, destinationAddress=0/1, profile=0104, cluster=0702, addressMode=DEVICE, radius=0, apsSecurity=false, apsCounter=2A, payload=18 3E 01 00 00 00 48 08 02 00 00 00]
 ReadAttributesResponse [Metering: 0/1 -> 0/1, cluster=0702, TID=3E, records=[ReadAttributeStatusRecord [attributeDataType=ORDERED_SEQUENCE_ARRAY, attributeIdentifier=0, status=SUCCESS, attributeValue=ZclArrayList [dataType=DATA_8_BIT, values=[0, 0]]]]]
 


### PR DESCRIPTION
This doesn't send the received ```DefaultResponse``` to listeners. This should not be needed by listeners, and this also prevents us sending a ```DefaultResponse``` to a received ```DefaultResponse```.

Closes #763 

Signed-off-by: Chris Jackson <chris@cd-jackson.com>