### PR TITLE
Complete ZCL transaction when APS ACK is received if no DefaultResponse requested

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransaction.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransaction.java
@@ -16,6 +16,7 @@ import com.zsmartsystems.zigbee.CommandResult;
 import com.zsmartsystems.zigbee.ZigBeeAddress;
 import com.zsmartsystems.zigbee.ZigBeeCommand;
 import com.zsmartsystems.zigbee.transport.ZigBeeTransportProgressState;
+import com.zsmartsystems.zigbee.zcl.ZclCommand;
 
 /**
  * Transaction class to handle the sending of commands and timeout in the event there is no response.
@@ -437,8 +438,9 @@ public class ZigBeeTransaction {
                     }
                     break;
                 case RX_ACK:
-                    // The remote device confirmed receipt of the command
-                    if (responseMatcher == null || state == TransactionState.RESPONDED) {
+                    // The remote device confirmed receipt of the command (ie APS ACK received)
+                    if (responseMatcher == null || state == TransactionState.RESPONDED
+                            || (command instanceof ZclCommand && ((ZclCommand) command).isDisableDefaultResponse())) {
                         // We've already received a response that completed the application level transaction,
                         // or we weren't waiting for a response - either way, we're done.
                         completeTransaction(completionCommand);

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransactionManager.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransactionManager.java
@@ -253,7 +253,7 @@ public class ZigBeeTransactionManager implements ZigBeeNetworkNodeListener {
     }
 
     /**
-     * Sets the default {@link ZigBeeTransactionProfile} for the node queues
+     * Sets the default {@link ZigBeeTransactionProfile} for the node queues.
      *
      * @param profile the {@link ZigBeeTransactionProfile}
      */
@@ -262,7 +262,7 @@ public class ZigBeeTransactionManager implements ZigBeeNetworkNodeListener {
     }
 
     /**
-     * Gets the default {@link ZigBeeTransactionProfile} for the node queues
+     * Gets the default {@link ZigBeeTransactionProfile} for the node queues.
      *
      * return the {@link ZigBeeTransactionProfile}
      */
@@ -271,7 +271,7 @@ public class ZigBeeTransactionManager implements ZigBeeNetworkNodeListener {
     }
 
     /**
-     * Sets the {@link ZigBeeTransactionProfile} for the sleepy node queues
+     * Sets the {@link ZigBeeTransactionProfile} for the sleepy node queues.
      *
      * @param profile the {@link ZigBeeTransactionProfile}
      */
@@ -280,7 +280,7 @@ public class ZigBeeTransactionManager implements ZigBeeNetworkNodeListener {
     }
 
     /**
-     * Gets the {@link ZigBeeTransactionProfile} for the sleepy node queues
+     * Gets the {@link ZigBeeTransactionProfile} for the sleepy node queues.
      *
      * return the {@link ZigBeeTransactionProfile}
      */
@@ -289,7 +289,7 @@ public class ZigBeeTransactionManager implements ZigBeeNetworkNodeListener {
     }
 
     /**
-     * Sets the {@link ZigBeeTransactionProfile} for the multicast queue
+     * Sets the {@link ZigBeeTransactionProfile} for the multicast queue.
      *
      * @param profile the {@link ZigBeeTransactionProfile}
      */
@@ -298,7 +298,7 @@ public class ZigBeeTransactionManager implements ZigBeeNetworkNodeListener {
     }
 
     /**
-     * Gets the {@link ZigBeeTransactionProfile} for the multicast queue
+     * Gets the {@link ZigBeeTransactionProfile} for the multicast queue.
      *
      * return the {@link ZigBeeTransactionProfile}
      */
@@ -307,7 +307,7 @@ public class ZigBeeTransactionManager implements ZigBeeNetworkNodeListener {
     }
 
     /**
-     * Sets the {@link ZigBeeTransactionProfile} for the broadcast queue
+     * Sets the {@link ZigBeeTransactionProfile} for the broadcast queue.
      *
      * @param profile the {@link ZigBeeTransactionProfile}
      */
