### PR TITLE
Protect against invalid key

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
@@ -1391,9 +1391,12 @@ public class ZigBeeDongleEzsp implements ZigBeeTransportTransmit, ZigBeeTranspor
      * Converts from an {@link EmberKeyStruct} to {@link ZigBeeKey}
      *
      * @param emberKey the {@link EmberKeyStruct} read from the NCP
-     * @return the {@link ZigBeeKey} used by the framework
+     * @return the {@link ZigBeeKey} used by the framework. May be null if the key is invalid.
      */
     private ZigBeeKey emberKeyToZigBeeKey(EmberKeyStruct emberKey) {
+        if (emberKey == null) {
+            return null;
+        }
         ZigBeeKey key = new ZigBeeKey(emberKey.getKey().getContents());
         if (emberKey.getBitmask().contains(EmberKeyStructBitmask.EMBER_KEY_HAS_PARTNER_EUI64)) {
             key.setAddress(emberKey.getPartnerEUI64());

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzspTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzspTest.java
@@ -10,10 +10,12 @@ package com.zsmartsystems.zigbee.dongle.ember;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -46,6 +48,9 @@ import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspTrustCenterJoinHan
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EmberApsFrame;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EmberDeviceUpdate;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EmberIncomingMessageType;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EmberKeyData;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EmberKeyStruct;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EmberKeyType;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EmberStatus;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EzspDecisionId;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EzspPolicyId;
@@ -603,5 +608,28 @@ public class ZigBeeDongleEzspTest {
         dongle.setNodeDescriptor(new IeeeAddress("1234567890ABCDEF"), nodeDescriptor);
         Mockito.verify(ncp, Mockito.timeout(TIMEOUT).times(1)).setExtendedTimeout(new IeeeAddress("1234567890ABCDEF"),
                 true);
+    }
+
+    @Test
+    public void getTcLinkKey() {
+        System.out.println("--- " + Thread.currentThread().getStackTrace()[1].getMethodName());
+        final EmberNcp ncp = Mockito.mock(EmberNcp.class);
+        ZigBeeDongleEzsp dongle = new ZigBeeDongleEzsp(null) {
+            @Override
+            public EmberNcp getEmberNcp() {
+                return ncp;
+            }
+        };
+
+        EmberKeyStruct emberKey = Mockito.mock(EmberKeyStruct.class);
+        EmberKeyData emberKeyData = new EmberKeyData();
+        emberKeyData.setContents(new int[16]);
+        Mockito.when(ncp.getKey(EmberKeyType.EMBER_TRUST_CENTER_LINK_KEY)).thenReturn(null);
+        Mockito.when(ncp.getKey(EmberKeyType.EMBER_CURRENT_NETWORK_KEY)).thenReturn(emberKey);
+        Mockito.when(emberKey.getBitmask()).thenReturn(Collections.emptySet());
+        Mockito.when(emberKey.getKey()).thenReturn(emberKeyData);
+
+        assertNull(dongle.getTcLinkKey());
+        assertNotNull(dongle.getZigBeeNetworkKey());
     }
 }


### PR DESCRIPTION
If a key is invalid, then the ```ncp.getKey()``` method returns null. This needs to be checked to avoid ```NPE```.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>