### PR TITLE
Add check to CBKE to ensure certificate issuers are consistent

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/security/ZigBeeCertificate.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/security/ZigBeeCertificate.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2016-2019 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.security;
+
+import com.zsmartsystems.zigbee.IeeeAddress;
+import com.zsmartsystems.zigbee.zcl.field.ByteArray;
+
+/**
+ * Provides a base implementation of the {@link ZigBeeCertificate}
+ *
+ * @author Chris Jackson
+ *
+ */
+public abstract class ZigBeeCertificate {
+    protected ZigBeeCryptoSuites cryptoSuite;
+
+    /**
+     * Gets the {@link ZigBeeCryptoSuites} that is applicable for this certificate
+     *
+     * @return the {@link ZigBeeCryptoSuites}
+     */
+    public ZigBeeCryptoSuites getCryptoSuite() {
+        return cryptoSuite;
+    }
+
+    abstract public IeeeAddress getIssuer();
+
+    abstract public IeeeAddress getSubject();
+
+    /**
+     * Converts a hex string array into an integer array
+     *
+     * @param hexString a string of data to convert to an integer array
+     * @return the integer array representation of the string array
+     */
+    protected int[] hexStringToIntArray(String hexString) {
+        if (hexString.length() % 2 != 0) {
+            throw new IllegalArgumentException(
+                    "Certificate string '" + hexString + "' must be even number of bytes long.");
+        }
+
+        int[] output = new int[hexString.length() / 2];
+        char enc[] = hexString.toCharArray();
+        for (int i = 0; i < enc.length - 1; i += 2) {
+            StringBuilder curr = new StringBuilder(2);
+            curr.append(enc[i]).append(enc[i + 1]);
+            output[i / 2] = Integer.parseInt(curr.toString(), 16);
+        }
+
+        return output;
+    }
+
+    protected int[] reverseCopy(int[] input) {
+        int[] output = new int[input.length];
+
+        int inCnt = 0;
+        for (int outCnt = input.length - 1; outCnt >= 0; outCnt--) {
+            output[outCnt] = input[inCnt];
+            inCnt++;
+        }
+        return output;
+    }
+
+    protected void appendArray(StringBuilder builder, int[] array) {
+        boolean first = true;
+        for (int val : array) {
+            if (!first) {
+                builder.append(' ');
+            }
+            first = false;
+            builder.append(String.format("%02X", val));
+        }
+    }
+
+    /**
+     * Returns a {@link ByteArray} containing the certificate data
+     *
+     * @return a {@link ByteArray} containing the certificate data
+     */
+    public abstract ByteArray getByteArray();
+}

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/security/ZigBeeCryptoSuite1Certificate.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/security/ZigBeeCryptoSuite1Certificate.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2016-2019 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.security;
+
+import com.zsmartsystems.zigbee.IeeeAddress;
+import com.zsmartsystems.zigbee.zcl.field.ByteArray;
+
+/**
+ * A 48 byte key used in ZigBee Smart Energy Crypto Suite 1
+ *
+ * @author Chris Jackson
+ *
+ */
+public class ZigBeeCryptoSuite1Certificate extends ZigBeeCertificate {
+    private final ByteArray keyData;
+
+    /**
+     * Construct a key. Key data is assumed to contain the following format -:
+     * PublicReconstrKey || Subject || Issuer || ProfileAttributeData
+     * <ul>
+     * <li>PublicReconstrKey: the 22-byte representation of the public-key reconstruction data BEU as specified in the
+     * implicit certificate generation protocol, which is an elliptic-curve point.
+     * <li>Subject: the 8-byte identifier of the entity U that is bound to the public-key reconstruction data BEU during
+     * execution of the implicit certificate generation protocol (i.e., the extended, 64-bit IEEE 802.15.4 address of
+     * the device that purportedly owns the private key corresponding to the public key that can be reconstructed with
+     * PublicReconstrKey).
+     * <li>Issuer: the 8-byte identifier of the CA that creates the implicit certificate during the execution of the
+     * implicit certificate generation protocol (the so-called Certificate Authority).
+     * <li>ProfileAttributeData: the 10-byte sequence of octets that can be used by a ZigBee profile for any purpose.
+     * The first two bytes of this sequence is reserved as a profile identifier, which must be defined by another ZigBee
+     * standard.
+     * </ul>
+     *
+     * @param keyData
+     */
+    public ZigBeeCryptoSuite1Certificate(ByteArray keyData) {
+        cryptoSuite = ZigBeeCryptoSuites.ECC_163K1;
+        this.keyData = keyData;
+    }
+
+    /**
+     * @return the public key
+     */
+    public int[] getPublicKey() {
+        return keyData.getAsIntArray(0, 22);
+    }
+
+    @Override
+    public IeeeAddress getIssuer() {
+        return new IeeeAddress(reverseCopy(keyData.getAsIntArray(30, 38)));
+    }
+
+    @Override
+    public IeeeAddress getSubject() {
+        return new IeeeAddress(reverseCopy(keyData.getAsIntArray(22, 30)));
+    }
+
+    public int[] getAttributeData() {
+        return keyData.getAsIntArray(38, 48);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder(185);
+
+        builder.append("CryptoSuite1Certificate [issuer=");
+        builder.append(getIssuer());
+        builder.append(", subject=");
+        builder.append(getSubject());
+        builder.append(", publicKey=");
+        appendArray(builder, getPublicKey());
+        builder.append(", attributeData=");
+        appendArray(builder, getAttributeData());
+        builder.append(']');
+
+        return builder.toString();
+    }
+
+    @Override
+    public ByteArray getByteArray() {
+        return keyData;
+    }
+}

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/field/ByteArray.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/field/ByteArray.java
@@ -75,6 +75,23 @@ public class ByteArray {
     }
 
     /**
+     * Gets a segment of the byte array as an array of integers
+     *
+     * @param start the start offset of the range to return (inclusive)
+     * @param finish the end offset of the range to return (exclusive)
+     * @return the integer array containing the requested segment
+     */
+    public int[] getAsIntArray(int start, int finish) {
+        int intArray[] = new int[finish - start];
+        int outCnt = 0;
+        for (int cnt = start; cnt < finish; cnt++) {
+            intArray[outCnt++] = value[cnt] & 0xFF;
+        }
+
+        return intArray;
+    }
+
+    /**
      * Get the length of the underlying byte array
      *
      * @return the length of the data in the array

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/security/ZigBeeCryptoSuite1CertificateTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/security/ZigBeeCryptoSuite1CertificateTest.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2016-2019 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.security;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+
+import com.zsmartsystems.zigbee.IeeeAddress;
+import com.zsmartsystems.zigbee.zcl.field.ByteArray;
+
+/**
+ *
+ * @author Chris Jackson
+ *
+ */
+public class ZigBeeCryptoSuite1CertificateTest {
+
+    @Test
+    public void test() {
+        ByteArray data = new ByteArray(new int[] { 0x02, 0x07, 0x5F, 0xDC, 0x7B, 0x30, 0x19, 0xF8, 0xDB, 0x9D, 0x7D,
+                0x55, 0x34, 0x23, 0x4D, 0x38, 0x11, 0xC4, 0xD8, 0xB4, 0x3E, 0xF1, 0x00, 0x0D, 0x6F, 0x00, 0x00, 0x61,
+                0x4E, 0xDF, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x01, 0x09, 0x00, 0x01, 0x00, 0x00, 0x11,
+                0x22, 0x33, 0x44 });
+
+        ZigBeeCryptoSuite1Certificate certificate = new ZigBeeCryptoSuite1Certificate(data);
+        System.out.println(certificate);
+
+        assertEquals(ZigBeeCryptoSuites.ECC_163K1, certificate.getCryptoSuite());
+        assertEquals(new IeeeAddress("0102030405060708"), certificate.getIssuer());
+        assertEquals(new IeeeAddress("000D6F0000614EDF"), certificate.getSubject());
+        assertTrue(Arrays.equals(new int[] { 0x02, 0x07, 0x5F, 0xDC, 0x7B, 0x30, 0x19, 0xF8, 0xDB, 0x9D, 0x7D, 0x55,
+                0x34, 0x23, 0x4D, 0x38, 0x11, 0xC4, 0xD8, 0xB4, 0x3E, 0xF1 }, certificate.getPublicKey()));
+        assertTrue(Arrays.equals(new int[] { 0x01, 0x09, 0x00, 0x01, 0x00, 0x00, 0x11, 0x22, 0x33, 0x44 },
+                certificate.getAttributeData()));
+    }
+}

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zcl/field/ByteArrayTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zcl/field/ByteArrayTest.java
@@ -41,5 +41,8 @@ public class ByteArrayTest {
         assertEquals(new ByteArray(new byte[] { 2, 3, 4, 5, 6, 7 }), array);
 
         assertTrue(Arrays.equals(new int[] { 2, 3, 4, 5, 6, 7 }, array.getAsIntArray()));
+
+        array = new ByteArray(new int[] { 1, 2, 3, 4, 5, 6, 7, 8, 9 });
+        assertTrue(Arrays.equals(new int[] { 2, 3, 4, 5, 6, 7 }, array.getAsIntArray(1, 7)));
     }
 }


### PR DESCRIPTION
This primarily adds a required check to the CBKE to ensure that the issue on the local and remote certificates are consistent.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>