### PR TITLE
Change compiler plugin settings to always generate package-info.class files.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,8 @@
 				<configuration>
 					<source>1.8</source>
 					<target>1.8</target>
-				</configuration>
+          <compilerArgs>-Xpkginfo:always</compilerArgs>
+        </configuration>
 			</plugin>
 
 			<plugin>


### PR DESCRIPTION
This avoids an issue with maven incremental compilation which will mark an entire source set as stale if a source file produced no output.

Signed-off-by: Simon Spero <sesuncedu@gmail.com>