@@ -316,7 +316,7 @@ public class ZigBeeTransactionManager implements ZigBeeNetworkNodeListener {
     }
 
     /**
-     * Gets the {@link ZigBeeTransactionProfile} for the broadcast queue
+     * Gets the {@link ZigBeeTransactionProfile} for the broadcast queue.
      *
      * return the {@link ZigBeeTransactionProfile}
      */
@@ -325,7 +325,7 @@ public class ZigBeeTransactionManager implements ZigBeeNetworkNodeListener {
     }
 
     /**
-     * Sends a command without waiting for a response
+     * Sends a command without waiting for a response. No retry mechanism will be implemented at application level.
      *
      * @param command the {@link ZigBeeCommand} to send
      */
@@ -357,7 +357,7 @@ public class ZigBeeTransactionManager implements ZigBeeNetworkNodeListener {
     }
 
     /**
-     * Adds a {@link ZigBeeTransaction} to the respective {@link ZigBeeTransactionQueue}
+     * Adds a {@link ZigBeeTransaction} to the respective {@link ZigBeeTransactionQueue}.
      *
      * @param transaction the {@link ZigBeeTransaction} to add to the queue. Not null.
      * @return the future {@link CommandResult}
@@ -468,7 +468,7 @@ public class ZigBeeTransactionManager implements ZigBeeNetworkNodeListener {
 
     /**
      * Adds a transaction to the list of outstanding transactions. Transactions will receive notifications when a
-     * command is received, or when the status is updated
+     * command is received, or when the status is updated.
      *
      * @param transaction the {@link ZigBeeTransaction} that will receive the notifications
      */

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransactionTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransactionTest.java
@@ -22,8 +22,10 @@ import org.mockito.Mockito;
 
 import com.zsmartsystems.zigbee.TestUtilities;
 import com.zsmartsystems.zigbee.ZigBeeCommand;
+import com.zsmartsystems.zigbee.ZigBeeEndpointAddress;
 import com.zsmartsystems.zigbee.transaction.ZigBeeTransaction.TransactionState;
 import com.zsmartsystems.zigbee.transport.ZigBeeTransportProgressState;
