### PR TITLE
Update SEP client lifecycle

### DIFF
--- a/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleLinkKeyCommand.java
+++ b/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleLinkKeyCommand.java
@@ -64,7 +64,7 @@ public class ZigBeeConsoleLinkKeyCommand extends ZigBeeConsoleAbstractCommand {
         }
 
         ZigBeeStatus result = networkManager.setZigBeeLinkKey(key);
-        out.println("Link key " + key.toString() + " was " + (result == ZigBeeStatus.SUCCESS ? "" : "not") + " set.");
+        out.println("Link key set to " + key.toString() + " completed with state " + result);
     }
 
 }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
@@ -1156,7 +1156,7 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
         // Filter out unwanted transport state changes
         synchronized (validTransportStateTransitions) {
             if (!validTransportStateTransitions.get(transportState).contains(state)) {
-                logger.debug("Ignoring invalid transport state transition in {} to {}", transportState, state);
+                logger.debug("Ignoring invalid transport state transition from {} to {}", transportState, state);
                 return;
             }
             transportState = state;
@@ -1566,7 +1566,7 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
         if (node == null) {
             return;
         }
-        logger.debug("{}: Node {} update", node.getIeeeAddress(), node.getNetworkAddress());
+        logger.debug("{}: Node {} update", node.getIeeeAddress(), String.format("%04X", node.getNetworkAddress()));
 
         final ZigBeeNode currentNode;
         synchronized (networkNodes) {

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/app/seclient/ZclKeyEstablishmentClientTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/app/seclient/ZclKeyEstablishmentClientTest.java
@@ -25,6 +25,7 @@ public class ZclKeyEstablishmentClientTest {
 
     @Test
     public void test() {
+        System.out.println("--- " + Thread.currentThread().getStackTrace()[1].getMethodName());
         SmartEnergyClient seClient = Mockito.mock(SmartEnergyClient.class);
         ZclKeyEstablishmentCluster keCluster = Mockito.mock(ZclKeyEstablishmentCluster.class);
 
@@ -36,6 +37,8 @@ public class ZclKeyEstablishmentClientTest {
         assertFalse(keClient.commandReceived(Mockito.mock(ZclCommand.class)));
 
         keClient.stop();
+
+        keClient.shutdown();
         Mockito.verify(keCluster, Mockito.times(1)).removeCommandListener(keClient);
     }
 }


### PR DESCRIPTION
This PR modifies the way the ```ZclKeyEstablishmentClient``` is managed. Instead of only instantiating this when required to perform the key establishment, it is instead instantiated when the node is first added, and it is not removed.

This primarily ensures that we have a registered response handler in place should the server send a message when the client is not performing a CBKE, and this should ensure that we reject any attempts to perform CBKE, or terminate any erroneous CBKE attempts rather than leaving the server hanging.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>