### PR TITLE
Add support for EZSP V8

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.ember.autocode/.project
+++ b/com.zsmartsystems.zigbee.dongle.ember.autocode/.project
@@ -10,8 +10,14 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
 </projectDescription>

--- a/com.zsmartsystems.zigbee.dongle.ember.autocode/pom.xml
+++ b/com.zsmartsystems.zigbee.dongle.ember.autocode/pom.xml
@@ -41,26 +41,4 @@
         </plugins>
     </build>
 
-    <dependencies>
-
-        <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-            <version>2.4</version>
-        </dependency>
-
-        <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
-            <version>2.6</version>
-        </dependency>
-
-        <dependency>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-            <version>1.8</version>
-        </dependency>
-
-    </dependencies>
-
 </project>

--- a/com.zsmartsystems.zigbee.dongle.ember.autocode/src/main/java/com/zsmartsystems/zigbee/dongle/ember/autocode/CommandGenerator.java
+++ b/com.zsmartsystems.zigbee.dongle.ember.autocode/src/main/java/com/zsmartsystems/zigbee/dongle/ember/autocode/CommandGenerator.java
@@ -963,7 +963,7 @@ public class CommandGenerator extends ClassGenerator {
         out.println("    /**");
         out.println("     * The maximum supported version of EZSP");
         out.println("     */");
-        out.println("    private static final int EZSP_MAX_VERSION = 7;");
+        out.println("    private static final int EZSP_MAX_VERSION = 8;");
         out.println();
         out.println("    /**");
         out.println("     * The current version of EZSP being used");
@@ -978,12 +978,12 @@ public class CommandGenerator extends ClassGenerator {
         out.println("    /**");
         out.println("     * EZSP Frame Control Request flag");
         out.println("     */");
-        out.println("    protected static final int EZSP_FC_REQUEST = 0x00;");
+        out.println("    protected static final int EZSP_FC_REQUEST = 0x0000;");
         out.println();
         out.println("    /**");
         out.println("     * EZSP Frame Control Response flag");
         out.println("     */");
-        out.println("    protected static final int EZSP_FC_RESPONSE = 0x80;");
+        out.println("    protected static final int EZSP_FC_RESPONSE = 0x0080;");
         out.println();
         for (Command command : commandMap.values()) {
             String reference = camelCaseToConstant(
@@ -1060,18 +1060,24 @@ public class CommandGenerator extends ClassGenerator {
         out.println("     * @return the {@link EzspFrameResponse} or null if the response can't be created.");
         out.println("     */");
         out.println("    public static EzspFrameResponse createHandler(int[] data) {");
-        out.println("        Class<?> ezspClass = null;");
+        out.println("        int frameId;");
         out.println();
         out.println("        try {");
-        out.println("            if (data[2] != 0xFF) {");
-        out.println("                ezspClass = ezspHandlerMap.get(data[2]);");
+        out.println("            if (ezspVersion >= 8) {");
+        out.println("                frameId = data[3] + (data[4] << 8);");
         out.println("            } else {");
-        out.println("                ezspClass = ezspHandlerMap.get(data[4]);");
+        out.println("                if (data[2] != 0xFF) {");
+        out.println("                    frameId = data[2];");
+        out.println("                } else {");
+        out.println("                    frameId = data[4];");
+        out.println("                }");
         out.println("            }");
         out.println("        } catch (ArrayIndexOutOfBoundsException e) {");
         out.println("            logger.debug(\"Error detecting the EZSP frame type\", e);");
+        out.println("            return null;");
         out.println("        }");
         out.println();
+        out.println("        Class<?> ezspClass = ezspHandlerMap.get(frameId);");
         out.println("        if (ezspClass == null) {");
         out.println("            return null;");
         out.println("        }");

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/EzspFrame.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/EzspFrame.java
@@ -58,7 +58,7 @@ public abstract class EzspFrame {
     /**
      * The maximum supported version of EZSP
      */
-    private static final int EZSP_MAX_VERSION = 7;
+    private static final int EZSP_MAX_VERSION = 8;
 
     /**
      * The current version of EZSP being used
@@ -73,12 +73,12 @@ public abstract class EzspFrame {
     /**
      * EZSP Frame Control Request flag
      */
-    protected static final int EZSP_FC_REQUEST = 0x00;
+    protected static final int EZSP_FC_REQUEST = 0x0000;
 
     /**
      * EZSP Frame Control Response flag
      */
-    protected static final int EZSP_FC_RESPONSE = 0x80;
+    protected static final int EZSP_FC_RESPONSE = 0x0080;
 
     protected static final int FRAME_ID_ADD_ENDPOINT = 0x02;
     protected static final int FRAME_ID_ADD_OR_UPDATE_KEY_TABLE_ENTRY = 0x66;
@@ -413,18 +413,24 @@ public abstract class EzspFrame {
      * @return the {@link EzspFrameResponse} or null if the response can't be created.
      */
     public static EzspFrameResponse createHandler(int[] data) {
-        Class<?> ezspClass = null;
+        int frameId;
 
         try {
-            if (data[2] != 0xFF) {
-                ezspClass = ezspHandlerMap.get(data[2]);
+            if (ezspVersion >= 8) {
+                frameId = data[3] + (data[4] << 8);
             } else {
-                ezspClass = ezspHandlerMap.get(data[4]);
+                if (data[2] != 0xFF) {
+                    frameId = data[2];
+                } else {
+                    frameId = data[4];
+                }
             }
         } catch (ArrayIndexOutOfBoundsException e) {
             logger.debug("Error detecting the EZSP frame type", e);
+            return null;
         }
 
+        Class<?> ezspClass = ezspHandlerMap.get(frameId);
         if (ezspClass == null) {
             return null;
         }

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/EzspFrameResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/EzspFrameResponse.java
@@ -56,13 +56,17 @@ public abstract class EzspFrameResponse extends EzspFrame {
     protected EzspFrameResponse(int[] inputBuffer) {
         super();
         deserializer = new EzspDeserializer(inputBuffer);
-
         sequenceNumber = deserializer.deserializeUInt8();
-        frameControl = deserializer.deserializeUInt8();
-        frameId = deserializer.deserializeUInt8();
-        if (frameId == EZSP_LEGACY_FRAME_ID) {
-            deserializer.deserializeUInt8();
+        if (ezspVersion >= 8) {
+            frameControl = deserializer.deserializeUInt16();
+            frameId = deserializer.deserializeUInt16();
+        } else {
+            frameControl = deserializer.deserializeUInt8();
             frameId = deserializer.deserializeUInt8();
+            if (frameId == EZSP_LEGACY_FRAME_ID) {
+                deserializer.deserializeUInt8();
+                frameId = deserializer.deserializeUInt8();
+            }
         }
         isResponse = (frameControl & EZSP_FC_RESPONSE) != 0;
         callbackPending = (frameControl & EZSP_FC_CB_PENDING) != 0;

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzspTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzspTest.java
@@ -117,8 +117,10 @@ public class ZigBeeDongleEzspTest {
         assertEquals(5, EzspFrame.getEzspVersion());
         assertTrue(EzspFrame.setEzspVersion(7));
         assertEquals(7, EzspFrame.getEzspVersion());
-        assertFalse(EzspFrame.setEzspVersion(8));
-        assertEquals(7, EzspFrame.getEzspVersion());
+        assertTrue(EzspFrame.setEzspVersion(8));
+        assertEquals(8, EzspFrame.getEzspVersion());
+        assertFalse(EzspFrame.setEzspVersion(9));
+        assertEquals(8, EzspFrame.getEzspVersion());
         EzspFrame.setEzspVersion(4);
     }
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/EzspFrameRequestTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/EzspFrameRequestTest.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2016-2020 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.dongle.ember.ezsp;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.zsmartsystems.zigbee.dongle.ember.internal.serializer.EzspSerializer;
+
+/**
+ *
+ * @author Chris Jackson
+ *
+ */
+public class EzspFrameRequestTest {
+
+    @Test
+    public void testResponseV4() {
+        EzspFrame.setEzspVersion(4);
+
+        EzspFrameRequest request = Mockito.mock(EzspFrameRequest.class, Mockito.CALLS_REAL_METHODS);
+
+        EzspSerializer serializer = new EzspSerializer();
+        request.serializeHeader(serializer);
+        assertTrue(Arrays.equals(new int[] { 0x00, 0x00, 0x00 }, serializer.getPayload()));
+        EzspFrame.setEzspVersion(4);
+    }
+
+    @Test
+    public void testResponseV5() {
+        EzspFrame.setEzspVersion(5);
+
+        EzspFrameRequest request = Mockito.mock(EzspFrameRequest.class, Mockito.CALLS_REAL_METHODS);
+
+        EzspSerializer serializer = new EzspSerializer();
+        request.serializeHeader(serializer);
+        assertTrue(Arrays.equals(new int[] { 0x00, 0x00, 0xFF, 0x00, 0x00 }, serializer.getPayload()));
+        EzspFrame.setEzspVersion(4);
+    }
+
+    @Test
+    public void testResponseV8() {
+        EzspFrame.setEzspVersion(8);
+
+        EzspFrameRequest request = Mockito.mock(EzspFrameRequest.class, Mockito.CALLS_REAL_METHODS);
+
+        EzspSerializer serializer = new EzspSerializer();
+        request.serializeHeader(serializer);
+        assertTrue(Arrays.equals(new int[] { 0x00, 0x00, 0x01, 0x00, 0x00 }, serializer.getPayload()));
+        EzspFrame.setEzspVersion(4);
+    }
+}

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/EzspFrameResponseTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/EzspFrameResponseTest.java
@@ -25,6 +25,7 @@ public class EzspFrameResponseTest {
 
     @Test
     public void testResponseV4() {
+        EzspFrame.setEzspVersion(4);
         EzspVersionResponse response = new EzspVersionResponse(new int[] { 0x01, 0x80, 0x00, 0x04, 0x02, 0x00, 0x59 });
         System.out.println(response);
 
@@ -34,6 +35,7 @@ public class EzspFrameResponseTest {
 
     @Test
     public void testResponseV5() {
+        EzspFrame.setEzspVersion(4);
         EzspVersionResponse response = new EzspVersionResponse(
                 new int[] { 0x01, 0x80, 0xFF, 0x00, 0x00, 0x05, 0x02, 0x10, 0x5A });
         System.out.println(response);
@@ -43,7 +45,20 @@ public class EzspFrameResponseTest {
     }
 
     @Test
+    public void testResponseV8() {
+        EzspFrame.setEzspVersion(4);
+        EzspFrame.setEzspVersion(8);
+        EzspVersionResponse response = new EzspVersionResponse(
+                new int[] { 0x01, 0x80, 0x01, 0x00, 0x00, 0x08, 0x02, 0x00, 0x67 });
+        System.out.println(response);
+
+        assertEquals(8, response.getProtocolVersion());
+        assertEquals(0x6700, response.getStackVersion());
+    }
+
+    @Test
     public void testResponse() {
+        EzspFrame.setEzspVersion(4);
         EzspNoCallbacksResponse response = new EzspNoCallbacksResponse(new int[] { 0x2C, 0x88, 0x07 });
         System.out.println(response);
         assertFalse(response.isCallbackPending());

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/transaction/EzspScanTransactionTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/transaction/EzspScanTransactionTest.java
@@ -18,6 +18,7 @@ import java.util.Set;
 import org.junit.Test;
 
 import com.zsmartsystems.zigbee.ZigBeeChannelMask;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.EzspFrame;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.EzspFrameResponse;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.EzspFrameTest;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspEnergyScanResultHandler;
@@ -27,7 +28,6 @@ import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspStartScanRequest;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspStartScanResponse;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EmberStatus;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EzspNetworkScanType;
-import com.zsmartsystems.zigbee.dongle.ember.internal.transaction.EzspMultiResponseTransaction;
 
 /**
  *
@@ -37,6 +37,7 @@ import com.zsmartsystems.zigbee.dongle.ember.internal.transaction.EzspMultiRespo
 public class EzspScanTransactionTest extends EzspFrameTest {
     @Test
     public void testScanTransaction() {
+        EzspFrame.setEzspVersion(4);
         EzspStartScanRequest energyScan = new EzspStartScanRequest();
         energyScan.setChannelMask(ZigBeeChannelMask.CHANNEL_MASK_2GHZ);
         energyScan.setDuration(1);


### PR DESCRIPTION
This implements support for EZSP v8 frame format and improves the allocation of sequence numbers to Ember frames.

Closes #791 
Closes #944 
Signed-off-by: Chris Jackson <chris@cd-jackson.com>