### PR TITLE
Fix bug defining clusters in EZSP AddEndpoint

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/EmberNcp.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/EmberNcp.java
@@ -306,8 +306,8 @@ public class EmberNcp {
         request.setEndpoint(endpointId);
         request.setDeviceId(deviceId);
         request.setProfileId(profileId);
-        request.setInputClusterList(new int[] { 0 });
-        request.setOutputClusterList(new int[] { 0 });
+        request.setInputClusterList(inputClusters);
+        request.setOutputClusterList(outputClusters);
         EzspTransaction transaction = protocolHandler
                 .sendEzspTransaction(new EzspSingleResponseTransaction(request, EzspAddEndpointResponse.class));
         EzspAddEndpointResponse response = (EzspAddEndpointResponse) transaction.getResponse();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
@@ -448,6 +448,10 @@ public class ZigBeeDongleEzsp implements ZigBeeTransportTransmit, ZigBeeTranspor
         EmberNcp ncp = getEmberNcp();
 
         // Add the endpoint
+        logger.debug("EZSP Adding Endpoint: ProfileID={}, DeviceID={}", String.format("%04X", defaultProfileId),
+                String.format("%04X", defaultDeviceId));
+        logger.debug("EZSP Adding Endpoint: Input Clusters   {}", inputClusters);
+        logger.debug("EZSP Adding Endpoint: Output Clusters  {}", outputClusters);
         ncp.addEndpoint(1, defaultDeviceId, defaultProfileId, inputClusters, outputClusters);
 
         // Now initialise the network


### PR DESCRIPTION
Fix bug setting the cluster definitions when adding Ember endpoints.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>