### PR TITLE
Add ability to discover supported attributes in BasicServer app

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/field/AttributeInformation.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/field/AttributeInformation.java
@@ -83,7 +83,7 @@ public class AttributeInformation implements ZclListItemField, Comparable<Attrib
 
     @Override
     public String toString() {
-        return "Attribute Information [dataType=" + dataType + ", identifier=" + identifier + "]";
+        return "AttributeInformation [dataType=" + dataType + ", identifier=" + identifier + "]";
     }
 
 }

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/app/basic/ZclBasicServerTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/app/basic/ZclBasicServerTest.java
@@ -8,6 +8,7 @@
 package com.zsmartsystems.zigbee.app.basic;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
@@ -20,8 +21,11 @@ import org.mockito.Mockito;
 import com.zsmartsystems.zigbee.ZigBeeCommand;
 import com.zsmartsystems.zigbee.ZigBeeEndpointAddress;
 import com.zsmartsystems.zigbee.ZigBeeNetworkManager;
+import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclStatus;
 import com.zsmartsystems.zigbee.zcl.clusters.ZclBasicCluster;
+import com.zsmartsystems.zigbee.zcl.clusters.general.DiscoverAttributesCommand;
+import com.zsmartsystems.zigbee.zcl.clusters.general.DiscoverAttributesResponse;
 import com.zsmartsystems.zigbee.zcl.clusters.general.ReadAttributesCommand;
 import com.zsmartsystems.zigbee.zcl.clusters.general.ReadAttributesResponse;
 import com.zsmartsystems.zigbee.zcl.field.ReadAttributeStatusRecord;
