### PR TITLE
OTA: Send OTA Response commands with Disable Default Response = True

### DIFF
--- a/com.zsmartsystems.zigbee.autocode/src/main/java/com/zsmartsystems/zigbee/autocode/xml/ZigBeeXmlCommand.java
+++ b/com.zsmartsystems.zigbee.autocode/src/main/java/com/zsmartsystems/zigbee/autocode/xml/ZigBeeXmlCommand.java
@@ -8,6 +8,7 @@
 package com.zsmartsystems.zigbee.autocode.xml;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  *
@@ -17,6 +18,7 @@ import java.util.List;
 public class ZigBeeXmlCommand {
     public Integer code;
     public String source;
+    public Optional<String> responseTo;
     public String name;
     public List<ZigBeeXmlDescription> description;
     public List<ZigBeeXmlField> fields;

--- a/com.zsmartsystems.zigbee.autocode/src/main/java/com/zsmartsystems/zigbee/autocode/xml/ZigBeeXmlParser.java
+++ b/com.zsmartsystems.zigbee.autocode/src/main/java/com/zsmartsystems/zigbee/autocode/xml/ZigBeeXmlParser.java
@@ -11,6 +11,7 @@ import java.io.File;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.TreeMap;
 
 import javax.xml.parsers.DocumentBuilder;
@@ -20,6 +21,8 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
+
+import static org.apache.commons.lang.StringUtils.stripToNull;
 
 /**
  * XML file parser - reads the XML cluster definitions
@@ -194,6 +197,7 @@ public class ZigBeeXmlParser {
                 command.name = e.getAttribute("name").trim();
                 command.code = getInteger(e.getAttribute("code")).intValue();
                 command.source = e.getAttribute("source");
+                command.responseTo = Optional.ofNullable(stripToNull(e.getAttribute("responseTo")));
 
                 for (int temp = 0; temp < nodes.getLength(); temp++) {
                     if (nodes.item(temp).getNodeName().equals("name")) {

--- a/com.zsmartsystems.zigbee.autocode/src/main/resources/0019_OtaUpgrade.xml
+++ b/com.zsmartsystems.zigbee.autocode/src/main/resources/0019_OtaUpgrade.xml
@@ -67,7 +67,7 @@
             </conditional>
         </field>
     </command>
-    <command code="0x02" source="server">
+    <command code="0x02" source="server" responseTo="Query Next Image Command">
         <name>Query Next Image Response</name>
         <description>The upgrade server sends a Query Next Image Response with one of the following status: SUCCESS, NO_IMAGE_AVAILABLE or NOT_AUTHORIZED. When a SUCCESS status is sent, it is considered to be the explicit authorization to a device by the upgrade server that the device may upgrade to a specific software image. &lt;br&gt; A status of NO_IMAGE_AVAILABLE indicates that the server is authorized to upgrade the client but it currently does not have the (new) OTA upgrade image available for the client. For all clients (both ZR and ZED)9 , they shall continue sending Query Next Image Requests to the server periodically until an image becomes available. &lt;br&gt; A status of NOT_AUTHORIZED indicates the server is not authorized to upgrade the client. In this case, the client may perform discovery again to find another upgrade server. The client may implement an intelligence to avoid querying the same unauthorized server.</description>
         <field type="ZCL_STATUS" class="StatusEnum">
@@ -180,7 +180,7 @@
             </conditional>
         </field>
     </command>
-    <command code="0x05" source="server">
+    <command code="0x05" source="server" responseTo="Zcl Command">
         <name>Image Block Response</name>
         <description>Upon receipt of an Image Block Request command the server shall generate an Image Block Response. If the server is able to retrieve the data for the client and does not wish to change the image download rate, it will respond with a status of SUCCESS and it will include all the fields in the payload. The use of file offset allows the server to send packets with variable data size during the upgrade process. This allows the server to support a case when the network topology of a client may change during the upgrade process, for example, mobile client may move around during the upgrade process. If the client has moved a few hops away, the data size shall be smaller. Moreover, using file offset eliminates the need for data padding since each Image Block Response command may contain different data size. A simple server implementation may choose to only support largest possible data size for the worst-case scenario in order to avoid supporting sending packets with variable data size. &lt;br&gt; The server shall respect the maximum data size value requested by the client and shall not send the data with length greater than that value. The server may send the data with length smaller than the value depending on the network topology of the client. For example, the client may be able to receive 100 bytes of data at once so it sends the request with 100 as maximum data size. But after considering all the security headers (perhaps from both APS and network levels) and source routing overhead (for example, the client is five hops away), the largest possible data size that the server can send to the client shall be smaller than 100 bytes.</description>
         <field type="ZCL_STATUS" class="StatusEnum">

--- a/com.zsmartsystems.zigbee.autocode/src/main/resources/zigbee-description.xsd
+++ b/com.zsmartsystems.zigbee.autocode/src/main/resources/zigbee-description.xsd
@@ -52,6 +52,7 @@
 						</xs:sequence>
 						<xs:attribute type="xs:string" name="code" use="optional" />
 						<xs:attribute type="xs:string" name="source" use="optional" />
+						<xs:attribute type="xs:string" name="responseTo" use="optional" />
 					</xs:complexType>
 				</xs:element>
 				<xs:element name="attribute" maxOccurs="unbounded" minOccurs="0">

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/otaserver/ZclOtaUpgradeServer.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/otaserver/ZclOtaUpgradeServer.java
@@ -83,7 +83,7 @@ import com.zsmartsystems.zigbee.zcl.field.ByteArray;
  * <li>... repeat to end of transfer
  * <li>Client sends <i>Upgrade End Request</i>. Status set to {@link ZigBeeOtaServerStatus#OTA_TRANSFER_COMPLETE}.
  * <li>Server waits for {@link #completeUpgrade()} to be called unless {@link ZclOtaUpgradeServer#autoUpgrade} is true.
- * <li>Server checks the client state. If it is {@link ImageUpgradeStatus.DOWNLOAD_COMPLETE} it sends <i>Upgrade End
+ * <li>Server checks the client state. If it is {@link ImageUpgradeStatus#DOWNLOAD_COMPLETE} it sends <i>Upgrade End
  * Response</i>.
  * <li>Client should respond with the default response, but this may not always be implemented as the device may start
  * to run the new firmware. Status set to {@link ZigBeeOtaServerStatus#OTA_UPGRADE_FIRMWARE_RESTARTING}.
@@ -102,7 +102,7 @@ import com.zsmartsystems.zigbee.zcl.field.ByteArray;
  * terminate.
  * </ul>
  * <p>
- * This class uses the {@link ZigBeeOtaCluster} which provides the low level commands.
+ * This class uses the {@link ZclOtaUpgradeCluster} which provides the low level commands.
  *
  * @author Chris Jackson
  */
@@ -366,7 +366,7 @@ public class ZclOtaUpgradeServer implements ZigBeeApplication, ZclCommandListene
 
     /**
      * Tells the server to automatically upgrade the firmware once the transfer is completed.
-     * If autoUpgrade is not set, then the user must explicitly call {@link #doUpgrade} once the server
+     * If autoUpgrade is not set, then the user must explicitly call {@link #completeUpgrade} once the server
      * state has reached {@link ZigBeeOtaServerStatus#OTA_TRANSFER_COMPLETE}.
      * <p>
      * It has been observed that if the upgrade is not completed quickly after the completion of
@@ -514,15 +514,16 @@ public class ZclOtaUpgradeServer implements ZigBeeApplication, ZclCommandListene
     /**
      * Sends an image block to the client
      *
+     * @param request the request command
      * @param fileOffset the offset into the {@link ZigBeeOtaFile} to send the block
      * @param maximumDataSize the maximum data size the client can accept
      * @return the number of bytes sent
      */
-    private int sendImageBlock(int fileOffset, int maximumDataSize) {
+    private int sendImageBlock(ZclCommand request, int fileOffset, int maximumDataSize) {
         ByteArray imageData = otaFile.getImageData(fileOffset, Math.min(dataSize, maximumDataSize));
         logger.debug("{} OTA Data: Sending {} bytes at offset {}", cluster.getZigBeeAddress(), imageData.size(),
                 fileOffset);
-        cluster.imageBlockResponse(ZclStatus.SUCCESS, otaFile.getManufacturerCode(), otaFile.getImageType(),
+        cluster.imageBlockResponse(request, ZclStatus.SUCCESS, otaFile.getManufacturerCode(), otaFile.getImageType(),
                 otaFile.getFileVersion(), fileOffset, imageData);
 
         return imageData.size();
@@ -531,23 +532,21 @@ public class ZclOtaUpgradeServer implements ZigBeeApplication, ZclCommandListene
     /**
      * Handles the sending of {@link ImageBlockResponse} following a {@link ImagePageCommand}
      *
-     * @param pageOffset the starting offset for the page
-     * @param pageLength the length of the page
-     * @param maximumDataSize the maximum size of each data block
-     * @param responseSpacing the delay between each block response in milliseconds
+     * @param request the request command
      */
-    private void doPageResponse(final int pageOffset, final int pageLength, final int maximumDataSize,
-            final int responseSpacing) {
+    private void doPageResponse(ImagePageCommand request) {
 
         class PageSender implements Runnable {
+            private ImagePageCommand request;
             private int pagePosition;
             private final int pageEnd;
             private final int maximumDataSize;
 
-            PageSender(final int pageOffset, final int pageLength, final int maximumDataSize) {
-                this.pagePosition = pageOffset;
-                this.pageEnd = pageOffset + pageLength;
-                this.maximumDataSize = maximumDataSize;
+            PageSender(ImagePageCommand request) {
+                this.request = request;
+                this.pagePosition = request.getFileOffset();
+                this.pageEnd = request.getFileOffset() + request.getPageSize();
+                this.maximumDataSize = request.getMaximumDataSize();
 
                 // Stop the timer - restart it once the page has been sent
                 // Restart the timer
@@ -558,7 +557,11 @@ public class ZclOtaUpgradeServer implements ZigBeeApplication, ZclCommandListene
             public void run() {
                 // Send the block response
                 // TODO: Ideally we should disable APS retry for page requests
-                int dataSent = sendImageBlock(pagePosition, maximumDataSize);
+                int dataSent = sendImageBlock(request, pagePosition, maximumDataSize);
+
+                // Refer to request only in a first block set.
+                // Following blocks will have incremental sequence id so we null request ref here
+                request = null;
 
                 // If dataSent is 0, then we either reached the end of file, or there was an error
                 // Either way, let's abort!
@@ -580,7 +583,6 @@ public class ZclOtaUpgradeServer implements ZigBeeApplication, ZclCommandListene
                 }
             }
         }
-        ;
 
         synchronized (pageScheduledExecutor) {
             // Stop our task if it's running
@@ -589,9 +591,9 @@ public class ZclOtaUpgradeServer implements ZigBeeApplication, ZclCommandListene
             }
 
             // Start the new task
-            PageSender pageSender = new PageSender(pageOffset, pageLength, maximumDataSize);
-            scheduledPageTask = pageScheduledExecutor.scheduleAtFixedRate(pageSender, responseSpacing, responseSpacing,
-                    TimeUnit.MILLISECONDS);
+            PageSender pageSender = new PageSender(request);
+            scheduledPageTask = pageScheduledExecutor.scheduleAtFixedRate(pageSender, request.getResponseSpacing(),
+                    request.getResponseSpacing(), TimeUnit.MILLISECONDS);
         }
     }
 
@@ -646,7 +648,7 @@ public class ZclOtaUpgradeServer implements ZigBeeApplication, ZclCommandListene
         updateStatus(ZigBeeOtaServerStatus.OTA_TRANSFER_IN_PROGRESS);
         startTransferTimer();
 
-        cluster.queryNextImageResponse(ZclStatus.SUCCESS, otaFile.getManufacturerCode(), otaFile.getImageType(),
+        cluster.queryNextImageResponse(command, ZclStatus.SUCCESS, otaFile.getManufacturerCode(), otaFile.getImageType(),
                 otaFile.getFileVersion(), otaFile.getImageSize());
 
         return true;
@@ -698,8 +700,7 @@ public class ZclOtaUpgradeServer implements ZigBeeApplication, ZclCommandListene
             return true;
         }
 
-        doPageResponse(command.getFileOffset(), command.getPageSize(), command.getMaximumDataSize(),
-                command.getResponseSpacing());
+        doPageResponse(command);
 
         return true;
     }
@@ -757,7 +758,7 @@ public class ZclOtaUpgradeServer implements ZigBeeApplication, ZclCommandListene
         }
 
         // Send the block response
-        sendImageBlock(command.getFileOffset(), command.getMaximumDataSize());
+        sendImageBlock(command, command.getFileOffset(), command.getMaximumDataSize());
         return true;
     }
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransactionManager.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransactionManager.java
@@ -651,11 +651,13 @@ public class ZigBeeTransactionManager implements ZigBeeNetworkNodeListener {
                     // Check if we've reached the maximum number of commands we can send
                     if (outstandingTransactions.size() >= maxOutstandingTransactions) {
                         sendDone = true;
+                        logger.debug("Max outstanding transactions limit exceeded");
                         break;
                     }
 
                     // If this is a sleepy queue, and we've exceeded the sleepy transmissions, then ignore the queue
                     if (queue.isSleepy() && sleepyTransactions >= maxSleepyTransactions) {
+                        logger.debug("Max sleeping transactions limit exceeded");
                         continue;
                     }
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/ZclCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/ZclCluster.java
@@ -281,7 +281,7 @@ public abstract class ZclCluster {
      * @param command the {@link ZclCommand} to send
      * @return the command result future
      */
-    protected Future<CommandResult> send(ZclCommand command) {
+    public Future<CommandResult> send(ZclCommand command) {
         if (isClient()) {
             command.setCommandDirection(ZclCommandDirection.SERVER_TO_CLIENT);
         }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclOtaUpgradeCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclOtaUpgradeCluster.java
@@ -317,17 +317,17 @@ public class ZclOtaUpgradeCluster extends ZclCluster {
      * @param imageSize {@link Integer} Image Size
      * @return the {@link Future<CommandResult>} command result future
      */
-    public Future<CommandResult> queryNextImageResponse(ZclStatus status, Integer manufacturerCode, Integer imageType, Integer fileVersion, Integer imageSize) {
-        QueryNextImageResponse command = new QueryNextImageResponse();
+    public void queryNextImageResponse(QueryNextImageCommand request, ZclStatus status, Integer manufacturerCode, Integer imageType, Integer fileVersion, Integer imageSize) {
+        QueryNextImageResponse response = new QueryNextImageResponse();
 
         // Set the fields
-        command.setStatus(status);
-        command.setManufacturerCode(manufacturerCode);
-        command.setImageType(imageType);
-        command.setFileVersion(fileVersion);
-        command.setImageSize(imageSize);
+        response.setStatus(status);
+        response.setManufacturerCode(manufacturerCode);
+        response.setImageType(imageType);
+        response.setFileVersion(fileVersion);
+        response.setImageSize(imageSize);
 
-        return send(command);
+        sendResponse(request, response);
     }
 
     /**
@@ -451,18 +451,23 @@ public class ZclOtaUpgradeCluster extends ZclCluster {
      * @param imageData {@link ByteArray} Image Data
      * @return the {@link Future<CommandResult>} command result future
      */
-    public Future<CommandResult> imageBlockResponse(ZclStatus status, Integer manufacturerCode, Integer imageType, Integer fileVersion, Integer fileOffset, ByteArray imageData) {
-        ImageBlockResponse command = new ImageBlockResponse();
+    public void imageBlockResponse(ZclCommand request, ZclStatus status, Integer manufacturerCode, Integer imageType, Integer fileVersion, Integer fileOffset, ByteArray imageData) {
+        ImageBlockResponse response = new ImageBlockResponse();
 
         // Set the fields
-        command.setStatus(status);
-        command.setManufacturerCode(manufacturerCode);
-        command.setImageType(imageType);
-        command.setFileVersion(fileVersion);
-        command.setFileOffset(fileOffset);
-        command.setImageData(imageData);
+        response.setStatus(status);
+        response.setManufacturerCode(manufacturerCode);
+        response.setImageType(imageType);
+        response.setFileVersion(fileVersion);
+        response.setFileOffset(fileOffset);
+        response.setImageData(imageData);
 
-        return send(command);
+        if (request != null) {
+            sendResponse(request, response);
+        } else {
+            response.setDisableDefaultResponse(true);
+            send(response);
+        }
     }
 
     /**

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclOtaUpgradeCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclOtaUpgradeCluster.java
@@ -63,7 +63,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-10-04T18:21:10Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-12-28T01:54:47Z")
 public class ZclOtaUpgradeCluster extends ZclCluster {
     /**
      * The ZigBee Cluster Library Cluster ID
@@ -310,24 +310,24 @@ public class ZclOtaUpgradeCluster extends ZclCluster {
      * may perform discovery again to find another upgrade server. The client may implement an
      * intelligence to avoid querying the same unauthorized server.
      *
+     * @param request {@link QueryNextImageCommand A request that this command replies to
      * @param status {@link ZclStatus} Status
      * @param manufacturerCode {@link Integer} Manufacturer Code
      * @param imageType {@link Integer} Image Type
      * @param fileVersion {@link Integer} File Version
      * @param imageSize {@link Integer} Image Size
-     * @return the {@link Future<CommandResult>} command result future
      */
     public void queryNextImageResponse(QueryNextImageCommand request, ZclStatus status, Integer manufacturerCode, Integer imageType, Integer fileVersion, Integer imageSize) {
-        QueryNextImageResponse response = new QueryNextImageResponse();
+        QueryNextImageResponse command = new QueryNextImageResponse();
 
         // Set the fields
-        response.setStatus(status);
-        response.setManufacturerCode(manufacturerCode);
-        response.setImageType(imageType);
-        response.setFileVersion(fileVersion);
-        response.setImageSize(imageSize);
+        command.setStatus(status);
+        command.setManufacturerCode(manufacturerCode);
+        command.setImageType(imageType);
+        command.setFileVersion(fileVersion);
+        command.setImageSize(imageSize);
 
-        sendResponse(request, response);
+        sendResponse(request, command);
     }
 
     /**
@@ -443,31 +443,26 @@ public class ZclOtaUpgradeCluster extends ZclCluster {
      * source routing overhead (for example, the client is five hops away), the largest
      * possible data size that the server can send to the client shall be smaller than 100 bytes.
      *
+     * @param request {@link ZclCommand A request that this command replies to
      * @param status {@link ZclStatus} Status
      * @param manufacturerCode {@link Integer} Manufacturer Code
      * @param imageType {@link Integer} Image Type
      * @param fileVersion {@link Integer} File Version
      * @param fileOffset {@link Integer} File Offset
      * @param imageData {@link ByteArray} Image Data
-     * @return the {@link Future<CommandResult>} command result future
      */
     public void imageBlockResponse(ZclCommand request, ZclStatus status, Integer manufacturerCode, Integer imageType, Integer fileVersion, Integer fileOffset, ByteArray imageData) {
-        ImageBlockResponse response = new ImageBlockResponse();
+        ImageBlockResponse command = new ImageBlockResponse();
 
         // Set the fields
-        response.setStatus(status);
-        response.setManufacturerCode(manufacturerCode);
-        response.setImageType(imageType);
-        response.setFileVersion(fileVersion);
-        response.setFileOffset(fileOffset);
-        response.setImageData(imageData);
+        command.setStatus(status);
+        command.setManufacturerCode(manufacturerCode);
+        command.setImageType(imageType);
+        command.setFileVersion(fileVersion);
+        command.setFileOffset(fileOffset);
+        command.setImageData(imageData);
 
-        if (request != null) {
-            sendResponse(request, response);
-        } else {
-            response.setDisableDefaultResponse(true);
-            send(response);
-        }
+        sendResponse(request, command);
     }
 
     /**


### PR DESCRIPTION
The OTA specification requires that all Request Commands sent by the client have Disable Default Response = False i.e. require ZCL respone with the same transaction seq number as the request. Moreover the Response commands should have Disable Default Response = True. We were incorrectly replying with different seq number and with Disable Default Response = False. That wouldn't be that bad if the client would reply to the response with the ZCL default response. Yet the client I was working with was quite fussy about it and decided to not reply (we were first not compliant with the standard so I don't blame it) leaving us with incomplete transactions which quickly got stuck in the queue until timeout which in turn caused the OTA process to freeze and timeout finally.
With this change we become compliant with the standard by sending responses with the seq id matching the one in the request and with disabled default response and also we complete the transaction on RX_ACK as we don't expect the response.