### PR TITLE
Only respond to supported local clusters

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/seclient/SmartEnergyClient.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/seclient/SmartEnergyClient.java
@@ -776,6 +776,7 @@ public class SmartEnergyClient implements ZigBeeNetworkExtension, ZigBeeCommandL
             logger.debug("{}: SEP node is not authorised", node.getIeeeAddress());
             return;
         }
+        logger.debug("{}: SEP node is authorised", node.getIeeeAddress());
 
         for (ZigBeeEndpoint endpoint : node.getEndpoints()) {
             if (endpoint.getProfileId() != ZigBeeProfileType.ZIGBEE_SMART_ENERGY.getKey()) {

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/internal/ClusterMatcher.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/internal/ClusterMatcher.java
@@ -43,9 +43,14 @@ public class ClusterMatcher implements ZigBeeCommandListener {
     private ZigBeeNetworkManager networkManager;
 
     /**
-     * List of clusters supported by the manager. This is used to respond to the {@link MatchDescriptorRequest}
+     * List of client clusters supported by the manager. This is used to respond to the {@link MatchDescriptorRequest}
      */
-    private Set<Integer> clusters = new CopyOnWriteArraySet<>();
+    private Set<Integer> clientClusters = new CopyOnWriteArraySet<>();
+
+    /**
+     * List of client clusters supported by the manager. This is used to respond to the {@link MatchDescriptorRequest}
+     */
+    private Set<Integer> serverClusters = new CopyOnWriteArraySet<>();
 
     /**
      * Constructor
@@ -60,13 +65,43 @@ public class ClusterMatcher implements ZigBeeCommandListener {
     }
 
     /**
-     * Adds a cluster to the list of clusters we will match
+     * Adds a cluster to the list of client clusters we will match
      *
-     * @param cluster the cluster to match
+     * @param cluster the client cluster to match
      */
-    public void addCluster(int cluster) {
-        logger.debug("ClusterMatcher adding cluster {}", cluster);
-        clusters.add(cluster);
+    public void addClientCluster(int cluster) {
+        logger.debug("ClusterMatcher adding client cluster {}", String.format("%04X", cluster));
+        clientClusters.add(cluster);
+    }
+
+    /**
+     * Adds a cluster to the list of server clusters we will match
+     *
+     * @param cluster the server cluster to match
+     */
+    public void addServerCluster(int cluster) {
+        logger.debug("ClusterMatcher adding server cluster {}", String.format("%04X", cluster));
+        serverClusters.add(cluster);
+    }
+
+    /**
+     * Returns true if the requested cluster is supported as a client
+     *
+     * @param cluster the cluster to test
+     * @return true if the requested cluster is supported as a client
+     */
+    public boolean isClientSupported(int cluster) {
+        return clientClusters.contains(cluster);
+    }
+
+    /**
+     * Returns true if the requested cluster is supported as a server
+     *
+     * @param cluster the cluster to test
+     * @return true if the requested cluster is supported as a server
+     */
+    public boolean isServerSupported(int cluster) {
+        return serverClusters.contains(cluster);
     }
 
     @Override
@@ -87,8 +122,8 @@ public class ClusterMatcher implements ZigBeeCommandListener {
 
             // We want to match any of our local servers (ie our input clusters) with any
             // requested clusters in the requests cluster list
-            if (Collections.disjoint(matchRequest.getInClusterList(), clusters)
-                    && Collections.disjoint(matchRequest.getOutClusterList(), clusters)) {
+            if (Collections.disjoint(matchRequest.getInClusterList(), serverClusters)
+                    && Collections.disjoint(matchRequest.getOutClusterList(), clientClusters)) {
                 logger.debug("{}: ClusterMatcher no match", networkManager.getZigBeeExtendedPanId());
                 return;
             }

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeNetworkManagerTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeNetworkManagerTest.java
@@ -68,6 +68,7 @@ import com.zsmartsystems.zigbee.zcl.clusters.ZclOtaUpgradeCluster;
 import com.zsmartsystems.zigbee.zcl.clusters.ZclThermostatCluster;
 import com.zsmartsystems.zigbee.zcl.clusters.general.ReadAttributesCommand;
 import com.zsmartsystems.zigbee.zcl.clusters.onoff.OnCommand;
+import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 import com.zsmartsystems.zigbee.zdo.command.ManagementPermitJoiningRequest;
 import com.zsmartsystems.zigbee.zdo.field.NodeDescriptor;
 import com.zsmartsystems.zigbee.zdo.field.NodeDescriptor.LogicalType;
@@ -318,6 +319,7 @@ public class ZigBeeNetworkManagerTest
     public void testReceiveZclCommand() throws Exception {
         ZigBeeNetworkManager networkManager = mockZigBeeNetworkManager();
         networkManager.setSerializer(DefaultSerializer.class, DefaultDeserializer.class);
+        networkManager.addSupportedServerCluster(6);
 
         ZigBeeEndpoint endpoint = Mockito.mock(ZigBeeEndpoint.class);
         ZclCluster cluster = new ZclOnOffCluster(endpoint);
@@ -344,6 +346,7 @@ public class ZigBeeNetworkManagerTest
         zclHeader.setCommandId(0);
         zclHeader.setFrameType(ZclFrameType.ENTIRE_PROFILE_COMMAND);
         zclHeader.setSequenceNumber(1);
+        zclHeader.setDirection(ZclCommandDirection.CLIENT_TO_SERVER);
 
         DefaultSerializer serializer = new DefaultSerializer();
         ZclFieldSerializer fieldSerializer = new ZclFieldSerializer(serializer);
@@ -382,6 +385,7 @@ public class ZigBeeNetworkManagerTest
         Mockito.verify(mockedTransport, Mockito.timeout(TIMEOUT).times(1)).sendCommand(msgTagCaptor.capture(),
                 apsFrameCaptor.capture());
         ZigBeeApsFrame apsResponse = apsFrameCaptor.getValue();
+        assertEquals(4321, apsResponse.getDestinationAddress());
         int[] defaultResponsePayload = apsResponse.getPayload();
         assertEquals(5, defaultResponsePayload.length);
         assertEquals(ZclStatus.FAILURE.getId(), defaultResponsePayload[4]);
@@ -1134,6 +1138,14 @@ public class ZigBeeNetworkManagerTest
         networkManager.rescheduleTask(Mockito.mock(ScheduledFuture.class), Mockito.mock(Runnable.class), 0);
         Mockito.verify(scheduler, Mockito.times(4)).schedule(ArgumentMatchers.any(Runnable.class),
                 ArgumentMatchers.anyLong(), ArgumentMatchers.any(TimeUnit.class));
+    }
+
+    @Test
+    public void addSupportedCluster() throws Exception {
+        ZigBeeNetworkManager networkManager = mockZigBeeNetworkManager();
+
+        networkManager.addSupportedClientCluster(123);
+        networkManager.addSupportedServerCluster(456);
     }
 
 }

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/internal/ClusterMatcherTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/internal/ClusterMatcherTest.java
@@ -8,6 +8,8 @@
 package com.zsmartsystems.zigbee.internal;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -49,7 +51,7 @@ public class ClusterMatcherTest {
     @Test
     public void testMatcherNoMatch() {
         ClusterMatcher matcher = getMatcher();
-        matcher.addCluster(0x500);
+        matcher.addClientCluster(0x500);
 
         List<Integer> clusterListIn = new ArrayList<Integer>();
         List<Integer> clusterListOut = new ArrayList<Integer>();
@@ -67,7 +69,7 @@ public class ClusterMatcherTest {
     @Test
     public void testMatcherNoAddressMatch() {
         ClusterMatcher matcher = getMatcher();
-        matcher.addCluster(0x500);
+        matcher.addClientCluster(0x500);
 
         List<Integer> clusterListIn = new ArrayList<Integer>();
         List<Integer> clusterListOut = new ArrayList<Integer>();
@@ -85,7 +87,9 @@ public class ClusterMatcherTest {
     @Test
     public void testMatcherBroadcast() {
         ClusterMatcher matcher = getMatcher();
-        matcher.addCluster(0x500);
+        matcher.addServerCluster(0x500);
+        assertTrue(matcher.isServerSupported(0x500));
+        assertFalse(matcher.isClientSupported(0x500));
 
         List<Integer> clusterListIn = new ArrayList<Integer>();
         List<Integer> clusterListOut = new ArrayList<Integer>();
@@ -106,12 +110,14 @@ public class ClusterMatcherTest {
     @Test
     public void testMatcherMatchIn() {
         ClusterMatcher matcher = getMatcher();
-        matcher.addCluster(0x500);
-        matcher.addCluster(0x600);
+        matcher.addClientCluster(0x500);
+        matcher.addServerCluster(0x600);
+        assertTrue(matcher.isServerSupported(0x600));
+        assertTrue(matcher.isClientSupported(0x500));
 
         List<Integer> clusterListIn = new ArrayList<Integer>();
         List<Integer> clusterListOut = new ArrayList<Integer>();
-        clusterListIn.add(0x500);
+        clusterListIn.add(0x600);
         MatchDescriptorRequest request = new MatchDescriptorRequest();
         request.setNwkAddrOfInterest(0);
         request.setSourceAddress(new ZigBeeEndpointAddress(1234, 5));
@@ -126,8 +132,8 @@ public class ClusterMatcherTest {
     @Test
     public void testMatcherMatchOut() {
         ClusterMatcher matcher = getMatcher();
-        matcher.addCluster(0x500);
-        matcher.addCluster(0x600);
+        matcher.addClientCluster(0x500);
+        matcher.addServerCluster(0x600);
 
         List<Integer> clusterListIn = new ArrayList<Integer>();
         List<Integer> clusterListOut = new ArrayList<Integer>();
@@ -146,8 +152,8 @@ public class ClusterMatcherTest {
     @Test
     public void testMatcherMatchInOut() {
         ClusterMatcher matcher = getMatcher();
-        matcher.addCluster(0x500);
-        matcher.addCluster(0x600);
+        matcher.addClientCluster(0x500);
+        matcher.addServerCluster(0x600);
 
         List<Integer> clusterListIn = new ArrayList<Integer>();
         List<Integer> clusterListOut = new ArrayList<Integer>();


### PR DESCRIPTION
This adds support for local clusters within the ```ZigBeeNetworkManager```. It stops the framework responding to commands sent to local node if the local node doesn't support the cluster.

To support this, the ```ZigBeeNetworkManager``` needs to know what client and server clusters are supported, so additional methods have been added to the ```ZigBeeNetworkManager``` to support this.

This probably should be linked up with the transport configuration that does the same thing such that the NodeDescriptor is properly aligned.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>