### PR TITLE
Set extended timeouts for EZSP unicast messages.

### DIFF
--- a/com.zsmartsystems.zigbee.autocode/pom.xml
+++ b/com.zsmartsystems.zigbee.autocode/pom.xml
@@ -11,7 +11,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.main.skip>true</maven.main.skip>
     </properties>
-    
+
     <parent>
         <groupId>com.zsmartsystems</groupId>
         <artifactId>zigbee</artifactId>
@@ -25,20 +25,33 @@
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>2.5</version>
             </plugin>
- 
-           	<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-source-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>attach-sources</id>
-						<goals>
-							<goal>jar</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
 
+          <plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>attach-sources</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>animal-sniffer-maven-plugin</artifactId>
+            <version>1.16</version>
+            <configuration>
+            </configuration>
+            <executions>
+              <execution>
+                <id>animal-sniffer</id>
+                <phase/>
+              </execution>
+            </executions>
+          </plugin>
         </plugins>
     </build>
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
@@ -281,7 +281,7 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
         this.transport = transport;
 
         transport.setZigBeeTransportReceive(this);
-
+        transport.setZigBeeNetworkManager(this);
         apsDataEntity = new ApsDataEntity(transport);
         transactionManager = new ZigBeeTransactionManager(this);
     }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transport/ZigBeeTransportTransmit.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transport/ZigBeeTransportTransmit.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import com.zsmartsystems.zigbee.ExtendedPanId;
 import com.zsmartsystems.zigbee.IeeeAddress;
 import com.zsmartsystems.zigbee.ZigBeeChannel;
+import com.zsmartsystems.zigbee.ZigBeeNetworkManager;
 import com.zsmartsystems.zigbee.ZigBeeStatus;
 import com.zsmartsystems.zigbee.aps.ZigBeeApsFrame;
 import com.zsmartsystems.zigbee.security.ZigBeeKey;
@@ -220,5 +221,11 @@ public interface ZigBeeTransportTransmit {
      * @param defaultDeviceId the device ID.
      */
     default void setDefaultDeviceId(int defaultDeviceId) {
+    }
+
+    /**
+     * Provides the transport with a {@link ZigBeeNetworkManager} instance.
+     */
+    default void setZigBeeNetworkManager(ZigBeeNetworkManager manager) {
     }
 }


### PR DESCRIPTION
Provide a ZigBeeNetworkManager.
If node information is available for a unicast destination, the ieee address is known, and the destination is known to be RX_OFF , set extended timeout.

The timeout flag is set for every outgoing message. 

An alternative approach would have been to maintain address table entries and send via the address table. 
