### PR TITLE
Pass generic commands to ZclCommandListeners

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/ZclCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/ZclCluster.java
@@ -1160,8 +1160,6 @@ public abstract class ZclCluster {
         for (AttributeReport report : command.getReports()) {
             updateAttribute(report.getAttributeIdentifier(), report.getAttributeValue());
         }
-
-        sendDefaultResponse(command, ZclStatus.SUCCESS);
     }
 
     /**
@@ -1182,8 +1180,6 @@ public abstract class ZclCluster {
 
             updateAttribute(record.getAttributeIdentifier(), record.getAttributeValue());
         }
-
-        sendDefaultResponse(command, ZclStatus.SUCCESS);
     }
 
     private void updateAttribute(int attributeId, Object attributeValue) {
@@ -1211,19 +1207,17 @@ public abstract class ZclCluster {
         if (command instanceof ReportAttributesCommand) {
             // Pass the reports to the cluster
             handleAttributeReport((ReportAttributesCommand) command);
-            return;
         }
 
         if (command instanceof ReadAttributesResponse) {
             // Pass the reports to the cluster
             handleAttributeStatus((ReadAttributesResponse) command);
-            return;
         }
 
         ZclStatus responseStatus;
 
         // If this is a specific cluster command, pass the command to the cluster command handler
-        if (!command.isGenericCommand() && notifyCommandListener(command)) {
+        if (notifyCommandListener(command)) {
             return;
         } else if (supportedGenericCommands.contains(command.getClass())) {
             responseStatus = ZclStatus.SUCCESS;

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zcl/ZclClusterTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zcl/ZclClusterTest.java
@@ -370,13 +370,22 @@ public class ZclClusterTest {
         command.setDestinationAddress(new ZigBeeEndpointAddress(0, 0));
         command.setClusterId(0x0000);
 
+        ArgumentCaptor<ZclCommand> zclCommandCapture = ArgumentCaptor.forClass(ZclCommand.class);
+
         cluster.handleCommand(command);
+        Mockito.verify(listenerMock, Mockito.timeout(TIMEOUT).times(5)).commandReceived(zclCommandCapture.capture());
+        assertEquals(command, zclCommandCapture.getValue());
         Mockito.verify(endpoint, Mockito.timeout(TIMEOUT).times(5)).sendTransaction(commandCapture.capture());
         response = commandCapture.getValue();
         assertTrue(response instanceof DefaultResponse);
         System.out.println(response);
         defaultResponse = (DefaultResponse) response;
         assertEquals(ZclStatus.SUCCESS, defaultResponse.getStatusCode());
+
+        Mockito.when(listenerMock.commandReceived(command)).thenReturn(true);
+        cluster.handleCommand(command);
+        assertEquals(command, zclCommandCapture.getValue());
+        Mockito.verify(endpoint, Mockito.timeout(TIMEOUT).times(5)).sendTransaction(commandCapture.capture());
 
         cluster.removeCommandListener(listenerMock);
         assertEquals(0, commandListeners.size());


### PR DESCRIPTION
This allows ```ZclCommandListener```s to receive Generic commands sent to a cluster if they are listening to commands on that cluster.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>