### PR TITLE
Send correct response to OTA QueryNextImageCommand when no image available.

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
@@ -781,6 +781,7 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
             zclHeader.setCommandId(zclCommand.getCommandId());
             zclHeader.setSequenceNumber(command.getTransactionId());
             zclHeader.setDirection(zclCommand.getCommandDirection());
+            zclHeader.setDisableDefaultResponse(zclCommand.isDisableDefaultResponse());
 
             if (zclCommand.isManufacturerSpecific()) {
                 zclHeader.setManufacturerSpecific(true);

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/ZclCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/ZclCluster.java
@@ -298,7 +298,7 @@ public abstract class ZclCluster {
      * @param command the {@link ZclCommand} to which the response is being sent
      * @param response the {@link ZclCommand} to send
      */
-    protected void sendResponse(ZclCommand command, ZclCommand response) {
+    public void sendResponse(ZclCommand command, ZclCommand response) {
         response.setDestinationAddress(command.getSourceAddress());
         response.setCommandDirection(command.getCommandDirection().getResponseDirection());
         response.setTransactionId(command.getTransactionId());
@@ -306,10 +306,6 @@ public abstract class ZclCluster {
 
         if (isManufacturerSpecific()) {
             response.setManufacturerCode(getManufacturerCode());
-        }
-
-        if (isClient()) {
-            response.setCommandDirection(ZclCommandDirection.SERVER_TO_CLIENT);
         }
 
         response.setApsSecurity(apsSecurityRequired);


### PR DESCRIPTION
This PR modifies ZclOtaUpgradeServer to use  the new ZclCluster sendResponse facility to send a QueryNextImageResponse with default responses disabled when replying to a QueryNextImageCommand when no image is available.

This required a few fixes outside of the upgrade server:

1.  ```ZigBeeNetworkManager::sendCommand``` now uses  the value of the  disable default response flag from the send command. 
2. ```ZclCluster::sendResponse``` is upgraded to public access from protected.  
3. ```ZclCluster::sendResponse``` sets the direction in the generated response  to the reverse of that in the command, rather than setting the direction to Server->Client if the cluster is marked as client. 

This code was not previously under test, and no new unit test has been constructed. However,  functionality has been evaluated using a packet sniffer. 

Observed cases where default responses were disabled:
1. QueryNextImageResponse (OTA, czz as server).
2. DefaultResponse (e.g. OnOff, czz as server).
3. DefaultResponse (e.g. TempratureMeasurement, czz as client).

Outgoing messages other than DefaultResponse and the no_image case for QueryNextImageResponse were sent with default responses enabled. 