### PR TITLE
Pass the NodeDescriptor to the transport layer

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transport/ZigBeeTransportTransmit.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transport/ZigBeeTransportTransmit.java
@@ -17,6 +17,7 @@ import com.zsmartsystems.zigbee.aps.ZigBeeApsFrame;
 import com.zsmartsystems.zigbee.security.ZigBeeKey;
 import com.zsmartsystems.zigbee.serialization.ZigBeeDeserializer;
 import com.zsmartsystems.zigbee.serialization.ZigBeeSerializer;
+import com.zsmartsystems.zigbee.zdo.field.NodeDescriptor;
 
 /**
  * Defines the interface for data passed to the transport layer (ie dongle) from the ZigBee stack framework.
@@ -220,5 +221,17 @@ public interface ZigBeeTransportTransmit {
      * @param defaultDeviceId the device ID.
      */
     default void setDefaultDeviceId(int defaultDeviceId) {
+    }
+
+    /**
+     * Provides the node descriptor to the transport layer. The {@link NodeDescriptor} contains information that may be
+     * of use to the transport layer and this is provided when available.
+     * <p>
+     * The transport layer can assume that this will only be set once {@link #initialize} has been called.
+     *
+     * @param ieeeAddress the {@link IeeeAddress} of the node
+     * @param nodeDescriptor the {@link NodeDescriptor} of the node
+     */
+    default void setNodeDescriptor(IeeeAddress ieeeAddress, NodeDescriptor nodeDescriptor) {
     }
 }


### PR DESCRIPTION
This adds a ```setNodeDescriptor()``` method to the ```ZigBeeTransportTransmit``` interface. This allows the ```ZigBeeNetworkManager``` to provide the ```NodeDescriptor``` of a device to the transport since the ```NodeDescriptor``` contains information that may be of use to the transport such as the MAC capabilities.

A default implementation is provided in the ```ZigBeeTransportTransmit``` interface to avoid this being a breaking change.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>