### PR TITLE
Fix handling of SEP responses

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/basic/ZigBeeBasicServerExtension.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/basic/ZigBeeBasicServerExtension.java
@@ -57,12 +57,14 @@ public class ZigBeeBasicServerExtension implements ZigBeeNetworkExtension, ZigBe
 
     @Override
     public ZigBeeStatus extensionStartup() {
+        logger.debug("Basic Server Extension: Startup");
         networkManager.addNetworkNodeListener(this);
         return ZigBeeStatus.SUCCESS;
     }
 
     @Override
     public void extensionShutdown() {
+        logger.debug("Basic Server Extension: Shutdown");
     }
 
     @Override
@@ -83,6 +85,7 @@ public class ZigBeeBasicServerExtension implements ZigBeeNetworkExtension, ZigBe
             ZclBasicCluster cluster = new ZclBasicCluster(null);
             ZclAttribute attribute = cluster.getAttribute(attributeId);
             if (attribute == null) {
+                logger.debug("Basic Server Extension: Attribute {} not found", attributeId);
                 return false;
             }
             attributes.put(attributeId, attribute);

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeNodeServiceDiscoverer.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeNodeServiceDiscoverer.java
@@ -433,7 +433,7 @@ public class ZigBeeNodeServiceDiscoverer {
         // Get the simple descriptors for all endpoints
         List<ZigBeeEndpoint> endpoints = new ArrayList<ZigBeeEndpoint>();
         for (final int endpointId : activeEndpointsResponse.getActiveEpList()) {
-            ZigBeeEndpoint endpoint = getSimpleDescriptor(endpointId);
+            ZigBeeEndpoint endpoint = requestSimpleDescriptor(endpointId);
             if (endpoint == null) {
                 return false;
             }
@@ -560,7 +560,7 @@ public class ZigBeeNodeServiceDiscoverer {
      * @throws ExecutionException
      * @throws InterruptedException
      */
-    private ZigBeeEndpoint getSimpleDescriptor(final int endpointId) throws InterruptedException, ExecutionException {
+    private ZigBeeEndpoint requestSimpleDescriptor(final int endpointId) throws InterruptedException, ExecutionException {
         final SimpleDescriptorRequest simpleDescriptorRequest = new SimpleDescriptorRequest();
         simpleDescriptorRequest.setDestinationAddress(new ZigBeeEndpointAddress(node.getNetworkAddress()));
         simpleDescriptorRequest.setNwkAddrOfInterest(node.getNetworkAddress());


### PR DESCRIPTION
This improves the SEP discovery, and adds the ability to define the Crypto Suite to be used. 

For the discovery, we now request the NodeDescriptor and SimpleDescriptor of the endpoint with the metering cluster.

If the Crypto Suite is defined manually, then the supported suites will not be requested from the TC during the CBKE. This is needed to avoid an issue with the CBKE where the ZigBee Alliance Test Harness always returns 0 (ie no suites supported).

Signed-off-by: Chris Jackson <chris@cd-jackson.com>