### PR TITLE
Check commands received have correct local endpoint

### DIFF
--- a/com.zsmartsystems.zigbee/src/test/resource/logs/cluster-0006-OnOff.txt
+++ b/com.zsmartsystems.zigbee/src/test/resource/logs/cluster-0006-OnOff.txt
@@ -2,8 +2,8 @@
 # The format must be two lines, with a ZigBeeApsFrame frame followed by the ZigBeeCommand it translates to
 # Comments can be added with the # on the first character and empty lines are allowed
 
-ZigBeeApsFrame [sourceAddress=0/1, destinationAddress=18314/3, profile=0104, cluster=0006, addressMode=DEVICE, radius=31, apsSecurity=false, apsCounter=20, payload=01 20 00]
-OffCommand [On/Off: 0/1 -> 18314/3, cluster=0006, TID=20]
+ZigBeeApsFrame [sourceAddress=0/1, destinationAddress=18314/1, profile=0104, cluster=0006, addressMode=DEVICE, radius=31, apsSecurity=false, apsCounter=20, payload=01 20 00]
+OffCommand [On/Off: 0/1 -> 18314/1, cluster=0006, TID=20]
 
-ZigBeeApsFrame [sourceAddress=0/1, destinationAddress=18314/3, profile=0104, cluster=0006, addressMode=DEVICE, radius=0, apsSecurity=false, apsCounter=20, payload=01 45 42 00 08 07 00 00]
-OnWithTimedOffCommand [On/Off: 0/1 -> DEVICE, cluster=0006, TID=45, onOffControl=0, onTime=1800, offWaitTime=0]
+ZigBeeApsFrame [sourceAddress=0/1, destinationAddress=18314/1, profile=0104, cluster=0006, addressMode=DEVICE, radius=0, apsSecurity=false, apsCounter=20, payload=01 45 42 00 08 07 00 00]
+OnWithTimedOffCommand [On/Off: 0/1 -> 18314/1, cluster=0006, TID=45, onOffControl=0, onTime=1800, offWaitTime=0]

--- a/com.zsmartsystems.zigbee/src/test/resource/logs/cluster-0019-OtaUpgrade.txt
+++ b/com.zsmartsystems.zigbee/src/test/resource/logs/cluster-0019-OtaUpgrade.txt
@@ -2,5 +2,5 @@
 # The format must be two lines, with a ZigBeeApsFrame frame followed by the ZigBeeCommand it translates to
 # Comments can be added with the # on the first character and empty lines are allowed
 
-ZigBeeApsFrame [sourceAddress=0/1, destinationAddress=17784/4, profile=0104, cluster=0019, addressMode=DEVICE, radius=31, apsSecurity=false, apsCounter=D9, payload=09 D9 05 00 94 27 01 01 30 00 00 00 C4 38 03 00 24 80 02 79 00 02 12 11 C0 82 C0 83 7A 00 79 00 12 23 EA D2 87 90 61 96 74 06 F0 D0 83 D0 82 02 12 11 FF FF FF]
-ImageBlockResponse [OTA Upgrade: 0/0 -> 17784/4, cluster=0019, TID=D9, status=SUCCESS, manufacturerCode=10132, imageType=257, fileVersion=48, fileOffset=211140, imageData=ByteArray [value=80 02 79 00 02 12 11 C0 82 C0 83 7A 00 79 00 12 23 EA D2 87 90 61 96 74 06 F0 D0 83 D0 82 02 12 11 FF FF FF]]
+ZigBeeApsFrame [sourceAddress=0/1, destinationAddress=17784/1, profile=0104, cluster=0019, addressMode=DEVICE, radius=31, apsSecurity=false, apsCounter=D9, payload=09 D9 05 00 94 27 01 01 30 00 00 00 C4 38 03 00 24 80 02 79 00 02 12 11 C0 82 C0 83 7A 00 79 00 12 23 EA D2 87 90 61 96 74 06 F0 D0 83 D0 82 02 12 11 FF FF FF]
+ImageBlockResponse [OTA Upgrade: 0/0 -> 17784/1, cluster=0019, TID=D9, status=SUCCESS, manufacturerCode=10132, imageType=257, fileVersion=48, fileOffset=211140, imageData=ByteArray [value=80 02 79 00 02 12 11 C0 82 C0 83 7A 00 79 00 12 23 EA D2 87 90 61 96 74 06 F0 D0 83 D0 82 02 12 11 FF FF FF]]

