### PR TITLE
Remove animal sniffer checks on autocoder

### DIFF
--- a/com.zsmartsystems.zigbee.autocode/pom.xml
+++ b/com.zsmartsystems.zigbee.autocode/pom.xml
@@ -38,7 +38,19 @@
 					</execution>
 				</executions>
 			</plugin>
-
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>animal-sniffer-maven-plugin</artifactId>
+				<version>1.16</version>
+				<configuration>
+				</configuration>
+				<executions>
+					<execution>
+						<id>animal-sniffer</id>
+						<phase />
+					</execution>
+				</executions>
+			</plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
Checks failed doing a ```mvn deploy```.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>