### PR TITLE
Fix updating transaction state for (near to) fragmented frames

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
@@ -1853,9 +1853,9 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
     @Override
     public void receiveCommandState(int msgTag, ZigBeeTransportProgressState state) {
         logger.debug("RX STA: msgTag={} state={}", String.format("%02X", msgTag), state);
-        if (apsDataEntity.receiveCommandState(msgTag, state) == false) {
-            return;
+        if (apsDataEntity.receiveCommandState(msgTag, state)) {
+            // Pass the update to the transaction if this is NACK or ACK for last/only fragment
+            transactionManager.receiveCommandState(msgTag, state);
         }
-        transactionManager.receiveCommandState(msgTag, state);
     }
 }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/aps/ZigBeeApsFrame.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/aps/ZigBeeApsFrame.java
@@ -426,4 +426,23 @@ public class ZigBeeApsFrame {
         return builder.toString();
     }
 
+    /**
+     * Calling this method indicates that transmission of a fragment has completed.
+     * It moves the fragment base and decrease outstanding fragments counter.
+     */
+    public void oneFragmentCompleted() {
+        fragmentBase++;
+        if (fragmentOutstanding > 0) {
+            fragmentOutstanding--;
+        }
+    }
+
+    /**
+     * Calling this method indicates that a fragment has been sent. It increases outstanding fragments counter.
+     */
+    public void oneFragmentSent() {
+        if (fragmentOutstanding <= fragmentTotal) {
+            this.fragmentOutstanding++;
+        }
+    }
 }

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/aps/ApsDataEntityTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/aps/ApsDataEntityTest.java
@@ -27,6 +27,7 @@ import com.zsmartsystems.zigbee.transport.ZigBeeTransportTransmit;
  *
  */
 public class ApsDataEntityTest {
+    public static final int FRAGMENTATION_LENGTH = 65;
     private static int TIMEOUT = 5000;
 
     @Test
@@ -223,6 +224,83 @@ public class ApsDataEntityTest {
         ZigBeeTransportTransmit transport = Mockito.mock(ZigBeeTransportTransmit.class);
         ApsDataEntity aps = new ApsDataEntity(transport);
 
+        assertTrue(aps.receiveCommandState(0, ZigBeeTransportProgressState.RX_ACK));
+    }
+
+    @Test
+    public void shouldExpectOneFrameReceivedForPayloadShorterThanFragmentationLength() {
+        ZigBeeTransportTransmit transport = Mockito.mock(ZigBeeTransportTransmit.class);
+        ApsDataEntity aps = new ApsDataEntity(transport);
+
+        aps.setFragmentationLength(FRAGMENTATION_LENGTH);
+
+        ZigBeeApsFrame apsFrame = new ZigBeeApsFrame();
+        apsFrame.setApsCounter(1);
+        apsFrame.setPayload(createData(0, FRAGMENTATION_LENGTH-1));
+
+        aps.send(0, apsFrame);
+
+        assertTrue(aps.receiveCommandState(0, ZigBeeTransportProgressState.TX_ACK));
+        assertTrue(aps.receiveCommandState(0, ZigBeeTransportProgressState.RX_ACK));
+    }
+
+    @Test
+    public void shouldExpectOneFrameReceivedForPayloadEqualToFragmentationLength() {
+        ZigBeeTransportTransmit transport = Mockito.mock(ZigBeeTransportTransmit.class);
+        ApsDataEntity aps = new ApsDataEntity(transport);
+
+        aps.setFragmentationLength(FRAGMENTATION_LENGTH);
+
+        ZigBeeApsFrame apsFrame = new ZigBeeApsFrame();
+        apsFrame.setApsCounter(1);
+        apsFrame.setPayload(createData(0, FRAGMENTATION_LENGTH));
+
+        aps.send(0, apsFrame);
+
+        assertTrue(aps.receiveCommandState(0, ZigBeeTransportProgressState.TX_ACK));
+        assertTrue(aps.receiveCommandState(0, ZigBeeTransportProgressState.RX_ACK));
+    }
+
+    @Test
+    public void shouldExpectTwoFramesReceivedForPayloadFittingInTwoFragments() {
+        ZigBeeTransportTransmit transport = Mockito.mock(ZigBeeTransportTransmit.class);
+        ApsDataEntity aps = new ApsDataEntity(transport);
+
+        aps.setFragmentationLength(FRAGMENTATION_LENGTH);
+
+        ZigBeeApsFrame apsFrame = new ZigBeeApsFrame();
+        apsFrame.setApsCounter(1);
+        apsFrame.setPayload(createData(0, FRAGMENTATION_LENGTH+1));
+
+        aps.send(0, apsFrame);
+
+        assertFalse(aps.receiveCommandState(0, ZigBeeTransportProgressState.TX_ACK));
+        assertFalse(aps.receiveCommandState(0, ZigBeeTransportProgressState.RX_ACK));
+
+        assertTrue(aps.receiveCommandState(0, ZigBeeTransportProgressState.TX_ACK));
+        assertTrue(aps.receiveCommandState(0, ZigBeeTransportProgressState.RX_ACK));
+    }
+
+    @Test
+    public void shouldExpectThreeFramesReceivedForPayloadFittingInThreeFragments() {
+        ZigBeeTransportTransmit transport = Mockito.mock(ZigBeeTransportTransmit.class);
+        ApsDataEntity aps = new ApsDataEntity(transport);
+
+        aps.setFragmentationLength(FRAGMENTATION_LENGTH);
+
+        ZigBeeApsFrame apsFrame = new ZigBeeApsFrame();
+        apsFrame.setApsCounter(1);
+        apsFrame.setPayload(createData(0, FRAGMENTATION_LENGTH*2+1));
+
+        aps.send(0, apsFrame);
+
+        assertFalse(aps.receiveCommandState(0, ZigBeeTransportProgressState.TX_ACK));
+        assertFalse(aps.receiveCommandState(0, ZigBeeTransportProgressState.RX_ACK));
+
+        assertFalse(aps.receiveCommandState(0, ZigBeeTransportProgressState.TX_ACK));
+        assertFalse(aps.receiveCommandState(0, ZigBeeTransportProgressState.RX_ACK));
+
+        assertTrue(aps.receiveCommandState(0, ZigBeeTransportProgressState.TX_ACK));
         assertTrue(aps.receiveCommandState(0, ZigBeeTransportProgressState.RX_ACK));
     }
 


### PR DESCRIPTION
When I was working on a test to demonstrate the problem I tried to fix with one of the commits in the PR #933 I found out that my fix was actually solving the problem only for case where APS payload length == fragmentation length. The original fix didn't address issues with payload > fragmentation threshold.

This PR attempts to fix it. The problem in general was that both TX and RX ACK were accounted for a frame fragment (block as called in ZigBee Specification) receipt while only RX ACK should. That lead to premature passing of RX/TX Ack to transaction manager (for payload > fragmentation length) OR not passing RX Ack to transaction manager (for payload = fragmentation length which was my initial case).

With this fix TX/RX Ack is passed upwards only for the last block being TX/RX Acked. There are two assumptions made here. One is that TX Ack arrives always before RX Ack. Other is that each block is RX Acked. Both are true as long as the implementation keeps only one block in the flight (fragmentation window is effectively = 1) what is the case at the moment. If this is going to change than we will need more advances tracking of each of the blocks state anyway as they can get ACKed out of order and more than once each.

I suggest to review the four tests I've added first. I think they express the intent quite clearly but obviously the implementation change is irrelevant if the testcases are incorrect. Running these tests on current implementation to see what the problem is.