### PR TITLE
Set Ember online start at end of startup()

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
@@ -511,11 +511,13 @@ public class ZigBeeDongleEzsp implements ZigBeeTransportTransmit, ZigBeeTranspor
         logger.debug("EZSP Startup complete. NWK Address = {}, State = {}", String.format("%04X", nwkAddress),
                 networkState);
 
+        // At this stage, we will now take note of the EzspStackStatusHandler notifications
+        boolean joinedNetwork = (networkState == EmberNetworkStatus.EMBER_JOINED_NETWORK
+                || networkState == EmberNetworkStatus.EMBER_JOINED_NETWORK_NO_PARENT);
         initialised = true;
+        handleLinkStateChange(joinedNetwork);
 
-        return (networkState == EmberNetworkStatus.EMBER_JOINED_NETWORK
-                || networkState == EmberNetworkStatus.EMBER_JOINED_NETWORK_NO_PARENT) ? ZigBeeStatus.SUCCESS
-                        : ZigBeeStatus.BAD_RESPONSE;
+        return joinedNetwork ? ZigBeeStatus.SUCCESS : ZigBeeStatus.BAD_RESPONSE;
     }
 
     /**


### PR DESCRIPTION
Setting the ember network state is disabled during initialisation to prevent the situation where the network goes online before being reset. However, this holdoff means that we must set the state at the end of ```startup()``` when we finally know the startup state.
Closes #899 
Signed-off-by: Chris Jackson <chris@cd-jackson.com>