### PR TITLE
Improve shutdown of Database Manager by disabling deferred timeout

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
@@ -671,12 +671,17 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
     public void shutdown() {
         logger.debug("ZigBeeNetworkManager shutdown: networkState={}", networkState);
 
+        // To avoid deferred writes, set the deferred write time to 0.
+        databaseManager.setDeferredWriteTime(0);
+        databaseManager.setMaxDeferredWriteTime(0);
+
         setNetworkState(ZigBeeNetworkState.SHUTDOWN);
 
         if (clusterMatcher != null) {
             clusterMatcher.shutdown();
         }
 
+        // Write out all nodes to the data store.
         for (ZigBeeNode node : networkNodes.values()) {
             databaseManager.nodeUpdated(node);
             node.shutdown();

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/database/ZigBeeNetworkDatabaseManager.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/database/ZigBeeNetworkDatabaseManager.java
@@ -125,11 +125,18 @@ public class ZigBeeNetworkDatabaseManager implements ZigBeeNetworkNodeListener {
      * @param deferredWriteTime the number of milliseconds to wait before writing to the store
      */
     public void setDeferredWriteTime(int deferredWriteTime) {
+        logger.debug("Data store: Deferred Write Time set to {}ms", deferredWriteTime);
+
         if (deferredWriteTime > DEFERRED_WRITE_TIMEOUT_MAX) {
             this.deferredWriteTime = DEFERRED_WRITE_TIMEOUT_MAX;
-            return;
+        } else {
+            this.deferredWriteTime = deferredWriteTime;
         }
-        this.deferredWriteTime = deferredWriteTime;
+
+        if (this.deferredWriteTimeout > TimeUnit.MILLISECONDS.toNanos(this.deferredWriteTime)) {
+            logger.debug("Data store: Deferred Write Time set less than Max Deferred Write Time");
+            this.deferredWriteTimeout = TimeUnit.MILLISECONDS.toNanos(this.deferredWriteTime);
+        }
     }
 
     /**
@@ -139,12 +146,19 @@ public class ZigBeeNetworkDatabaseManager implements ZigBeeNetworkNodeListener {
      * @param deferredWriteMax the maximum number of milliseconds that writes will be deferred
      */
     public void setMaxDeferredWriteTime(int deferredWriteMax) {
+        logger.debug("Data store: Max Deferred Write Time set to {}ms", deferredWriteMax);
+
+        // Note that internally this is stored in nanoseconds
         if (deferredWriteMax > DEFERRED_WRITE_TIMEOUT_MAX) {
             this.deferredWriteTimeout = TimeUnit.MILLISECONDS.toNanos(DEFERRED_WRITE_TIMEOUT_MAX);
-            return;
+        } else {
+            this.deferredWriteTimeout = TimeUnit.MILLISECONDS.toNanos(deferredWriteMax);
         }
-        // Note that internally this is stored in nanoseconds
-        this.deferredWriteTimeout = TimeUnit.MILLISECONDS.toNanos(deferredWriteMax);
+
+        if (TimeUnit.NANOSECONDS.toMillis(this.deferredWriteTimeout) < this.deferredWriteTime) {
+            logger.debug("Data store: Max Deferred Time set less than Write Time");
+            this.deferredWriteTime = (int) TimeUnit.NANOSECONDS.toMillis(this.deferredWriteTimeout);
+        }
     }
 
     /**

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/database/ZigBeeNetworkDatabaseManagerTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/database/ZigBeeNetworkDatabaseManagerTest.java
@@ -7,6 +7,8 @@
  */
 package com.zsmartsystems.zigbee.database;
 
+import static org.junit.Assert.assertEquals;
+
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -14,6 +16,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -133,5 +136,23 @@ public class ZigBeeNetworkDatabaseManagerTest {
 
         databaseManager.shutdown();
         Mockito.verify(networkManager, Mockito.timeout(TIMEOUT).times(1)).removeNetworkNodeListener(databaseManager);
+    }
+
+    @Test
+    public void timerConfiguration() throws Exception {
+        ZigBeeNetworkManager networkManager = Mockito.mock(ZigBeeNetworkManager.class);
+        ZigBeeNetworkDatabaseManager databaseManager = new ZigBeeNetworkDatabaseManager(networkManager);
+
+        databaseManager.setDeferredWriteTime(10);
+        assertEquals(10,
+                TestUtilities.getField(ZigBeeNetworkDatabaseManager.class, databaseManager, "deferredWriteTime"));
+        databaseManager.setMaxDeferredWriteTime(5);
+        assertEquals(5,
+                TestUtilities.getField(ZigBeeNetworkDatabaseManager.class, databaseManager, "deferredWriteTime"));
+        assertEquals(TimeUnit.MILLISECONDS.toNanos(5),
+                TestUtilities.getField(ZigBeeNetworkDatabaseManager.class, databaseManager, "deferredWriteTimeout"));
+        databaseManager.setDeferredWriteTime(3);
+        assertEquals(3,
+                TestUtilities.getField(ZigBeeNetworkDatabaseManager.class, databaseManager, "deferredWriteTime"));
     }
 }


### PR DESCRIPTION
This primarily is designed to set the write delay to 0 when shutting down the system. It also adds some protection when setting the write time, and max write time.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>