### PR TITLE
Clear Ember key table when joining a new network.

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/EmberNetworkInitialisation.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/EmberNetworkInitialisation.java
@@ -167,10 +167,11 @@ public class EmberNetworkInitialisation {
         logger.debug("Joining Ember network with configuration {}", networkParameters);
 
         // Leave the current network so we can initialise a new network
+        EmberNcp ncp = new EmberNcp(protocolHandler);
         if (checkNetworkJoined()) {
-            EmberNcp ncp = new EmberNcp(protocolHandler);
             ncp.leaveNetwork();
         }
+        ncp.clearKeyTable();
 
         // Initialise security - no network key as we'll get that from the coordinator
         setSecurityState(linkKey, null);


### PR DESCRIPTION
When joining a new network as a router, we should clear the Ember key table.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>