### PR TITLE
Signal application to leave network if UNKNOWN_ISSUER error received

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeStatus.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeStatus.java
@@ -16,17 +16,17 @@ package com.zsmartsystems.zigbee;
  */
 public enum ZigBeeStatus {
     /**
-     * The operation completed successfully
+     * The operation completed successfully.
      */
     SUCCESS,
 
     /**
-     * The operation failed and no further information on the reason is available
+     * The operation failed and no further information on the reason is available.
      */
     FAILURE,
 
     /**
-     * The caller provided invalid arguments for the requested function
+     * The caller provided invalid arguments for the requested function.
      */
     INVALID_ARGUMENTS,
 
@@ -36,12 +36,12 @@ public enum ZigBeeStatus {
     NO_RESPONSE,
 
     /**
-     * The system was not in the correct state to process the request
+     * The system was not in the correct state to process the request.
      */
     INVALID_STATE,
 
     /**
-     * A request was made that is not supported by the function
+     * A request was made that is not supported by the function.
      */
     UNSUPPORTED,
 
@@ -58,5 +58,10 @@ public enum ZigBeeStatus {
     /**
      * An unexpected response was received
      */
-    BAD_RESPONSE
+    BAD_RESPONSE,
+
+    /**
+     * A fatal error occurred that cannot be recovered from.
+     */
+    FATAL_ERROR
 }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/seclient/SmartEnergyClientState.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/seclient/SmartEnergyClientState.java
@@ -21,5 +21,6 @@ public enum SmartEnergyClientState {
     DISCOVER_METERING_SERVERS,
     DISCOVER_KEEP_ALIVE,
     DISCOVER_KEEP_ALIVE_TIMEOUT,
-    KEEP_ALIVE
+    KEEP_ALIVE,
+    FATAL
 }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/seclient/ZigBeeSepClientStatus.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/seclient/ZigBeeSepClientStatus.java
@@ -14,7 +14,20 @@ package com.zsmartsystems.zigbee.app.seclient;
  *
  */
 public enum ZigBeeSepClientStatus {
+    /**
+     * The Smart Energy client is initialising and performing any key exchange required.
+     */
     INITIALIZING,
+    /**
+     * The Smart Energy client is connected to the server and operating normally.
+     */
     CONNECTED,
+    /**
+     * The Smart Energy client is disconnected from the server.
+     */
     DISCONNECTED,
+    /**
+     * The Smart Energy client is disconnected from the server and the application should leave the network.
+     */
+    FATAL_ERROR
 }

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/app/seclient/SmartEnergyClientTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/app/seclient/SmartEnergyClientTest.java
@@ -14,6 +14,7 @@ import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
 import com.zsmartsystems.zigbee.IeeeAddress;
+import com.zsmartsystems.zigbee.TestUtilities;
 import com.zsmartsystems.zigbee.ZigBeeCommandListener;
 import com.zsmartsystems.zigbee.ZigBeeNetworkManager;
 import com.zsmartsystems.zigbee.ZigBeeNetworkNodeListener;
@@ -22,6 +23,7 @@ import com.zsmartsystems.zigbee.ZigBeeNode;
 import com.zsmartsystems.zigbee.ZigBeeNode.ZigBeeNodeState;
 import com.zsmartsystems.zigbee.ZigBeeStatus;
 import com.zsmartsystems.zigbee.security.ZigBeeCbkeProvider;
+import com.zsmartsystems.zigbee.security.ZigBeeCryptoSuites;
 
 /**
  *
@@ -29,15 +31,22 @@ import com.zsmartsystems.zigbee.security.ZigBeeCbkeProvider;
  *
  */
 public class SmartEnergyClientTest {
+    private final static int TIMEOUT = 5000;
+
     @Test
     public void testStartupShutdown() throws Exception {
+        System.out.println("--- testStartupShutdown");
         ZigBeeNetworkManager networkManager = Mockito.mock(ZigBeeNetworkManager.class);
 
         ZigBeeNode node = Mockito.mock(ZigBeeNode.class);
         Mockito.when(node.getIeeeAddress()).thenReturn(new IeeeAddress("1234567890ABCDEF"));
         Mockito.when(node.getNodeState()).thenReturn(ZigBeeNodeState.ONLINE);
 
-        SmartEnergyClient extension = new SmartEnergyClient(Mockito.mock(ZigBeeCbkeProvider.class));
+        ZigBeeCbkeProvider cbkeProvider = Mockito.mock(ZigBeeCbkeProvider.class);
+        SmartEnergyClient extension = new SmartEnergyClient(cbkeProvider);
+        assertEquals(cbkeProvider, extension.getCbkeProvider());
+
+        extension.setCryptoSuite(ZigBeeCryptoSuites.ECC_163K1);
 
         assertEquals(ZigBeeStatus.SUCCESS, extension.extensionInitialize(networkManager));
         assertEquals(ZigBeeStatus.SUCCESS, extension.extensionStartup());
@@ -60,5 +69,36 @@ public class SmartEnergyClientTest {
                 .removeCommandListener(ArgumentMatchers.any(ZigBeeCommandListener.class));
         Mockito.verify(networkManager, Mockito.timeout(1000).atLeast(1))
                 .removeNetworkStateListener(ArgumentMatchers.any(ZigBeeNetworkStateListener.class));
+    }
+
+    @Test
+    public void keyEstablishmentCallback() throws Exception {
+        System.out.println("--- keyEstablishmentCallback");
+        ZigBeeNetworkManager networkManager = Mockito.mock(ZigBeeNetworkManager.class);
+        SmartEnergyClient extension = new SmartEnergyClient(Mockito.mock(ZigBeeCbkeProvider.class));
+        SmartEnergyStatusCallback listener = Mockito.mock(SmartEnergyStatusCallback.class);
+        extension.addListener(listener);
+
+        assertEquals(ZigBeeStatus.SUCCESS, extension.extensionInitialize(networkManager));
+        assertEquals(ZigBeeStatus.SUCCESS, extension.extensionStartup());
+
+        TestUtilities.setField(SmartEnergyClient.class, extension, "seState",
+                SmartEnergyClientState.PERFORM_KEY_ESTABLISHMENT);
+        assertEquals(SmartEnergyClientState.PERFORM_KEY_ESTABLISHMENT, extension.getDiscoveryState());
+
+        ZigBeeNode node = Mockito.mock(ZigBeeNode.class);
+        Mockito.when(networkManager.getNode(0)).thenReturn(node);
+        Mockito.when(node.getIeeeAddress()).thenReturn(new IeeeAddress("1234567890ABCDEF"));
+        Mockito.when(node.getNodeState()).thenReturn(ZigBeeNodeState.ONLINE);
+        extension.nodeAdded(node);
+
+        extension.keyEstablishmentCallback(ZigBeeStatus.SUCCESS, 0);
+        Mockito.verify(listener, Mockito.timeout(TIMEOUT)).sepStatusUpdate(ZigBeeSepClientStatus.INITIALIZING);
+        assertEquals(SmartEnergyClientState.DISCOVER_METERING_SERVERS, extension.getDiscoveryState());
+
+        extension.keyEstablishmentCallback(ZigBeeStatus.FATAL_ERROR, 0);
+        Mockito.verify(listener, Mockito.timeout(TIMEOUT)).sepStatusUpdate(ZigBeeSepClientStatus.FATAL_ERROR);
+
+        extension.removeListener(listener);
     }
 }


### PR DESCRIPTION
If the CBKE receives a ```UNKNOWN_ISSUER``` error then it is required to leave the network.

This PR ripples this error up to the application through the ```SmartEnergyStatusCallback``` callback by providing the ```ZigBeeSepClientStatus.FATAL_ERROR``` status.

It it then the responsibility of the application to leave the network and rejoin the same or another network.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>