@@ -46,17 +50,20 @@ public class ZclBasicServerTest {
         assertTrue(basicServer.setAttribute(ZclBasicCluster.ATTR_MODELIDENTIFIER, "ModelId"));
         assertTrue(basicServer.setAttribute(ZclBasicCluster.ATTR_MANUFACTURERNAME, "ZSmartSystems"));
 
+        assertFalse(basicServer.setAttribute(65535, 0));
+
         List<Integer> identifiers = new ArrayList<>();
         identifiers.add(ZclBasicCluster.ATTR_MODELIDENTIFIER);
         identifiers.add(ZclBasicCluster.ATTR_MANUFACTURERNAME);
         identifiers.add(ZclBasicCluster.ATTR_ZCLVERSION);
+        identifiers.add(ZclBasicCluster.ATTR_LOCATIONDESCRIPTION);
         identifiers.add(9999);
 
         ReadAttributesCommand command = new ReadAttributesCommand();
         command.setClusterId(ZclBasicCluster.CLUSTER_ID);
         command.setSourceAddress(new ZigBeeEndpointAddress(1234));
         command.setDestinationAddress(new ZigBeeEndpointAddress(5678));
-        command.setCommandDirection(ZclCommandDirection.SERVER_TO_CLIENT);
+        command.setCommandDirection(ZclCommandDirection.CLIENT_TO_SERVER);
         command.setTransactionId(55);
         command.setIdentifiers(identifiers);
 
@@ -65,30 +72,81 @@ public class ZclBasicServerTest {
         assertEquals(1, commandListener.getAllValues().size());
         ReadAttributesResponse response = (ReadAttributesResponse) commandListener.getValue();
         assertEquals(Integer.valueOf(ZclBasicCluster.CLUSTER_ID), response.getClusterId());
-        assertEquals(ZclCommandDirection.CLIENT_TO_SERVER, response.getCommandDirection());
+        assertEquals(ZclCommandDirection.SERVER_TO_CLIENT, response.getCommandDirection());
         assertEquals(new ZigBeeEndpointAddress(1234), response.getDestinationAddress());
         assertEquals(Integer.valueOf(55), response.getTransactionId());
 
         List<ReadAttributeStatusRecord> responseIndentifiers = response.getRecords();
-        assertEquals(4, responseIndentifiers.size());
+        assertEquals(5, responseIndentifiers.size());
 
+        assertEquals(ZclBasicCluster.ATTR_MODELIDENTIFIER, responseIndentifiers.get(0).getAttributeIdentifier());
         assertEquals(ZclStatus.SUCCESS, responseIndentifiers.get(0).getStatus());
         assertEquals(ZclDataType.CHARACTER_STRING, responseIndentifiers.get(0).getAttributeDataType());
-        assertEquals(ZclBasicCluster.ATTR_MODELIDENTIFIER, responseIndentifiers.get(0).getAttributeIdentifier());
         assertEquals("ModelId", responseIndentifiers.get(0).getAttributeValue());
 
+        assertEquals(ZclBasicCluster.ATTR_MANUFACTURERNAME, responseIndentifiers.get(1).getAttributeIdentifier());
         assertEquals(ZclStatus.SUCCESS, responseIndentifiers.get(1).getStatus());
         assertEquals(ZclDataType.CHARACTER_STRING, responseIndentifiers.get(1).getAttributeDataType());
-        assertEquals(ZclBasicCluster.ATTR_MANUFACTURERNAME, responseIndentifiers.get(1).getAttributeIdentifier());
         assertEquals("ZSmartSystems", responseIndentifiers.get(1).getAttributeValue());
 
+        assertEquals(ZclBasicCluster.ATTR_ZCLVERSION, responseIndentifiers.get(2).getAttributeIdentifier());
         assertEquals(ZclStatus.SUCCESS, responseIndentifiers.get(2).getStatus());
         assertEquals(ZclDataType.UNSIGNED_8_BIT_INTEGER, responseIndentifiers.get(2).getAttributeDataType());
-        assertEquals(ZclBasicCluster.ATTR_ZCLVERSION, responseIndentifiers.get(2).getAttributeIdentifier());
         assertEquals(Integer.valueOf(2), responseIndentifiers.get(2).getAttributeValue());
 
+        assertEquals(ZclBasicCluster.ATTR_LOCATIONDESCRIPTION, responseIndentifiers.get(3).getAttributeIdentifier());
         assertEquals(ZclStatus.UNSUPPORTED_ATTRIBUTE, responseIndentifiers.get(3).getStatus());
-        assertEquals(9999, responseIndentifiers.get(3).getAttributeIdentifier());
+
+        assertEquals(9999, responseIndentifiers.get(4).getAttributeIdentifier());
+        assertEquals(ZclStatus.UNSUPPORTED_ATTRIBUTE, responseIndentifiers.get(4).getStatus());
+
+        basicServer.commandReceived(Mockito.mock(ZigBeeCommand.class));
+        assertEquals(1, commandListener.getAllValues().size());
+
+        ZclCommand zclCommand = Mockito.mock(ReadAttributesCommand.class);
+        Mockito.when(zclCommand.getClusterId()).thenReturn(1);
+        basicServer.commandReceived(zclCommand);
+        assertEquals(1, commandListener.getAllValues().size());
+
+        Mockito.when(zclCommand.getClusterId()).thenReturn(0);
+        Mockito.when(zclCommand.getCommandDirection()).thenReturn(ZclCommandDirection.SERVER_TO_CLIENT);
+        basicServer.commandReceived(zclCommand);
+        assertEquals(1, commandListener.getAllValues().size());
+
+        DiscoverAttributesCommand discoverCommand = new DiscoverAttributesCommand();
+        discoverCommand.setClusterId(ZclBasicCluster.CLUSTER_ID);
+        discoverCommand.setSourceAddress(new ZigBeeEndpointAddress(1234));
+        discoverCommand.setDestinationAddress(new ZigBeeEndpointAddress(5678));
+        discoverCommand.setCommandDirection(ZclCommandDirection.CLIENT_TO_SERVER);
+        discoverCommand.setTransactionId(55);
+        discoverCommand.setStartAttributeIdentifier(0);
+        discoverCommand.setMaximumAttributeIdentifiers(10);
+
+        basicServer.commandReceived(discoverCommand);
+        assertEquals(2, commandListener.getAllValues().size());
+        DiscoverAttributesResponse discoverResponse = (DiscoverAttributesResponse) commandListener.getValue();
+        System.out.println(discoverResponse);
+        assertEquals(4, discoverResponse.getAttributeInformation().size());
+        assertEquals(0, discoverResponse.getAttributeInformation().get(0).getIdentifier());
+        assertEquals(ZclDataType.UNSIGNED_8_BIT_INTEGER,
+                discoverResponse.getAttributeInformation().get(0).getDataType());
+
+        discoverCommand = new DiscoverAttributesCommand();
+        discoverCommand.setClusterId(ZclBasicCluster.CLUSTER_ID);
+        discoverCommand.setSourceAddress(new ZigBeeEndpointAddress(1234));
+        discoverCommand.setDestinationAddress(new ZigBeeEndpointAddress(5678));
+        discoverCommand.setCommandDirection(ZclCommandDirection.CLIENT_TO_SERVER);
+        discoverCommand.setTransactionId(55);
+        discoverCommand.setStartAttributeIdentifier(3);
+        discoverCommand.setMaximumAttributeIdentifiers(2);
+
+        basicServer.commandReceived(discoverCommand);
+        assertEquals(3, commandListener.getAllValues().size());
+        discoverResponse = (DiscoverAttributesResponse) commandListener.getValue();
+        System.out.println(discoverResponse);
+        assertEquals(2, discoverResponse.getAttributeInformation().size());
+        assertEquals(4, discoverResponse.getAttributeInformation().get(0).getIdentifier());
+        assertEquals(ZclDataType.CHARACTER_STRING, discoverResponse.getAttributeInformation().get(0).getDataType());
 
         basicServer.shutdown();
     }

--- a/com.zsmartsystems.zigbee/src/test/resource/logs/cluster-FFFF-General.txt
+++ b/com.zsmartsystems.zigbee/src/test/resource/logs/cluster-FFFF-General.txt
@@ -9,7 +9,7 @@ ZigBeeApsFrame [sourceAddress=0/1, destinationAddress=18314/3, profile=0104, clu
 DiscoverAttributesCommand [On/Off: 0/1 -> 18314/3, cluster=0006, TID=15, startAttributeIdentifier=0, maximumAttributeIdentifiers=10]
 
 ZigBeeApsFrame [sourceAddress=0/1, destinationAddress=0/1, profile=0104, cluster=0006, addressMode=DEVICE, radius=0, apsSecurity=false, apsCounter=17, payload=18 15 0D 01 00 00 10 00 40 10 01 40 21 02 40 21]
-DiscoverAttributesResponse [On/Off: 0/1 -> 0/1, cluster=0006, TID=15, discoveryComplete=true, attributeInformation=[Attribute Information [dataType=BOOLEAN, identifier=0], Attribute Information [dataType=BOOLEAN, identifier=16384], Attribute Information [dataType=UNSIGNED_16_BIT_INTEGER, identifier=16385], Attribute Information [dataType=UNSIGNED_16_BIT_INTEGER, identifier=16386]]]
+DiscoverAttributesResponse [On/Off: 0/1 -> 0/1, cluster=0006, TID=15, discoveryComplete=true, attributeInformation=[AttributeInformation [dataType=BOOLEAN, identifier=0], AttributeInformation [dataType=BOOLEAN, identifier=16384], AttributeInformation [dataType=UNSIGNED_16_BIT_INTEGER, identifier=16385], AttributeInformation [dataType=UNSIGNED_16_BIT_INTEGER, identifier=16386]]]
 
 ZigBeeApsFrame [sourceAddress=0/1, destinationAddress=0/1, profile=0104, cluster=0201, addressMode=DEVICE, radius=0, apsSecurity=false, apsCounter=00, payload=18 3D 0D 01]
 DiscoverAttributesResponse [Thermostat: 0/1 -> 0/1, cluster=0201, TID=3D, discoveryComplete=true, attributeInformation=[]]


### PR DESCRIPTION
This adds support to the ```ZclBasicServer``` to discovery supported attributes as required for certification.

This code might be better moved into the ```ZclCluster``` class, but for now it's left here for traceability.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>