### PR TITLE
Don't reprocess EZSP messages consumed by transactions in ZigBeeDongleEzsp::handlePacket

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
@@ -924,6 +924,13 @@ public class ZigBeeDongleEzsp implements ZigBeeTransportTransmit, ZigBeeTranspor
             }
             return;
         }
+        if (response.isCallback()) {
+            logger.debug("handlePacket: Discarding unhandled EZSP callback: {}", response);
+        } else if (!response.isResponse()) {
+            logger.debug("handlePacket: Discarding unhandled EZSP request: {}", response);
+        } else {
+            logger.warn("handlePacket: Discarding unhandled EZSP response: {}", response);
+        }
     }
 
     @Override

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/EzspFrame.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/EzspFrame.java
@@ -398,6 +398,21 @@ public abstract class EzspFrame {
     }
 
     /**
+     * Is this frame is a callback.
+     *
+     * @return true if this frame is a callback
+     */
+    public boolean isCallback() {
+        if (!isResponse) {
+            return false;
+        } else {
+            final int callbackTypeOffset = 3;
+            final int callbackTypeMask = 0b11 << callbackTypeOffset;
+            return (frameControl & callbackTypeMask) >> callbackTypeOffset != 0;
+        }
+    }
+
+    /**
      * Gets the Ember frame ID for this frame
      *
      * @return the Ember frame Id
@@ -465,4 +480,5 @@ public abstract class EzspFrame {
     public static int getEzspVersion() {
         return EzspFrame.ezspVersion;
     }
+
 }

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/EzspFrame.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/EzspFrame.java
@@ -408,7 +408,7 @@ public abstract class EzspFrame {
         } else {
             final int callbackTypeOffset = 3;
             final int callbackTypeMask = 0b11 << callbackTypeOffset;
-            return (frameControl & callbackTypeMask) >> callbackTypeOffset != 0;
+            return (frameControl & callbackTypeMask) != 0;
         }
     }
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/ash/AshFrameHandler.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/ash/AshFrameHandler.java
@@ -202,8 +202,10 @@ public class AshFrameHandler implements EzspProtocolHandler {
                                         if (response == null) {
                                             logger.debug("ASH: No frame handler created for {}", packet);
                                         } else {
-                                            notifyTransactionComplete(response);
-                                            handleIncomingFrame(response);
+                                            if (!notifyTransactionComplete(response)) {
+                                                logger.trace("ASH: no EZSP transaction match for {}", response);
+                                                handleIncomingFrame(response);
+                                            }
                                         }
                                     } else if (!dataPacket.getReTx()) {
                                         // Send a NAK - this is out of sequence and not a retransmission
@@ -702,14 +704,14 @@ public class AshFrameHandler implements EzspProtocolHandler {
 
             @Override
             public boolean transactionEvent(EzspFrameResponse ezspResponse) {
-                // Check if this response completes our transaction
-                if (!ezspTransaction.isMatch(ezspResponse)) {
+                // Check to see if response was processed
+                if (!ezspTransaction.handleResponse(ezspResponse)) {
                     return false;
                 }
-
-                transactionComplete();
-                // response = request;
-
+                // check to see if transaction was completed
+                if (ezspTransaction.isComplete()) {
+                    transactionComplete();
+                }
                 return true;
             }
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/spi/SpiFrameHandler.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/spi/SpiFrameHandler.java
@@ -719,17 +719,17 @@ public class SpiFrameHandler implements EzspProtocolHandler {
 
             @Override
             public boolean transactionEvent(EzspFrameResponse ezspResponse) {
-                // Check if this response completes our transaction
-                if (!ezspTransaction.isMatch(ezspResponse)) {
+                // Check if this response was handled
+                if (!ezspTransaction.handleResponse(ezspResponse)) {
                     return false;
                 }
 
-                // response = request;
-                synchronized (this) {
-                    complete = true;
-                    notify();
+                if (ezspTransaction.isComplete()) {
+                    synchronized (this) {
+                        complete = true;
+                        notify();
+                    }
                 }
-
                 return true;
             }
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/transaction/EzspMultiResponseTransaction.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/transaction/EzspMultiResponseTransaction.java
@@ -10,6 +10,7 @@ package com.zsmartsystems.zigbee.dongle.ember.internal.transaction;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.EzspFrame;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.EzspFrameRequest;
@@ -60,20 +61,28 @@ public class EzspMultiResponseTransaction implements EzspTransaction {
         this.relatedResponses = relatedResponses;
     }
 
+    private AtomicBoolean complete = new AtomicBoolean();
+
     @Override
-    public synchronized boolean isMatch(EzspFrameResponse response) {
+    public boolean isComplete() {
+        return complete.get();
+    }
+
+    @Override
+    public synchronized boolean handleResponse(EzspFrameResponse response) {
         // Check if this response is related to this transaction
         if (relatedResponses.contains(response.getClass())) {
             // TODO: Check for a failure
 
             // Add the response to our responses received list
             responses.add(response);
-            return false;
+            return true;
         }
 
         // Check if this response completes the transaction
         if (response.getClass() == requiredResponse) {
             responses.add(response);
+            complete.set(true);
             return true;
         } else {
             return false;

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/transaction/EzspSingleResponseTransaction.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/transaction/EzspSingleResponseTransaction.java
@@ -33,7 +33,12 @@ public class EzspSingleResponseTransaction implements EzspTransaction {
     }
 
     @Override
-    public boolean isMatch(EzspFrameResponse response) {
+    public boolean isComplete() {
+        return response != null;
+    }
+
+    @Override
+    public boolean handleResponse(EzspFrameResponse response) {
         if (response.getClass() == requiredResponse && request.getSequenceNumber() == response.getSequenceNumber()) {
             this.response = response;
             return true;

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/transaction/EzspTransaction.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/transaction/EzspTransaction.java
@@ -16,20 +16,26 @@ import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EmberStatus;
 /**
  * Interface for EZSP protocol transaction.
  * <p>
- * The transaction looks for a {@link EzspFrameResponse} that matches the {@link EzspFrameRequest}.
- * The {@link EzspFrameResponse} and {@link EzspFrameRequest} classes are provided when the transaction is created.
+ * The transaction looks for a {@link EzspFrameResponse} that matches the {@link EzspFrameRequest}. The {@link
+ * EzspFrameResponse} and {@link EzspFrameRequest} classes are provided when the transaction is created.
  *
  * @author Chris Jackson
- *
  */
 public interface EzspTransaction {
+
+    /**
+     * Check transaction completion status
+     */
+    boolean isComplete();
+
     /**
      * Matches request and response.
      *
      * @param response the response {@link EzspFrameResponse}
+     *
      * @return true if response matches the request
      */
-    boolean isMatch(EzspFrameResponse response);
+    boolean handleResponse(EzspFrameResponse response);
 
     /**
      * Gets the {@link EzspFrameRequest} associated with this transaction

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/transaction/EzspMultiResponseTransactionTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/transaction/EzspMultiResponseTransactionTest.java
@@ -26,7 +26,6 @@ import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspStartScanRequest;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspStartScanResponse;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EmberStatus;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EzspNetworkScanType;
-import com.zsmartsystems.zigbee.dongle.ember.internal.transaction.EzspMultiResponseTransaction;
 
 /**
  *
@@ -41,30 +40,38 @@ public class EzspMultiResponseTransactionTest extends EzspFrameTest {
         request.setDuration(1);
         request.setScanType(EzspNetworkScanType.EZSP_ENERGY_SCAN);
 
-        Set<Class<?>> relatedResponses = new HashSet<Class<?>>(Arrays.asList(EzspStartScanResponse.class,
-                EzspNetworkFoundHandler.class, EzspEnergyScanResultHandler.class));
+        Set<Class<?>> relatedResponses = new HashSet<Class<?>>(
+                Arrays.asList(EzspStartScanResponse.class, EzspNetworkFoundHandler.class,
+                        EzspEnergyScanResultHandler.class));
         EzspMultiResponseTransaction transaction = new EzspMultiResponseTransaction(request,
                 EzspScanCompleteHandler.class, relatedResponses);
 
         EzspStartScanResponse scanResponse = new EzspStartScanResponse(getPacketData("39 80 1A 00"));
         System.out.println(scanResponse);
-        assertFalse(transaction.isMatch(scanResponse));
+        assertTrue("message handled", transaction.handleResponse(scanResponse));
+        assertFalse(transaction.isComplete());
         EzspEnergyScanResultHandler scanResult = new EzspEnergyScanResultHandler(getPacketData("39 8C 48 0B C1"));
         System.out.println(scanResult);
-        assertFalse(transaction.isMatch(scanResult));
+        assertTrue("message handled", transaction.handleResponse(scanResult));
+        assertFalse(transaction.isComplete());
         scanResult = new EzspEnergyScanResultHandler(getPacketData("3A 8C 48 0E C6"));
         System.out.println(scanResult);
-        assertFalse(transaction.isMatch(scanResult));
+        assertTrue("message handled", transaction.handleResponse(scanResult));
+        assertFalse(transaction.isComplete());
         scanResult = new EzspEnergyScanResultHandler(getPacketData("3B 8C 48 0F B4"));
         System.out.println(scanResult);
-        assertFalse(transaction.isMatch(scanResult));
+        assertTrue("message handled", transaction.handleResponse(scanResult));
+        assertFalse(transaction.isComplete());
         scanResult = new EzspEnergyScanResultHandler(getPacketData("3B 8C 48 10 AA"));
-        assertFalse(transaction.isMatch(scanResult));
+        assertTrue("message handled", transaction.handleResponse(scanResult));
+        assertFalse(transaction.isComplete());
         scanResult = new EzspEnergyScanResultHandler(getPacketData("3C 8C 48 12 B3"));
-        assertFalse(transaction.isMatch(scanResult));
+        assertTrue("message handled", transaction.handleResponse(scanResult));
+        assertFalse(transaction.isComplete());
         EzspScanCompleteHandler scanComplete = new EzspScanCompleteHandler(getPacketData("3F 88 1C 02 00"));
         System.out.println(scanComplete);
-        assertTrue(transaction.isMatch(scanComplete));
+        assertTrue(transaction.handleResponse(scanComplete));
+        assertTrue(transaction.isComplete());
 
         EzspScanCompleteHandler response = (EzspScanCompleteHandler) transaction.getResponse();
         assertEquals(2, response.getChannel());

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/transaction/EzspScanTransactionTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/transaction/EzspScanTransactionTest.java
@@ -27,7 +27,6 @@ import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspStartScanRequest;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspStartScanResponse;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EmberStatus;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EzspNetworkScanType;
-import com.zsmartsystems.zigbee.dongle.ember.internal.transaction.EzspMultiResponseTransaction;
 
 /**
  *
@@ -43,8 +42,9 @@ public class EzspScanTransactionTest extends EzspFrameTest {
         energyScan.setSequenceNumber(3);
         energyScan.setScanType(EzspNetworkScanType.EZSP_ENERGY_SCAN);
 
-        Set<Class<?>> relatedResponses = new HashSet<Class<?>>(Arrays.asList(EzspStartScanResponse.class,
-                EzspNetworkFoundHandler.class, EzspEnergyScanResultHandler.class));
+        Set<Class<?>> relatedResponses = new HashSet<Class<?>>(
+                Arrays.asList(EzspStartScanResponse.class, EzspNetworkFoundHandler.class,
+                        EzspEnergyScanResultHandler.class));
         EzspMultiResponseTransaction scanTransaction = new EzspMultiResponseTransaction(energyScan,
                 EzspScanCompleteHandler.class, relatedResponses);
 
@@ -52,27 +52,33 @@ public class EzspScanTransactionTest extends EzspFrameTest {
 
         // Start Scan Response
         response = new EzspStartScanResponse(getPacketData("03 80 1A 00"));
-        assertFalse(scanTransaction.isMatch(response));
+        assertTrue(scanTransaction.handleResponse(response));
+        assertFalse(scanTransaction.isComplete());
 
         response = new EzspEnergyScanResultHandler(getPacketData("03 90 48 0B 9D"));
         assertEquals(11, ((EzspEnergyScanResultHandler) response).getChannel());
         assertEquals(-99, ((EzspEnergyScanResultHandler) response).getMaxRssiValue());
-        assertFalse(scanTransaction.isMatch(response));
+        assertTrue(scanTransaction.handleResponse(response));
+        assertFalse(scanTransaction.isComplete());
 
         response = new EzspEnergyScanResultHandler(getPacketData("03 90 48 0C 9D"));
-        assertFalse(scanTransaction.isMatch(response));
+        assertTrue(scanTransaction.handleResponse(response));
+        assertFalse(scanTransaction.isComplete());
 
         response = new EzspEnergyScanResultHandler(getPacketData("03 90 48 0D AB"));
         assertEquals(13, ((EzspEnergyScanResultHandler) response).getChannel());
         assertEquals(-85, ((EzspEnergyScanResultHandler) response).getMaxRssiValue());
-        assertFalse(scanTransaction.isMatch(response));
+        assertTrue(scanTransaction.handleResponse(response));
+        assertFalse(scanTransaction.isComplete());
 
         response = new EzspEnergyScanResultHandler(getPacketData("03 90 48 0E 9D"));
-        assertFalse(scanTransaction.isMatch(response));
+        assertTrue(scanTransaction.handleResponse(response));
+        assertFalse(scanTransaction.isComplete());
 
         response = new EzspScanCompleteHandler(getPacketData("03 90 1C 0B 00"));
         assertEquals(EmberStatus.EMBER_SUCCESS, ((EzspScanCompleteHandler) response).getStatus());
-        assertTrue(scanTransaction.isMatch(response));
+        assertTrue(scanTransaction.handleResponse(response));
+        assertTrue(scanTransaction.isComplete());
 
         assertEquals(6, scanTransaction.getResponses().size());
         assertTrue(scanTransaction.getResponses().get(0) instanceof EzspStartScanResponse);

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/transaction/EzspSingleResponseTransactionTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/transaction/EzspSingleResponseTransactionTest.java
@@ -18,8 +18,6 @@ import org.junit.Test;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.EzspFrameTest;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspVersionRequest;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspVersionResponse;
-import com.zsmartsystems.zigbee.dongle.ember.internal.transaction.EzspSingleResponseTransaction;
-import com.zsmartsystems.zigbee.dongle.ember.internal.transaction.EzspTransaction;
 
 /**
  *
@@ -37,7 +35,7 @@ public class EzspSingleResponseTransactionTest extends EzspFrameTest {
 
         EzspVersionResponse versionResponse = new EzspVersionResponse(getPacketData("03 80 00 04 02 00 58"));
 
-        assertTrue(versionTransaction.isMatch(versionResponse));
+        assertTrue(versionTransaction.handleResponse(versionResponse));
 
         versionTransaction.getRequest();
         assertEquals(1, versionTransaction.getResponses().size());
@@ -55,7 +53,7 @@ public class EzspSingleResponseTransactionTest extends EzspFrameTest {
 
         EzspVersionResponse versionResponse = new EzspVersionResponse(getPacketData("03 80 00 04 02 00 58"));
 
-        assertFalse(versionTransaction.isMatch(versionResponse));
+        assertFalse(versionTransaction.handleResponse(versionResponse));
         assertNull(versionTransaction.getResponse());
         assertNull(versionTransaction.getResponses());
     }


### PR DESCRIPTION
This PR contains changes previously included in an earlier transaction related PR. 

- Don't pass ezsp messages to ZigBeeDongleEzsp::handlePacket if they are consumed by a transaction.
- Rename of EzspTransaction::isMatch to handleResponse.
- Define semantics of handleResponse to return true iff the message is consumed, even it is part of a multi-response transaction.
- Add an isComplete method to EzspTransaction to indicate whether the last expected message in the transaction has been processed.
- Log discarded EZSP frames that are neither consumed by a transaction nor handled by ZigBeeDongleEzsp::handlePacket. 
  - Discarded  callbacks are logged at the debug level. 
  - Discarded  requests are logged at the debug level. 
  - Discarded responses are logged as warnings.

Signed-off-by: Simon Spero <sesuncedu@gmail.com>