### PR TITLE
Improve handling of ezsp transactions.

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/EmberCbkeProvider.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/EmberCbkeProvider.java
@@ -290,9 +290,9 @@ public class EmberCbkeProvider implements ZigBeeCbkeProvider {
         request.setMyKey(myKey);
         request.setMyCert(myCert);
         request.setCaCert(caCert);
-        EzspTransaction transaction = protocolHandler.sendEzspTransaction(
-                new EzspSingleResponseTransaction(request, EzspSetPreinstalledCbkeDataResponse.class));
-        EzspSetPreinstalledCbkeDataResponse response = (EzspSetPreinstalledCbkeDataResponse) transaction.getResponse();
+        EzspTransaction<EzspSetPreinstalledCbkeDataResponse> transaction = protocolHandler.sendEzspTransaction(
+                new EzspSingleResponseTransaction<>(request, EzspSetPreinstalledCbkeDataResponse.class));
+        EzspSetPreinstalledCbkeDataResponse response = transaction.getResponse();
         logger.debug(response.toString());
 
         return response.getStatus();
@@ -328,29 +328,28 @@ public class EmberCbkeProvider implements ZigBeeCbkeProvider {
         EzspSetValueRequest setMyCert = new EzspSetValueRequest();
         setMyCert.setValueId(EzspValueId.EZSP_VALUE_CERTIFICATE_283K1);
         setMyCert.setValue(certificate.getCertificate());
-        EzspTransaction transaction = protocolHandler
-                .sendEzspTransaction(new EzspSingleResponseTransaction(setMyCert, EzspSetValueResponse.class));
-        EzspSetValueResponse response = (EzspSetValueResponse) transaction.getResponse();
+        EzspTransaction<EzspSetValueResponse> transaction = protocolHandler.sendEzspTransaction(
+                new EzspSingleResponseTransaction<>(setMyCert, EzspSetValueResponse.class));
+        EzspSetValueResponse response = transaction.getResponse();
 
         EzspSetValueRequest setCaKey = new EzspSetValueRequest();
         setCaKey.setValueId(EzspValueId.EZSP_VALUE_PUBLIC_KEY_283K1);
         setCaKey.setValue(certificate.getCaPublicKey());
-        transaction = protocolHandler
-                .sendEzspTransaction(new EzspSingleResponseTransaction(setCaKey, EzspSetValueResponse.class));
-        response = (EzspSetValueResponse) transaction.getResponse();
+        transaction = protocolHandler.sendEzspTransaction(
+                new EzspSingleResponseTransaction<>(setCaKey, EzspSetValueResponse.class));
+        response = transaction.getResponse();
 
         EzspSetValueRequest setMyKey = new EzspSetValueRequest();
         setMyKey.setValueId(EzspValueId.EZSP_VALUE_PRIVATE_KEY_283K1);
         setMyKey.setValue(certificate.getPrivateKey());
-        transaction = protocolHandler
-                .sendEzspTransaction(new EzspSingleResponseTransaction(setMyKey, EzspSetValueResponse.class));
-        response = (EzspSetValueResponse) transaction.getResponse();
+        transaction = protocolHandler.sendEzspTransaction(
+                new EzspSingleResponseTransaction<>(setMyKey, EzspSetValueResponse.class));
+        response = transaction.getResponse();
 
         EzspSetPreinstalledCbkeData283k1Request request = new EzspSetPreinstalledCbkeData283k1Request();
-        transaction = protocolHandler.sendEzspTransaction(
-                new EzspSingleResponseTransaction(request, EzspSetPreinstalledCbkeData283k1Response.class));
-        EzspSetPreinstalledCbkeData283k1Response setCbkeResponse = (EzspSetPreinstalledCbkeData283k1Response) transaction
-                .getResponse();
+        EzspTransaction<EzspSetPreinstalledCbkeData283k1Response> t2 = protocolHandler.sendEzspTransaction(
+                new EzspSingleResponseTransaction<>(request, EzspSetPreinstalledCbkeData283k1Response.class));
+        EzspSetPreinstalledCbkeData283k1Response setCbkeResponse = t2.getResponse();
         logger.debug(response.toString());
 
         return setCbkeResponse.getStatus();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/EmberNcp.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/EmberNcp.java
@@ -163,9 +163,9 @@ public class EmberNcp {
     public EzspVersionResponse getVersion(int desiredVersion) {
         EzspVersionRequest request = new EzspVersionRequest();
         request.setDesiredProtocolVersion(EzspFrame.getEzspVersion());
-        EzspTransaction transaction = protocolHandler
-                .sendEzspTransaction(new EzspSingleResponseTransaction(request, EzspVersionResponse.class));
-        EzspVersionResponse response = (EzspVersionResponse) transaction.getResponse();
+        EzspTransaction<EzspVersionResponse> transaction = protocolHandler.sendEzspTransaction(
+                new EzspSingleResponseTransaction<>(request, EzspVersionResponse.class));
+        EzspVersionResponse response = transaction.getResponse();
         if (response == null) {
             logger.debug("No response from ezspVersion command");
             return null;
@@ -185,9 +185,9 @@ public class EmberNcp {
      */
     public EmberStatus networkInit() {
         EzspNetworkInitRequest request = new EzspNetworkInitRequest();
-        EzspTransaction transaction = protocolHandler
-                .sendEzspTransaction(new EzspSingleResponseTransaction(request, EzspNetworkInitResponse.class));
-        EzspNetworkInitResponse response = (EzspNetworkInitResponse) transaction.getResponse();
+        EzspTransaction<EzspNetworkInitResponse> transaction = protocolHandler.sendEzspTransaction(
+                new EzspSingleResponseTransaction<>(request, EzspNetworkInitResponse.class));
+        EzspNetworkInitResponse response = transaction.getResponse();
         logger.debug(response.toString());
 
         return response.getStatus();
@@ -201,9 +201,9 @@ public class EmberNcp {
      */
     public EmberStatus leaveNetwork() {
         EzspLeaveNetworkRequest request = new EzspLeaveNetworkRequest();
-        EzspTransaction transaction = protocolHandler
-                .sendEzspTransaction(new EzspSingleResponseTransaction(request, EzspLeaveNetworkResponse.class));
-        EzspLeaveNetworkResponse response = (EzspLeaveNetworkResponse) transaction.getResponse();
+        EzspTransaction<EzspLeaveNetworkResponse> transaction = protocolHandler.sendEzspTransaction(
+                new EzspSingleResponseTransaction<>(request, EzspLeaveNetworkResponse.class));
+        EzspLeaveNetworkResponse response = transaction.getResponse();
         logger.debug(response.toString());
 
         return response.getStatus();
@@ -216,9 +216,9 @@ public class EmberNcp {
      */
     public EmberCurrentSecurityState getCurrentSecurityState() {
         EzspGetCurrentSecurityStateRequest request = new EzspGetCurrentSecurityStateRequest();
-        EzspTransaction transaction = protocolHandler.sendEzspTransaction(
-                new EzspSingleResponseTransaction(request, EzspGetCurrentSecurityStateResponse.class));
-        EzspGetCurrentSecurityStateResponse response = (EzspGetCurrentSecurityStateResponse) transaction.getResponse();
+        EzspTransaction<EzspGetCurrentSecurityStateResponse> transaction = protocolHandler.sendEzspTransaction(
+                new EzspSingleResponseTransaction<>(request, EzspGetCurrentSecurityStateResponse.class));
+        EzspGetCurrentSecurityStateResponse response = transaction.getResponse();
         logger.debug(response.toString());
         lastStatus = response.getStatus();
         return response.getState();
@@ -231,9 +231,9 @@ public class EmberNcp {
      */
     public EzspGetNetworkParametersResponse getNetworkParameters() {
         EzspGetNetworkParametersRequest request = new EzspGetNetworkParametersRequest();
-        EzspTransaction transaction = protocolHandler.sendEzspTransaction(
-                new EzspSingleResponseTransaction(request, EzspGetNetworkParametersResponse.class));
-        return (EzspGetNetworkParametersResponse) transaction.getResponse();
+        EzspTransaction<EzspGetNetworkParametersResponse> transaction = protocolHandler.sendEzspTransaction(
+                new EzspSingleResponseTransaction<>(request, EzspGetNetworkParametersResponse.class));
+        return transaction.getResponse();
     }
 
     /**
@@ -243,9 +243,9 @@ public class EmberNcp {
      */
     public EmberNetworkStatus getNetworkState() {
         EzspNetworkStateRequest request = new EzspNetworkStateRequest();
-        EzspTransaction transaction = protocolHandler
-                .sendEzspTransaction(new EzspSingleResponseTransaction(request, EzspNetworkStateResponse.class));
-        EzspNetworkStateResponse response = (EzspNetworkStateResponse) transaction.getResponse();
+        EzspTransaction<EzspNetworkStateResponse> transaction = protocolHandler.sendEzspTransaction(
+                new EzspSingleResponseTransaction<>(request, EzspNetworkStateResponse.class));
+        EzspNetworkStateResponse response = transaction.getResponse();
         logger.debug(response.toString());
         lastStatus = null;
 
@@ -259,10 +259,9 @@ public class EmberNcp {
      */
     public EzspGetParentChildParametersResponse getChildParameters() {
         EzspGetParentChildParametersRequest request = new EzspGetParentChildParametersRequest();
-        EzspTransaction transaction = protocolHandler.sendEzspTransaction(
-                new EzspSingleResponseTransaction(request, EzspGetParentChildParametersResponse.class));
-        EzspGetParentChildParametersResponse response = (EzspGetParentChildParametersResponse) transaction
-                .getResponse();
+        EzspTransaction<EzspGetParentChildParametersResponse> transaction = protocolHandler.sendEzspTransaction(
+                new EzspSingleResponseTransaction<>(request, EzspGetParentChildParametersResponse.class));
+        EzspGetParentChildParametersResponse response = transaction.getResponse();
         lastStatus = null;
 
         return response;
@@ -277,9 +276,9 @@ public class EmberNcp {
     public EzspGetChildDataResponse getChildInformation(int childId) {
         EzspGetChildDataRequest request = new EzspGetChildDataRequest();
         request.setIndex(childId);
-        EzspTransaction transaction = protocolHandler
-                .sendEzspTransaction(new EzspSingleResponseTransaction(request, EzspGetChildDataResponse.class));
-        EzspGetChildDataResponse response = (EzspGetChildDataResponse) transaction.getResponse();
+        EzspTransaction<EzspGetChildDataResponse> transaction = protocolHandler.sendEzspTransaction(
+                new EzspSingleResponseTransaction<>(request, EzspGetChildDataResponse.class));
+        EzspGetChildDataResponse response = transaction.getResponse();
         logger.debug(response.toString());
         lastStatus = response.getStatus();
         if (lastStatus != EmberStatus.EMBER_SUCCESS) {
@@ -309,9 +308,9 @@ public class EmberNcp {
         request.setProfileId(profileId);
         request.setInputClusterList(new int[] { 0 });
         request.setOutputClusterList(new int[] { 0 });
-        EzspTransaction transaction = protocolHandler
-                .sendEzspTransaction(new EzspSingleResponseTransaction(request, EzspAddEndpointResponse.class));
-        EzspAddEndpointResponse response = (EzspAddEndpointResponse) transaction.getResponse();
+        EzspTransaction<EzspAddEndpointResponse> transaction = protocolHandler.sendEzspTransaction(
+                new EzspSingleResponseTransaction<>(request, EzspAddEndpointResponse.class));
+        EzspAddEndpointResponse response = transaction.getResponse();
 
         logger.debug(response.toString());
         lastStatus = null;
@@ -326,9 +325,9 @@ public class EmberNcp {
      */
     public int[] getCounters() {
         EzspReadCountersRequest request = new EzspReadCountersRequest();
-        EzspTransaction transaction = protocolHandler
-                .sendEzspTransaction(new EzspSingleResponseTransaction(request, EzspReadCountersResponse.class));
-        EzspReadCountersResponse response = (EzspReadCountersResponse) transaction.getResponse();
+        EzspTransaction<EzspReadCountersResponse> transaction = protocolHandler.sendEzspTransaction(
+                new EzspSingleResponseTransaction<>(request, EzspReadCountersResponse.class));
+        EzspReadCountersResponse response = transaction.getResponse();
         logger.debug(response.toString());
         lastStatus = null;
         return response.getValues();
@@ -341,9 +340,9 @@ public class EmberNcp {
      */
     public EmberStatus clearKeyTable() {
         EzspClearKeyTableRequest request = new EzspClearKeyTableRequest();
-        EzspTransaction transaction = protocolHandler
-                .sendEzspTransaction(new EzspSingleResponseTransaction(request, EzspClearKeyTableResponse.class));
-        EzspClearKeyTableResponse response = (EzspClearKeyTableResponse) transaction.getResponse();
+        EzspTransaction<EzspClearKeyTableResponse> transaction = protocolHandler.sendEzspTransaction(
+                new EzspSingleResponseTransaction<>(request, EzspClearKeyTableResponse.class));
+        EzspClearKeyTableResponse response = transaction.getResponse();
         logger.debug(response.toString());
         lastStatus = response.getStatus();
         return lastStatus;
@@ -358,9 +357,9 @@ public class EmberNcp {
     public EmberKeyStruct getKey(EmberKeyType keyType) {
         EzspGetKeyRequest request = new EzspGetKeyRequest();
         request.setKeyType(keyType);
-        EzspTransaction transaction = protocolHandler
-                .sendEzspTransaction(new EzspSingleResponseTransaction(request, EzspGetKeyResponse.class));
-        EzspGetKeyResponse response = (EzspGetKeyResponse) transaction.getResponse();
+        EzspTransaction<EzspGetKeyResponse> transaction = protocolHandler.sendEzspTransaction(
+                new EzspSingleResponseTransaction<>(request, EzspGetKeyResponse.class));
+        EzspGetKeyResponse response = transaction.getResponse();
         logger.debug(response.toString());
         lastStatus = response.getStatus();
         if (lastStatus != EmberStatus.EMBER_SUCCESS) {
@@ -378,9 +377,9 @@ public class EmberNcp {
     public EmberKeyStruct getKeyTableEntry(int index) {
         EzspGetKeyTableEntryRequest request = new EzspGetKeyTableEntryRequest();
         request.setIndex(index);
-        EzspTransaction transaction = protocolHandler
-                .sendEzspTransaction(new EzspSingleResponseTransaction(request, EzspGetKeyTableEntryResponse.class));
-        EzspGetKeyTableEntryResponse response = (EzspGetKeyTableEntryResponse) transaction.getResponse();
+        EzspTransaction<EzspGetKeyTableEntryResponse> transaction = protocolHandler.sendEzspTransaction(
+                new EzspSingleResponseTransaction<>(request, EzspGetKeyTableEntryResponse.class));
+        EzspGetKeyTableEntryResponse response = transaction.getResponse();
         logger.debug(response.toString());
         lastStatus = response.getStatus();
         if (lastStatus != EmberStatus.EMBER_SUCCESS) {
@@ -399,9 +398,9 @@ public class EmberNcp {
         EzspGetConfigurationValueRequest request = new EzspGetConfigurationValueRequest();
         request.setConfigId(configId);
 
-        EzspTransaction transaction = protocolHandler.sendEzspTransaction(
-                new EzspSingleResponseTransaction(request, EzspGetConfigurationValueResponse.class));
-        EzspGetConfigurationValueResponse response = (EzspGetConfigurationValueResponse) transaction.getResponse();
+        EzspTransaction<EzspGetConfigurationValueResponse> transaction = protocolHandler.sendEzspTransaction(
+                new EzspSingleResponseTransaction<>(request, EzspGetConfigurationValueResponse.class));
+        EzspGetConfigurationValueResponse response = transaction.getResponse();
         lastStatus = null;
         logger.debug(response.toString());
 
@@ -425,9 +424,9 @@ public class EmberNcp {
         request.setValue(value);
         logger.debug(request.toString());
 
-        EzspTransaction transaction = protocolHandler.sendEzspTransaction(
-                new EzspSingleResponseTransaction(request, EzspSetConfigurationValueResponse.class));
-        EzspSetConfigurationValueResponse response = (EzspSetConfigurationValueResponse) transaction.getResponse();
+        EzspTransaction<EzspSetConfigurationValueResponse> transaction = protocolHandler.sendEzspTransaction(
+                new EzspSingleResponseTransaction<>(request, EzspSetConfigurationValueResponse.class));
+        EzspSetConfigurationValueResponse response = transaction.getResponse();
         lastStatus = null;
         logger.debug(response.toString());
 
@@ -445,9 +444,9 @@ public class EmberNcp {
         EzspSetPolicyRequest setPolicyRequest = new EzspSetPolicyRequest();
         setPolicyRequest.setPolicyId(policyId);
         setPolicyRequest.setDecisionId(decisionId);
-        EzspTransaction transaction = protocolHandler
-                .sendEzspTransaction(new EzspSingleResponseTransaction(setPolicyRequest, EzspSetPolicyResponse.class));
-        EzspSetPolicyResponse setPolicyResponse = (EzspSetPolicyResponse) transaction.getResponse();
+        EzspTransaction<EzspSetPolicyResponse> transaction = protocolHandler.sendEzspTransaction(
+                new EzspSingleResponseTransaction<>(setPolicyRequest, EzspSetPolicyResponse.class));
+        EzspSetPolicyResponse setPolicyResponse = transaction.getResponse();
         lastStatus = null;
         logger.debug(setPolicyResponse.toString());
         if (setPolicyResponse.getStatus() != EzspStatus.EZSP_SUCCESS) {
@@ -467,9 +466,9 @@ public class EmberNcp {
     public EzspDecisionId getPolicy(EzspPolicyId policyId) {
         EzspGetPolicyRequest getPolicyRequest = new EzspGetPolicyRequest();
         getPolicyRequest.setPolicyId(policyId);
-        EzspTransaction transaction = protocolHandler
-                .sendEzspTransaction(new EzspSingleResponseTransaction(getPolicyRequest, EzspGetPolicyResponse.class));
-        EzspGetPolicyResponse getPolicyResponse = (EzspGetPolicyResponse) transaction.getResponse();
+        EzspTransaction<EzspGetPolicyResponse> transaction = protocolHandler.sendEzspTransaction(
+                new EzspSingleResponseTransaction<>(getPolicyRequest, EzspGetPolicyResponse.class));
+        EzspGetPolicyResponse getPolicyResponse = transaction.getResponse();
         lastStatus = null;
         logger.debug(getPolicyResponse.toString());
         if (getPolicyResponse.getStatus() != EzspStatus.EZSP_SUCCESS) {
@@ -491,9 +490,9 @@ public class EmberNcp {
         EzspSetValueRequest request = new EzspSetValueRequest();
         request.setValueId(valueId);
         request.setValue(value);
-        EzspTransaction transaction = protocolHandler
-                .sendEzspTransaction(new EzspSingleResponseTransaction(request, EzspSetValueResponse.class));
-        EzspSetValueResponse response = (EzspSetValueResponse) transaction.getResponse();
+        EzspTransaction<EzspSetValueResponse> transaction = protocolHandler.sendEzspTransaction(
+                new EzspSingleResponseTransaction<>(request, EzspSetValueResponse.class));
+        EzspSetValueResponse response = transaction.getResponse();
         lastStatus = null;
         logger.debug(response.toString());
         if (response.getStatus() != EzspStatus.EZSP_SUCCESS) {
@@ -512,9 +511,9 @@ public class EmberNcp {
     public int[] getValue(EzspValueId valueId) {
         EzspGetValueRequest request = new EzspGetValueRequest();
         request.setValueId(valueId);
-        EzspTransaction transaction = protocolHandler
-                .sendEzspTransaction(new EzspSingleResponseTransaction(request, EzspGetValueResponse.class));
-        EzspGetValueResponse response = (EzspGetValueResponse) transaction.getResponse();
+        EzspTransaction<EzspGetValueResponse> transaction = protocolHandler.sendEzspTransaction(
+                new EzspSingleResponseTransaction<>(request, EzspGetValueResponse.class));
+        EzspGetValueResponse response = transaction.getResponse();
         lastStatus = null;
         logger.debug(response.toString());
         if (response.getStatus() != EzspStatus.EZSP_SUCCESS) {
@@ -538,9 +537,9 @@ public class EmberNcp {
         EzspAddTransientLinkKeyRequest request = new EzspAddTransientLinkKeyRequest();
         request.setPartner(partner);
         request.setTransientKey(emberKey);
-        EzspTransaction transaction = protocolHandler
-                .sendEzspTransaction(new EzspSingleResponseTransaction(request, EzspAddTransientLinkKeyResponse.class));
-        EzspAddTransientLinkKeyResponse response = (EzspAddTransientLinkKeyResponse) transaction.getResponse();
+        EzspTransaction<EzspAddTransientLinkKeyResponse> transaction = protocolHandler.sendEzspTransaction(
+                new EzspSingleResponseTransaction<>(request, EzspAddTransientLinkKeyResponse.class));
+        EzspAddTransientLinkKeyResponse response = transaction.getResponse();
         lastStatus = response.getStatus();
         logger.debug(response.toString());
         if (response.getStatus() != EmberStatus.EMBER_SUCCESS) {
@@ -559,9 +558,9 @@ public class EmberNcp {
      */
     public EmberCertificateData getCertificateData() {
         EzspGetCertificateRequest request = new EzspGetCertificateRequest();
-        EzspTransaction transaction = protocolHandler
-                .sendEzspTransaction(new EzspSingleResponseTransaction(request, EzspGetCertificateResponse.class));
-        EzspGetCertificateResponse response = (EzspGetCertificateResponse) transaction.getResponse();
+        EzspTransaction<EzspGetCertificateResponse> transaction = protocolHandler.sendEzspTransaction(
+                new EzspSingleResponseTransaction<>(request, EzspGetCertificateResponse.class));
+        EzspGetCertificateResponse response = transaction.getResponse();
         lastStatus = response.getStatus();
         if (response.getStatus() != EmberStatus.EMBER_SUCCESS) {
             logger.debug("Error getting 163k1 certificate: {}", response);
@@ -578,9 +577,9 @@ public class EmberNcp {
      */
     public EmberCertificate283k1Data getCertificate283k1Data() {
         EzspGetCertificate283k1Request request = new EzspGetCertificate283k1Request();
-        EzspTransaction transaction = protocolHandler
-                .sendEzspTransaction(new EzspSingleResponseTransaction(request, EzspGetCertificate283k1Response.class));
-        EzspGetCertificate283k1Response response = (EzspGetCertificate283k1Response) transaction.getResponse();
+        EzspTransaction<EzspGetCertificate283k1Response> transaction = protocolHandler.sendEzspTransaction(
+                new EzspSingleResponseTransaction<>(request, EzspGetCertificate283k1Response.class));
+        EzspGetCertificate283k1Response response = transaction.getResponse();
         lastStatus = response.getStatus();
         if (response.getStatus() != EmberStatus.EMBER_SUCCESS) {
             logger.debug("Error getting 283k1 certificate: {}", response);
@@ -607,9 +606,9 @@ public class EmberNcp {
         request.setData(code);
         request.setFinalize(true);
         request.setLength(code.length);
-        EzspTransaction transaction = protocolHandler
-                .sendEzspTransaction(new EzspSingleResponseTransaction(request, EzspAesMmoHashResponse.class));
-        EzspAesMmoHashResponse response = (EzspAesMmoHashResponse) transaction.getResponse();
+        EzspTransaction<EzspAesMmoHashResponse> transaction = protocolHandler.sendEzspTransaction(
+                new EzspSingleResponseTransaction<>(request, EzspAesMmoHashResponse.class));
+        EzspAesMmoHashResponse response = transaction.getResponse();
         lastStatus = response.getStatus();
         logger.debug(response.toString());
         if (response.getStatus() != EmberStatus.EMBER_SUCCESS) {
@@ -626,9 +625,9 @@ public class EmberNcp {
      */
     public IeeeAddress getIeeeAddress() {
         EzspGetEui64Request request = new EzspGetEui64Request();
-        EzspTransaction transaction = protocolHandler
-                .sendEzspTransaction(new EzspSingleResponseTransaction(request, EzspGetEui64Response.class));
-        EzspGetEui64Response response = (EzspGetEui64Response) transaction.getResponse();
+        EzspTransaction<EzspGetEui64Response> transaction = protocolHandler.sendEzspTransaction(
+                new EzspSingleResponseTransaction<>(request, EzspGetEui64Response.class));
+        EzspGetEui64Response response = transaction.getResponse();
         return response.getEui64();
     }
 
@@ -639,9 +638,9 @@ public class EmberNcp {
      */
     public int getNwkAddress() {
         EzspGetNodeIdRequest request = new EzspGetNodeIdRequest();
-        EzspTransaction transaction = protocolHandler
-                .sendEzspTransaction(new EzspSingleResponseTransaction(request, EzspGetNodeIdResponse.class));
-        EzspGetNodeIdResponse response = (EzspGetNodeIdResponse) transaction.getResponse();
+        EzspTransaction<EzspGetNodeIdResponse> transaction = protocolHandler.sendEzspTransaction(
+                new EzspSingleResponseTransaction<>(request, EzspGetNodeIdResponse.class));
+        EzspGetNodeIdResponse response = transaction.getResponse();
         return response.getNodeId();
     }
 
@@ -658,9 +657,9 @@ public class EmberNcp {
     public EmberStatus setRadioPower(int power) {
         EzspSetRadioPowerRequest request = new EzspSetRadioPowerRequest();
         request.setPower(power);
-        EzspTransaction transaction = protocolHandler
-                .sendEzspTransaction(new EzspSingleResponseTransaction(request, EzspSetRadioPowerResponse.class));
-        EzspSetRadioPowerResponse response = (EzspSetRadioPowerResponse) transaction.getResponse();
+        EzspTransaction<EzspSetRadioPowerResponse> transaction = protocolHandler.sendEzspTransaction(
+                new EzspSingleResponseTransaction<>(request, EzspSetRadioPowerResponse.class));
+        EzspSetRadioPowerResponse response = transaction.getResponse();
         return response.getStatus();
     }
 
@@ -672,9 +671,9 @@ public class EmberNcp {
     public EmberLibraryStatus getLibraryStatus(EmberLibraryId libraryId) {
         EzspGetLibraryStatusRequest request = new EzspGetLibraryStatusRequest();
         request.setLibraryId(libraryId);
-        EzspTransaction transaction = protocolHandler
-                .sendEzspTransaction(new EzspSingleResponseTransaction(request, EzspGetLibraryStatusResponse.class));
-        EzspGetLibraryStatusResponse response = (EzspGetLibraryStatusResponse) transaction.getResponse();
+        EzspTransaction<EzspGetLibraryStatusResponse> transaction = protocolHandler.sendEzspTransaction(
+                new EzspSingleResponseTransaction<>(request, EzspGetLibraryStatusResponse.class));
+        EzspGetLibraryStatusResponse response = transaction.getResponse();
         return response.getStatus();
     }
 
@@ -697,10 +696,9 @@ public class EmberNcp {
         request.setAddress(address);
         request.setKeyData(keyData);
         request.setLinkKey(linkKey);
-        EzspTransaction transaction = protocolHandler.sendEzspTransaction(
-                new EzspSingleResponseTransaction(request, EzspAddOrUpdateKeyTableEntryResponse.class));
-        EzspAddOrUpdateKeyTableEntryResponse response = (EzspAddOrUpdateKeyTableEntryResponse) transaction
-                .getResponse();
+        EzspTransaction<EzspAddOrUpdateKeyTableEntryResponse> transaction = protocolHandler.sendEzspTransaction(
+                new EzspSingleResponseTransaction<>(request, EzspAddOrUpdateKeyTableEntryResponse.class));
+        EzspAddOrUpdateKeyTableEntryResponse response = transaction.getResponse();
         return response.getStatus();
     }
 
@@ -714,8 +712,8 @@ public class EmberNcp {
         EzspSetPowerDescriptorRequest request = new EzspSetPowerDescriptorRequest();
         request.setDescriptor(descriptor);
         protocolHandler.queueFrame(request);
-        protocolHandler
-                .sendEzspTransaction(new EzspSingleResponseTransaction(request, EzspSetPowerDescriptorResponse.class));
+        protocolHandler.sendEzspTransaction(
+                new EzspSingleResponseTransaction<>(request, EzspSetPowerDescriptorResponse.class));
     }
 
     /**
@@ -728,8 +726,8 @@ public class EmberNcp {
         EzspSetManufacturerCodeRequest request = new EzspSetManufacturerCodeRequest();
         request.setCode(code);
         protocolHandler.queueFrame(request);
-        protocolHandler
-                .sendEzspTransaction(new EzspSingleResponseTransaction(request, EzspSetManufacturerCodeResponse.class));
+        protocolHandler.sendEzspTransaction(
+                new EzspSingleResponseTransaction<>(request, EzspSetManufacturerCodeResponse.class));
     }
 
     /**
@@ -814,11 +812,11 @@ public class EmberNcp {
         activeScan.setDuration(scanDuration);
         activeScan.setScanType(EzspNetworkScanType.EZSP_ACTIVE_SCAN);
 
-        Set<Class<?>> relatedResponses = new HashSet<Class<?>>(
+        Set<Class<? extends EzspFrameResponse>> relatedResponses = new HashSet<>(
                 Arrays.asList(EzspStartScanResponse.class, EzspNetworkFoundHandler.class));
-        EzspTransaction transaction = protocolHandler.sendEzspTransaction(
-                new EzspMultiResponseTransaction(activeScan, EzspScanCompleteHandler.class, relatedResponses));
-        EzspScanCompleteHandler activeScanCompleteResponse = (EzspScanCompleteHandler) transaction.getResponse();
+        EzspTransaction<EzspScanCompleteHandler> transaction = protocolHandler.sendEzspTransaction(
+                new EzspMultiResponseTransaction<>(activeScan, EzspScanCompleteHandler.class, relatedResponses));
+        EzspScanCompleteHandler activeScanCompleteResponse = transaction.getResponse();
         logger.debug(activeScanCompleteResponse.toString());
 
         if (activeScanCompleteResponse.getStatus() != EmberStatus.EMBER_SUCCESS) {
@@ -852,12 +850,13 @@ public class EmberNcp {
         energyScan.setDuration(scanDuration);
         energyScan.setScanType(EzspNetworkScanType.EZSP_ENERGY_SCAN);
 
-        Set<Class<?>> relatedResponses = new HashSet<Class<?>>(
+        Set<Class<? extends EzspFrameResponse>> relatedResponses = new HashSet<>(
                 Arrays.asList(EzspStartScanResponse.class, EzspEnergyScanResultHandler.class));
-        EzspTransaction transaction = protocolHandler.sendEzspTransaction(
-                new EzspMultiResponseTransaction(energyScan, EzspScanCompleteHandler.class, relatedResponses));
 
-        EzspScanCompleteHandler scanCompleteResponse = (EzspScanCompleteHandler) transaction.getResponse();
+        EzspTransaction<EzspScanCompleteHandler> transaction = protocolHandler.sendEzspTransaction(
+                new EzspMultiResponseTransaction<>(energyScan, EzspScanCompleteHandler.class, relatedResponses));
+
+        EzspScanCompleteHandler scanCompleteResponse = transaction.getResponse();
         logger.debug(scanCompleteResponse.toString());
 
         List<EzspEnergyScanResultHandler> channels = new ArrayList<>();
@@ -885,9 +884,9 @@ public class EmberNcp {
     private int[] getMfgToken(EzspMfgTokenId tokenId) {
         EzspGetMfgTokenRequest request = new EzspGetMfgTokenRequest();
         request.setTokenId(tokenId);
-        EzspTransaction transaction = protocolHandler
-                .sendEzspTransaction(new EzspSingleResponseTransaction(request, EzspGetMfgTokenResponse.class));
-        EzspGetMfgTokenResponse response = (EzspGetMfgTokenResponse) transaction.getResponse();
+        EzspTransaction<EzspGetMfgTokenResponse> transaction = protocolHandler.sendEzspTransaction(
+                new EzspSingleResponseTransaction<>(request, EzspGetMfgTokenResponse.class));
+        EzspGetMfgTokenResponse response = transaction.getResponse();
         return response.getTokenData();
     }
 }

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
@@ -886,6 +886,7 @@ public class ZigBeeDongleEzsp implements ZigBeeTransportTransmit, ZigBeeTranspor
             }
             return;
         }
+        logger.warn("Unhandled EZSP response received: {}", response);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/EzspProtocolHandler.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/EzspProtocolHandler.java
@@ -67,18 +67,20 @@ public interface EzspProtocolHandler {
      * Sends an EZSP request to the NCP without waiting for the response.
      *
      * @param ezspTransaction Request {@link EzspTransaction}
+     *
      * @return response {@link Future} {@link EzspFrame}
      */
-    public Future<EzspFrame> sendEzspRequestAsync(final EzspTransaction ezspTransaction);
+    public <T extends EzspFrameResponse> Future<T> sendEzspRequestAsync(final EzspTransaction<T> ezspTransaction);
 
     /**
      * Sends an EZSP request to the NCP and waits for the response. The response is correlated with the request and the
      * returned {@link EzspTransaction} contains the request and response data.
      *
      * @param ezspTransaction Request {@link EzspTransaction}
+     *
      * @return response {@link EzspTransaction}
      */
-    public EzspTransaction sendEzspTransaction(EzspTransaction ezspTransaction);
+    public <T extends EzspFrameResponse> EzspTransaction<T> sendEzspTransaction(EzspTransaction<T> ezspTransaction);
 
     /**
      * Wait for the requested {@link EzspFrameResponse} to be received

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/ash/AshFrameHandler.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/ash/AshFrameHandler.java
@@ -704,14 +704,14 @@ public class AshFrameHandler implements EzspProtocolHandler {
 
             @Override
             public boolean transactionEvent(EzspFrameResponse ezspResponse) {
-                // Check if this response completes our transaction
-                if (!ezspTransaction.isMatch(ezspResponse)) {
+                // Check to see if response was processed
+                if (!ezspTransaction.handleResponse(ezspResponse)) {
                     return false;
                 }
-
-                transactionComplete();
-                // response = request;
-
+                // check to see if transaction was completed
+                if (ezspTransaction.isComplete()) {
+                    transactionComplete();
+                }
                 return true;
             }
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/ash/AshFrameHandler.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/ash/AshFrameHandler.java
@@ -202,8 +202,10 @@ public class AshFrameHandler implements EzspProtocolHandler {
                                         if (response == null) {
                                             logger.debug("ASH: No frame handler created for {}", packet);
                                         } else {
-                                            notifyTransactionComplete(response);
-                                            handleIncomingFrame(response);
+                                            if (!notifyTransactionComplete(response)) {
+                                                logger.trace("ASH: no EZSP transaction match for {}", response);
+                                                handleIncomingFrame(response);
+                                            }
                                         }
                                     } else if (!dataPacket.getReTx()) {
                                         // Send a NAK - this is out of sequence and not a retransmission

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/spi/SpiFrameHandler.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/spi/SpiFrameHandler.java
@@ -687,13 +687,13 @@ public class SpiFrameHandler implements EzspProtocolHandler {
     }
 
     @Override
-    public Future<EzspFrame> sendEzspRequestAsync(final EzspTransaction ezspTransaction) {
-        class TransactionWaiter implements Callable<EzspFrame>, SpiListener {
+    public <T extends EzspFrameResponse> Future<T> sendEzspRequestAsync(final EzspTransaction<T> ezspTransaction) {
+        class TransactionWaiter implements Callable<T>, SpiListener {
             // private EzspFrame response = null;
             private boolean complete = false;
 
             @Override
-            public EzspFrame call() {
+            public T call() {
                 // Register a listener
                 addTransactionListener(this);
 
@@ -714,7 +714,7 @@ public class SpiFrameHandler implements EzspProtocolHandler {
                 // Remove the listener
                 removeTransactionListener(this);
 
-                return null;// response;
+                return ezspTransaction.getResponse();// response;
             }
 
             @Override
@@ -742,8 +742,7 @@ public class SpiFrameHandler implements EzspProtocolHandler {
             }
         }
 
-        Callable<EzspFrame> worker = new TransactionWaiter();
-        return executor.submit(worker);
+        return executor.submit(new TransactionWaiter());
     }
 
     @Override

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/spi/SpiFrameHandler.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/spi/SpiFrameHandler.java
@@ -719,17 +719,17 @@ public class SpiFrameHandler implements EzspProtocolHandler {
 
             @Override
             public boolean transactionEvent(EzspFrameResponse ezspResponse) {
-                // Check if this response completes our transaction
-                if (!ezspTransaction.isMatch(ezspResponse)) {
+                // Check if this response was handled
+                if (!ezspTransaction.handleResponse(ezspResponse)) {
                     return false;
                 }
 
-                // response = request;
-                synchronized (this) {
-                    complete = true;
-                    notify();
+                if (ezspTransaction.isComplete()) {
+                    synchronized (this) {
+                        complete = true;
+                        notify();
+                    }
                 }
-
                 return true;
             }
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/transaction/EzspMultiResponseTransaction.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/transaction/EzspMultiResponseTransaction.java
@@ -33,7 +33,7 @@ import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EmberStatus;
  * @author Chris Jackson
  *
  */
-public class EzspMultiResponseTransaction implements EzspTransaction {
+public class EzspMultiResponseTransaction<R extends EzspFrameResponse> implements EzspTransaction<R> {
     /**
      * The request we sent
      */
@@ -47,15 +47,15 @@ public class EzspMultiResponseTransaction implements EzspTransaction {
     /**
      * The response required to complete the transaction
      */
-    private Class<?> requiredResponse;
+    private Class<R> requiredResponse;
 
     /**
      * The response required to complete the transaction
      */
-    private Set<Class<?>> relatedResponses;
+    private Set<Class<? extends EzspFrameResponse>> relatedResponses;
 
-    public EzspMultiResponseTransaction(EzspFrameRequest request, Class<?> requiredResponse,
-            Set<Class<?>> relatedResponses) {
+    public EzspMultiResponseTransaction(EzspFrameRequest request, Class<R> requiredResponse,
+            Set<Class<? extends EzspFrameResponse>> relatedResponses) {
         this.request = request;
         this.requiredResponse = requiredResponse;
         this.relatedResponses = relatedResponses;
@@ -108,9 +108,9 @@ public class EzspMultiResponseTransaction implements EzspTransaction {
     }
 
     @Override
-    public synchronized EzspFrameResponse getResponse() {
+    public synchronized R getResponse() {
         if (!responses.isEmpty()) {
-            return responses.get(responses.size() - 1);
+            return (R) responses.get(responses.size() - 1);
         }
         return null;
     }

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/transaction/EzspSingleResponseTransaction.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/transaction/EzspSingleResponseTransaction.java
@@ -33,7 +33,12 @@ public class EzspSingleResponseTransaction implements EzspTransaction {
     }
 
     @Override
-    public boolean isMatch(EzspFrameResponse response) {
+    public boolean isComplete() {
+        return response != null;
+    }
+
+    @Override
+    public boolean handleResponse(EzspFrameResponse response) {
         if (response.getClass() == requiredResponse && request.getSequenceNumber() == response.getSequenceNumber()) {
             this.response = response;
             return true;

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/transaction/EzspSingleResponseTransaction.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/transaction/EzspSingleResponseTransaction.java
@@ -16,18 +16,17 @@ import com.zsmartsystems.zigbee.dongle.ember.ezsp.EzspFrameResponse;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EmberStatus;
 
 /**
- * Single EZSP transaction response handling. This matches a {@link EzspFrameRequest} with a single
- * {@link EzspFrameResponse}. {@link EzspFrame#frameId} must also match.
+ * Single EZSP transaction response handling. This matches a {@link EzspFrameRequest} with a single {@link
+ * EzspFrameResponse}. {@link EzspFrame#frameId} must also match.
  *
  * @author Chris Jackson
- *
  */
-public class EzspSingleResponseTransaction implements EzspTransaction {
+public class EzspSingleResponseTransaction<T extends EzspFrameResponse> implements EzspTransaction<T> {
     private EzspFrameRequest request;
-    private EzspFrameResponse response;
-    private Class<?> requiredResponse;
+    private T response;
+    private Class<T> requiredResponse;
 
-    public EzspSingleResponseTransaction(EzspFrameRequest request, Class<?> requiredResponse) {
+    public EzspSingleResponseTransaction(EzspFrameRequest request, Class<T> requiredResponse) {
         this.request = request;
         this.requiredResponse = requiredResponse;
     }
@@ -39,9 +38,13 @@ public class EzspSingleResponseTransaction implements EzspTransaction {
 
     @Override
     public boolean handleResponse(EzspFrameResponse response) {
-        if (response.getClass() == requiredResponse && request.getSequenceNumber() == response.getSequenceNumber()) {
-            this.response = response;
-            return true;
+        if (request.getSequenceNumber() == response.getSequenceNumber()) {
+            if (requiredResponse.isInstance(response)) {
+                this.response = (T) response;
+                return true;
+            } else {
+                return false;
+            }
         } else {
             return false;
         }
@@ -63,7 +66,7 @@ public class EzspSingleResponseTransaction implements EzspTransaction {
     }
 
     @Override
-    public EzspFrameResponse getResponse() {
+    public T getResponse() {
         return response;
     }
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/transaction/EzspTransaction.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/transaction/EzspTransaction.java
@@ -19,13 +19,14 @@ import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EmberStatus;
  * The transaction looks for a {@link EzspFrameResponse} that matches the {@link EzspFrameRequest}. The {@link
  * EzspFrameResponse} and {@link EzspFrameRequest} classes are provided when the transaction is created.
  *
+ * @param <R> The type of the final response to the message.
+ *
  * @author Chris Jackson
  */
-public interface EzspTransaction {
+public interface EzspTransaction<R extends EzspFrameResponse> {
 
     /**
      * Check transaction completion status
-     * @return
      */
     boolean isComplete();
 
@@ -50,7 +51,7 @@ public interface EzspTransaction {
      *
      * @return {@link EzspFrameResponse} to complete the transaction or null if no response received
      */
-    EzspFrameResponse getResponse();
+    R getResponse();
 
     /**
      * Gets a {@link List} of the {@link EzspFrameResponse}s received for the transaction. This is used for transactions
@@ -58,7 +59,7 @@ public interface EzspTransaction {
      *
      * @return {@link EzspFrameResponse} to complete the transaction or null if no response received
      */
-    List<EzspFrameResponse> getResponses();
+    List<? extends EzspFrameResponse> getResponses();
 
     /**
      * Get the {@link EmberStatus} of the transaction. If multiple responses are returned, this will return the last

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/transaction/EzspTransaction.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/transaction/EzspTransaction.java
@@ -16,20 +16,26 @@ import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EmberStatus;
 /**
  * Interface for EZSP protocol transaction.
  * <p>
- * The transaction looks for a {@link EzspFrameResponse} that matches the {@link EzspFrameRequest}.
- * The {@link EzspFrameResponse} and {@link EzspFrameRequest} classes are provided when the transaction is created.
+ * The transaction looks for a {@link EzspFrameResponse} that matches the {@link EzspFrameRequest}. The {@link
+ * EzspFrameResponse} and {@link EzspFrameRequest} classes are provided when the transaction is created.
  *
  * @author Chris Jackson
- *
  */
 public interface EzspTransaction {
+
+    /**
+     * Check transaction completion status
+     * @return
+     */
+    boolean isComplete();
+
     /**
      * Matches request and response.
      *
      * @param response the response {@link EzspFrameResponse}
      * @return true if response matches the request
      */
-    boolean isMatch(EzspFrameResponse response);
+    boolean handleResponse(EzspFrameResponse response);
 
     /**
      * Gets the {@link EzspFrameRequest} associated with this transaction

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/ash/AshFrameHandlerTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/ash/AshFrameHandlerTest.java
@@ -234,8 +234,8 @@ public class AshFrameHandlerTest {
         request.setSequenceNumber(3);
         request.setDesiredProtocolVersion(4);
 
-        EzspTransaction transaction = frameHandler
-                .sendEzspTransaction(new EzspSingleResponseTransaction(request, EzspVersionResponse.class));
+        EzspTransaction<EzspVersionResponse> transaction = frameHandler.sendEzspTransaction(
+                new EzspSingleResponseTransaction<>(request, EzspVersionResponse.class));
 
         assertNull(transaction.getResponse());
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/transaction/EzspMultiResponseTransactionTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/transaction/EzspMultiResponseTransactionTest.java
@@ -26,7 +26,6 @@ import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspStartScanRequest;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspStartScanResponse;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EmberStatus;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EzspNetworkScanType;
-import com.zsmartsystems.zigbee.dongle.ember.internal.transaction.EzspMultiResponseTransaction;
 
 /**
  *
@@ -41,30 +40,38 @@ public class EzspMultiResponseTransactionTest extends EzspFrameTest {
         request.setDuration(1);
         request.setScanType(EzspNetworkScanType.EZSP_ENERGY_SCAN);
 
-        Set<Class<?>> relatedResponses = new HashSet<Class<?>>(Arrays.asList(EzspStartScanResponse.class,
-                EzspNetworkFoundHandler.class, EzspEnergyScanResultHandler.class));
+        Set<Class<?>> relatedResponses = new HashSet<Class<?>>(
+                Arrays.asList(EzspStartScanResponse.class, EzspNetworkFoundHandler.class,
+                        EzspEnergyScanResultHandler.class));
         EzspMultiResponseTransaction transaction = new EzspMultiResponseTransaction(request,
                 EzspScanCompleteHandler.class, relatedResponses);
 
         EzspStartScanResponse scanResponse = new EzspStartScanResponse(getPacketData("39 80 1A 00"));
         System.out.println(scanResponse);
-        assertFalse(transaction.isMatch(scanResponse));
+        assertTrue("message handled", transaction.handleResponse(scanResponse));
+        assertFalse(transaction.isComplete());
         EzspEnergyScanResultHandler scanResult = new EzspEnergyScanResultHandler(getPacketData("39 8C 48 0B C1"));
         System.out.println(scanResult);
-        assertFalse(transaction.isMatch(scanResult));
+        assertTrue("message handled", transaction.handleResponse(scanResult));
+        assertFalse(transaction.isComplete());
         scanResult = new EzspEnergyScanResultHandler(getPacketData("3A 8C 48 0E C6"));
         System.out.println(scanResult);
-        assertFalse(transaction.isMatch(scanResult));
+        assertTrue("message handled", transaction.handleResponse(scanResult));
+        assertFalse(transaction.isComplete());
         scanResult = new EzspEnergyScanResultHandler(getPacketData("3B 8C 48 0F B4"));
         System.out.println(scanResult);
-        assertFalse(transaction.isMatch(scanResult));
+        assertTrue("message handled", transaction.handleResponse(scanResult));
+        assertFalse(transaction.isComplete());
         scanResult = new EzspEnergyScanResultHandler(getPacketData("3B 8C 48 10 AA"));
-        assertFalse(transaction.isMatch(scanResult));
+        assertTrue("message handled", transaction.handleResponse(scanResult));
+        assertFalse(transaction.isComplete());
         scanResult = new EzspEnergyScanResultHandler(getPacketData("3C 8C 48 12 B3"));
-        assertFalse(transaction.isMatch(scanResult));
+        assertTrue("message handled", transaction.handleResponse(scanResult));
+        assertFalse(transaction.isComplete());
         EzspScanCompleteHandler scanComplete = new EzspScanCompleteHandler(getPacketData("3F 88 1C 02 00"));
         System.out.println(scanComplete);
-        assertTrue(transaction.isMatch(scanComplete));
+        assertTrue(transaction.handleResponse(scanComplete));
+        assertTrue(transaction.isComplete());
 
         EzspScanCompleteHandler response = (EzspScanCompleteHandler) transaction.getResponse();
         assertEquals(2, response.getChannel());

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/transaction/EzspScanTransactionTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/transaction/EzspScanTransactionTest.java
@@ -27,7 +27,6 @@ import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspStartScanRequest;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspStartScanResponse;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EmberStatus;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EzspNetworkScanType;
-import com.zsmartsystems.zigbee.dongle.ember.internal.transaction.EzspMultiResponseTransaction;
 
 /**
  *
@@ -43,8 +42,9 @@ public class EzspScanTransactionTest extends EzspFrameTest {
         energyScan.setSequenceNumber(3);
         energyScan.setScanType(EzspNetworkScanType.EZSP_ENERGY_SCAN);
 
-        Set<Class<?>> relatedResponses = new HashSet<Class<?>>(Arrays.asList(EzspStartScanResponse.class,
-                EzspNetworkFoundHandler.class, EzspEnergyScanResultHandler.class));
+        Set<Class<?>> relatedResponses = new HashSet<Class<?>>(
+                Arrays.asList(EzspStartScanResponse.class, EzspNetworkFoundHandler.class,
+                        EzspEnergyScanResultHandler.class));
         EzspMultiResponseTransaction scanTransaction = new EzspMultiResponseTransaction(energyScan,
                 EzspScanCompleteHandler.class, relatedResponses);
 
@@ -52,27 +52,33 @@ public class EzspScanTransactionTest extends EzspFrameTest {
 
         // Start Scan Response
         response = new EzspStartScanResponse(getPacketData("03 80 1A 00"));
-        assertFalse(scanTransaction.isMatch(response));
+        assertTrue(scanTransaction.handleResponse(response));
+        assertFalse(scanTransaction.isComplete());
 
         response = new EzspEnergyScanResultHandler(getPacketData("03 90 48 0B 9D"));
         assertEquals(11, ((EzspEnergyScanResultHandler) response).getChannel());
         assertEquals(-99, ((EzspEnergyScanResultHandler) response).getMaxRssiValue());
-        assertFalse(scanTransaction.isMatch(response));
+        assertTrue(scanTransaction.handleResponse(response));
+        assertFalse(scanTransaction.isComplete());
 
         response = new EzspEnergyScanResultHandler(getPacketData("03 90 48 0C 9D"));
-        assertFalse(scanTransaction.isMatch(response));
+        assertTrue(scanTransaction.handleResponse(response));
+        assertFalse(scanTransaction.isComplete());
 
         response = new EzspEnergyScanResultHandler(getPacketData("03 90 48 0D AB"));
         assertEquals(13, ((EzspEnergyScanResultHandler) response).getChannel());
         assertEquals(-85, ((EzspEnergyScanResultHandler) response).getMaxRssiValue());
-        assertFalse(scanTransaction.isMatch(response));
+        assertTrue(scanTransaction.handleResponse(response));
+        assertFalse(scanTransaction.isComplete());
 
         response = new EzspEnergyScanResultHandler(getPacketData("03 90 48 0E 9D"));
-        assertFalse(scanTransaction.isMatch(response));
+        assertTrue(scanTransaction.handleResponse(response));
+        assertFalse(scanTransaction.isComplete());
 
         response = new EzspScanCompleteHandler(getPacketData("03 90 1C 0B 00"));
         assertEquals(EmberStatus.EMBER_SUCCESS, ((EzspScanCompleteHandler) response).getStatus());
-        assertTrue(scanTransaction.isMatch(response));
+        assertTrue(scanTransaction.handleResponse(response));
+        assertTrue(scanTransaction.isComplete());
 
         assertEquals(6, scanTransaction.getResponses().size());
         assertTrue(scanTransaction.getResponses().get(0) instanceof EzspStartScanResponse);

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/transaction/EzspSingleResponseTransactionTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/transaction/EzspSingleResponseTransactionTest.java
@@ -18,8 +18,6 @@ import org.junit.Test;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.EzspFrameTest;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspVersionRequest;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspVersionResponse;
-import com.zsmartsystems.zigbee.dongle.ember.internal.transaction.EzspSingleResponseTransaction;
-import com.zsmartsystems.zigbee.dongle.ember.internal.transaction.EzspTransaction;
 
 /**
  *
@@ -37,7 +35,7 @@ public class EzspSingleResponseTransactionTest extends EzspFrameTest {
 
         EzspVersionResponse versionResponse = new EzspVersionResponse(getPacketData("03 80 00 04 02 00 58"));
 
-        assertTrue(versionTransaction.isMatch(versionResponse));
+        assertTrue(versionTransaction.handleResponse(versionResponse));
 
         versionTransaction.getRequest();
         assertEquals(1, versionTransaction.getResponses().size());
@@ -55,7 +53,7 @@ public class EzspSingleResponseTransactionTest extends EzspFrameTest {
 
         EzspVersionResponse versionResponse = new EzspVersionResponse(getPacketData("03 80 00 04 02 00 58"));
 
-        assertFalse(versionTransaction.isMatch(versionResponse));
+        assertFalse(versionTransaction.handleResponse(versionResponse));
         assertNull(versionTransaction.getResponse());
         assertNull(versionTransaction.getResponses());
     }


### PR DESCRIPTION
Don't process messages that are consumed by a transaction to non-specific callback handler. 
Make responses are returned as results of futures.
Make transactions generic, with terminal response as parameter. 