### PR TITLE
Add check to ensure Telegesis version is R309

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.telegesis/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/ZigBeeDongleTelegesis.java
+++ b/com.zsmartsystems.zigbee.dongle.telegesis/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/ZigBeeDongleTelegesis.java
@@ -415,7 +415,14 @@ public class ZigBeeDongleTelegesis
             builder.append(productInfo.getFirmwareRevision());
             versionString = builder.toString();
 
+            if (!productInfo.getFirmwareRevision().startsWith("309")) {
+                logger.error("Telegesis driver will not work with R{}, R309 is required",
+                        productInfo.getFirmwareRevision());
+                return ZigBeeStatus.FAILURE;
+            }
             ieeeAddress = productInfo.getIeeeAddress();
+        } else {
+            logger.info("Unable to read Telegesis dongle firmware version");
         }
 
         return ZigBeeStatus.SUCCESS;


### PR DESCRIPTION
We recently had an issue with OH where someone purchased a new Telegesis dongle which stated it used R309, but was actually running R308 and many of the commands are quite different. This adds a check during the ```startup``` method to fail the start if the firmware is not ```R309```.

@triller-telekom @hsudbrock FYI - this was tested using a DTAG version of the firmware, but let me know if you experience any issues.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>