### PR TITLE
Add a delay when adding new services from unknown clusters

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
@@ -1047,6 +1047,14 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
                 newNode.addEndpoint(newEndpoint);
                 updateNode(newNode);
 
+                // TODO: Find a better way to delay until the endpoint, and all attached extensions, have updated
+                try {
+                    Thread.sleep(1000);
+                } catch (InterruptedException e) {
+                    // TODO Auto-generated catch block
+                    e.printStackTrace();
+                }
+
                 cluster = endpoint.getInputCluster(apsFrame.getCluster());
             }
             command = cluster.getResponseFromId(zclHeader.getFrameType(), zclHeader.getCommandId());
@@ -1067,6 +1075,14 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
                 newEndpoint.updateEndpoint(newEndpoint);
                 newNode.addEndpoint(newEndpoint);
                 updateNode(newNode);
+
+                // TODO: Find a better way to delay until the endpoint, and all attached extensions, have updated
+                try {
+                    Thread.sleep(1000);
+                } catch (InterruptedException e) {
+                    // TODO Auto-generated catch block
+                    e.printStackTrace();
+                }
 
                 cluster = endpoint.getOutputCluster(apsFrame.getCluster());
             }


### PR DESCRIPTION
This proposes an initial solution to #928. The fixed delay added here when new clusters are added should only be implemented for clusters not discovered as part of the initial discovery.

This is not a deterministic implementation!! Something nicer would be MUCH better.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>