### PR TITLE
Partially revert #826 by not rejecting messages to unsupported client clusters. ISSUE #837

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
@@ -968,11 +968,6 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
 
         ZclCommand command;
         if (zclHeader.getDirection() == ZclCommandDirection.SERVER_TO_CLIENT) {
-            if (clusterMatcher != null && !clusterMatcher.isClientSupported(apsFrame.getCluster())) {
-                logger.debug("Unsupported local client cluster {}", String.format("%04X", apsFrame.getCluster()));
-                createDefaultResponse(apsFrame, zclHeader, ZclStatus.FAILURE);
-                return null;
-            }
             ZclCluster cluster = endpoint.getInputCluster(apsFrame.getCluster());
             if (cluster == null) {
                 logger.debug("Unknown input cluster {}", String.format("%04X", apsFrame.getCluster()));


### PR DESCRIPTION

These messages include responses to commands sent to servers.

This change does not change the results of any tests, but prevents desired responses from being dropped, such as read attribute responses and attribute reporting triggered by   device discovery or channel drivers when deployed in openhab.

I have not checked whether there are issues relating to rejected server commands remaining.

Signed-off-by: Simon Spero <sesuncedu@gmail.com>