### PR TITLE
Use transactionId property in ZdoCommand as the sequence number 

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/ZdoCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/ZdoCommand.java
@@ -21,11 +21,15 @@ public abstract class ZdoCommand extends ZigBeeCommand {
 
     @Override
     public void serialize(ZclFieldSerializer serializer) {
-        serializer.serialize(0, ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        if (getTransactionId() == null) {
+            setTransactionId(0);
+        }
+        serializer.serialize(getTransactionId(), ZclDataType.UNSIGNED_8_BIT_INTEGER);
     }
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        Integer sequenceNumber = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        setTransactionId(sequenceNumber);
     }
 }


### PR DESCRIPTION
If no sequence number is provided, a value of 0 is used as before.  It may be possible to assign more distinct sequence numbers using a windowing system if the NCP makes responses to  internally generated  ZDO  messages available to the application.  

When serializing:
If no sequence number is provided in the transactionId property, set the transactionId to zero.
Use the value of transactionId as the sequence number.

When deserializing:
Set the transactionId property to the value of the received sequence number

Signed-off-by: Simon Spero <sesuncedu@gmail.com>