### PR TITLE
Enforce that initialisation can only be completed when network is in correct state

### DIFF
--- a/com.zsmartsystems.zigbee.console.main/src/main/java/com/zsmartsystems/zigbee/console/main/ZigBeeConsole.java
+++ b/com.zsmartsystems.zigbee.console.main/src/main/java/com/zsmartsystems/zigbee/console/main/ZigBeeConsole.java
@@ -36,14 +36,10 @@ import com.zsmartsystems.zigbee.ZigBeeNetworkNodeListener;
 import com.zsmartsystems.zigbee.ZigBeeNetworkState;
 import com.zsmartsystems.zigbee.ZigBeeNetworkStateListener;
 import com.zsmartsystems.zigbee.ZigBeeNode;
-import com.zsmartsystems.zigbee.app.basic.ZigBeeBasicServerExtension;
-import com.zsmartsystems.zigbee.app.discovery.ZigBeeDiscoveryExtension;
-import com.zsmartsystems.zigbee.app.iasclient.ZigBeeIasCieExtension;
 import com.zsmartsystems.zigbee.app.otaserver.ZclOtaUpgradeServer;
 import com.zsmartsystems.zigbee.app.otaserver.ZigBeeOtaFile;
 import com.zsmartsystems.zigbee.app.otaserver.ZigBeeOtaServerStatus;
 import com.zsmartsystems.zigbee.app.otaserver.ZigBeeOtaStatusCallback;
-import com.zsmartsystems.zigbee.app.otaserver.ZigBeeOtaUpgradeExtension;
 import com.zsmartsystems.zigbee.console.ZigBeeConsoleAttributeReadCommand;
 import com.zsmartsystems.zigbee.console.ZigBeeConsoleAttributeSupportedCommand;
 import com.zsmartsystems.zigbee.console.ZigBeeConsoleAttributeWriteCommand;
@@ -144,15 +140,6 @@ public final class ZigBeeConsole {
         runtime.gc();
         // Calculate the used memory
         initialMemory = runtime.totalMemory() - runtime.freeMemory();
-
-        // Add the extensions to the network
-        networkManager.addExtension(new ZigBeeIasCieExtension());
-        networkManager.addExtension(new ZigBeeOtaUpgradeExtension());
-        networkManager.addExtension(new ZigBeeBasicServerExtension());
-
-        ZigBeeDiscoveryExtension discoveryExtension = new ZigBeeDiscoveryExtension();
-        discoveryExtension.setUpdatePeriod(60);
-        networkManager.addExtension(discoveryExtension);
 
         createCommands(newCommands, transportCommands);
 

--- a/com.zsmartsystems.zigbee.console.main/src/main/java/com/zsmartsystems/zigbee/console/main/ZigBeeConsoleMain.java
+++ b/com.zsmartsystems.zigbee.console.main/src/main/java/com/zsmartsystems/zigbee/console/main/ZigBeeConsoleMain.java
@@ -28,6 +28,10 @@ import com.zsmartsystems.zigbee.ExtendedPanId;
 import com.zsmartsystems.zigbee.ZigBeeChannel;
 import com.zsmartsystems.zigbee.ZigBeeNetworkManager;
 import com.zsmartsystems.zigbee.ZigBeeStatus;
+import com.zsmartsystems.zigbee.app.basic.ZigBeeBasicServerExtension;
+import com.zsmartsystems.zigbee.app.discovery.ZigBeeDiscoveryExtension;
+import com.zsmartsystems.zigbee.app.iasclient.ZigBeeIasCieExtension;
+import com.zsmartsystems.zigbee.app.otaserver.ZigBeeOtaUpgradeExtension;
 import com.zsmartsystems.zigbee.console.ZigBeeConsoleCommand;
 import com.zsmartsystems.zigbee.console.ember.EmberConsoleMmoHashCommand;
 import com.zsmartsystems.zigbee.console.ember.EmberConsoleNcpChildrenCommand;
@@ -348,14 +352,23 @@ public class ZigBeeConsoleMain {
 
         dongle.updateTransportConfig(transportOptions);
 
+        // Add the extensions to the network
+        networkManager.addExtension(new ZigBeeIasCieExtension());
+        networkManager.addExtension(new ZigBeeOtaUpgradeExtension());
+        networkManager.addExtension(new ZigBeeBasicServerExtension());
+
+        ZigBeeDiscoveryExtension discoveryExtension = new ZigBeeDiscoveryExtension();
+        discoveryExtension.setUpdatePeriod(0);
+        networkManager.addExtension(discoveryExtension);
+
+        supportedClientClusters.stream().forEach(clusterId -> networkManager.addSupportedClientCluster(clusterId));
+        supportedServerClusters.stream().forEach(clusterId -> networkManager.addSupportedServerCluster(clusterId));
+
         if (networkManager.startup(resetNetwork) != ZigBeeStatus.SUCCESS) {
             System.out.println("ZigBee console starting up ... [FAIL]");
         } else {
             System.out.println("ZigBee console starting up ... [OK]");
         }
-
-        supportedClientClusters.stream().forEach(clusterId -> networkManager.addSupportedClientCluster(clusterId));
-        supportedServerClusters.stream().forEach(clusterId -> networkManager.addSupportedServerCluster(clusterId));
 
         if (dongleName.toUpperCase().equals("CC2531")) {
             ZigBeeDongleTiCc2531 tiDongle = (ZigBeeDongleTiCc2531) dongle;


### PR DESCRIPTION
Checks that extensions, clusters etc are only configured when the network is in ```ZigBeeNetworkState.INITIALISING``` state.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>