### PR TITLE
Add Key Establishment Server

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/EmberCbkeProvider.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/EmberCbkeProvider.java
@@ -235,16 +235,26 @@ public class EmberCbkeProvider implements ZigBeeCbkeProvider {
                     break;
                 }
 
-                responderMac = new ByteArray(response163k1.getResponderSmac().getContents());
-                return new ByteArray(response163k1.getInitiatorSmac().getContents());
+                if (amInitiator) {
+                    responderMac = new ByteArray(response163k1.getResponderSmac().getContents());
+                    return new ByteArray(response163k1.getInitiatorSmac().getContents());
+                } else {
+                    responderMac = new ByteArray(response163k1.getInitiatorSmac().getContents());
+                    return new ByteArray(response163k1.getResponderSmac().getContents());
+                }
             case ECC_283K1:
                 EzspCalculateSmacs283k1Handler response283k1 = ezspCalculateSmacs283k1();
                 if (response283k1 == null || response283k1.getStatus() != EmberStatus.EMBER_SUCCESS) {
                     break;
                 }
 
-                responderMac = new ByteArray(response283k1.getResponderSmac().getContents());
-                return new ByteArray(response283k1.getInitiatorSmac().getContents());
+                if (amInitiator) {
+                    responderMac = new ByteArray(response283k1.getResponderSmac().getContents());
+                    return new ByteArray(response283k1.getInitiatorSmac().getContents());
+                } else {
+                    responderMac = new ByteArray(response283k1.getInitiatorSmac().getContents());
+                    return new ByteArray(response283k1.getResponderSmac().getContents());
+                }
             default:
                 break;
         }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/seclient/ZclKeyEstablishmentClient.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/seclient/ZclKeyEstablishmentClient.java
