### PR TITLE
Improve handling of Ember network startup wait

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/EmberNcp.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/EmberNcp.java
@@ -246,7 +246,6 @@ public class EmberNcp {
         EzspTransaction transaction = protocolHandler
                 .sendEzspTransaction(new EzspSingleResponseTransaction(request, EzspNetworkStateResponse.class));
         EzspNetworkStateResponse response = (EzspNetworkStateResponse) transaction.getResponse();
-        logger.debug(response.toString());
         lastStatus = null;
 
         return response.getStatus();


### PR DESCRIPTION
This splits out the startup wait in the Ember NCP where we wait for the NCP to come online. The main improvement here is that if the NCP transitions to ```EMBER_NO_NETWORK``` after being in ```EMBER_JOINING_NETWORK``` then it will immediately return rather than waiting for the full timeout.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>