### PR TITLE
Print PANID as hex value

### DIFF
--- a/com.zsmartsystems.zigbee.console.ember/src/main/java/com/zsmartsystems/zigbee/console/ember/EmberConsoleNcpScanCommand.java
+++ b/com.zsmartsystems.zigbee.console.ember/src/main/java/com/zsmartsystems/zigbee/console/ember/EmberConsoleNcpScanCommand.java
@@ -76,7 +76,7 @@ public class EmberConsoleNcpScanCommand extends EmberConsoleAbstractCommand {
         out.println("CH  PAN   Extended PAN      Stk  Join   Upd");
         for (EzspNetworkFoundHandler network : networksFound) {
             EmberZigbeeNetwork params = network.getNetworkFound();
-            ExtendedPanId epanId = new ExtendedPanId(params.getExtendedPanId());
+            ExtendedPanId epanId = params.getExtendedPanId();
             out.println(String.format("%-2d  %04X  %s  %d    %s  %d", params.getChannel(), params.getPanId(), epanId,
                     params.getStackProfile(), params.getAllowingJoin() ? "True " : "False", params.getNwkUpdateId()));
         }

--- a/com.zsmartsystems.zigbee.dongle.ember.autocode/src/main/resources/ezsp_protocol.xml
+++ b/com.zsmartsystems.zigbee.dongle.ember.autocode/src/main/resources/ezsp_protocol.xml
@@ -3571,6 +3571,7 @@
 				<data_type>uint16_t</data_type>
 				<name>panId</name>
 				<description>The network's PAN identifier.</description>
+				<display>hex[4]</display>
 			</parameter>
 			<parameter>
 				<data_type>uint8_t</data_type>
@@ -3619,12 +3620,12 @@
 				<data_type>uint16_t</data_type>
 				<name>panId</name>
 				<description>The network's PAN identifier</description>
+				<display>hex[4]</display>
 			</parameter>
 			<parameter>
-				<data_type>uint8_t[8]</data_type>
+				<data_type>ExtendedPanId</data_type>
 				<name>extendedPanId</name>
 				<description>The network's extended PAN identifier.</description>
-				<display>hex[2]</display>
 			</parameter>
 			<parameter>
 				<data_type>bool</data_type>

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/EmberNcp.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/EmberNcp.java
@@ -221,10 +221,6 @@ public class EmberNcp {
         EzspGetCurrentSecurityStateResponse response = (EzspGetCurrentSecurityStateResponse) transaction.getResponse();
         logger.debug(response.toString());
         lastStatus = response.getStatus();
-        if (response.getStatus() != EmberStatus.EMBER_SUCCESS) {
-            logger.debug("Error during retrieval of security parameters: {}", response);
-            return null;
-        }
         return response.getState();
     }
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/structure/EmberNetworkParameters.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/structure/EmberNetworkParameters.java
@@ -304,7 +304,7 @@ public class EmberNetworkParameters {
         builder.append("EmberNetworkParameters [extendedPanId=");
         builder.append(extendedPanId);
         builder.append(", panId=");
-        builder.append(panId);
+        builder.append(String.format("%04X", panId));
         builder.append(", radioTxPower=");
         builder.append(radioTxPower);
         builder.append(", radioChannel=");

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/structure/EmberZigbeeNetwork.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/structure/EmberZigbeeNetwork.java
@@ -7,6 +7,7 @@
  */
 package com.zsmartsystems.zigbee.dongle.ember.ezsp.structure;
 
+import com.zsmartsystems.zigbee.ExtendedPanId;
 import com.zsmartsystems.zigbee.dongle.ember.internal.serializer.EzspDeserializer;
 import com.zsmartsystems.zigbee.dongle.ember.internal.serializer.EzspSerializer;
 
@@ -38,9 +39,9 @@ public class EmberZigbeeNetwork {
     /**
      * The network's extended PAN identifier.
      * <p>
-     * EZSP type is <i>uint8_t[8]</i> - Java type is {@link int[]}
+     * EZSP type is <i>ExtendedPanId</i> - Java type is {@link ExtendedPanId}
      */
-    private int[] extendedPanId;
+    private ExtendedPanId extendedPanId;
 
     /**
      * Whether the network is allowing MAC associations.
@@ -116,20 +117,20 @@ public class EmberZigbeeNetwork {
     /**
      * The network's extended PAN identifier.
      * <p>
-     * EZSP type is <i>uint8_t[8]</i> - Java type is {@link int[]}
+     * EZSP type is <i>ExtendedPanId</i> - Java type is {@link ExtendedPanId}
      *
-     * @return the current extendedPanId as {@link int[]}
+     * @return the current extendedPanId as {@link ExtendedPanId}
      */
-    public int[] getExtendedPanId() {
+    public ExtendedPanId getExtendedPanId() {
         return extendedPanId;
     }
 
     /**
      * The network's extended PAN identifier.
      *
-     * @param extendedPanId the extendedPanId to set as {@link int[]}
+     * @param extendedPanId the extendedPanId to set as {@link ExtendedPanId}
      */
-    public void setExtendedPanId(int[] extendedPanId) {
+    public void setExtendedPanId(ExtendedPanId extendedPanId) {
         this.extendedPanId = extendedPanId;
     }
 
@@ -202,7 +203,7 @@ public class EmberZigbeeNetwork {
         // Serialize the fields
         serializer.serializeUInt8(channel);
         serializer.serializeUInt16(panId);
-        serializer.serializeUInt8Array(extendedPanId);
+        serializer.serializeExtendedPanId(extendedPanId);
         serializer.serializeBool(allowingJoin);
         serializer.serializeUInt8(stackProfile);
         serializer.serializeUInt8(nwkUpdateId);
@@ -218,7 +219,7 @@ public class EmberZigbeeNetwork {
         // Deserialize the fields
         channel = deserializer.deserializeUInt8();
         panId = deserializer.deserializeUInt16();
-        extendedPanId = deserializer.deserializeUInt8Array(8);
+        extendedPanId = deserializer.deserializeExtendedPanId();
         allowingJoin = deserializer.deserializeBool();
         stackProfile = deserializer.deserializeUInt8();
         nwkUpdateId = deserializer.deserializeUInt8();
@@ -230,20 +231,9 @@ public class EmberZigbeeNetwork {
         builder.append("EmberZigbeeNetwork [channel=");
         builder.append(channel);
         builder.append(", panId=");
-        builder.append(panId);
+        builder.append(String.format("%04X", panId));
         builder.append(", extendedPanId=");
-        builder.append('{');
-        if (extendedPanId == null) {
-            builder.append("null");
-        } else {
-            for (int cnt = 0; cnt < extendedPanId.length; cnt++) {
-                if (cnt != 0) {
-                    builder.append(' ');
-                }
-                builder.append(String.format("%02X", extendedPanId[cnt]));
-            }
-        }
-        builder.append('}');
+        builder.append(extendedPanId);
         builder.append(", allowingJoin=");
         builder.append(allowingJoin);
         builder.append(", stackProfile=");

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspNetworkFoundHandlerTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspNetworkFoundHandlerTest.java
@@ -10,10 +10,9 @@ package com.zsmartsystems.zigbee.dongle.ember.ezsp.command;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import java.util.Arrays;
-
 import org.junit.Test;
 
+import com.zsmartsystems.zigbee.ExtendedPanId;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.EzspFrame;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.EzspFrameTest;
 
@@ -39,8 +38,8 @@ public class EzspNetworkFoundHandlerTest extends EzspFrameTest {
         assertEquals(2, handler.getNetworkFound().getStackProfile());
         assertEquals(1, handler.getNetworkFound().getNwkUpdateId());
         assertEquals(55691, handler.getNetworkFound().getPanId());
-        assertTrue(Arrays.equals(new int[] { 0x63, 0x08, 0x1D, 0xDC, 0x2D, 0xC4, 0xF2, 0x46 },
-                handler.getNetworkFound().getExtendedPanId()));
+        assertEquals(new ExtendedPanId(new int[] { 0x63, 0x08, 0x1D, 0xDC, 0x2D, 0xC4, 0xF2, 0x46 }),
+                handler.getNetworkFound().getExtendedPanId());
     }
 
 }


### PR DESCRIPTION
Trying to ensure consistency throughout the framework.
This also fixes an Ember definition of the ExtendedPanId in the ZigBeeNetwork structure in Ember.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>