### PR TITLE
Minor updates after previous change

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransactionManager.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransactionManager.java
@@ -338,9 +338,9 @@ public class ZigBeeTransactionManager implements ZigBeeNetworkNodeListener {
      * Sends a command, and uses the {@link ZigBeeTransactionMatcher} to match the response which will complete the
      * transaction.
      *
-     * @param command         the {@link ZigBeeCommand} to send
+     * @param command the {@link ZigBeeCommand} to send
      * @param responseMatcher the {@link ZigBeeTransactionMatcher} to match the response which will complete the
-     *                            transaction.
+     *            transaction.
      * @return the future {@link CommandResult}
      */
     public Future<CommandResult> sendTransaction(ZigBeeCommand command, ZigBeeTransactionMatcher responseMatcher) {
@@ -413,7 +413,7 @@ public class ZigBeeTransactionManager implements ZigBeeNetworkNodeListener {
     /**
      * Sets the queue type to sleepy or non-sleepy. This will update the profile, and the sleepy flag in the quque
      *
-     * @param node  the {@link ZigBeeNode} of the queue to update
+     * @param node the {@link ZigBeeNode} of the queue to update
      * @param queue the {@link ZigBeeTransactionQueue} to update
      * @return true if the queue state was changed
      */
@@ -461,7 +461,7 @@ public class ZigBeeTransactionManager implements ZigBeeNetworkNodeListener {
      * Callback from the transport layer when it has progressed the state of the transaction.
      *
      * @param transactionId the transaction ID whose state is updated
-     * @param state         the updated {@link ZigBeeTransportProgressState} for the transaction
+     * @param state the updated {@link ZigBeeTransportProgressState} for the transaction
      */
     public void receiveCommandState(int transactionId, ZigBeeTransportProgressState state) {
         notifyTransactionProgress(transactionId, state);
@@ -498,7 +498,7 @@ public class ZigBeeTransactionManager implements ZigBeeNetworkNodeListener {
      * Schedules a task with a timeout. Used by {@link ZigBeeTransaction}s to time out failed transactions
      *
      * @param runnableTask the {@link Runnable} to call when the timer expires
-     * @param delay        the delay in milliseconds
+     * @param delay the delay in milliseconds
      * @return the {@link ScheduledFuture} for this task
      */
     protected ScheduledFuture<?> scheduleTask(Runnable runnableTask, long delay) {
@@ -509,7 +509,7 @@ public class ZigBeeTransactionManager implements ZigBeeNetworkNodeListener {
      * Callback from {@link ZigBeeTransaction} when a transaction has completed or failed.
      *
      * @param transaction the {@link ZigBeeTransaction} to complete. Not null.
-     * @param state       the {@link TransactionState} of the transaction on completion
+     * @param state the {@link TransactionState} of the transaction on completion
      */
     protected void transactionComplete(ZigBeeTransaction transaction, TransactionState state) {
         logger.debug("Transaction complete: {}", transaction);
@@ -556,7 +556,7 @@ public class ZigBeeTransactionManager implements ZigBeeNetworkNodeListener {
      * Notify transactions of the current {@link ZigBeeTransportProgressState} from the transport layer
      *
      * @param transactionId the ID of the transaction whose state has been updated
-     * @param state         the current {@link ZigBeeTransportProgressState} for the transaction
+     * @param state the current {@link ZigBeeTransportProgressState} for the transaction
      */
     private void notifyTransactionProgress(final int transactionId, ZigBeeTransportProgressState state) {
         logger.debug("notifyTransactionProgress: TID={}, state={}, outstanding={}",
@@ -726,7 +726,7 @@ public class ZigBeeTransactionManager implements ZigBeeNetworkNodeListener {
             return;
         }
 
-        // if the node has rejoined the network with a different network address, we have to rewrite all pending
+        // If the node has rejoined the network with a different network address, we have to rewrite all pending
         // transactions
         queue.rewriteDestinationAddresses(node.getNetworkAddress());
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransactionQueue.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransactionQueue.java
@@ -116,7 +116,7 @@ public class ZigBeeTransactionQueue {
     /**
      * Constructs a {@link ZigBeeTransactionQueue}
      *
-     * @param queueName         a queue name - used for logging to differentiate multiple queues
+     * @param queueName a queue name - used for logging to differentiate multiple queues
      * @param deviceIeeeAddress - the {@link IEEEAddress} of the device for which this queue holds transactions
      */
     protected ZigBeeTransactionQueue(String queueName, IeeeAddress deviceIeeeAddress) {
@@ -283,7 +283,7 @@ public class ZigBeeTransactionQueue {
      * unsuccessfully)
      *
      * @param transaction the {@link ZigBeeTransaction} that is complete
-     * @param state       the {@link TransactionState} of the transaction on completion
+     * @param state the {@link TransactionState} of the transaction on completion
      */
     protected void transactionComplete(ZigBeeTransaction transaction, TransactionState state) {
         outstandingTransactions--;
@@ -306,11 +306,11 @@ public class ZigBeeTransactionQueue {
     }
 
     /**
-     * Rewrites all transactions in the queue to have the network address of the passed node as destination address
+     * Rewrites all transactions in the queue to have the network address of the passed node as destination address.
      *
      * @param newAddress the new address where the transactions should be send to
      */
-    void rewriteDestinationAddresses(Integer newAddress) {
+    protected void rewriteDestinationAddresses(Integer newAddress) {
         LinkedList<ZigBeeTransaction> transactions = new LinkedList<>();
 
         synchronized (queue) {
@@ -332,7 +332,8 @@ public class ZigBeeTransactionQueue {
 
     @Override
     public String toString() {
-        return "ZigBeeTransactionQueue [queueName=" + queueName + " deviceIeeeAddress=" + deviceIeeeAdress + ", sleepy="
-                + sleepy + ", outstandingTransactions=" + outstandingTransactions + ", profile=" + profile + "]";
+        return "ZigBeeTransactionQueue [queueName=" + queueName + ", deviceIeeeAddress=" + deviceIeeeAdress
+                + ", sleepy=" + sleepy + ", outstandingTransactions=" + outstandingTransactions + ", profile=" + profile
+                + "]";
     }
 }


### PR DESCRIPTION
Fixes visibility of ```rewriteDestinationAddresses``` method and adds comma to ```toString()```.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>