--- a/com.zsmartsystems.zigbee/src/test/resource/logs/cluster-0300-ColorControl.txt
+++ b/com.zsmartsystems.zigbee/src/test/resource/logs/cluster-0300-ColorControl.txt
@@ -2,6 +2,6 @@
 # The format must be two lines, with a ZigBeeApsFrame frame followed by the ZigBeeCommand it translates to
 # Comments can be added with the # on the first character and empty lines are allowed
 
-ZigBeeApsFrame [sourceAddress=0/1, destinationAddress=28592/3, profile=0104, cluster=0300, addressMode=DEVICE, radius=31, apsSecurity=false, apsCounter=3C, payload=00 3C 00 00 00]
-ReadAttributesCommand [Color Control: 0/0 -> 28592/3, cluster=0300, TID=3C, identifiers=[0]]
+ZigBeeApsFrame [sourceAddress=0/1, destinationAddress=28592/1, profile=0104, cluster=0300, addressMode=DEVICE, radius=31, apsSecurity=false, apsCounter=3C, payload=00 3C 00 00 00]
+ReadAttributesCommand [Color Control: 0/0 -> 28592/1, cluster=0300, TID=3C, identifiers=[0]]
 

--- a/com.zsmartsystems.zigbee/src/test/resource/logs/cluster-FFFF-General.txt
+++ b/com.zsmartsystems.zigbee/src/test/resource/logs/cluster-FFFF-General.txt
@@ -2,11 +2,11 @@
 # The format must be two lines, with a ZigBeeApsFrame frame followed by the ZigBeeCommand it translates to
 # Comments can be added with the # on the first character and empty lines are allowed
 
-ZigBeeApsFrame [sourceAddress=0/1, destinationAddress=29303/3, profile=0104, cluster=0006, addressMode=DEVICE, radius=31, apsSecurity=false, apsCounter=51, payload=00 51 06 00 00 00 10 01 00 20 1C]
-ConfigureReportingCommand [On/Off: 0/1 -> 29303/3, cluster=0006, TID=51, records=[AttributeReportingConfigurationRecord [attributeDataType=BOOLEAN, attributeIdentifier=0, direction=0, minimumReportingInterval=1, maximumReportingInterval=7200]]]
+ZigBeeApsFrame [sourceAddress=0/1, destinationAddress=29303/1, profile=0104, cluster=0006, addressMode=DEVICE, radius=31, apsSecurity=false, apsCounter=51, payload=00 51 06 00 00 00 10 01 00 20 1C]
+ConfigureReportingCommand [On/Off: 0/1 -> 29303/1, cluster=0006, TID=51, records=[AttributeReportingConfigurationRecord [attributeDataType=BOOLEAN, attributeIdentifier=0, direction=0, minimumReportingInterval=1, maximumReportingInterval=7200]]]
 
