### PR TITLE
Update Ember class printing to print cluster and profile IDs in hex

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.ember.autocode/src/main/resources/ezsp_protocol.xml
+++ b/com.zsmartsystems.zigbee.dongle.ember.autocode/src/main/resources/ezsp_protocol.xml
@@ -212,6 +212,7 @@
 				<data_type>uint16_t</data_type>
 				<name>profileId</name>
 				<description>The endpoint's application profile.</description>
+				<display>hex[4]</display>
 			</parameter>
 			<parameter>
 				<data_type>uint16_t</data_type>
@@ -3653,11 +3654,13 @@
 				<data_type>uint16_t</data_type>
 				<name>profileId</name>
 				<description>The application profile ID that describes the format of the message.</description>
+				<display>hex[4]</display>
 			</parameter>
 			<parameter>
 				<data_type>uint16_t</data_type>
 				<name>clusterId</name>
 				<description>The cluster ID for this message</description>
+				<display>hex[4]</display>
 			</parameter>
 			<parameter>
 				<data_type>uint8_t</data_type>
@@ -3812,6 +3815,7 @@
 				<data_type>uint16_t</data_type>
 				<name>clusterId</name>
 				<description>A cluster ID that matches one from the local endpoint's simple descriptor. This cluster ID is set by the provisioning application to indicate which part an endpoint's functionality is bound to this particular remote node and is used to distinguish between unicast and multicast bindings. Note that a binding can be used to send messages with any cluster ID, not just that listed in the binding.</description>
+				<display>hex[4]</display>
 			</parameter>
 			<parameter>
 				<data_type>uint8_t</data_type>

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspAddEndpointRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspAddEndpointRequest.java
@@ -225,7 +225,7 @@ public class EzspAddEndpointRequest extends EzspFrameRequest {
         builder.append("EzspAddEndpointRequest [endpoint=");
         builder.append(endpoint);
         builder.append(", profileId=");
-        builder.append(profileId);
+        builder.append(String.format("%04X", profileId));
         builder.append(", deviceId=");
         builder.append(deviceId);
         builder.append(", appFlags=");

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/structure/EmberApsFrame.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/structure/EmberApsFrame.java
@@ -269,9 +269,9 @@ public class EmberApsFrame {
     public String toString() {
         final StringBuilder builder = new StringBuilder(191);
         builder.append("EmberApsFrame [profileId=");
-        builder.append(profileId);
+        builder.append(String.format("%04X", profileId));
         builder.append(", clusterId=");
-        builder.append(clusterId);
+        builder.append(String.format("%04X", clusterId));
         builder.append(", sourceEndpoint=");
         builder.append(sourceEndpoint);
         builder.append(", destinationEndpoint=");

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/structure/EmberBindingTableEntry.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/structure/EmberBindingTableEntry.java
@@ -248,7 +248,7 @@ public class EmberBindingTableEntry {
         builder.append(", local=");
         builder.append(local);
         builder.append(", clusterId=");
-        builder.append(clusterId);
+        builder.append(String.format("%04X", clusterId));
         builder.append(", remote=");
         builder.append(remote);
         builder.append(", identifier=");


### PR DESCRIPTION
Change Ember printing of cluster IDs and profile IDs to hex for consistency with the rest of the framework.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>