@@ -187,6 +187,7 @@ public class ZclKeyEstablishmentClient implements ZclCommandListener {
      */
     public void setCbkeProvider(ZigBeeCbkeProvider cbkeProvider) {
         this.cbkeProvider = cbkeProvider;
+        this.cbkeProvider.setClientServer(true);
     }
 
     /**
@@ -203,7 +204,8 @@ public class ZclKeyEstablishmentClient implements ZclCommandListener {
      */
     public boolean setCryptoSuite(ZigBeeCryptoSuites requestedCryptoSuite) {
         if (cbkeProvider == null) {
-            logger.debug("CBKE Key Establishment Client: Failed to set crypto suite as CBKE provider is not set");
+            logger.debug("{}: CBKE Key Establishment Client: Failed to set crypto suite as CBKE provider is not set",
+                    ieeeAddress);
             return false;
         }
         if (requestedCryptoSuite == null) {
@@ -211,8 +213,8 @@ public class ZclKeyEstablishmentClient implements ZclCommandListener {
             return true;
         }
         if (!cbkeProvider.getSupportedCryptoSuites().contains(requestedCryptoSuite)) {
-            logger.debug("CBKE Key Establishment Client: Failed to set crypto suite to unsupported value {}",
-                    requestedCryptoSuite);
+            logger.debug("{}: CBKE Key Establishment Client: Failed to set crypto suite to unsupported value {}",
+                    ieeeAddress, requestedCryptoSuite);
             return false;
         }
 
@@ -236,23 +238,25 @@ public class ZclKeyEstablishmentClient implements ZclCommandListener {
      */
     public boolean start() {
         if (cbkeProvider == null) {
-            logger.debug("CBKE Key Establishment Client: Initiate key establishment failed - cbkeProvider is null");
+            logger.debug("{}: CBKE Key Establishment Client: Initiate key establishment failed - cbkeProvider is null",
+                    ieeeAddress);
 
             return false;
         }
 
         if (state != KeyEstablishmentState.UNINITIALISED) {
-            logger.debug("CBKE Key Establishment Client: Initiate key establishment failed - state is {}", state);
+            logger.debug("{}: CBKE Key Establishment Client: Initiate key establishment failed - state is {}",
+                    ieeeAddress, state);
 
             return false;
         }
 
-        logger.debug("CBKE Key Establishment Client: Initiate key establishment");
+        logger.debug("{}: CBKE Key Establishment Client: Initiate key establishment", ieeeAddress);
 
         ZigBeeCryptoSuites requestedCryptoSuite;
         if (forceCryptoSuite != null) {
             requestedCryptoSuite = forceCryptoSuite;
-            logger.debug("CBKE Key Establishment Client: Forced suite {}", requestedCryptoSuite);
+            logger.debug("{}: CBKE Key Establishment Client: Forced suite {}", ieeeAddress, requestedCryptoSuite);
         } else {
             setState(KeyEstablishmentState.CHECK_CURVES);
             ZclAttribute keSuitesAttr = keCluster
@@ -266,7 +270,7 @@ public class ZclKeyEstablishmentClient implements ZclCommandListener {
             if ((availableSuites & 0x0002) != 0) {
                 suites.add(ZigBeeCryptoSuites.ECC_283K1);
             }
-            logger.debug("CBKE Key Establishment Client: Remote supports suites {}", suites);
+            logger.debug("{}: CBKE Key Establishment Client: Remote supports suites {}", ieeeAddress, suites);
 
             // Find a matching suite - using the highest possible security
             if (forceCryptoSuite != null) {
@@ -283,14 +287,15 @@ public class ZclKeyEstablishmentClient implements ZclCommandListener {
 
                 return false;
             }
-            logger.debug("CBKE Key Establishment Client: Selected suite {}", requestedCryptoSuite);
+            logger.debug("{}: CBKE Key Establishment Client: Selected suite {}", ieeeAddress, requestedCryptoSuite);
         }
 
         setState(KeyEstablishmentState.INITIATE_REQUEST);
         ByteArray certificate = cbkeProvider.getCertificate(requestedCryptoSuite);
         if (certificate == null) {
             logger.debug(
-                    "CBKE Key Establishment Client: Initiate key establishment failed - no certificate returned from CBKE provider");
+                    "{}: CBKE Key Establishment Client: Initiate key establishment failed - no certificate returned from CBKE provider",
+                    ieeeAddress);
 
             setState(KeyEstablishmentState.FAILED);
             stopCbke(0);
@@ -312,7 +317,7 @@ public class ZclKeyEstablishmentClient implements ZclCommandListener {
      * restarted.
      */
     public void shutdown() {
-        logger.debug("CBKE Key Establishment Client: Shutdown key establishment at state {}", state);
+        logger.debug("{}: CBKE Key Establishment Client: Shutdown key establishment at state {}", ieeeAddress, state);
 
         state = KeyEstablishmentState.UNINITIALISED;
         keCluster.removeCommandListener(this);
@@ -325,13 +330,13 @@ public class ZclKeyEstablishmentClient implements ZclCommandListener {
      * Stops the CBKE if it's currently in progress.
      */
     public void stop() {
-        logger.debug("CBKE Key Establishment Client: Key establishment stopped");
+        logger.debug("{}: CBKE Key Establishment Client: Key establishment stopped", ieeeAddress);
         stopTerminationTimer();
         setState(KeyEstablishmentState.UNINITIALISED);
     }
 
     private void setState(KeyEstablishmentState newState) {
-        logger.debug("CBKE Key Establishment Client: state updated from {} to {}", state, newState);
+        logger.debug("{}: CBKE Key Establishment Client: state updated from {} to {}", ieeeAddress, state, newState);
         state = newState;
     }
 
@@ -344,14 +349,15 @@ public class ZclKeyEstablishmentClient implements ZclCommandListener {
 
         @Override
         public void run() {
-            logger.debug("CBKE Key Establishment Client: handleInitiateKeyEstablishmentResponse {}", response);
+            logger.debug("{}: CBKE Key Establishment Client: handleInitiateKeyEstablishmentResponse {}", ieeeAddress,
+                    response);
             stopTerminationTimer();
 
             // Check the state and terminate if we're not expecting this response
             if (state != KeyEstablishmentState.INITIATE_REQUEST) {
                 logger.debug(
-                        "CBKE Key Establishment Client: Invalid InitiateKeyEstablishmentResponse packet with state {}",
-                        state);
+                        "{}: CBKE Key Establishment Client: Invalid InitiateKeyEstablishmentResponse packet with state {}",
+                        ieeeAddress, state);
                 keCluster.terminateKeyEstablishment(KeyEstablishmentStatusEnum.BAD_MESSAGE.getKey(), DELAY_BEFORE_RETRY,
                         KeyEstablishmentSuiteBitmap.CRYPTO_SUITE_1.getKey());
                 setState(KeyEstablishmentState.FAILED);
@@ -362,8 +368,8 @@ public class ZclKeyEstablishmentClient implements ZclCommandListener {
             // Only one crypto suite can be selected
             if (Integer.bitCount(response.getRequestedKeyEstablishmentSuite()) != 1) {
                 logger.debug(
-                        "CBKE Key Establishment Client: Invalid InitiateKeyEstablishmentResponse packet with multiple suites selected [{}]",
-                        response.getRequestedKeyEstablishmentSuite());
+                        "{}: CBKE Key Establishment Client: Invalid InitiateKeyEstablishmentResponse packet with multiple suites selected [{}]",
+                        ieeeAddress, response.getRequestedKeyEstablishmentSuite());
                 keCluster.terminateKeyEstablishment(KeyEstablishmentStatusEnum.BAD_MESSAGE.getKey(), DELAY_BEFORE_RETRY,
                         getPreferredCryptoSuite().getKey());
                 setState(KeyEstablishmentState.FAILED);
@@ -383,8 +389,8 @@ public class ZclKeyEstablishmentClient implements ZclCommandListener {
 
             if (requestedSuite != cryptoSuite) {
                 logger.debug(
-                        "CBKE Key Establishment Client: Requested crypto suite from remote {} is inconsistent with our request {}",
-                        cryptoSuite, requestedSuite);
+                        "{}: CBKE Key Establishment Client: Requested crypto suite from remote {} is inconsistent with our request {}",
+                        ieeeAddress, cryptoSuite, requestedSuite);
                 keCluster.sendDefaultResponse(response, ZclStatus.FAILURE);
                 setState(KeyEstablishmentState.FAILED);
                 stopCbke(0);
@@ -415,7 +421,8 @@ public class ZclKeyEstablishmentClient implements ZclCommandListener {
                         break;
                 }
             } catch (IllegalArgumentException e) {
-                logger.debug("CBKE Key Establishment Client: Certificates invalid: {}", e.getMessage());
+                logger.debug("{}: CBKE Key Establishment Client: Certificates invalid: {}", ieeeAddress,
+                        e.getMessage());
                 keCluster.terminateKeyEstablishment(KeyEstablishmentStatusEnum.BAD_MESSAGE.getKey(), DELAY_BEFORE_RETRY,
                         KeyEstablishmentSuiteBitmap.CRYPTO_SUITE_1.getKey());
                 setState(KeyEstablishmentState.FAILED);
@@ -423,18 +430,18 @@ public class ZclKeyEstablishmentClient implements ZclCommandListener {
                 return;
             }
 
-            logger.debug("CBKE Key Establishment Client: Local  Certificate is {}", localCertificate);
-            logger.debug("CBKE Key Establishment Client: Remote Certificate is {}", remoteCertificate);
+            logger.debug("{}: CBKE Key Establishment Client: Local  Certificate is {}", ieeeAddress, localCertificate);
+            logger.debug("{}: CBKE Key Establishment Client: Remote Certificate is {}", ieeeAddress, remoteCertificate);
             if (localCertificate == null || remoteCertificate == null) {
-                logger.debug("CBKE Key Establishment Client: Certificates not found");
+                logger.debug("{}: CBKE Key Establishment Client: Certificates not found", ieeeAddress);
                 keCluster.terminateKeyEstablishment(KeyEstablishmentStatusEnum.UNSUPPORTED_SUITE.getKey(),
                         DELAY_BEFORE_RETRY, KeyEstablishmentSuiteBitmap.CRYPTO_SUITE_1.getKey());
                 setState(KeyEstablishmentState.FAILED);
                 stopCbke(0);
                 return;
             } else if (!Objects.equals(localCertificate.getIssuer(), remoteCertificate.getIssuer())) {
-                logger.debug("CBKE Key Establishment Client: Issuer is not known - expected={}, received={}",
-                        localCertificate.getIssuer(), remoteCertificate.getIssuer());
+                logger.debug("{}: CBKE Key Establishment Client: Issuer is not known - expected={}, received={}",
+                        ieeeAddress, localCertificate.getIssuer(), remoteCertificate.getIssuer());
                 keCluster.terminateKeyEstablishment(KeyEstablishmentStatusEnum.UNKNOWN_ISSUER.getKey(),
                         DELAY_BEFORE_RETRY, KeyEstablishmentSuiteBitmap.CRYPTO_SUITE_1.getKey());
                 setState(KeyEstablishmentState.FAILED);
@@ -445,8 +452,8 @@ public class ZclKeyEstablishmentClient implements ZclCommandListener {
             // The device should verify the certificate belongs to the address that the device is communicating with.
             if (!remoteCertificate.getSubject().equals(ieeeAddress)) {
                 logger.debug(
-                        "CBKE Key Establishment Client: Certificate is not for this address - expected={}, received={}",
-                        ieeeAddress, remoteCertificate.getSubject());
+                        "{}: CBKE Key Establishment Client: Certificate is not for this address - expected={}, received={}",
+                        ieeeAddress, ieeeAddress, remoteCertificate.getSubject());
                 keCluster.terminateKeyEstablishment(KeyEstablishmentStatusEnum.BAD_MESSAGE.getKey(), DELAY_BEFORE_RETRY,
                         KeyEstablishmentSuiteBitmap.CRYPTO_SUITE_1.getKey());
                 setState(KeyEstablishmentState.FAILED);
@@ -459,16 +466,16 @@ public class ZclKeyEstablishmentClient implements ZclCommandListener {
             // Make sure we have a certificate for the requested crypto suite
             if (ephemeralData == null) {
                 logger.debug(
-                        "CBKE Key Establishment Client: Unable to get ephemeral data for requested security suite {}",
-                        requestedSuite);
+                        "{}: CBKE Key Establishment Client: Unable to get ephemeral data for requested security suite {}",
+                        ieeeAddress, requestedSuite);
                 keCluster.terminateKeyEstablishment(KeyEstablishmentStatusEnum.UNSUPPORTED_SUITE.getKey(),
                         DELAY_BEFORE_RETRY, KeyEstablishmentSuiteBitmap.CRYPTO_SUITE_1.getKey());
                 setState(KeyEstablishmentState.FAILED);
                 stopCbke(0);
                 return;
             }
-            logger.debug("CBKE Key Establishment Client: Certificate for requested security suite {} is {}",
-                    requestedSuite, ephemeralData);
+            logger.debug("{}: CBKE Key Establishment Client: Certificate for requested security suite {} is {}",
+                    ieeeAddress, requestedSuite, ephemeralData);
 
             cbkeProvider.addPartnerCertificate(cryptoSuite, remoteCertificate.getByteArray());
             keCluster.ephemeralDataRequestCommand(ephemeralData);
@@ -488,13 +495,13 @@ public class ZclKeyEstablishmentClient implements ZclCommandListener {
 
         @Override
         public void run() {
-            logger.debug("CBKE Key Establishment Client: handleEphemeralDataResponse {}", response);
+            logger.debug("{}: CBKE Key Establishment Client: handleEphemeralDataResponse {}", ieeeAddress, response);
             stopTerminationTimer();
 
             // Check the state and terminate if we're not expecting this response
             if (state != KeyEstablishmentState.EPHEMERAL_DATA_REQUEST) {
-                logger.debug("CBKE Key Establishment Client: Invalid EphemeralDataResponse packet with state {}",
-                        state);
+                logger.debug("{}: CBKE Key Establishment Client: Invalid EphemeralDataResponse packet with state {}",
+                        ieeeAddress, state);
                 keCluster.terminateKeyEstablishment(KeyEstablishmentStatusEnum.BAD_MESSAGE.getKey(), DELAY_BEFORE_RETRY,
                         KeyEstablishmentSuiteBitmap.CRYPTO_SUITE_1.getKey());
                 setState(KeyEstablishmentState.FAILED);
@@ -521,12 +528,12 @@ public class ZclKeyEstablishmentClient implements ZclCommandListener {
 
         @Override
         public void run() {
-            logger.debug("CBKE Key Establishment Client: handleConfirmKeyResponse {}", response);
+            logger.debug("{}: CBKE Key Establishment Client: handleConfirmKeyResponse {}", ieeeAddress, response);
             stopTerminationTimer();
 
             // Check the state and terminate if we're not expecting this response
             if (state != KeyEstablishmentState.CONFIRM_KEY_REQUEST) {
-                logger.debug("CBKE Invalid ConfirmKeyResponse packet with state {}", state);
+                logger.debug("{}: CBKE Invalid ConfirmKeyResponse packet with state {}", ieeeAddress, state);
                 keCluster.terminateKeyEstablishment(KeyEstablishmentStatusEnum.BAD_MESSAGE.getKey(), DELAY_BEFORE_RETRY,
                         KeyEstablishmentSuiteBitmap.CRYPTO_SUITE_1.getKey());
                 setState(KeyEstablishmentState.FAILED);
@@ -536,13 +543,15 @@ public class ZclKeyEstablishmentClient implements ZclCommandListener {
 
             ByteArray responseMac = cbkeProvider.getResponderMac(cryptoSuite);
 
-            logger.debug("CBKE Key Establishment Client: Confirm key response our={} theirs={}", responseMac,
-                    response.getSecureMessageAuthenticationCode());
+            logger.debug("{}: CBKE Key Establishment Client: Confirm key response our={} theirs={}", ieeeAddress,
+                    responseMac, response.getSecureMessageAuthenticationCode());
             boolean success = responseMac.equals(response.getSecureMessageAuthenticationCode());
 
             if (!success) {
                 // Failure
-                logger.debug("CBKE Key Establishment Client: Key establishment failed - SMAC codes were not confirmed");
+                logger.debug(
+                        "{}: CBKE Key Establishment Client: Key establishment failed - SMAC codes were not confirmed",
+                        ieeeAddress);
                 keCluster.terminateKeyEstablishment(KeyEstablishmentStatusEnum.BAD_KEY_CONFIRM.getKey(),
                         DELAY_BEFORE_RETRY, KeyEstablishmentSuiteBitmap.CRYPTO_SUITE_1.getKey());
                 setState(KeyEstablishmentState.FAILED);
@@ -565,7 +574,8 @@ public class ZclKeyEstablishmentClient implements ZclCommandListener {
 
         @Override
         public void run() {
-            logger.debug("CBKE Key Establishment Client: handleTerminateKeyEstablishment {}", response);
+            logger.debug("{}: CBKE Key Establishment Client: handleTerminateKeyEstablishment {}", ieeeAddress,
+                    response);
             stopTerminationTimer();
 
             Integer suite = response.getKeyEstablishmentSuite();
@@ -577,8 +587,8 @@ public class ZclKeyEstablishmentClient implements ZclCommandListener {
             } else {
                 setState(KeyEstablishmentState.FAILED);
             }
-            logger.debug("CBKE Terminate Key establishment client: Terminate status={}, suite={}, wait={} seconds",
-                    status, suite, waitTime);
+            logger.debug("{}: CBKE Terminate Key establishment client: Terminate status={}, suite={}, wait={} seconds",
+                    ieeeAddress, status, suite, waitTime);
             stopCbke(waitTime);
         }
     }
@@ -590,13 +600,15 @@ public class ZclKeyEstablishmentClient implements ZclCommandListener {
      */
     private void startTerminationTimer(int delay) {
         stopTerminationTimer();
-        logger.debug("CBKE Key Establishment Client: Timer started for {} seconds at {}", delay, state);
+        logger.debug("{}: CBKE Key Establishment Client: Timer started for {} seconds at {}", ieeeAddress, delay,
+                state);
 
         timer = timerService.schedule(new Runnable() {
             @Override
             public void run() {
                 timer = null;
-                logger.debug("CBKE Key Establishment Client: Timeout waiting for message in state {}", state);
+                logger.debug("{}: CBKE Key Establishment Client: Timeout waiting for message in state {}", ieeeAddress,
+                        state);
                 // Note that no TerminateKeyEstablishment message should be sent.
                 setState(KeyEstablishmentState.FAILED);
                 stopCbke(0);
@@ -609,7 +621,7 @@ public class ZclKeyEstablishmentClient implements ZclCommandListener {
      */
     private void stopTerminationTimer() {
         if (timer != null) {
-            logger.debug("CBKE Key Establishment Client: Timer stopped");
+            logger.debug("{}: CBKE Key Establishment Client: Timer stopped", ieeeAddress);
             timer.cancel(true);
             timer = null;
         }
@@ -645,7 +657,7 @@ public class ZclKeyEstablishmentClient implements ZclCommandListener {
     }
 
     private void stopCbke(int waitTime) {
-        logger.debug("CBKE Key Establishment Client: Terminated");
+        logger.debug("{}: CBKE Key Establishment Client: Terminated", ieeeAddress);
         stopTerminationTimer();
 
         ZigBeeStatus returnState;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/seclient/ZclKeyEstablishmentServer.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/seclient/ZclKeyEstablishmentServer.java
@@ -1,0 +1,494 @@
+/**
+ * Copyright (c) 2016-2019 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.app.seclient;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.zsmartsystems.zigbee.CommandResult;
+import com.zsmartsystems.zigbee.IeeeAddress;
+import com.zsmartsystems.zigbee.ZigBeeExecutors;
+import com.zsmartsystems.zigbee.security.ZigBeeCbkeProvider;
+import com.zsmartsystems.zigbee.security.ZigBeeCertificate;
+import com.zsmartsystems.zigbee.security.ZigBeeCryptoSuite1Certificate;
+import com.zsmartsystems.zigbee.security.ZigBeeCryptoSuites;
+import com.zsmartsystems.zigbee.zcl.ZclAttribute;
+import com.zsmartsystems.zigbee.zcl.ZclCommand;
+import com.zsmartsystems.zigbee.zcl.ZclCommandListener;
+import com.zsmartsystems.zigbee.zcl.clusters.ZclKeyEstablishmentCluster;
+import com.zsmartsystems.zigbee.zcl.clusters.keyestablishment.ConfirmKeyDataRequestCommand;
+import com.zsmartsystems.zigbee.zcl.clusters.keyestablishment.EphemeralDataRequestCommand;
+import com.zsmartsystems.zigbee.zcl.clusters.keyestablishment.InitiateKeyEstablishmentRequestCommand;
+import com.zsmartsystems.zigbee.zcl.clusters.keyestablishment.KeyEstablishmentStatusEnum;
+import com.zsmartsystems.zigbee.zcl.clusters.keyestablishment.KeyEstablishmentSuiteBitmap;
+import com.zsmartsystems.zigbee.zcl.clusters.keyestablishment.TerminateKeyEstablishment;
+import com.zsmartsystems.zigbee.zcl.field.ByteArray;
+import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
+
+/**
+ * Implements the Key Establishment Server
+ *
+ * @author Chris Jackson
+ *
+ */
+public class ZclKeyEstablishmentServer implements ZclCommandListener {
+    /**
+     * Number of seconds to wait when there is already a key establishment running.
+     */
+    private static final int DELAY_NO_RESOURCES = 20;
+
+    /**
+     * The logger.
+     */
+    private final Logger logger = LoggerFactory.getLogger(ZclKeyEstablishmentServer.class);
+
+    /**
+     * The {@link IeeeAddress} of the remote node. The client will check that the certificate is valid for this address
+     */
+    private final IeeeAddress ieeeAddress;
+
+    /**
+     * The KeyEstablishmentCluster used to communicate with the remote device
+     */
+    private ZclKeyEstablishmentCluster keCluster;
+
+    /**
+     * The crypto suite that we are using for key exchange.
+     */
+    private ZigBeeCryptoSuites cryptoSuite;
+
+    /**
+     * The {@link ZigBeeCbkeProvider} provides the security algorithms required for the Certificate Based Key Exchange.
+     */
+    private ZigBeeCbkeProvider cbkeProvider;
+
+    /**
+     * Used to manually define the crypto suite. May be set by the application to limit the crypto suite to a known
+     * value rather than let the system choose the highest usable suite.
+     */
+    private ZigBeeCryptoSuites forceCryptoSuite;
+
+    private ExecutorService executorService;
+    private ScheduledExecutorService timerService;
+
+    private ScheduledFuture<?> timer;
+
+    /**
+     * Stores the number of seconds the server will take to generate the confirm key message
+     */
+    private int confirmKeyGenerateTime;
+
+    private Map<ZigBeeCryptoSuites, KeyEstablishmentSuiteBitmap> cryptoSuiteTranslation = new HashMap<>();
+
+    private KeyEstablishmentState keyEstablishmentState = KeyEstablishmentState.UNINITIALISED;
+
+    private Future<CommandResult> lastTransaction;
+
+    protected enum KeyEstablishmentState {
+        UNINITIALISED,
+        CHECK_CURVES,
+        INITIATE_REQUEST,
+        EPHEMERAL_DATA_REQUEST,
+        CONFIRM_KEY_REQUEST,
+        COMPLETE,
+        FAILED
+    }
+
+    /**
+     * The period to wait (in seconds) before retrying the key exchange if there's an error.
+     */
+    private final static int DELAY_BEFORE_RETRY = 10;
+
+    /**
+     * Constructs a Key Establishment Server.
+     *
+     * @param ieeeAddress the {@link IeeeAddress} of the remote node
+     * @param keCluster the {@link ZclKeyEstablishmentCluster} used for communicating with the remote device
+     */
+    ZclKeyEstablishmentServer(IeeeAddress ieeeAddress, ZclKeyEstablishmentCluster keCluster) {
+        this.ieeeAddress = ieeeAddress;
+        this.keCluster = keCluster;
+
+        cryptoSuiteTranslation.put(ZigBeeCryptoSuites.ECC_163K1, KeyEstablishmentSuiteBitmap.CRYPTO_SUITE_1);
+        cryptoSuiteTranslation.put(ZigBeeCryptoSuites.ECC_283K1, KeyEstablishmentSuiteBitmap.CRYPTO_SUITE_2);
+
+        executorService = ZigBeeExecutors.newSingleThreadScheduledExecutor("ZclKeyEstablishmentServer");
+        timerService = ZigBeeExecutors.newScheduledThreadPool(1, "ZclKeyEstablishmentServerTimeout");
+
+        keCluster.addCommandListener(this);
+    }
+
+    /**
+     * Sets the {@link ZigBeeCbkeProvider} to be used for the crypto services
+     */
+    public void setCbkeProvider(ZigBeeCbkeProvider cbkeProvider) {
+        this.cbkeProvider = cbkeProvider;
+        this.cbkeProvider.setClientServer(false);
+
+        cbkeProvider.getAvailableCryptoSuites();
+    }
+
+    public void shutdown() {
+        keCluster.removeCommandListener(this);
+    }
+
+    /**
+     * Set the crypto suite to a fixed value. May be set by the application to limit the crypto suite to a known value
+     * rather than let the system choose the highest usable suite.
+     * <p>
+     * Cannot be called before the {@link ZigBeeCbkeProvider} is set via the
+     * {@link #setCbkeProvider(ZigBeeCbkeProvider)} method.
+     *
+     * @param requestedCryptoSuite the {@link ZigBeeCryptoSuites} to use
+     * @return true if the {@link ZigBeeCryptoSuites} was set
+     */
+    public boolean setCryptoSuite(ZigBeeCryptoSuites requestedCryptoSuite) {
+        if (cbkeProvider == null || !cbkeProvider.getAvailableCryptoSuites().contains(requestedCryptoSuite)) {
+            logger.debug("{}: CBKE Key Establishment Server: Failed to set crypto suite to unsupported value {}",
+                    ieeeAddress, requestedCryptoSuite,
+                    cbkeProvider == null ? "[]" : cbkeProvider.getAvailableCryptoSuites());
+            return false;
+        }
+
+        forceCryptoSuite = requestedCryptoSuite;
+        setServerCryptoSuite(cryptoSuiteTranslation.get(forceCryptoSuite).getKey());
+        return true;
+    }
+
+    private void setServerCryptoSuite(int suite) {
+        ZclAttribute attribute = keCluster
+                .getLocalAttribute(ZclKeyEstablishmentCluster.ATTR_SERVERKEYESTABLISHMENTSUITE);
+        if (attribute == null) {
+            logger.debug("{}: CBKE Key Establishment Server: Failed to get local server attribute", ieeeAddress);
+            return;
+        }
+        attribute.setValue(suite);
+    }
+
+    /**
+     * Gets the {@link ZigBeeCryptoSuites} being used by the CBKE procedure
+     *
+     * @return the {@link ZigBeeCryptoSuites} in use. If CBKE has not started, this will return null.
+     */
+    public ZigBeeCryptoSuites getCryptoSuite() {
+        return cryptoSuite;
+    }
+
+    class HandleInitiateKeyEstablishmentRequest implements Runnable {
+        private final InitiateKeyEstablishmentRequestCommand request;
+
+        HandleInitiateKeyEstablishmentRequest(InitiateKeyEstablishmentRequestCommand request) {
+            this.request = request;
+        }
+
+        @Override
+        public void run() {
+            logger.debug("{}: CBKE Key Establishment Server: handleInitiateKeyEstablishmentRequest {}", ieeeAddress,
+                    request);
+
+            // If the device does not currently have the resources to respond to a key establishment request it shall
+            // send a Terminate Key Establishment command with the result value set to NO_RESOURCES and the Wait Time
+            // field shall be set to an approximation of the time that must pass before the device will have the
+            // resources to process a new Key Establishment Request.
+            if (cbkeProvider == null || keyEstablishmentState != KeyEstablishmentState.UNINITIALISED) {
+                if (cbkeProvider == null) {
+                    logger.debug("{}: CBKE Key Establishment Server: Initiate Key Establishment with no key provider",
+                            ieeeAddress);
+                } else {
+                    logger.debug("{}: CBKE Key Establishment Server: Initiate Key Establishment Invalid state {}",
+                            ieeeAddress, keyEstablishmentState);
+                }
+                keCluster.terminateKeyEstablishment(KeyEstablishmentStatusEnum.NO_RESOURCES.getKey(),
+                        DELAY_NO_RESOURCES, request.getKeyEstablishmentSuite());
+                setState(KeyEstablishmentState.UNINITIALISED);
+                stopCbke();
+                return;
+            }
+
+            ZigBeeCertificate localCertificate = null;
+            ZigBeeCertificate remoteCertificate = null;
+
+            try {
+                switch (request.getKeyEstablishmentSuite()) {
+                    case 1:
+                        cryptoSuite = ZigBeeCryptoSuites.ECC_163K1;
+                        if (request.getIdentity().size() < ZigBeeCryptoSuite1Certificate.CERTIFICATE_LENGTH) {
+                            keCluster.terminateKeyEstablishment(KeyEstablishmentStatusEnum.BAD_MESSAGE.getKey(),
+                                    DELAY_BEFORE_RETRY, KeyEstablishmentSuiteBitmap.CRYPTO_SUITE_1.getKey());
+                            setState(KeyEstablishmentState.FAILED);
+                            stopCbke();
+                            return;
+                        }
+                        localCertificate = new ZigBeeCryptoSuite1Certificate(
+                                cbkeProvider.getCertificate(ZigBeeCryptoSuites.ECC_163K1));
+                        remoteCertificate = new ZigBeeCryptoSuite1Certificate(new ByteArray(request.getIdentity()
+                                .getAsIntArray(0, ZigBeeCryptoSuite1Certificate.CERTIFICATE_LENGTH)));
+                        break;
+                    case 2:
+                        cryptoSuite = ZigBeeCryptoSuites.ECC_283K1;
+                        break;
+                    default:
+                        break;
+                }
+            } catch (IllegalArgumentException e) {
+                logger.debug("{}: CBKE Key Establishment Server: Certificates invalid: {}", ieeeAddress,
+                        e.getMessage());
+                keCluster.terminateKeyEstablishment(KeyEstablishmentStatusEnum.BAD_MESSAGE.getKey(), DELAY_BEFORE_RETRY,
+                        KeyEstablishmentSuiteBitmap.CRYPTO_SUITE_1.getKey());
+                setState(KeyEstablishmentState.FAILED);
+                stopCbke();
+                return;
+            }
+
+            logger.debug("{}: CBKE Key Establishment Server: Local  Certificate is {}", ieeeAddress, localCertificate);
+            logger.debug("{}: CBKE Key Establishment Server: Remote Certificate is {}", ieeeAddress, remoteCertificate);
+
+            // If the device can process this request, it shall check the Issuer field of the device's implicit
+            // certificate. If the Issuer field does not contain a value that corresponds to a known Certificate
+            // Authority, the device shall send a Terminate Key Establishment command with the result set to
+            // UNKNOWN_ISSUER.
+            if (!Objects.equals(localCertificate.getIssuer(), remoteCertificate.getIssuer())) {
+                logger.debug("{}: CBKE Key Establishment Server: Issuer is not known - expected={}, received={}",
+                        ieeeAddress, localCertificate.getIssuer(), remoteCertificate.getIssuer());
+                keCluster.terminateKeyEstablishment(KeyEstablishmentStatusEnum.UNKNOWN_ISSUER.getKey(),
+                        DELAY_BEFORE_RETRY, KeyEstablishmentSuiteBitmap.CRYPTO_SUITE_1.getKey());
+                setState(KeyEstablishmentState.UNINITIALISED);
+                stopCbke();
+                return;
+            }
+
+            // The device should verify the certificate belongs to the address that the device is communicating with.
+            if (!remoteCertificate.getSubject().equals(ieeeAddress)) {
+                logger.debug(
+                        "{}: CBKE Key Establishment Server: Certificate is not for this address - expected={}, received={}",
+                        ieeeAddress, ieeeAddress, remoteCertificate.getSubject());
+                keCluster.terminateKeyEstablishment(KeyEstablishmentStatusEnum.BAD_MESSAGE.getKey(), DELAY_BEFORE_RETRY,
+                        KeyEstablishmentSuiteBitmap.CRYPTO_SUITE_1.getKey());
+                setState(KeyEstablishmentState.FAILED);
+                stopCbke();
+                return;
+            }
+
+            // If the device accepts the request it shall send an Initiate Key Establishment Response command containing
+            // its own identity information. The device should verify the certificate belongs to the address that the
+            // device is communicating with. The binding between the identity of the communicating device and its
+            // address is verifiable using out-of-band method.
+            int requestedSuite = request.getKeyEstablishmentSuite();
+            cbkeProvider.addPartnerCertificate(cryptoSuite, request.getIdentity());
+
+            setState(KeyEstablishmentState.INITIATE_REQUEST);
+            lastTransaction = keCluster.initiateKeyEstablishmentResponse(requestedSuite,
+                    cbkeProvider.getEphemeralDataGenerateTime(), cbkeProvider.getConfirmKeyGenerateTime(),
+                    localCertificate.getByteArray());
+            startTerminationTimer(request.getEphemeralDataGenerateTime());
+            confirmKeyGenerateTime = request.getConfirmKeyGenerateTime();
+        }
+    }
+
+    class HandleEphemeralDataRequest implements Runnable {
+        private final EphemeralDataRequestCommand request;
+
+        HandleEphemeralDataRequest(EphemeralDataRequestCommand request) {
+            this.request = request;
+        }
+
+        @Override
+        public void run() {
+            logger.debug("{}: CBKE Key Establishment Server: handleEphemeralDataRequest {}", ieeeAddress, request);
+            stopTerminationTimer();
+            completeLastTransaction();
+
+            // If the device is not currently in the middle of negotiating Key Establishment with the sending device
+            // when it receives this message, it shall send back a Terminate Key Establishment message with a result of
+            // BAD_MESSAGE.
+            // If the device is in the middle of Key Establishment with the sender but did not receive this message in
+            // response to an Initiate Key Establishment Response command, it shall send back a Terminate Key
+            // Establishment message with a result of BAD_MESSAGE.
+            if (keyEstablishmentState != KeyEstablishmentState.INITIATE_REQUEST) {
+                logger.debug("{}: CBKE Key Establishment Server: Ephemeral Data Request Invalid state {}", ieeeAddress,
+                        keyEstablishmentState);
+                keCluster.terminateKeyEstablishment(KeyEstablishmentStatusEnum.BAD_MESSAGE.getKey(), 10, 1);
+                setState(KeyEstablishmentState.UNINITIALISED);
+                stopCbke();
+                return;
+            }
+
+            // If the device can process the request it shall respond by generating its own ephemeral data and sending
+            // an Ephemeral Data Response command containing that value.
+            cbkeProvider.addPartnerEphemeralData(cryptoSuite, request.getEphemeralData());
+
+            setState(KeyEstablishmentState.CONFIRM_KEY_REQUEST);
+            lastTransaction = keCluster.ephemeralDataResponse(cbkeProvider.getCbkeEphemeralData(cryptoSuite));
+            startTerminationTimer(confirmKeyGenerateTime);
+        }
+    }
+
+    class HandleConfirmKeyRequest implements Runnable {
+        private final ConfirmKeyDataRequestCommand request;
+
+        HandleConfirmKeyRequest(ConfirmKeyDataRequestCommand request) {
+            this.request = request;
+        }
+
+        @Override
+        public void run() {
+            logger.debug("{}: CBKE Key Establishment Server: handleConfirmKeyRequest {}", ieeeAddress, request);
+            stopTerminationTimer();
+            completeLastTransaction();
+
+            // If the device is not currently in the middle of negotiating Key Establishment with the sending device
+            // when it receives this message, it shall send back a Terminate Key Establishment message with a result of
+            // BAD_MESSAGE.
+            // If the device is in the middle of Key Establishment with the sender but did not receive this message in
+            // response to an Ephemeral Data Response command, it shall send back a Terminate Key Establishment message
+            // with a result of BAD_MESSAGE.
+            if (keyEstablishmentState != KeyEstablishmentState.CONFIRM_KEY_REQUEST) {
+                logger.debug("{}: CBKE Key Establishment Server: Confirm Key Invalid state {}", ieeeAddress,
+                        keyEstablishmentState);
+                keCluster.terminateKeyEstablishment(KeyEstablishmentStatusEnum.BAD_MESSAGE.getKey(), DELAY_BEFORE_RETRY,
+                        1);
+                setState(KeyEstablishmentState.UNINITIALISED);
+                stopCbke();
+                return;
+            }
+
+            // On receipt of the Confirm Key Request command the responder device shall compare the received MACU value
+            // with its own reconstructed version of MACU. If the two match the responder shall send back MACV by
+            // generating an appropriate Confirm Key Response command. If the two do not match, the responder shall send
+            // back a Terminate Key Establishment with a result of BAD KEY_CONFIRM and terminate the key establishment.
+            ByteArray secureMessageAuthenticationCode = request.getSecureMessageAuthenticationCode();
+            ByteArray remoteMac = cbkeProvider.getInitiatorMac(cryptoSuite);
+            ByteArray localMac = cbkeProvider.getResponderMac(cryptoSuite);
+            boolean success = secureMessageAuthenticationCode.equals(localMac);
+            cbkeProvider.completeKeyExchange(cryptoSuite, success);
+            if (!success) {
+                logger.debug("{}: CBKE Key Establishment Server: Confirm Key Invalid SMAC = expected {}, received {}",
+                        ieeeAddress, localMac, secureMessageAuthenticationCode);
+                keCluster.terminateKeyEstablishment(KeyEstablishmentStatusEnum.BAD_KEY_CONFIRM.getKey(),
+                        DELAY_BEFORE_RETRY, 1);
+                setState(KeyEstablishmentState.UNINITIALISED);
+                stopCbke();
+                return;
+            }
+
+            lastTransaction = keCluster.confirmKeyResponse(remoteMac);
+        }
+    }
+
+    class HandleTerminateKeyEstablishment implements Runnable {
+        private final TerminateKeyEstablishment request;
+
+        HandleTerminateKeyEstablishment(TerminateKeyEstablishment request) {
+            this.request = request;
+        }
+
+        @Override
+        public void run() {
+            logger.debug("{}: CBKE Key Establishment Server: handleTerminateKeyEstablishment {}", ieeeAddress, request);
+            stopTerminationTimer();
+            completeLastTransaction();
+
+            setState(KeyEstablishmentState.UNINITIALISED);
+            stopCbke();
+        }
+    }
+
+    private void setState(KeyEstablishmentState newState) {
+        logger.debug("{}: CBKE Key Establishment Server: State updated from {} to {}", ieeeAddress,
+                keyEstablishmentState, newState);
+        keyEstablishmentState = newState;
+    }
+
+    private void stopCbke() {
+        logger.debug("{}: CBKE Key Establishment Server: Terminated", ieeeAddress);
+        stopTerminationTimer();
+    }
+
+    private void completeLastTransaction() {
+        if (lastTransaction == null) {
+            return;
+        }
+        lastTransaction.cancel(true);
+        lastTransaction = null;
+    }
+
+    /**
+     * Starts a timer, after which the CBKE will be terminated
+     *
+     * @param delay the number of seconds to wait
+     */
+    private void startTerminationTimer(int delay) {
+        stopTerminationTimer();
+        logger.debug("{}: CBKE Key Establishment Server: Timer started for {} seconds at {}", ieeeAddress, delay,
+                keyEstablishmentState);
+
+        timer = timerService.schedule(new Runnable() {
+            @Override
+            public void run() {
+                timer = null;
+                logger.debug("{}: CBKE Key Establishment Server: Timeout waiting for message in state {}", ieeeAddress,
+                        keyEstablishmentState);
+                // Note that no TerminateKeyEstablishment message should be sent.
+                setState(KeyEstablishmentState.FAILED);
+                stopCbke();
+            }
+        }, delay, TimeUnit.SECONDS);
+    }
+
+    /**
+     * Stops a currently running termination timer.
+     */
+    private void stopTerminationTimer() {
+        if (timer != null) {
+            logger.debug("{}: CBKE Key Establishment Server: Timer stopped", ieeeAddress);
+            timer.cancel(true);
+            timer = null;
+        }
+    }
+
+    @Override
+    public boolean commandReceived(ZclCommand command) {
+        logger.debug("{}: CBKE Key Establishment Server: Received {}", ieeeAddress, command);
+        Runnable handler = null;
+
+        if (command.getCommandDirection() != ZclCommandDirection.CLIENT_TO_SERVER) {
+            return false;
+        }
+
+        // Process the response
+        if (command instanceof InitiateKeyEstablishmentRequestCommand) {
+            handler = new HandleInitiateKeyEstablishmentRequest((InitiateKeyEstablishmentRequestCommand) command);
+        }
+        if (command instanceof EphemeralDataRequestCommand) {
+            handler = new HandleEphemeralDataRequest((EphemeralDataRequestCommand) command);
+        }
+        if (command instanceof ConfirmKeyDataRequestCommand) {
+            handler = new HandleConfirmKeyRequest((ConfirmKeyDataRequestCommand) command);
+        }
+        if (command instanceof TerminateKeyEstablishment) {
+            handler = new HandleTerminateKeyEstablishment((TerminateKeyEstablishment) command);
+        }
+
+        if (handler != null) {
+            executorService.submit(handler);
+            return true;
+        }
+
+        return false;
+    }
+
+}

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclKeyEstablishmentCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclKeyEstablishmentCluster.java
@@ -94,7 +94,8 @@ public class ZclKeyEstablishmentCluster extends ZclCluster {
     protected Map<Integer, ZclAttribute> initializeClientAttributes() {
         Map<Integer, ZclAttribute> attributeMap = new ConcurrentSkipListMap<>();
 
-        attributeMap.put(ATTR_CLIENTKEYESTABLISHMENTSUITE, new ZclAttribute(this, ATTR_CLIENTKEYESTABLISHMENTSUITE, "Client Key Establishment Suite", ZclDataType.ENUMERATION_16_BIT, true, true, false, false));
+        attributeMap.put(ATTR_CLIENTKEYESTABLISHMENTSUITE, new ZclAttribute(this, ATTR_CLIENTKEYESTABLISHMENTSUITE,
+                "Client Key Establishment Suite", ZclDataType.ENUMERATION_16_BIT, true, true, false, false));
 
         return attributeMap;
     }
@@ -103,7 +104,8 @@ public class ZclKeyEstablishmentCluster extends ZclCluster {
     protected Map<Integer, ZclAttribute> initializeServerAttributes() {
         Map<Integer, ZclAttribute> attributeMap = new ConcurrentSkipListMap<>();
 
-        attributeMap.put(ATTR_SERVERKEYESTABLISHMENTSUITE, new ZclAttribute(this, ATTR_SERVERKEYESTABLISHMENTSUITE, "Server Key Establishment Suite", ZclDataType.ENUMERATION_16_BIT, true, true, false, false));
+        attributeMap.put(ATTR_SERVERKEYESTABLISHMENTSUITE, new ZclAttribute(this, ATTR_SERVERKEYESTABLISHMENTSUITE,
+                "Server Key Establishment Suite", ZclDataType.ENUMERATION_16_BIT, true, true, false, false));
 
         return attributeMap;
     }
@@ -207,7 +209,8 @@ public class ZclKeyEstablishmentCluster extends ZclCluster {
      * @param minInterval minimum reporting period
      * @param maxInterval maximum reporting period
      * @return the {@link Future<CommandResult>} command result future
-     * @deprecated As of release 1.2.0, replaced by {@link #setReporting(int attributeId, int minInterval, int maxInterval)}
+     * @deprecated As of release 1.2.0, replaced by
+     *             {@link #setReporting(int attributeId, int minInterval, int maxInterval)}
      */
     @Deprecated
     public Future<CommandResult> setServerKeyEstablishmentSuiteReporting(final int minInterval, final int maxInterval) {
@@ -244,7 +247,8 @@ public class ZclKeyEstablishmentCluster extends ZclCluster {
      * @param identity {@link ByteArray} Identity
      * @return the {@link Future<CommandResult>} command result future
      */
-    public Future<CommandResult> initiateKeyEstablishmentRequestCommand(Integer keyEstablishmentSuite, Integer ephemeralDataGenerateTime, Integer confirmKeyGenerateTime, ByteArray identity) {
+    public Future<CommandResult> initiateKeyEstablishmentRequestCommand(Integer keyEstablishmentSuite,
+            Integer ephemeralDataGenerateTime, Integer confirmKeyGenerateTime, ByteArray identity) {
         InitiateKeyEstablishmentRequestCommand command = new InitiateKeyEstablishmentRequestCommand();
 
         // Set the fields
@@ -252,6 +256,7 @@ public class ZclKeyEstablishmentCluster extends ZclCluster {
         command.setEphemeralDataGenerateTime(ephemeralDataGenerateTime);
         command.setConfirmKeyGenerateTime(confirmKeyGenerateTime);
         command.setIdentity(identity);
+        command.setDisableDefaultResponse(true);
 
         return send(command);
     }
@@ -270,6 +275,7 @@ public class ZclKeyEstablishmentCluster extends ZclCluster {
 
         // Set the fields
         command.setEphemeralData(ephemeralData);
+        command.setDisableDefaultResponse(true);
 
         return send(command);
     }
@@ -290,6 +296,7 @@ public class ZclKeyEstablishmentCluster extends ZclCluster {
 
         // Set the fields
         command.setSecureMessageAuthenticationCode(secureMessageAuthenticationCode);
+        command.setDisableDefaultResponse(true);
 
         return send(command);
     }
@@ -308,7 +315,8 @@ public class ZclKeyEstablishmentCluster extends ZclCluster {
      * @param identity {@link ByteArray} Identity
      * @return the {@link Future<CommandResult>} command result future
      */
-    public Future<CommandResult> initiateKeyEstablishmentResponse(Integer requestedKeyEstablishmentSuite, Integer ephemeralDataGenerateTime, Integer confirmKeyGenerateTime, ByteArray identity) {
+    public Future<CommandResult> initiateKeyEstablishmentResponse(Integer requestedKeyEstablishmentSuite,
+            Integer ephemeralDataGenerateTime, Integer confirmKeyGenerateTime, ByteArray identity) {
         InitiateKeyEstablishmentResponse command = new InitiateKeyEstablishmentResponse();
 
         // Set the fields
@@ -316,6 +324,7 @@ public class ZclKeyEstablishmentCluster extends ZclCluster {
         command.setEphemeralDataGenerateTime(ephemeralDataGenerateTime);
         command.setConfirmKeyGenerateTime(confirmKeyGenerateTime);
         command.setIdentity(identity);
+        command.setDisableDefaultResponse(true);
 
         return send(command);
     }
@@ -334,6 +343,7 @@ public class ZclKeyEstablishmentCluster extends ZclCluster {
 
         // Set the fields
         command.setEphemeralData(ephemeralData);
+        command.setDisableDefaultResponse(true);
 
         return send(command);
     }
@@ -354,6 +364,7 @@ public class ZclKeyEstablishmentCluster extends ZclCluster {
 
         // Set the fields
         command.setSecureMessageAuthenticationCode(secureMessageAuthenticationCode);
+        command.setDisableDefaultResponse(true);
 
         return send(command);
     }
@@ -369,13 +380,15 @@ public class ZclKeyEstablishmentCluster extends ZclCluster {
      * @param keyEstablishmentSuite {@link Integer} Key Establishment Suite
      * @return the {@link Future<CommandResult>} command result future
      */
-    public Future<CommandResult> terminateKeyEstablishment(Integer statusCode, Integer waitTime, Integer keyEstablishmentSuite) {
+    public Future<CommandResult> terminateKeyEstablishment(Integer statusCode, Integer waitTime,
+            Integer keyEstablishmentSuite) {
         TerminateKeyEstablishment command = new TerminateKeyEstablishment();
 
         // Set the fields
         command.setStatusCode(statusCode);
         command.setWaitTime(waitTime);
         command.setKeyEstablishmentSuite(keyEstablishmentSuite);
+        command.setDisableDefaultResponse(true);
 
         return send(command);
     }

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/app/seclient/ZclKeyEstablishmentClientTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/app/seclient/ZclKeyEstablishmentClientTest.java
@@ -62,6 +62,7 @@ public class ZclKeyEstablishmentClientTest {
         System.out.println("--- " + Thread.currentThread().getStackTrace()[1].getMethodName());
         SmartEnergyClient seClient = Mockito.mock(SmartEnergyClient.class);
         ZclKeyEstablishmentCluster keCluster = Mockito.mock(ZclKeyEstablishmentCluster.class);
+
         IeeeAddress ieeeAddress = Mockito.mock(IeeeAddress.class);
 
         ZclKeyEstablishmentClient keClient = new ZclKeyEstablishmentClient(ieeeAddress, seClient, keCluster);
@@ -122,7 +123,7 @@ public class ZclKeyEstablishmentClientTest {
                 ZclKeyEstablishmentClient.KeyEstablishmentState.INITIATE_REQUEST);
         TestUtilities.setField(ZclKeyEstablishmentClient.class, keClient, "cryptoSuite", ZigBeeCryptoSuites.ECC_163K1);
 
-        ByteArray identity = new ByteArray(new int[49]);
+        ByteArray identity = new ByteArray(new int[58]);
         ByteArray local = new ByteArray(new int[48]);
 
         ZigBeeCbkeProvider cbkeProvider = Mockito.mock(ZigBeeCbkeProvider.class);
@@ -186,7 +187,6 @@ public class ZclKeyEstablishmentClientTest {
         TestUtilities.setField(ZclKeyEstablishmentClient.class, keClient, "cryptoSuite", ZigBeeCryptoSuites.ECC_283K1);
 
         ByteArray identity = new ByteArray(new int[48]);
-        ByteArray local = new ByteArray(new int[48]);
 
         ZigBeeCbkeProvider cbkeProvider = Mockito.mock(ZigBeeCbkeProvider.class);
         keClient.setCbkeProvider(cbkeProvider);

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/app/seclient/ZclKeyEstablishmentServerTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/app/seclient/ZclKeyEstablishmentServerTest.java
@@ -1,0 +1,281 @@
+/**
+ * Copyright (c) 2016-2019 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.app.seclient;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.zsmartsystems.zigbee.IeeeAddress;
+import com.zsmartsystems.zigbee.TestUtilities;
+import com.zsmartsystems.zigbee.app.seclient.ZclKeyEstablishmentServer.KeyEstablishmentState;
+import com.zsmartsystems.zigbee.security.CerticomCbkeCertificate;
+import com.zsmartsystems.zigbee.security.ZigBeeCbkeCertificate;
+import com.zsmartsystems.zigbee.security.ZigBeeCbkeProvider;
+import com.zsmartsystems.zigbee.security.ZigBeeCryptoSuites;
+import com.zsmartsystems.zigbee.zcl.ZclAttribute;
+import com.zsmartsystems.zigbee.zcl.ZclCommand;
+import com.zsmartsystems.zigbee.zcl.clusters.ZclKeyEstablishmentCluster;
+import com.zsmartsystems.zigbee.zcl.clusters.keyestablishment.ConfirmKeyDataRequestCommand;
+import com.zsmartsystems.zigbee.zcl.clusters.keyestablishment.EphemeralDataRequestCommand;
+import com.zsmartsystems.zigbee.zcl.clusters.keyestablishment.InitiateKeyEstablishmentRequestCommand;
+import com.zsmartsystems.zigbee.zcl.clusters.keyestablishment.KeyEstablishmentStatusEnum;
+import com.zsmartsystems.zigbee.zcl.clusters.keyestablishment.TerminateKeyEstablishment;
+import com.zsmartsystems.zigbee.zcl.field.ByteArray;
+import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
+
+/**
+ *
+ * @author Chris Jackson
+ *
+ */
+public class ZclKeyEstablishmentServerTest {
+    private final static int TIMEOUT = 5000;
+
+    @Test
+    public void InitiateKeyEstablishmentRequestCommandSuccess() {
+        System.out.println("--- " + Thread.currentThread().getStackTrace()[1].getMethodName());
+        ZclKeyEstablishmentCluster keCluster = Mockito.mock(ZclKeyEstablishmentCluster.class);
+        IeeeAddress ieeeAddress = new IeeeAddress("0022A300001731F3");
+
+        ZclKeyEstablishmentServer keServer = new ZclKeyEstablishmentServer(ieeeAddress, keCluster);
+
+        ByteArray certificateByteArray = new ByteArray(new int[] { 0x02, 0x00, 0xCA, 0xA1, 0x5B, 0x4B, 0xEE, 0xDE, 0x65,
+                0xC3, 0x13, 0x9A, 0x5C, 0x3B, 0xC4, 0x0C, 0x9A, 0xD1, 0x53, 0x85, 0x4A, 0x27, 0x00, 0x22, 0xA3, 0x00,
+                0x00, 0x17, 0x31, 0xF3, 0x54, 0x45, 0x53, 0x54, 0x53, 0x45, 0x43, 0x41, 0x01, 0x09, 0x10, 0x83, 0x01,
+                0x23, 0x45, 0x67, 0x89, 0x0A });
+        ZigBeeCbkeProvider cbkeProvider = Mockito.mock(ZigBeeCbkeProvider.class);
+        Mockito.when(cbkeProvider.getEphemeralDataGenerateTime()).thenReturn(44);
+        Mockito.when(cbkeProvider.getConfirmKeyGenerateTime()).thenReturn(55);
+        Mockito.when(cbkeProvider.getCertificate(ZigBeeCryptoSuites.ECC_163K1)).thenReturn(certificateByteArray);
+        keServer.setCbkeProvider(cbkeProvider);
+
+        assertFalse(keServer.commandReceived(Mockito.mock(ZclCommand.class)));
+
+        ZigBeeCbkeCertificate remoteCert = new CerticomCbkeCertificate(
+                "CAPubKey:0200fde8a7f3d1084224962a4e7c54e69ac3f04da6b8DeviceImplicitCert:0200caa15b4beede65c3139a5c3bc40c9ad153854a270022a300001731f354455354534543410109108301234567890aPrivateKeyReconstructionData:019fcc486fc46980ab4a612725b36f005edff075feDevicePublicKey:020366d312a0abf55654ead3e1624c31faed89c3bb20");
+        InitiateKeyEstablishmentRequestCommand initiateCommand = new InitiateKeyEstablishmentRequestCommand();
+        initiateCommand.setCommandDirection(ZclCommandDirection.CLIENT_TO_SERVER);
+        initiateCommand.setKeyEstablishmentSuite(1);
+        initiateCommand.setIdentity(new ByteArray(remoteCert.getCertificate()));
+        initiateCommand.setEphemeralDataGenerateTime(22);
+        initiateCommand.setConfirmKeyGenerateTime(33);
+        assertTrue(keServer.commandReceived(initiateCommand));
+
+        Mockito.verify(cbkeProvider, Mockito.timeout(TIMEOUT)).getCertificate(ZigBeeCryptoSuites.ECC_163K1);
+
+        Mockito.verify(keCluster, Mockito.timeout(TIMEOUT)).initiateKeyEstablishmentResponse(1, 44, 55,
+                certificateByteArray);
+
+        // Send the command again - this time we're in the wrong state so we get an error
+        assertTrue(keServer.commandReceived(initiateCommand));
+
+        Mockito.verify(keCluster, Mockito.timeout(TIMEOUT))
+                .terminateKeyEstablishment(KeyEstablishmentStatusEnum.NO_RESOURCES.getKey(), 20, 1);
+    }
+
+    @Test
+    public void InitiateKeyEstablishmentRequestCommandInvalidIssuer() {
+        System.out.println("--- " + Thread.currentThread().getStackTrace()[1].getMethodName());
+        ZclKeyEstablishmentCluster keCluster = Mockito.mock(ZclKeyEstablishmentCluster.class);
+        IeeeAddress ieeeAddress = new IeeeAddress("1111111111111111");
+
+        ZclKeyEstablishmentServer keServer = new ZclKeyEstablishmentServer(ieeeAddress, keCluster);
+
+        ByteArray certificateByteArray = new ByteArray(new int[] { 0x02, 0x00, 0xCA, 0xA2, 0x5B, 0x4B, 0xEE, 0xDE, 0x65,
+                0xC3, 0x13, 0x9A, 0x5C, 0x3B, 0xC4, 0x0C, 0x9A, 0xD1, 0x53, 0x85, 0x4A, 0x27, 0x00, 0x22, 0xA3, 0x00,
+                0x00, 0x17, 0x31, 0xF3, 0x54, 0x45, 0x53, 0x54, 0x55, 0x45, 0x43, 0x41, 0x01, 0x09, 0x10, 0x83, 0x01,
+                0x23, 0x45, 0x67, 0x89, 0x0A });
+        ZigBeeCbkeProvider cbkeProvider = Mockito.mock(ZigBeeCbkeProvider.class);
+        Mockito.when(cbkeProvider.getEphemeralDataGenerateTime()).thenReturn(44);
+        Mockito.when(cbkeProvider.getConfirmKeyGenerateTime()).thenReturn(55);
+        Mockito.when(cbkeProvider.getCertificate(ZigBeeCryptoSuites.ECC_163K1)).thenReturn(certificateByteArray);
+        Mockito.verify(keCluster, Mockito.times(1)).addCommandListener(keServer);
+        keServer.setCbkeProvider(cbkeProvider);
+
+        assertFalse(keServer.commandReceived(Mockito.mock(ZclCommand.class)));
+
+        ZigBeeCbkeCertificate remoteCert = new CerticomCbkeCertificate(
+                "CAPubKey:0200fde8a7f3d1084224962a4e7c54e69ac3f04da6b8DeviceImplicitCert:0200caa15b4beede65c3139a5c3bc40c9ad153854a270022a300001731f354455354534543410109108301234567890aPrivateKeyReconstructionData:019fcc486fc46980ab4a612725b36f005edff075feDevicePublicKey:020366d312a0abf55654ead3e1624c31faed89c3bb20");
+        InitiateKeyEstablishmentRequestCommand initiateCommand = new InitiateKeyEstablishmentRequestCommand();
+        initiateCommand.setKeyEstablishmentSuite(1);
+        initiateCommand.setIdentity(new ByteArray(remoteCert.getCertificate()));
+        initiateCommand.setEphemeralDataGenerateTime(22);
+        initiateCommand.setConfirmKeyGenerateTime(33);
+        initiateCommand.setCommandDirection(ZclCommandDirection.CLIENT_TO_SERVER);
+        assertTrue(keServer.commandReceived(initiateCommand));
+
+        Mockito.verify(keCluster, Mockito.timeout(TIMEOUT))
+                .terminateKeyEstablishment(KeyEstablishmentStatusEnum.UNKNOWN_ISSUER.getKey(), 10, 1);
+    }
+
+    @Test
+    public void HandleEphemeralDataRequestUninitialised() {
+        System.out.println("--- " + Thread.currentThread().getStackTrace()[1].getMethodName());
+        ZclKeyEstablishmentCluster keCluster = Mockito.mock(ZclKeyEstablishmentCluster.class);
+        IeeeAddress ieeeAddress = new IeeeAddress("1111111111111111");
+
+        ZclKeyEstablishmentServer keServer = new ZclKeyEstablishmentServer(ieeeAddress, keCluster);
+
+        EphemeralDataRequestCommand command = new EphemeralDataRequestCommand();
+        command.setCommandDirection(ZclCommandDirection.CLIENT_TO_SERVER);
+        assertTrue(keServer.commandReceived(command));
+
+        // State is not initialised
+        Mockito.verify(keCluster, Mockito.timeout(TIMEOUT))
+                .terminateKeyEstablishment(KeyEstablishmentStatusEnum.BAD_MESSAGE.getKey(), 10, 1);
+    }
+
+    @Test
+    public void HandleConfirmKeyRequestUninitialised() {
+        System.out.println("--- " + Thread.currentThread().getStackTrace()[1].getMethodName());
+        ZclKeyEstablishmentCluster keCluster = Mockito.mock(ZclKeyEstablishmentCluster.class);
+        IeeeAddress ieeeAddress = new IeeeAddress("1111111111111111");
+
+        ZclKeyEstablishmentServer keServer = new ZclKeyEstablishmentServer(ieeeAddress, keCluster);
+
+        ConfirmKeyDataRequestCommand command = new ConfirmKeyDataRequestCommand();
+        command.setCommandDirection(ZclCommandDirection.CLIENT_TO_SERVER);
+        assertTrue(keServer.commandReceived(command));
+
+        // State is not initialised
+        Mockito.verify(keCluster, Mockito.timeout(TIMEOUT))
+                .terminateKeyEstablishment(KeyEstablishmentStatusEnum.BAD_MESSAGE.getKey(), 10, 1);
+    }
+
+    @Test
+    public void HandleConfirmKeyRequestBadKey() throws Exception {
+        System.out.println("--- " + Thread.currentThread().getStackTrace()[1].getMethodName());
+        ZclKeyEstablishmentCluster keCluster = Mockito.mock(ZclKeyEstablishmentCluster.class);
+        IeeeAddress ieeeAddress = new IeeeAddress("1111111111111111");
+
+        ZclKeyEstablishmentServer keServer = new ZclKeyEstablishmentServer(ieeeAddress, keCluster);
+        TestUtilities.setField(ZclKeyEstablishmentServer.class, keServer, "keyEstablishmentState",
+                KeyEstablishmentState.CONFIRM_KEY_REQUEST);
+
+        ByteArray localMacButeArray = new ByteArray(new int[] { 1, 2, 3, 4, 5, 6, 7, 8 });
+        ByteArray remoteMacButeArray = new ByteArray(new int[] { 8, 7, 6, 5, 4, 3, 2, 1 });
+
+        ZigBeeCbkeProvider cbkeProvider = Mockito.mock(ZigBeeCbkeProvider.class);
+        Mockito.when(cbkeProvider.getResponderMac(ZigBeeCryptoSuites.ECC_163K1)).thenReturn(localMacButeArray);
+        keServer.setCbkeProvider(cbkeProvider);
+
+        ConfirmKeyDataRequestCommand command = new ConfirmKeyDataRequestCommand();
+        command.setCommandDirection(ZclCommandDirection.CLIENT_TO_SERVER);
+        command.setSecureMessageAuthenticationCode(remoteMacButeArray);
+        assertTrue(keServer.commandReceived(command));
+
+        Mockito.verify(keCluster, Mockito.timeout(TIMEOUT))
+                .terminateKeyEstablishment(KeyEstablishmentStatusEnum.BAD_KEY_CONFIRM.getKey(), 10, 1);
+    }
+
+    @Test
+    public void HandleTerminateKeyEstablishment() {
+        System.out.println("--- " + Thread.currentThread().getStackTrace()[1].getMethodName());
+        ZclKeyEstablishmentCluster keCluster = Mockito.mock(ZclKeyEstablishmentCluster.class);
+        IeeeAddress ieeeAddress = new IeeeAddress("1111111111111111");
+
+        ZclKeyEstablishmentServer keServer = new ZclKeyEstablishmentServer(ieeeAddress, keCluster);
+
+        TerminateKeyEstablishment command = new TerminateKeyEstablishment();
+        command.setStatusCode(KeyEstablishmentStatusEnum.BAD_MESSAGE.getKey());
+        command.setCommandDirection(ZclCommandDirection.CLIENT_TO_SERVER);
+        assertTrue(keServer.commandReceived(command));
+
+        command.setCommandDirection(ZclCommandDirection.SERVER_TO_CLIENT);
+        assertFalse(keServer.commandReceived(command));
+
+    }
+
+    @Test
+    public void Success() {
+        System.out.println("--- " + Thread.currentThread().getStackTrace()[1].getMethodName());
+        ZclKeyEstablishmentCluster keCluster = Mockito.mock(ZclKeyEstablishmentCluster.class);
+        IeeeAddress ieeeAddress = new IeeeAddress("0022A300001731F3");
+
+        ZclKeyEstablishmentServer keServer = new ZclKeyEstablishmentServer(ieeeAddress, keCluster);
+
+        keServer.setCryptoSuite(ZigBeeCryptoSuites.ECC_163K1);
+
+        ByteArray certificateByteArray = new ByteArray(new int[] { 0x02, 0x00, 0xCA, 0xA1, 0x5B, 0x4B, 0xEE, 0xDE, 0x65,
+                0xC3, 0x13, 0x9A, 0x5C, 0x3B, 0xC4, 0x0C, 0x9A, 0xD1, 0x53, 0x85, 0x4A, 0x27, 0x00, 0x22, 0xA3, 0x00,
+                0x00, 0x17, 0x31, 0xF3, 0x54, 0x45, 0x53, 0x54, 0x53, 0x45, 0x43, 0x41, 0x01, 0x09, 0x10, 0x83, 0x01,
+                0x23, 0x45, 0x67, 0x89, 0x0A });
+        ByteArray ephemeralDataByteArray = new ByteArray(
+                new int[] { 0x02, 0x00, 0xCA, 0xA1, 0x5B, 0x4B, 0xEE, 0xDE, 0x65 });
+        ByteArray secureMessageAuthenticationCodeButeArray = new ByteArray(
+                new int[] { 0x02, 0x00, 0xCA, 0xA1, 0x5B, 0x4B, 0xEE, 0xDE, 0x65 });
+
+        Set<ZigBeeCryptoSuites> cryptoSuites = new HashSet<>();
+        cryptoSuites.add(ZigBeeCryptoSuites.ECC_163K1);
+        ZigBeeCbkeProvider cbkeProvider = Mockito.mock(ZigBeeCbkeProvider.class);
+        Mockito.when(cbkeProvider.getAvailableCryptoSuites()).thenReturn(cryptoSuites);
+        Mockito.when(cbkeProvider.getEphemeralDataGenerateTime()).thenReturn(44);
+        Mockito.when(cbkeProvider.getConfirmKeyGenerateTime()).thenReturn(55);
+        Mockito.when(cbkeProvider.getCertificate(ZigBeeCryptoSuites.ECC_163K1)).thenReturn(certificateByteArray);
+        Mockito.when(cbkeProvider.getCbkeEphemeralData(ZigBeeCryptoSuites.ECC_163K1))
+                .thenReturn(ephemeralDataByteArray);
+        Mockito.when(cbkeProvider.getResponderMac(ZigBeeCryptoSuites.ECC_163K1))
+                .thenReturn(secureMessageAuthenticationCodeButeArray);
+        Mockito.verify(keCluster, Mockito.times(1)).addCommandListener(keServer);
+        keServer.setCbkeProvider(cbkeProvider);
+
+        ZclAttribute attribute = Mockito.mock(ZclAttribute.class);
+        keServer.setCryptoSuite(ZigBeeCryptoSuites.ECC_283K1);
+        keServer.setCryptoSuite(ZigBeeCryptoSuites.ECC_163K1);
+        Mockito.when(keCluster.getLocalAttribute(ZclKeyEstablishmentCluster.ATTR_SERVERKEYESTABLISHMENTSUITE))
+                .thenReturn(attribute);
+        keServer.setCryptoSuite(ZigBeeCryptoSuites.ECC_163K1);
+        Mockito.verify(attribute).setValue(1);
+        assertNull(keServer.getCryptoSuite());
+
+        assertFalse(keServer.commandReceived(Mockito.mock(ZclCommand.class)));
+
+        ZigBeeCbkeCertificate remoteCert = new CerticomCbkeCertificate(
+                "CAPubKey:0200fde8a7f3d1084224962a4e7c54e69ac3f04da6b8DeviceImplicitCert:0200caa15b4beede65c3139a5c3bc40c9ad153854a270022a300001731f354455354534543410109108301234567890aPrivateKeyReconstructionData:019fcc486fc46980ab4a612725b36f005edff075feDevicePublicKey:020366d312a0abf55654ead3e1624c31faed89c3bb20");
+        InitiateKeyEstablishmentRequestCommand initiateCommand = new InitiateKeyEstablishmentRequestCommand();
+        initiateCommand.setKeyEstablishmentSuite(1);
+        initiateCommand.setIdentity(new ByteArray(remoteCert.getCertificate()));
+        initiateCommand.setEphemeralDataGenerateTime(22);
+        initiateCommand.setConfirmKeyGenerateTime(33);
+        assertTrue(keServer.commandReceived(initiateCommand));
+
+        Mockito.verify(cbkeProvider, Mockito.timeout(TIMEOUT)).getCertificate(ZigBeeCryptoSuites.ECC_163K1);
+
+        Mockito.verify(keCluster, Mockito.timeout(TIMEOUT)).initiateKeyEstablishmentResponse(1, 44, 55,
+                certificateByteArray);
+
+        assertEquals(ZigBeeCryptoSuites.ECC_163K1, keServer.getCryptoSuite());
+
+        EphemeralDataRequestCommand dataRequest = new EphemeralDataRequestCommand();
+        dataRequest.setEphemeralData(ephemeralDataByteArray);
+        assertTrue(keServer.commandReceived(dataRequest));
+
+        Mockito.verify(cbkeProvider, Mockito.timeout(TIMEOUT)).getCbkeEphemeralData(ZigBeeCryptoSuites.ECC_163K1);
+        Mockito.verify(keCluster, Mockito.timeout(TIMEOUT)).ephemeralDataResponse(ephemeralDataByteArray);
+
+        ConfirmKeyDataRequestCommand confirmKey = new ConfirmKeyDataRequestCommand();
+        confirmKey.setSecureMessageAuthenticationCode(secureMessageAuthenticationCodeButeArray);
+        assertTrue(keServer.commandReceived(confirmKey));
+
+        Mockito.verify(cbkeProvider, Mockito.timeout(TIMEOUT)).getResponderMac(ZigBeeCryptoSuites.ECC_163K1);
+        Mockito.verify(keCluster, Mockito.timeout(TIMEOUT)).initiateKeyEstablishmentResponse(1, 44, 55,
+                certificateByteArray);
+
+        keServer.shutdown();
+        Mockito.verify(keCluster, Mockito.times(1)).removeCommandListener(keServer);
+    }
+
+}


### PR DESCRIPTION
Add server side of the CBKE exchange.

Note that this PR disables the ```DefaultResponse``` for all ```ZclKeyEstablishmentCluster``` commands so that transactions complete on the APS ACK (pending #919).

Signed-off-by: Chris Jackson <chris@cd-jackson.com>