### PR TITLE
Allow updates of endpoints to add clusters

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
@@ -1444,7 +1444,8 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
             return;
         }
 
-        logger.debug("{}: Updating node NWK={}", node.getIeeeAddress(), node.getNetworkAddress());
+        logger.debug("{}: Updating node NWK={}", node.getIeeeAddress(),
+                String.format("%04X", node.getNetworkAddress()));
 
         synchronized (networkNodes) {
             // Don't add if the node is already known
@@ -1509,7 +1510,7 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
             sendNodeAdded = true;
         } else if (!currentNode.isDiscovered() && !currentNode.getIeeeAddress().equals(localIeeeAddress)) {
             logger.debug("{}: Node {} discovery is not complete - not sending nodeUpdated notification",
-                    node.getIeeeAddress(), node.getNetworkAddress());
+                    node.getIeeeAddress(), String.format("%04X", node.getNetworkAddress()));
             return;
         } else {
             sendNodeAdded = false;

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeEndpointTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeEndpointTest.java
@@ -212,6 +212,30 @@ public class ZigBeeEndpointTest {
     }
 
     @Test
+    public void updateEndpoint() {
+        ZigBeeEndpoint endpoint1 = getEndpoint();
+        ZigBeeEndpoint endpoint2 = new ZigBeeEndpoint(node, 5);
+
+        assertFalse(endpoint1.updateEndpoint(endpoint2));
+
+        List<Integer> clusterIds = new ArrayList<>();
+        clusterIds.add(1);
+        clusterIds.add(2);
+        endpoint2.setInputClusterIds(clusterIds);
+        assertTrue(endpoint1.updateEndpoint(endpoint2));
+        assertEquals(endpoint1.getInputClusterIds().size(), 2);
+        assertTrue(endpoint1.getInputClusterIds().contains(1));
+        assertTrue(endpoint1.getInputClusterIds().contains(2));
+
+        endpoint2.setOutputClusterIds(clusterIds);
+        assertTrue(endpoint1.updateEndpoint(endpoint2));
+        assertEquals(endpoint1.getOutputClusterIds().size(), 2);
+        assertTrue(endpoint1.getOutputClusterIds().contains(1));
+        assertTrue(endpoint1.getOutputClusterIds().contains(2));
+
+    }
+
+    @Test
     public void setDao() {
         ZigBeeEndpoint endpoint = getEndpoint();
 
@@ -229,6 +253,7 @@ public class ZigBeeEndpointTest {
 
     private ZigBeeEndpoint getEndpoint() {
         node = Mockito.mock(ZigBeeNode.class);
+        Mockito.when(node.getIeeeAddress()).thenReturn(new IeeeAddress("1234567890ABCDEF"));
         Mockito.when(node.getNetworkAddress()).thenReturn(1234);
         commandCapture = ArgumentCaptor.forClass(ZigBeeCommand.class);
 


### PR DESCRIPTION
This adds an ```updateEndpoint``` method to the ```ZigBeeEndpoint``` class to allow updating of clusters. This allows incremental discovery of clusters which may be needed in some discovery implementations.

Additionally there are a few logging improvements in this PR - often these are aimed at trying to print cluster IDs consistently as a hex value.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>