### PR TITLE
Avoid a race condition when assigning sequence numbers in the constructor of EzspFrameRequest.

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/EzspFrameRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/EzspFrameRequest.java
@@ -7,6 +7,7 @@
  */
 package com.zsmartsystems.zigbee.dongle.ember.ezsp;
 
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 import com.zsmartsystems.zigbee.dongle.ember.internal.serializer.EzspSerializer;
@@ -40,16 +41,13 @@ import com.zsmartsystems.zigbee.dongle.ember.internal.serializer.EzspSerializer;
  *
  */
 public abstract class EzspFrameRequest extends EzspFrame {
-    private final static AtomicLong sequence = new AtomicLong(1);
+    private final static AtomicInteger sequence = new AtomicInteger(1);
 
     /**
      * Constructor used to create an outgoing frame
      */
     protected EzspFrameRequest() {
-        sequenceNumber = (int) sequence.getAndIncrement();
-        if (sequenceNumber == 254) {
-            sequence.set(1);
-        }
+        sequenceNumber = sequence.getAndUpdate(n -> n <254 ? n+1 : 1);
     }
 
     protected void serializeHeader(final EzspSerializer serializer) {

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/EzspFrameRequestTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/EzspFrameRequestTest.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2016-2019 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
 package com.zsmartsystems.zigbee.dongle.ember.ezsp;
 
 import org.junit.Test;

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/EzspFrameRequestTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/EzspFrameRequestTest.java
@@ -1,0 +1,27 @@
+package com.zsmartsystems.zigbee.dongle.ember.ezsp;
+
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import static org.junit.Assert.*;
+
+public class EzspFrameRequestTest {
+    private class TestRequestFrame extends EzspFrameRequest {
+
+    }
+
+    @Test
+    public void testSequenceNumbers() {
+        TestRequestFrame frame;
+
+        for (int i = 1; i < 255; i++) {
+            frame = new TestRequestFrame();
+            assertEquals("sequenceNumber", i, frame.getSequenceNumber());
+        }
+        for (int i = 1; i < 255; i++) {
+            frame = new TestRequestFrame();
+            assertEquals("sequenceNumber", i, frame.getSequenceNumber());
+        }
+
+    }
+}

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/EzspFrameRequestTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/EzspFrameRequestTest.java
@@ -19,8 +19,12 @@ public class EzspFrameRequestTest {
 
     @Test
     public void testSequenceNumbers() {
-        TestRequestFrame frame;
-
+        TestRequestFrame frame = new TestRequestFrame();
+        int k = 255;
+        do {
+            frame = new TestRequestFrame();
+        } while(frame.sequenceNumber != 254 && --k>0);
+        assertNotEquals("k",0,k);
         for (int i = 1; i < 255; i++) {
             frame = new TestRequestFrame();
             assertEquals("sequenceNumber", i, frame.getSequenceNumber());


### PR DESCRIPTION
See: #791 

Signed-off-by: Simon Spero <sesuncedu@gmail.com>