### PR TITLE
Remove data store nodes when network is initialised

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/database/ZigBeeNetworkDatabaseManager.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/database/ZigBeeNetworkDatabaseManager.java
@@ -148,12 +148,28 @@ public class ZigBeeNetworkDatabaseManager implements ZigBeeNetworkNodeListener {
     }
 
     /**
+     * Clears all data from the data store. This may be used when initialising a network to remove any previous data.
+     */
+    public void clear() {
+        if (dataStore == null) {
+            logger.debug("Data store: Undefined so network is not cleared.");
+            return;
+        }
+
+        logger.debug("Data store:  Clearing all nodes.");
+        Set<IeeeAddress> nodes = dataStore.readNetworkNodes();
+        for (IeeeAddress nodeAddress : nodes) {
+            dataStore.removeNode(nodeAddress);
+        }
+    }
+
+    /**
      * Starts the database manager. This will call the {@link ZigBeeNetworkDataStore} to retrieve the list of nodes, and
      * then read all the nodes from the store, adding them to the {@link ZigBeeNetworkManager}.
      */
     public void startup() {
         if (dataStore == null) {
-            logger.debug("Data store: undefined so no network is restored.");
+            logger.debug("Data store: Undefined so network is not restored.");
             return;
         }
 
@@ -178,13 +194,13 @@ public class ZigBeeNetworkDatabaseManager implements ZigBeeNetworkNodeListener {
      * the network is saved.
      */
     public void shutdown() {
-        logger.debug("Data store: shutting down.");
+        logger.debug("Data store: Shutting down.");
         networkManager.removeNetworkNodeListener(this);
         executorService.shutdown();
         try {
             executorService.awaitTermination(SHUTDOWN_TIMEOUT, TimeUnit.MILLISECONDS);
         } catch (InterruptedException e) {
-            logger.debug("Data store: shutdown did not complete all tasks.");
+            logger.debug("Data store: Shutdown did not complete all tasks.");
         }
         executorService.shutdownNow();
     }

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/database/ZigBeeNetworkDatabaseManagerTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/database/ZigBeeNetworkDatabaseManagerTest.java
@@ -81,6 +81,7 @@ public class ZigBeeNetworkDatabaseManagerTest {
         Mockito.when(node.getIeeeAddress()).thenReturn(new IeeeAddress("1234567890ABCDEF"));
 
         // No data store - make sure nothing happens
+        databaseManager.clear();
         databaseManager.nodeAdded(node);
         databaseManager.nodeUpdated(node);
         databaseManager.nodeRemoved(node);
@@ -90,6 +91,8 @@ public class ZigBeeNetworkDatabaseManagerTest {
         databaseManager.startup();
         Mockito.verify(networkManager, Mockito.times(1)).addNetworkNodeListener(databaseManager);
         Mockito.verify(networkManager, Mockito.times(1)).updateNode(ArgumentMatchers.any(ZigBeeNode.class));
+
+        databaseManager.setDeferredWriteTime(Integer.MAX_VALUE);
 
         databaseManager.setDeferredWriteTime(0);
 
@@ -125,6 +128,8 @@ public class ZigBeeNetworkDatabaseManagerTest {
 
         databaseManager.nodeRemoved(node);
         Mockito.verify(dataStore, Mockito.timeout(TIMEOUT).times(1)).removeNode(new IeeeAddress("1234567890ABCDEF"));
+
+        databaseManager.clear();
 
         databaseManager.shutdown();
         Mockito.verify(networkManager, Mockito.timeout(TIMEOUT).times(1)).removeNetworkNodeListener(databaseManager);


### PR DESCRIPTION
If the network is reinitialized, then all nodes are removed and the data store is cleared. This prevents attempting to discover nodes that have no hope of still being on the network once it is reinitialised.

Closes #813 

Signed-off-by: Chris Jackson <chris@cd-jackson.com>