### PR TITLE
Reset CBKE after completion and failure

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/seclient/SmartEnergyClient.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/seclient/SmartEnergyClient.java
@@ -980,13 +980,11 @@ public class SmartEnergyClient implements ZigBeeNetworkExtension, ZigBeeCommandL
         logger.debug("SEP Extension: Adding node {} [{}]", node.getIeeeAddress(),
                 String.format("%04X", node.getNetworkAddress()));
         for (ZigBeeEndpoint endpoint : node.getEndpoints()) {
-            ZclKeyEstablishmentCluster keCluster;
-
             if (cbkeClientRegistry.get(endpoint.getEndpointAddress()) != null) {
                 logger.debug("SEP Extension: CBKE client handler for node {} endpoint {} already set",
                         node.getIeeeAddress(), endpoint.getEndpointId());
             } else {
-                keCluster = (ZclKeyEstablishmentCluster) endpoint
+                ZclKeyEstablishmentCluster keCluster = (ZclKeyEstablishmentCluster) endpoint
                         .getInputCluster(ZclKeyEstablishmentCluster.CLUSTER_ID);
                 if (keCluster != null) {
                     logger.debug("SEP Extension: Adding CBKE client handler to node {} endpoint {}",
@@ -1003,7 +1001,7 @@ public class SmartEnergyClient implements ZigBeeNetworkExtension, ZigBeeCommandL
                 logger.debug("SEP Extension: CBKE server handler for node {} endpoint {} already set",
                         node.getIeeeAddress(), endpoint.getEndpointId());
             } else {
-                keCluster = (ZclKeyEstablishmentCluster) endpoint
+                ZclKeyEstablishmentCluster keCluster = (ZclKeyEstablishmentCluster) endpoint
                         .getOutputCluster(ZclKeyEstablishmentCluster.CLUSTER_ID);
                 if (keCluster != null) {
                     logger.debug("SEP Extension: Adding CBKE server handler to node {} endpoint {}",
@@ -1026,5 +1024,10 @@ public class SmartEnergyClient implements ZigBeeNetworkExtension, ZigBeeCommandL
         }
 
         setProfileSecurity(node);
+    }
+
+    @Override
+    public void nodeUpdated(ZigBeeNode node) {
+        nodeAdded(node);
     }
 }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/seclient/ZclKeyEstablishmentClient.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/seclient/ZclKeyEstablishmentClient.java
@@ -244,11 +244,7 @@ public class ZclKeyEstablishmentClient implements ZclCommandListener {
             return false;
         }
 
-        if (state == KeyEstablishmentState.FAILED) {
-            logger.debug("{}: CBKE Key Establishment Client: Key establishment reset after previous failed attempt",
-                    ieeeAddress, state);
-            state = KeyEstablishmentState.UNINITIALISED;
-        } else if (state != KeyEstablishmentState.UNINITIALISED) {
+        if (state != KeyEstablishmentState.UNINITIALISED) {
             logger.debug("{}: CBKE Key Establishment Client: Initiate key establishment failed - state is {}",
                     ieeeAddress, state);
 
@@ -678,6 +674,7 @@ public class ZclKeyEstablishmentClient implements ZclCommandListener {
         }
 
         smartEnergyClient.keyEstablishmentCallback(returnState, waitTime);
+        setState(KeyEstablishmentState.UNINITIALISED);
     }
 
     private KeyEstablishmentSuiteBitmap getPreferredCryptoSuite() {

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/seclient/ZclKeyEstablishmentServer.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/seclient/ZclKeyEstablishmentServer.java
@@ -410,7 +410,12 @@ public class ZclKeyEstablishmentServer implements ZclCommandListener {
     private void setState(KeyEstablishmentState newState) {
         logger.debug("{}: CBKE Key Establishment Server: State updated from {} to {}", ieeeAddress,
                 keyEstablishmentState, newState);
-        keyEstablishmentState = newState;
+
+        if (newState == KeyEstablishmentState.COMPLETE || newState == KeyEstablishmentState.FAILED) {
+            logger.debug("{}: CBKE Key Establishment Server: Resetting state to UNINITIALIZED", ieeeAddress);
+        } else {
+            keyEstablishmentState = newState;
+        }
     }
 
     private void stopCbke() {

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/app/seclient/ZclKeyEstablishmentClientTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/app/seclient/ZclKeyEstablishmentClientTest.java
@@ -7,6 +7,7 @@
  */
 package com.zsmartsystems.zigbee.app.seclient;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -16,12 +17,13 @@ import org.mockito.Mockito;
 
 import com.zsmartsystems.zigbee.IeeeAddress;
 import com.zsmartsystems.zigbee.TestUtilities;
+import com.zsmartsystems.zigbee.ZigBeeStatus;
+import com.zsmartsystems.zigbee.app.seclient.ZclKeyEstablishmentClient.KeyEstablishmentState;
 import com.zsmartsystems.zigbee.security.CerticomCbkeCertificate;
 import com.zsmartsystems.zigbee.security.ZigBeeCbkeCertificate;
 import com.zsmartsystems.zigbee.security.ZigBeeCbkeProvider;
 import com.zsmartsystems.zigbee.security.ZigBeeCryptoSuites;
 import com.zsmartsystems.zigbee.zcl.ZclCommand;
-import com.zsmartsystems.zigbee.zcl.ZclStatus;
 import com.zsmartsystems.zigbee.zcl.clusters.ZclKeyEstablishmentCluster;
 import com.zsmartsystems.zigbee.zcl.clusters.keyestablishment.InitiateKeyEstablishmentResponse;
 import com.zsmartsystems.zigbee.zcl.clusters.keyestablishment.KeyEstablishmentStatusEnum;
@@ -35,7 +37,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  *
  */
 public class ZclKeyEstablishmentClientTest {
-    private final static int TIMEOUT = 500000;
+    private final static int TIMEOUT = 5000;
 
     @Test
     public void testStartShutdown() {
@@ -109,6 +111,11 @@ public class ZclKeyEstablishmentClientTest {
 
         Mockito.verify(keCluster, Mockito.timeout(TIMEOUT))
                 .terminateKeyEstablishment(KeyEstablishmentStatusEnum.BAD_MESSAGE.getKey(), 10, 1);
+
+        // State gets reset back to UNINITIALISED after the FAILURE
+        Mockito.verify(seClient, Mockito.timeout(TIMEOUT)).keyEstablishmentCallback(ZigBeeStatus.FAILURE, 0);
+        assertEquals(KeyEstablishmentState.UNINITIALISED,
+                TestUtilities.getField(ZclKeyEstablishmentClient.class, keClient, "state"));
     }
 
     @Test
@@ -172,6 +179,11 @@ public class ZclKeyEstablishmentClientTest {
 
         Mockito.verify(keCluster, Mockito.timeout(TIMEOUT))
                 .terminateKeyEstablishment(KeyEstablishmentStatusEnum.BAD_MESSAGE.getKey(), 10, 1);
+
+        // State gets reset back to UNINITIALISED after the FAILURE
+        Mockito.verify(seClient, Mockito.timeout(TIMEOUT)).keyEstablishmentCallback(ZigBeeStatus.FAILURE, 0);
+        assertEquals(KeyEstablishmentState.UNINITIALISED,
+                TestUtilities.getField(ZclKeyEstablishmentClient.class, keClient, "state"));
     }
 
     @Test
@@ -199,7 +211,10 @@ public class ZclKeyEstablishmentClientTest {
         command.setIdentity(identity);
         assertTrue(keClient.commandReceived(command));
 
-        Mockito.verify(keCluster, Mockito.timeout(TIMEOUT)).sendDefaultResponse(command, ZclStatus.FAILURE);
+        // State gets reset back to UNINITIALISED after the FAILURE
+        Mockito.verify(seClient, Mockito.timeout(TIMEOUT)).keyEstablishmentCallback(ZigBeeStatus.FAILURE, 0);
+        assertEquals(KeyEstablishmentState.UNINITIALISED,
+                TestUtilities.getField(ZclKeyEstablishmentClient.class, keClient, "state"));
     }
 
     @Test
@@ -239,6 +254,11 @@ public class ZclKeyEstablishmentClientTest {
 
         Mockito.verify(keCluster, Mockito.timeout(TIMEOUT))
                 .terminateKeyEstablishment(KeyEstablishmentStatusEnum.UNKNOWN_ISSUER.getKey(), 10, 1);
+
+        // State gets reset back to UNINITIALISED after the FAILURE
+        Mockito.verify(seClient, Mockito.timeout(TIMEOUT)).keyEstablishmentCallback(ZigBeeStatus.FAILURE, 0);
+        assertEquals(KeyEstablishmentState.UNINITIALISED,
+                TestUtilities.getField(ZclKeyEstablishmentClient.class, keClient, "state"));
     }
 
 }

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/app/seclient/ZclKeyEstablishmentServerTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/app/seclient/ZclKeyEstablishmentServerTest.java
@@ -45,7 +45,7 @@ public class ZclKeyEstablishmentServerTest {
     private final static int TIMEOUT = 5000;
 
     @Test
-    public void InitiateKeyEstablishmentRequestCommandSuccess() {
+    public void InitiateKeyEstablishmentRequestCommandSuccess() throws Exception {
         System.out.println("--- " + Thread.currentThread().getStackTrace()[1].getMethodName());
         ZclKeyEstablishmentCluster keCluster = Mockito.mock(ZclKeyEstablishmentCluster.class);
         IeeeAddress ieeeAddress = new IeeeAddress("0022A300001731F3");
@@ -84,10 +84,14 @@ public class ZclKeyEstablishmentServerTest {
 
         Mockito.verify(keCluster, Mockito.timeout(TIMEOUT))
                 .terminateKeyEstablishment(KeyEstablishmentStatusEnum.NO_RESOURCES.getKey(), 20, 1);
+
+        // State gets reset back to UNINITIALISED after the FAILURE
+        assertEquals(KeyEstablishmentState.UNINITIALISED,
+                TestUtilities.getField(ZclKeyEstablishmentServer.class, keServer, "keyEstablishmentState"));
     }
 
     @Test
-    public void InitiateKeyEstablishmentRequestCommandInvalidIssuer() {
+    public void InitiateKeyEstablishmentRequestCommandInvalidIssuer() throws Exception {
         System.out.println("--- " + Thread.currentThread().getStackTrace()[1].getMethodName());
         ZclKeyEstablishmentCluster keCluster = Mockito.mock(ZclKeyEstablishmentCluster.class);
         IeeeAddress ieeeAddress = new IeeeAddress("1111111111111111");
@@ -119,10 +123,14 @@ public class ZclKeyEstablishmentServerTest {
 
         Mockito.verify(keCluster, Mockito.timeout(TIMEOUT))
                 .terminateKeyEstablishment(KeyEstablishmentStatusEnum.UNKNOWN_ISSUER.getKey(), 10, 1);
+
+        // State gets reset back to UNINITIALISED after the FAILURE
+        assertEquals(KeyEstablishmentState.UNINITIALISED,
+                TestUtilities.getField(ZclKeyEstablishmentServer.class, keServer, "keyEstablishmentState"));
     }
 
     @Test
-    public void HandleEphemeralDataRequestUninitialised() {
+    public void HandleEphemeralDataRequestUninitialised() throws Exception {
         System.out.println("--- " + Thread.currentThread().getStackTrace()[1].getMethodName());
         ZclKeyEstablishmentCluster keCluster = Mockito.mock(ZclKeyEstablishmentCluster.class);
         IeeeAddress ieeeAddress = new IeeeAddress("1111111111111111");
@@ -136,10 +144,14 @@ public class ZclKeyEstablishmentServerTest {
         // State is not initialised
         Mockito.verify(keCluster, Mockito.timeout(TIMEOUT))
                 .terminateKeyEstablishment(KeyEstablishmentStatusEnum.BAD_MESSAGE.getKey(), 10, 1);
+
+        // State gets reset back to UNINITIALISED after the FAILURE
+        assertEquals(KeyEstablishmentState.UNINITIALISED,
+                TestUtilities.getField(ZclKeyEstablishmentServer.class, keServer, "keyEstablishmentState"));
     }
 
     @Test
-    public void HandleConfirmKeyRequestUninitialised() {
+    public void HandleConfirmKeyRequestUninitialised() throws Exception {
         System.out.println("--- " + Thread.currentThread().getStackTrace()[1].getMethodName());
         ZclKeyEstablishmentCluster keCluster = Mockito.mock(ZclKeyEstablishmentCluster.class);
         IeeeAddress ieeeAddress = new IeeeAddress("1111111111111111");
@@ -153,6 +165,10 @@ public class ZclKeyEstablishmentServerTest {
         // State is not initialised
         Mockito.verify(keCluster, Mockito.timeout(TIMEOUT))
                 .terminateKeyEstablishment(KeyEstablishmentStatusEnum.BAD_MESSAGE.getKey(), 10, 1);
+
+        // State gets reset back to UNINITIALISED after the FAILURE
+        assertEquals(KeyEstablishmentState.UNINITIALISED,
+                TestUtilities.getField(ZclKeyEstablishmentServer.class, keServer, "keyEstablishmentState"));
     }
 
     @Test
@@ -179,10 +195,14 @@ public class ZclKeyEstablishmentServerTest {
 
         Mockito.verify(keCluster, Mockito.timeout(TIMEOUT))
                 .terminateKeyEstablishment(KeyEstablishmentStatusEnum.BAD_KEY_CONFIRM.getKey(), 10, 1);
+
+        // State gets reset back to UNINITIALISED after the FAILURE
+        assertEquals(KeyEstablishmentState.UNINITIALISED,
+                TestUtilities.getField(ZclKeyEstablishmentServer.class, keServer, "keyEstablishmentState"));
     }
 
     @Test
-    public void HandleTerminateKeyEstablishment() {
+    public void HandleTerminateKeyEstablishment() throws Exception {
         System.out.println("--- " + Thread.currentThread().getStackTrace()[1].getMethodName());
         ZclKeyEstablishmentCluster keCluster = Mockito.mock(ZclKeyEstablishmentCluster.class);
         IeeeAddress ieeeAddress = new IeeeAddress("1111111111111111");
@@ -197,6 +217,9 @@ public class ZclKeyEstablishmentServerTest {
         command.setCommandDirection(ZclCommandDirection.SERVER_TO_CLIENT);
         assertFalse(keServer.commandReceived(command));
 
+        // State gets reset back to UNINITIALISED after the FAILURE
+        assertEquals(KeyEstablishmentState.UNINITIALISED,
+                TestUtilities.getField(ZclKeyEstablishmentServer.class, keServer, "keyEstablishmentState"));
     }
 
     @Test


### PR DESCRIPTION
Once the CBKE transfers are complete, reset the state so that the process can be restarted if key updates are required.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>