### PR TITLE
Only discover neighbours for nodes known to not be end-nodes.

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeNodeServiceDiscoverer.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeNodeServiceDiscoverer.java
@@ -457,9 +457,6 @@ public class ZigBeeNodeServiceDiscoverer {
      * @throws InterruptedException
      */
     private boolean requestNeighborTable() throws InterruptedException, ExecutionException {
-        if (!supportsManagementLqi) {
-            return true;
-        }
         // Start index for the list is 0
         int startIndex = 0;
         int totalNeighbors = 0;
@@ -514,9 +511,6 @@ public class ZigBeeNodeServiceDiscoverer {
      * @throws InterruptedException
      */
     private boolean requestRoutingTable() throws InterruptedException, ExecutionException {
-        if (!supportsManagementRouting) {
-            return true;
-        }
         // Start index for the list is 0
         int startIndex = 0;
         int totalRoutes = 0;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeNodeServiceDiscoverer.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeNodeServiceDiscoverer.java
@@ -733,12 +733,10 @@ public class ZigBeeNodeServiceDiscoverer {
      * @return true if the device is not known to not be an end-device
      */
     private boolean isPossibleEndDevice() {
-        if (node.getNodeDescriptor() != null) {
-            switch (node.getLogicalType()) {
-                case ROUTER:
-                case COORDINATOR:
-                    return false;
-            }
+        switch (node.getLogicalType()) {
+            case ROUTER:
+            case COORDINATOR:
+                return false;
         }
         return true;
     }

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeNodeServiceDiscovererTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeNodeServiceDiscovererTest.java
@@ -275,7 +275,13 @@ public class ZigBeeNodeServiceDiscovererTest {
 
         NodeDescriptor initialNodeDescriptor = Mockito.mock(NodeDescriptor.class);
         Mockito.when(initialNodeDescriptor.getLogicalType()).thenReturn(LogicalType.END_DEVICE);
-        Mockito.when(node.getNodeDescriptor()).thenReturn(initialNodeDescriptor);
+        Mockito.when(node.getLogicalType()).thenAnswer(x -> {
+            if (node.getNodeDescriptor() == null) {
+                return LogicalType.UNKNOWN;
+            } else {
+                return node.getNodeDescriptor().getLogicalType();
+            }
+        });
 
         PowerDescriptor initialPowerDescriptor = Mockito.mock(PowerDescriptor.class);
         Mockito.when(initialPowerDescriptor.getCurrentPowerMode()).thenReturn(CurrentPowerModeType.UNKNOWN);
@@ -288,8 +294,16 @@ public class ZigBeeNodeServiceDiscovererTest {
         TestUtilities.setField(ZigBeeNodeServiceDiscoverer.class, discoverer, "futureTask", futureTask);
 
         discoverer.updateMesh();
+        assertEquals(LogicalType.UNKNOWN, discoverer.getNode().getLogicalType());
         assertFalse(discoverer.getTasks().contains(NodeDiscoveryTask.ROUTES));
-        assertTrue(discoverer.getTasks().contains(NodeDiscoveryTask.NEIGHBORS));
+        assertFalse(discoverer.getTasks().contains(NodeDiscoveryTask.NEIGHBORS));
+
+        Mockito.when(node.getNodeDescriptor()).thenReturn(initialNodeDescriptor);
+
+        discoverer.updateMesh();
+        assertEquals(LogicalType.END_DEVICE, discoverer.getNode().getLogicalType());
+        assertFalse(discoverer.getTasks().contains(NodeDiscoveryTask.ROUTES));
+        assertFalse(discoverer.getTasks().contains(NodeDiscoveryTask.NEIGHBORS));
 
         Mockito.when(initialNodeDescriptor.getLogicalType()).thenReturn(LogicalType.ROUTER);
         discoverer.updateMesh();

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeNodeServiceDiscovererTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeNodeServiceDiscovererTest.java
@@ -119,7 +119,13 @@ public class ZigBeeNodeServiceDiscovererTest {
         NodeDescriptor initialNodeDescriptor = Mockito.mock(NodeDescriptor.class);
         Mockito.when(initialNodeDescriptor.getLogicalType()).thenReturn(LogicalType.UNKNOWN);
         Mockito.when(node.getNodeDescriptor()).thenReturn(initialNodeDescriptor);
-
+        Mockito.when(node.getLogicalType()).thenAnswer(x -> {
+            if (node.getNodeDescriptor() == null) {
+                return LogicalType.UNKNOWN;
+            } else {
+                return node.getNodeDescriptor().getLogicalType();
+            }
+        });
         PowerDescriptor initialPowerDescriptor = Mockito.mock(PowerDescriptor.class);
         Mockito.when(initialPowerDescriptor.getCurrentPowerMode()).thenReturn(CurrentPowerModeType.UNKNOWN);
         Mockito.when(node.getPowerDescriptor()).thenReturn(initialPowerDescriptor);
@@ -235,7 +241,13 @@ public class ZigBeeNodeServiceDiscovererTest {
         NodeDescriptor initialNodeDescriptor = Mockito.mock(NodeDescriptor.class);
         Mockito.when(initialNodeDescriptor.getLogicalType()).thenReturn(LogicalType.UNKNOWN);
         Mockito.when(node.getNodeDescriptor()).thenReturn(initialNodeDescriptor);
-
+        Mockito.when(node.getLogicalType()).thenAnswer(x -> {
+            if (node.getNodeDescriptor() == null) {
+                return LogicalType.UNKNOWN;
+            } else {
+                return node.getNodeDescriptor().getLogicalType();
+            }
+        });
         PowerDescriptor initialPowerDescriptor = Mockito.mock(PowerDescriptor.class);
         Mockito.when(initialPowerDescriptor.getCurrentPowerMode()).thenReturn(CurrentPowerModeType.UNKNOWN);
         Mockito.when(node.getPowerDescriptor()).thenReturn(initialPowerDescriptor);


### PR DESCRIPTION
Both Mgmt_Lqi_req and Mgmt_Rtg_req must only be sent to a router or coordinator.

The ZigBeeNodeServiceDiscoverer did not verify this when discovering/updating neighbour information.