### PR TITLE
Avoid duplicate networks in Ember scan handler

### DIFF
--- a/com.zsmartsystems.zigbee.console.ember/src/main/java/com/zsmartsystems/zigbee/console/ember/EmberConsoleNcpScanCommand.java
+++ b/com.zsmartsystems.zigbee.console.ember/src/main/java/com/zsmartsystems/zigbee/console/ember/EmberConsoleNcpScanCommand.java
@@ -8,7 +8,7 @@
 package com.zsmartsystems.zigbee.console.ember;
 
 import java.io.PrintStream;
-import java.util.List;
+import java.util.Collection;
 
 import com.zsmartsystems.zigbee.ExtendedPanId;
 import com.zsmartsystems.zigbee.ZigBeeChannelMask;
@@ -50,8 +50,8 @@ public class EmberConsoleNcpScanCommand extends EmberConsoleAbstractCommand {
             throws IllegalArgumentException {
         EmberNcp ncp = getEmberNcp(networkManager);
 
-        List<EzspNetworkFoundHandler> networksFound = ncp.doActiveScan(ZigBeeChannelMask.CHANNEL_MASK_2GHZ, 6);
-        List<EzspEnergyScanResultHandler> channels = ncp.doEnergyScan(ZigBeeChannelMask.CHANNEL_MASK_2GHZ, 6);
+        Collection<EzspNetworkFoundHandler> networksFound = ncp.doActiveScan(ZigBeeChannelMask.CHANNEL_MASK_2GHZ, 6);
+        Collection<EzspEnergyScanResultHandler> channels = ncp.doEnergyScan(ZigBeeChannelMask.CHANNEL_MASK_2GHZ, 6);
 
         if (networksFound == null) {
             out.println("Error performing active scan");
@@ -72,7 +72,7 @@ public class EmberConsoleNcpScanCommand extends EmberConsoleAbstractCommand {
         }
     }
 
-    private void outputNetworksFound(PrintStream out, List<EzspNetworkFoundHandler> networksFound) {
+    private void outputNetworksFound(PrintStream out, Collection<EzspNetworkFoundHandler> networksFound) {
         out.println("CH  PAN   Extended PAN      Stk  Join   Upd");
         for (EzspNetworkFoundHandler network : networksFound) {
             EmberZigbeeNetwork params = network.getNetworkFound();
@@ -82,7 +82,7 @@ public class EmberConsoleNcpScanCommand extends EmberConsoleAbstractCommand {
         }
     }
 
-    private void outputChannelEnergy(PrintStream out, List<EzspEnergyScanResultHandler> channels) {
+    private void outputChannelEnergy(PrintStream out, Collection<EzspEnergyScanResultHandler> channels) {
         out.println("CH  RSSI");
         for (EzspEnergyScanResultHandler channel : channels) {
             out.println(String.format("%-2d  %d", channel.getChannel(), channel.getMaxRssiValue()));

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/EmberNcp.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/EmberNcp.java
@@ -9,13 +9,17 @@ package com.zsmartsystems.zigbee.dongle.ember;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.zsmartsystems.zigbee.ExtendedPanId;
 import com.zsmartsystems.zigbee.IeeeAddress;
 import com.zsmartsystems.zigbee.ZigBeeStatus;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.EzspFrame;
@@ -819,7 +823,7 @@ public class EmberNcp {
      * @return a List of {@link EzspNetworkFoundHandler} on success. If there was an error during the scan, null is
      *         returned.
      */
-    public List<EzspNetworkFoundHandler> doActiveScan(int channelMask, int scanDuration) {
+    public Collection<EzspNetworkFoundHandler> doActiveScan(int channelMask, int scanDuration) {
         EzspStartScanRequest activeScan = new EzspStartScanRequest();
         activeScan.setChannelMask(channelMask);
         activeScan.setDuration(scanDuration);
@@ -838,14 +842,15 @@ public class EmberNcp {
             return null;
         }
 
-        List<EzspNetworkFoundHandler> networksFound = new ArrayList<>();
-        for (EzspFrameResponse network : transaction.getResponses()) {
-            if (network instanceof EzspNetworkFoundHandler) {
-                networksFound.add((EzspNetworkFoundHandler) network);
+        Map<ExtendedPanId, EzspNetworkFoundHandler> networksFound = new HashMap<>();
+        for (EzspFrameResponse response : transaction.getResponses()) {
+            if (response instanceof EzspNetworkFoundHandler) {
+                EzspNetworkFoundHandler network = (EzspNetworkFoundHandler) response;
+                networksFound.put(network.getNetworkFound().getExtendedPanId(), network);
             }
         }
 
-        return networksFound;
+        return networksFound.values();
     }
 
     /**


### PR DESCRIPTION
Note that this changes the return type of ```EmberNcp.doActiveScan()``` from ```List``` to ```Collection```.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>