+import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.clusters.onoff.OffCommand;
 
 /**
@@ -161,6 +163,41 @@ public class ZigBeeTransactionTest {
     }
 
     @Test
+    public void testMatchedAfterRxAck() {
+        ZigBeeTransactionManager transactionManager = Mockito.mock(ZigBeeTransactionManager.class);
+        ZigBeeCommand command = Mockito.mock(ZigBeeCommand.class);
+        Mockito.when(command.getTransactionId()).thenReturn(12);
+        ZigBeeTransactionMatcher matcher = Mockito.mock(ZigBeeTransactionMatcher.class);
+
+        ZigBeeCommand request = Mockito.mock(ZigBeeCommand.class);
+        Mockito.when(matcher.isTransactionMatch(command, request)).thenReturn(true);
+
+        ZigBeeTransactionFuture transactionFuture = new ZigBeeTransactionFuture();
+
+        ZigBeeTransaction transaction = new ZigBeeTransaction(transactionManager, command, matcher);
+        transaction.setFuture(transactionFuture);
+
+        assertEquals(command, transaction.startTransaction());
+        Mockito.verify(transactionManager, Mockito.times(1)).scheduleTask(ArgumentMatchers.any(Runnable.class),
+                ArgumentMatchers.anyLong());
+
+        transaction.transactionStatusReceived(ZigBeeTransportProgressState.TX_ACK, 12);
+
+        Mockito.verify(transactionManager, Mockito.times(1)).scheduleTask(ArgumentMatchers.any(Runnable.class),
+                ArgumentMatchers.eq(8000L));
+
+        Mockito.verify(transactionManager, Mockito.never()).transactionComplete(transaction, TransactionState.COMPLETE);
+
+        transaction.transactionStatusReceived(ZigBeeTransportProgressState.RX_ACK, 12);
+        Mockito.verify(transactionManager, Mockito.never()).transactionComplete(transaction, TransactionState.COMPLETE);
+
+        transaction.commandReceived(request);
+
+        Mockito.verify(transactionManager, Mockito.times(1)).transactionComplete(transaction,
+                TransactionState.COMPLETE);
+    }
+
+    @Test
     public void testMatchedBeforeRxAck() {
         ZigBeeTransactionManager transactionManager = Mockito.mock(ZigBeeTransactionManager.class);
         ZigBeeCommand command = Mockito.mock(ZigBeeCommand.class);
@@ -187,6 +224,44 @@ public class ZigBeeTransactionTest {
         // We've updated state with TX_ACK, but not RX_ACK,
         // so providing the application response here should not complete the transaction
         transaction.commandReceived(request);
+        Mockito.verify(transactionManager, Mockito.never()).transactionComplete(transaction, TransactionState.COMPLETE);
+
+        transaction.transactionStatusReceived(ZigBeeTransportProgressState.RX_ACK, 12);
+
+        Mockito.verify(transactionManager, Mockito.times(1)).transactionComplete(transaction,
+                TransactionState.COMPLETE);
+    }
+
+    @Test
+    public void testZclNoDefaultResponse() {
+        ZigBeeTransactionManager transactionManager = Mockito.mock(ZigBeeTransactionManager.class);
+        ZclCommand command = Mockito.mock(ZclCommand.class);
+        Mockito.when(command.isDisableDefaultResponse()).thenReturn(true);
+        Mockito.when(command.getTransactionId()).thenReturn(12);
+        Mockito.when(command.getDestinationAddress()).thenReturn(new ZigBeeEndpointAddress(1234, 5));
+        ZigBeeTransactionMatcher matcher = Mockito.mock(ZigBeeTransactionMatcher.class);
+
+        ZigBeeCommand request = Mockito.mock(ZigBeeCommand.class);
+        Mockito.when(matcher.isTransactionMatch(command, request)).thenReturn(true);
+
+        ZigBeeTransactionFuture transactionFuture = new ZigBeeTransactionFuture();
+
+        ZigBeeTransaction transaction = new ZigBeeTransaction(transactionManager, command, matcher);
+        transaction.setFuture(transactionFuture);
+
+        assertEquals(new ZigBeeEndpointAddress(1234, 5), transaction.getDestinationAddress());
+
+        assertEquals(command, transaction.startTransaction());
+        Mockito.verify(transactionManager, Mockito.times(1)).scheduleTask(ArgumentMatchers.any(Runnable.class),
+                ArgumentMatchers.anyLong());
+
+        Mockito.verify(transactionManager, Mockito.never()).transactionComplete(transaction, TransactionState.COMPLETE);
+
+        transaction.transactionStatusReceived(ZigBeeTransportProgressState.TX_ACK, 12);
+
+        Mockito.verify(transactionManager, Mockito.times(1)).scheduleTask(ArgumentMatchers.any(Runnable.class),
+                ArgumentMatchers.eq(8000L));
+
         Mockito.verify(transactionManager, Mockito.never()).transactionComplete(transaction, TransactionState.COMPLETE);
 
         transaction.transactionStatusReceived(ZigBeeTransportProgressState.RX_ACK, 12);
@@ -316,6 +391,9 @@ public class ZigBeeTransactionTest {
         int timeout2 = transaction.getTimerPeriod1();
         transaction.setTimerPeriod1(timeout2 + 23);
         assertEquals(timeout2 + 23, transaction.getTimerPeriod1());
+
+        // No response matcher, so it should be ignored
+        transaction.commandReceived(null);
     }
 
     @Test


### PR DESCRIPTION
If a ```ZclCommand``` is sent and the default response is disabled, then we complete the transaction once the APS ACK is received to avoid a timeout waiting for the response that will never come.

Closes #845
Signed-off-by: Chris Jackson <chris@cd-jackson.com>