### PR TITLE
Improve Ember startup state management

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
@@ -389,6 +389,7 @@ public class ZigBeeDongleEzsp implements ZigBeeTransportTransmit, ZigBeeTranspor
     @Override
     public ZigBeeStatus initialize() {
         logger.debug("EZSP dongle initialize with protocol {}.", protocol);
+        zigbeeTransportReceive.setTransportState(ZigBeeTransportState.INITIALISING);
 
         if (protocol != EmberSerialProtocol.NONE && !initialiseEzspProtocol()) {
             return ZigBeeStatus.COMMUNICATION_ERROR;
@@ -439,7 +440,7 @@ public class ZigBeeDongleEzsp implements ZigBeeTransportTransmit, ZigBeeTranspor
     public ZigBeeStatus startup(boolean reinitialize) {
         logger.debug("EZSP dongle startup. reinitialize={}", reinitialize);
 
-        // If ashHandler is null then the serial port didn't initialise
+        // If frameHandler is null then the serial port didn't initialise or startup has not been called
         if (frameHandler == null) {
             logger.error("Initialising Ember Dongle but low level handler is not initialised.");
             return ZigBeeStatus.INVALID_STATE;
@@ -500,13 +501,14 @@ public class ZigBeeDongleEzsp implements ZigBeeTransportTransmit, ZigBeeTranspor
         if (address != 0xFFFE) {
             nwkAddress = address;
         }
-        logger.debug("EZSP Initialisation complete. NWK Address = {}, State = {}", String.format("%04X", nwkAddress),
+        logger.debug("EZSP Startup complete. NWK Address = {}, State = {}", String.format("%04X", nwkAddress),
                 networkState);
 
         initialised = true;
 
-        return (networkState == EmberNetworkStatus.EMBER_JOINED_NETWORK) ? ZigBeeStatus.SUCCESS
-                : ZigBeeStatus.BAD_RESPONSE;
+        return (networkState == EmberNetworkStatus.EMBER_JOINED_NETWORK
+                || networkState == EmberNetworkStatus.EMBER_JOINED_NETWORK_NO_PARENT) ? ZigBeeStatus.SUCCESS
+                        : ZigBeeStatus.BAD_RESPONSE;
     }
 
     /**

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/transport/ZigBeeTransportTransmitAbstractTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/transport/ZigBeeTransportTransmitAbstractTest.java
@@ -11,6 +11,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import com.zsmartsystems.zigbee.ZigBeeStatus;
 
@@ -30,6 +31,7 @@ public abstract class ZigBeeTransportTransmitAbstractTest {
      */
     @Test
     public void getIeeeAddress() {
+        transport.setZigBeeTransportReceive(Mockito.mock(ZigBeeTransportReceive.class));
         assertEquals(ZigBeeStatus.SUCCESS, transport.initialize());
         assertNotNull(transport.getIeeeAddress());
     }
@@ -40,6 +42,7 @@ public abstract class ZigBeeTransportTransmitAbstractTest {
      */
     @Test
     public void getNwkAddress() {
+        transport.setZigBeeTransportReceive(Mockito.mock(ZigBeeTransportReceive.class));
         assertEquals(ZigBeeStatus.SUCCESS, transport.initialize());
         assertEquals(ZigBeeStatus.SUCCESS, transport.startup(false));
         assertNotNull(transport.getNwkAddress());


### PR DESCRIPTION
Sets the Ember transport state to ```INITIALISING```, and allows ```EMBER_JOINED_NETWORK_NO_PARENT``` to be considered as ```ONLINE```.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>