### PR TITLE
Fix for race condition in ZclCluster::notifyCommandListener per  #773

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/ZclCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/ZclCluster.java
@@ -1130,7 +1130,7 @@ public abstract class ZclCluster {
 
                     if (listener.commandReceived(command)) {
                         response.set(true);
-                        while( latch.getCount() > 0) {
+                        while (latch.getCount() > 0) {
                             latch.countDown();
                         }
                     } else {
@@ -1142,18 +1142,18 @@ public abstract class ZclCluster {
 
         try {
             // TODO: Set the timer properly
-            if(latch.await(1, TimeUnit.SECONDS)) {
+            if (latch.await(1, TimeUnit.SECONDS)) {
                 final boolean b = response.get();
-                logger.trace(" LATCH done - {}" , b);
+                logger.trace(" LATCH done - {}", b);
                 return b;
-            }else {
+            } else {
                 long cnt = latch.getCount();
-                logger.trace("LATCH TIME OUT, cnt = {}" ,cnt);
+                logger.trace("LATCH TIME OUT, cnt = {}", cnt);
                 return response.get();
             }
         } catch (InterruptedException e) {
             long cnt = latch.getCount();
-            logger.trace("LATCH Interrupted, cnt = {}" ,cnt);
+            logger.trace("LATCH Interrupted, cnt = {}", cnt);
             return response.get();
         }
     }

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zcl/ZclClusterTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zcl/ZclClusterTest.java
@@ -74,7 +74,7 @@ public class ZclClusterTest {
 
     private void createEndpoint() {
         node = Mockito.mock(ZigBeeNode.class);
-        endpoint = Mockito.mock(ZigBeeEndpoint.class, MOCK_SETTINGS_VERBOSE);
+        endpoint = Mockito.mock(ZigBeeEndpoint.class);
         Mockito.when(endpoint.getEndpointId()).thenReturn(5);
         Mockito.when(endpoint.getEndpointAddress()).thenReturn(new ZigBeeEndpointAddress(1234, 5));
         commandCapture = ArgumentCaptor.forClass(ZigBeeCommand.class);
@@ -315,7 +315,7 @@ public class ZclClusterTest {
         Mockito.when(command.isGenericCommand()).thenReturn(false);
         Mockito.when(command.isManufacturerSpecific()).thenReturn(false);
 
-        ZclCommandListener listenerMock = Mockito.mock(ZclCommandListener.class,MOCK_SETTINGS_VERBOSE);
+        ZclCommandListener listenerMock = Mockito.mock(ZclCommandListener.class);
         cluster.addCommandListener(listenerMock);
         assertEquals(1, commandListeners.size());
         cluster.addCommandListener(listenerMock);


### PR DESCRIPTION
Fix for immediate issue in #773
Fix race condition causing incorrect value to be returned in ```ZclCluster::notifyCommandListener```, wherein the latch count was decremented before the response was set.

In the event of a timeout or interrupted exception, the current value of the response is used. This will give the correct result (possibly after a timeout) if the size of the listener set is reduced after the latch has been created, but before the loop has started. 

This PR does not fix other preexisting concurrency issues such as those involving multiple listeners which may return true. 

The 

Signed-off-by: Simon Spero <sesuncedu@gmail.com>
