### PR TITLE
Add ASH connect timer to avoid responding to multiple reset ACKs

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/ash/AshFrameHandler.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/ash/AshFrameHandler.java
@@ -63,15 +63,18 @@ public class AshFrameHandler implements EzspProtocolHandler {
     /**
      * The receive timeout settings - min/initial/max - defined in milliseconds
      */
-    private final int T_RX_ACK_MIN = 400;
-    private final int T_RX_ACK_INIT = 1600;
-    private final int T_RX_ACK_MAX = 3200;
+    private final static int T_RX_ACK_MIN = 400;
+    private final static int T_RX_ACK_INIT = 1600;
+    private final static int T_RX_ACK_MAX = 3200;
     private int receiveTimeout = T_RX_ACK_INIT;
+
+    private final static int T_CON_HOLDOFF = 1250;
+    private int connectTimeout = T_CON_HOLDOFF;
 
     /**
      * Maximum number of consecutive timeouts allowed while waiting to receive an ACK
      */
-    private final int ACK_TIMEOUTS = 4;
+    private final static int ACK_TIMEOUTS = 4;
     private int retries = 0;
 
     /**
@@ -81,14 +84,14 @@ public class AshFrameHandler implements EzspProtocolHandler {
 
     private long sentTime;
 
-    private final int ASH_CANCEL_BYTE = 0x1A;
-    private final int ASH_FLAG_BYTE = 0x7E;
-    private final int ASH_SUBSTITUTE_BYTE = 0x18;
-    private final int ASH_XON_BYTE = 0x11;
-    private final int ASH_OFF_BYTE = 0x13;
-    private final int ASH_TIMEOUT = -1;
+    private final static int ASH_CANCEL_BYTE = 0x1A;
+    private final static int ASH_FLAG_BYTE = 0x7E;
+    private final static int ASH_SUBSTITUTE_BYTE = 0x18;
+    private final static int ASH_XON_BYTE = 0x11;
+    private final static int ASH_OFF_BYTE = 0x13;
+    private final static int ASH_TIMEOUT = -1;
 
-    private final int ASH_MAX_LENGTH = 220;
+    private final static int ASH_MAX_LENGTH = 220;
 
     private Integer ackNum = 0;
     private int frmNum = 0;
@@ -349,11 +352,7 @@ public class AshFrameHandler implements EzspProtocolHandler {
 
         // Check the version
         if (rstAck.getVersion() == 2) {
-            stateConnected = true;
-            ackNum = 0;
-            frmNum = 0;
-            sentQueue.clear();
-            logger.debug("ASH: Connected");
+            startConnectTimer();
         } else {
             logger.debug("ASH: Invalid version");
         }
@@ -509,13 +508,19 @@ public class AshFrameHandler implements EzspProtocolHandler {
      */
     @Override
     public synchronized void connect() {
+        logger.debug("ASH: Connect");
         stateConnected = false;
 
-        ackNum = 0;
-        frmNum = 0;
         sentQueue.clear();
         sendQueue.clear();
 
+        reconnect();
+    }
+
+    public synchronized void reconnect() {
+        logger.debug("ASH: Reconnect");
+        ackNum = 0;
+        frmNum = 0;
         receiveTimeout = T_RX_ACK_INIT;
 
         sendFrame(new AshFrameRst());
@@ -563,6 +568,15 @@ public class AshFrameHandler implements EzspProtocolHandler {
         logger.trace("ASH: Started retry timer");
     }
 
+    private synchronized void startConnectTimer() {
+        // Stop any existing timer - shouldn't happen here, but play safe!
+        stopRetryTimer();
+
+        timerFuture = timer.schedule(new AshConnectTimer(), connectTimeout, TimeUnit.MILLISECONDS);
+
+        logger.trace("ASH: Started connect timer");
+    }
+
     private synchronized void stopRetryTimer() {
         // Stop any existing timer
         if (timerFuture != null) {
@@ -582,7 +596,7 @@ public class AshFrameHandler implements EzspProtocolHandler {
             // If we're not connected, then try again
             if (!stateConnected) {
                 stopRetryTimer();
-                connect();
+                reconnect();
                 return;
             }
 
@@ -613,6 +627,20 @@ public class AshFrameHandler implements EzspProtocolHandler {
             } catch (Exception e) {
                 logger.warn("Caught exception while attempting to retry message in AshRetryTimer", e);
             }
+        }
+    }
+
+    private class AshConnectTimer implements Runnable {
+        @Override
+        public void run() {
+            stopRetryTimer();
+            stateConnected = true;
+            ackNum = 0;
+            frmNum = 0;
+            sentQueue.clear();
+            frameHandler.handleLinkStateChange(true);
+            logger.debug("ASH: Connected");
+            sendNextFrame();
         }
     }
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/ash/AshFrameHandlerTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/ash/AshFrameHandlerTest.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.junit.Test;
-import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 import com.zsmartsystems.zigbee.TestUtilities;
@@ -75,6 +74,7 @@ public class AshFrameHandlerTest {
 
     @Test
     public void testReceivePacket() {
+        System.out.println("--- " + Thread.currentThread().getStackTrace()[1].getMethodName());
         int[] response = getPacket(new int[] { 0x01, 0x02, 0x03, 0x04, 0x7E });
         assertNotNull(response);
         assertEquals(4, response.length);
@@ -83,6 +83,7 @@ public class AshFrameHandlerTest {
 
     @Test
     public void testReceivePacket_FlagStart() {
+        System.out.println("--- " + Thread.currentThread().getStackTrace()[1].getMethodName());
         int[] response = getPacket(new int[] { 0x7E, 0x01, 0x02, 0x03, 0x04, 0x7E });
         assertNotNull(response);
         assertEquals(4, response.length);
@@ -91,6 +92,7 @@ public class AshFrameHandlerTest {
 
     @Test
     public void testReceivePacket_IgnoreXonXoff() {
+        System.out.println("--- " + Thread.currentThread().getStackTrace()[1].getMethodName());
         int[] response = getPacket(new int[] { 0x7E, 0x01, 0x02, 0x11, 0x03, 0x13, 0x04, 0x7E });
         assertNotNull(response);
         assertEquals(4, response.length);
@@ -99,6 +101,7 @@ public class AshFrameHandlerTest {
 
     @Test
     public void testReceivePacket_Cancel() {
+        System.out.println("--- " + Thread.currentThread().getStackTrace()[1].getMethodName());
         int[] response = getPacket(new int[] { 0x7E, 0x01, 0x02, 0x1A, 0x03, 0x04, 0x05, 0x06, 0x07, 0x7E });
         assertNotNull(response);
         assertEquals(5, response.length);
@@ -107,6 +110,7 @@ public class AshFrameHandlerTest {
 
     @Test
     public void testReceivePacket_Substitute() {
+        System.out.println("--- " + Thread.currentThread().getStackTrace()[1].getMethodName());
         int[] response = getPacket(new int[] { 0x7E, 0x01, 0x02, 0x18, 0x03, 0x04, 0x7E, 0x05, 0x06, 0x07, 0x7E });
         assertNotNull(response);
         assertEquals(3, response.length);
@@ -115,6 +119,7 @@ public class AshFrameHandlerTest {
 
     @Test
     public void testRunning() {
+        System.out.println("--- " + Thread.currentThread().getStackTrace()[1].getMethodName());
         EzspFrameHandler ezspHandler = Mockito.mock(EzspFrameHandler.class);
         AshFrameHandler frameHandler = new AshFrameHandler(ezspHandler);
         frameHandler.start(Mockito.mock(ZigBeePort.class));
@@ -131,6 +136,7 @@ public class AshFrameHandlerTest {
 
     @Test
     public void testReceivePacketx() {
+        System.out.println("--- " + Thread.currentThread().getStackTrace()[1].getMethodName());
         int[] response = getPacket(
                 new int[] { 0x44, 0x0E, 0xA1, 0x57, 0x54, 0x45, 0x15, 0x58, 0x94, 0x6C, 0x1B, 0x6E, 0x35, 0x27, 0xEA,
                         0x61, 0xE0, 0x60, 0x31, 0xFB, 0x04, 0xF3, 0xA7, 0x9D, 0x86, 0x86, 0xB0, 0x3E, 0x29, 0x7E });
@@ -198,6 +204,7 @@ public class AshFrameHandlerTest {
 
     @Test
     public void testGetCounters() {
+        System.out.println("--- " + Thread.currentThread().getStackTrace()[1].getMethodName());
         AshFrameHandler frameHandler = new AshFrameHandler(null);
 
         assertNotNull(frameHandler.getCounters());
@@ -215,6 +222,7 @@ public class AshFrameHandlerTest {
 
     @Test
     public void testTimeout() throws NoSuchFieldException, SecurityException, Exception {
+        System.out.println("--- " + Thread.currentThread().getStackTrace()[1].getMethodName());
         ZigBeePort port = new TestPort(null, null);
 
         EzspFrameHandler ezspHandler = Mockito.mock(EzspFrameHandler.class);
@@ -228,8 +236,6 @@ public class AshFrameHandlerTest {
         TestUtilities.setField(AshFrameHandler.class, frameHandler, "receiveTimeout", 0);
         TestUtilities.setField(AshFrameHandler.class, frameHandler, "stateConnected", true);
 
-        ArgumentCaptor<Boolean> stateCapture = ArgumentCaptor.forClass(Boolean.class);
-
         EzspVersionRequest request = new EzspVersionRequest();
         request.setSequenceNumber(3);
         request.setDesiredProtocolVersion(4);
@@ -239,12 +245,12 @@ public class AshFrameHandlerTest {
 
         assertNull(transaction.getResponse());
 
-        Mockito.verify(ezspHandler, Mockito.timeout(TIMEOUT).times(1)).handleLinkStateChange(stateCapture.capture());
-        assertFalse(stateCapture.getValue());
+        Mockito.verify(ezspHandler, Mockito.timeout(TIMEOUT).times(1)).handleLinkStateChange(false);
     }
 
     @Test
     public void testErrorToOffline() {
+        System.out.println("--- " + Thread.currentThread().getStackTrace()[1].getMethodName());
         int[] data = new int[] { 0xC2, 0x02, 0x52, 0x98, 0xDE, 0x7E, 0xC1, 0x02, 0x0B, 0x0A, 0x52, 0x7E, 0xC2, 0x02,
                 0x52, 0x98, 0xDE, 0x7E };
 
@@ -255,18 +261,18 @@ public class AshFrameHandlerTest {
         }
         ByteArrayInputStream stream = new ByteArrayInputStream(bytedata);
         ZigBeePort port = new TestPort(stream, null);
-        ArgumentCaptor<Boolean> stateCapture = ArgumentCaptor.forClass(Boolean.class);
 
         EzspFrameHandler ezspHandler = Mockito.mock(EzspFrameHandler.class);
         AshFrameHandler frameHandler = new AshFrameHandler(ezspHandler);
 
         frameHandler.start(port);
         frameHandler.connect();
-        Mockito.verify(ezspHandler, Mockito.timeout(TIMEOUT).times(1)).handleLinkStateChange(stateCapture.capture());
+        Mockito.verify(ezspHandler, Mockito.timeout(TIMEOUT).times(1)).handleLinkStateChange(true);
     }
 
     @Test
     public void handleReset() throws Exception {
+        System.out.println("--- " + Thread.currentThread().getStackTrace()[1].getMethodName());
         // PoR reset is ignored
         // Software Reset V1 ignored
         // Software Reset V2 goes online and state to connected
@@ -295,13 +301,12 @@ public class AshFrameHandlerTest {
         }
         ByteArrayInputStream stream = new ByteArrayInputStream(bytedata);
         ZigBeePort port = new TestPort(stream, null);
-        ArgumentCaptor<Boolean> stateCapture = ArgumentCaptor.forClass(Boolean.class);
 
         EzspFrameHandler ezspHandler = Mockito.mock(EzspFrameHandler.class);
         AshFrameHandler frameHandler = new AshFrameHandler(ezspHandler);
 
         frameHandler.start(port);
 
-        Mockito.verify(ezspHandler, Mockito.timeout(TIMEOUT)).handleLinkStateChange(stateCapture.capture());
+        Mockito.verify(ezspHandler, Mockito.timeout(TIMEOUT)).handleLinkStateChange(true);
     }
 }

--- a/com.zsmartsystems.zigbee.serial/src/main/java/com/zsmartsystems/zigbee/serial/ZigBeeSerialPort.java
+++ b/com.zsmartsystems.zigbee.serial/src/main/java/com/zsmartsystems/zigbee/serial/ZigBeeSerialPort.java
@@ -131,7 +131,7 @@ public class ZigBeeSerialPort implements ZigBeePort, SerialPortEventListener {
         serialPort = new jssc.SerialPort(portName);
         try {
             serialPort.openPort();
-            serialPort.setParams(baudRate, 8, 1, 0);
+            serialPort.setParams(baudRate, 8, 1, 0, true, true);
             switch (flowControl) {
                 case FLOWCONTROL_OUT_NONE:
                     serialPort.setFlowControlMode(jssc.SerialPort.FLOWCONTROL_NONE);


### PR DESCRIPTION
In some cases it is possible for the NCP to respond with multiple ```RSTACK``` responses during startup, and in this event the ASH handler will not connect as the second ```RSTACK``` will cause it to disconnect. This is required in order to detect a reset during normal operation, however is undesirable during initialisation.

This PR adds a timer to avoid placing the ASH handler into the connected state for a short time after the first ```RSTACK``` is received.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>