-ZigBeeApsFrame [sourceAddress=0/1, destinationAddress=18314/3, profile=0104, cluster=0006, addressMode=DEVICE, radius=31, apsSecurity=false, apsCounter=15, payload=00 15 0C 00 00 0A]
-DiscoverAttributesCommand [On/Off: 0/1 -> 18314/3, cluster=0006, TID=15, startAttributeIdentifier=0, maximumAttributeIdentifiers=10]
+ZigBeeApsFrame [sourceAddress=0/1, destinationAddress=18314/1, profile=0104, cluster=0006, addressMode=DEVICE, radius=31, apsSecurity=false, apsCounter=15, payload=00 15 0C 00 00 0A]
+DiscoverAttributesCommand [On/Off: 0/1 -> 18314/1, cluster=0006, TID=15, startAttributeIdentifier=0, maximumAttributeIdentifiers=10]
 
 ZigBeeApsFrame [sourceAddress=0/1, destinationAddress=0/1, profile=0104, cluster=0006, addressMode=DEVICE, radius=0, apsSecurity=false, apsCounter=17, payload=18 15 0D 01 00 00 10 00 40 10 01 40 21 02 40 21]
 DiscoverAttributesResponse [On/Off: 0/1 -> 0/1, cluster=0006, TID=15, discoveryComplete=true, attributeInformation=[AttributeInformation [dataType=BOOLEAN, identifier=0], AttributeInformation [dataType=BOOLEAN, identifier=16384], AttributeInformation [dataType=UNSIGNED_16_BIT_INTEGER, identifier=16385], AttributeInformation [dataType=UNSIGNED_16_BIT_INTEGER, identifier=16386]]]
@@ -14,13 +14,13 @@ DiscoverAttributesResponse [On/Off: 0/1 -> 0/1, cluster=0006, TID=15, discoveryC
 ZigBeeApsFrame [sourceAddress=0/1, destinationAddress=0/1, profile=0104, cluster=0201, addressMode=DEVICE, radius=0, apsSecurity=false, apsCounter=00, payload=18 3D 0D 01]
 DiscoverAttributesResponse [Thermostat: 0/1 -> 0/1, cluster=0201, TID=3D, discoveryComplete=true, attributeInformation=[]]
 
-ZigBeeApsFrame [sourceAddress=0/1, destinationAddress=18314/3, profile=0104, cluster=0006, addressMode=DEVICE, radius=31, apsSecurity=false, apsCounter=11, payload=00 11 11 00 14]
+ZigBeeApsFrame [sourceAddress=0/1, destinationAddress=18314/1, profile=0104, cluster=0006, addressMode=DEVICE, radius=31, apsSecurity=false, apsCounter=11, payload=00 11 11 00 14]
 DiscoverCommandsReceived [On/Off: 0/1 -> 0/1, cluster=0006, TID=11, startCommandIdentifier=0, maximumCommandIdentifiers=20]
 
 ZigBeeApsFrame [sourceAddress=0/1, destinationAddress=37410/1, profile=0104, cluster=0B04, addressMode=DEVICE, radius=31, sequence=40, payload=00 28 06 00 08 05 21 03 00 20 1C 01 00]
 ConfigureReportingCommand [Electrical Measurement: 0/1 -> 37410/1, cluster=0B04, TID=28, records=[AttributeReportingConfigurationRecord [attributeDataType=UNSIGNED_16_BIT_INTEGER, attributeIdentifier=1288, direction=0, minimumReportingInterval=3, maximumReportingInterval=7200, reportableChange=1]]]
 
-ZigBeeApsFrame [sourceAddress=0/1, destinationAddress=0/0, profile=0104, cluster=0B04, addressMode=DEVICE, radius=0, sequence=0, payload=08 28 07 00]
+ZigBeeApsFrame [sourceAddress=0/1, destinationAddress=0/1, profile=0104, cluster=0B04, addressMode=DEVICE, radius=0, sequence=0, payload=08 28 07 00]
 ConfigureReportingResponse [Electrical Measurement: 0/1 -> 0/0, cluster=0B04, TID=28, status=SUCCESS, records=null]
 
 ZigBeeApsFrame [sourceAddress=0/1, destinationAddress=0/1, profile=0104, cluster=0702, addressMode=DEVICE, radius=0, apsSecurity=false, apsCounter=2A, payload=18 3E 01 00 00 00 48 08 02 00 00 00]


### PR DESCRIPTION
This performs a check that all received commands are for endpoint 0 if the command is using the ZDP, or endpoint 1 if it is a ZCL command.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>