### PR TITLE
DataStore.clear() should only be called on reinitialisation of network

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
@@ -592,8 +592,8 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
                 }
                 removeNode(node);
             }
+            databaseManager.clear();
         }
-        databaseManager.clear();
 
         ZigBeeStatus status = transport.startup(reinitialize);
         if (status != ZigBeeStatus.SUCCESS) {

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeNetworkManagerTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeNetworkManagerTest.java
@@ -953,9 +953,11 @@ public class ZigBeeNetworkManagerTest
         ZigBeeNetworkManager manager = mockZigBeeNetworkManager();
         Mockito.when(mockedTransport.initialize()).thenReturn(ZigBeeStatus.COMMUNICATION_ERROR);
 
+        ZigBeeNetworkDatabaseManager databaseManager = Mockito.mock(ZigBeeNetworkDatabaseManager.class);
         assertEquals(ZigBeeStatus.INVALID_STATE, manager.startup(true));
 
         TestUtilities.setField(ZigBeeNetworkManager.class, manager, "networkState", ZigBeeNetworkState.INITIALISING);
+        TestUtilities.setField(ZigBeeNetworkManager.class, manager, "databaseManager", databaseManager);
 
         assertEquals(mockedTransport, manager.getZigBeeTransport());
 
@@ -964,6 +966,7 @@ public class ZigBeeNetworkManagerTest
 
         assertEquals(ZigBeeStatus.COMMUNICATION_ERROR, manager.startup(false));
         Mockito.verify(mockedTransport, Mockito.times(1)).startup(false);
+        Mockito.verify(databaseManager, Mockito.never()).clear();
 
         TestUtilities.setField(ZigBeeNetworkManager.class, manager, "networkState", ZigBeeNetworkState.INITIALISING);
         manager.setTransportState(ZigBeeTransportState.OFFLINE);
@@ -971,6 +974,7 @@ public class ZigBeeNetworkManagerTest
 
         assertEquals(ZigBeeStatus.SUCCESS, manager.startup(true));
         Mockito.verify(mockedTransport, Mockito.timeout(TIMEOUT).times(1)).startup(true);
+        Mockito.verify(databaseManager, Mockito.times(1)).clear();
 
         Mockito.verify(mockedStateListener, Mockito.timeout(TIMEOUT).times(1))
                 .networkStateUpdated(ZigBeeNetworkState.ONLINE);


### PR DESCRIPTION
Signed-off-by: Chris Jackson <chris@cd-jackson.com>