### PR TITLE
Refactor ZclCluster.send() to sendCommand() and provide public methods

### DIFF
--- a/com.zsmartsystems.zigbee.autocode/src/main/java/com/zsmartsystems/zigbee/autocode/ZigBeeBaseClassGenerator.java
+++ b/com.zsmartsystems.zigbee.autocode/src/main/java/com/zsmartsystems/zigbee/autocode/ZigBeeBaseClassGenerator.java
@@ -83,6 +83,7 @@ public abstract class ZigBeeBaseClassGenerator {
         fixedCaseAcronyms.add("MAC");
         fixedCaseAcronyms.add("MMO");
         fixedCaseAcronyms.add("NWK");
+        fixedCaseAcronyms.add("OTA");
         fixedCaseAcronyms.add("PIN");
         fixedCaseAcronyms.add("PIR");
         fixedCaseAcronyms.add("RMS");
@@ -94,6 +95,8 @@ public abstract class ZigBeeBaseClassGenerator {
         fixedCaseAcronyms.add("WD");
         fixedCaseAcronyms.add("XY");
         fixedCaseAcronyms.add("ZCL");
+        fixedCaseAcronyms.add("ZED");
+        fixedCaseAcronyms.add("ZR");
 
         fixedCaseAcronyms.add("may");
         fixedCaseAcronyms.add("shall");

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/ZclCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/ZclCluster.java
@@ -276,12 +276,13 @@ public abstract class ZclCluster {
     }
 
     /**
-     * Sends a {@link ZclCommand}
+     * Sends a {@link ZclCommand} and returns the {@link Future} to the result which will complete when the remote
+     * device response is received, or the request times out.
      *
      * @param command the {@link ZclCommand} to send
      * @return the command result future
      */
-    protected Future<CommandResult> send(ZclCommand command) {
+    protected Future<CommandResult> sendCommand(ZclCommand command) {
         if (isClient()) {
             command.setCommandDirection(ZclCommandDirection.SERVER_TO_CLIENT);
         }
@@ -298,7 +299,7 @@ public abstract class ZclCluster {
      * @param command the {@link ZclCommand} to which the response is being sent
      * @param response the {@link ZclCommand} to send
      */
-    public void sendResponse(ZclCommand command, ZclCommand response) {
+    protected void sendResponse(ZclCommand command, ZclCommand response) {
         response.setDestinationAddress(command.getSourceAddress());
         response.setCommandDirection(command.getCommandDirection().getResponseDirection());
         response.setTransactionId(command.getTransactionId());
@@ -354,7 +355,7 @@ public abstract class ZclCluster {
             defaultResponse.setManufacturerCode(manufacturerCode);
         }
 
-        send(defaultResponse);
+        sendCommand(defaultResponse);
     }
 
     /**
@@ -418,7 +419,7 @@ public abstract class ZclCluster {
             command.setManufacturerCode(manufacturerSpecificAttribute.getManufacturerCode());
         }
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -452,7 +453,7 @@ public abstract class ZclCluster {
             command.setManufacturerCode(getAttribute(attributeIds.get(0)).getManufacturerCode());
         }
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -541,7 +542,7 @@ public abstract class ZclCluster {
             command.setManufacturerCode(manufacturerSpecificAttribute.getManufacturerCode());
         }
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -625,7 +626,7 @@ public abstract class ZclCluster {
             command.setManufacturerCode(getAttribute(attributeId).getManufacturerCode());
         }
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -906,7 +907,7 @@ public abstract class ZclCluster {
                             command.setManufacturerCode(manufacturerCode);
                         }
 
-                        CommandResult result = send(command).get();
+                        CommandResult result = sendCommand(command).get();
                         if (result.isError()) {
                             return false;
                         }
@@ -1028,7 +1029,7 @@ public abstract class ZclCluster {
                             command.setManufacturerCode(manufacturerCode);
                         }
 
-                        CommandResult result = send(command).get();
+                        CommandResult result = sendCommand(command).get();
                         if (result.isError()) {
                             return false;
                         }
@@ -1137,7 +1138,7 @@ public abstract class ZclCluster {
                             command.setManufacturerCode(manufacturerCode);
                         }
 
-                        CommandResult result = send(command).get();
+                        CommandResult result = sendCommand(command).get();
                         if (result.isError()) {
                             return false;
                         }
@@ -1765,7 +1766,7 @@ public abstract class ZclCluster {
             command.setManufacturerCode(attribute.getManufacturerCode());
         }
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -1815,7 +1816,7 @@ public abstract class ZclCluster {
         command.setRecords(Collections.singletonList(record));
         command.setDestinationAddress(zigbeeEndpoint.getEndpointAddress());
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclAlarmsCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclAlarmsCluster.java
@@ -24,6 +24,7 @@ import com.zsmartsystems.zigbee.zcl.clusters.alarms.GetAlarmResponse;
 import com.zsmartsystems.zigbee.zcl.clusters.alarms.ResetAlarmCommand;
 import com.zsmartsystems.zigbee.zcl.clusters.alarms.ResetAlarmLogCommand;
 import com.zsmartsystems.zigbee.zcl.clusters.alarms.ResetAllAlarmsCommand;
+import com.zsmartsystems.zigbee.zcl.clusters.alarms.ZclAlarmsCommand;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
 /**
@@ -44,7 +45,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-10-04T18:21:10Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:04:47Z")
 public class ZclAlarmsCluster extends ZclCluster {
     /**
      * The ZigBee Cluster Library Cluster ID
@@ -111,6 +112,28 @@ public class ZclAlarmsCluster extends ZclCluster {
      */
     public ZclAlarmsCluster(final ZigBeeEndpoint zigbeeEndpoint) {
         super(zigbeeEndpoint, CLUSTER_ID, CLUSTER_NAME);
+    }
+
+    /**
+     * Sends a {@link ZclAlarmsCommand} and returns the {@link Future} to the result which will complete when the remote
+     * device response is received, or the request times out.
+     *
+     * @param command the {@link ZclAlarmsCommand} to send
+     * @return the command result future
+     */
+    public Future<CommandResult> sendCommand(ZclAlarmsCommand command) {
+        return super.sendCommand(command);
+    }
+
+    /**
+     * Sends a response to the command. This method sets all the common elements of the response based on the command -
+     * eg transactionId, direction, address...
+     *
+     * @param command the {@link ZclAlarmsCommand} to which the response is being sent
+     * @param response the {@link ZclAlarmsCommand} to send
+     */
+    public void sendResponse(ZclAlarmsCommand command, ZclAlarmsCommand response) {
+        super.sendResponse(command, response);
     }
 
     /**
@@ -186,7 +209,7 @@ public class ZclAlarmsCluster extends ZclCluster {
         command.setAlarmCode(alarmCode);
         command.setClusterIdentifier(clusterIdentifier);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -199,7 +222,7 @@ public class ZclAlarmsCluster extends ZclCluster {
      * @return the {@link Future<CommandResult>} command result future
      */
     public Future<CommandResult> resetAllAlarmsCommand() {
-        return send(new ResetAllAlarmsCommand());
+        return sendCommand(new ResetAllAlarmsCommand());
     }
 
     /**
@@ -213,7 +236,7 @@ public class ZclAlarmsCluster extends ZclCluster {
      * @return the {@link Future<CommandResult>} command result future
      */
     public Future<CommandResult> getAlarmCommand() {
-        return send(new GetAlarmCommand());
+        return sendCommand(new GetAlarmCommand());
     }
 
     /**
@@ -224,7 +247,7 @@ public class ZclAlarmsCluster extends ZclCluster {
      * @return the {@link Future<CommandResult>} command result future
      */
     public Future<CommandResult> resetAlarmLogCommand() {
-        return send(new ResetAlarmLogCommand());
+        return sendCommand(new ResetAlarmLogCommand());
     }
 
     /**
@@ -246,7 +269,7 @@ public class ZclAlarmsCluster extends ZclCluster {
         command.setAlarmCode(alarmCode);
         command.setClusterIdentifier(clusterIdentifier);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -274,6 +297,6 @@ public class ZclAlarmsCluster extends ZclCluster {
         command.setClusterIdentifier(clusterIdentifier);
         command.setTimestamp(timestamp);
 
-        return send(command);
+        return sendCommand(command);
     }
 }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclAnalogInputBasicCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclAnalogInputBasicCluster.java
@@ -28,7 +28,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-10-04T18:21:10Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T11:55:03Z")
 public class ZclAnalogInputBasicCluster extends ZclCluster {
     /**
      * The ZigBee Cluster Library Cluster ID
@@ -178,6 +178,7 @@ public class ZclAnalogInputBasicCluster extends ZclCluster {
 
         return attributeMap;
     }
+
 
     /**
      * Default constructor to create a Analog Input (Basic) cluster.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclBasicCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclBasicCluster.java
@@ -19,6 +19,7 @@ import com.zsmartsystems.zigbee.zcl.ZclAttribute;
 import com.zsmartsystems.zigbee.zcl.ZclCluster;
 import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.clusters.basic.ResetToFactoryDefaultsCommand;
+import com.zsmartsystems.zigbee.zcl.clusters.basic.ZclBasicCommand;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
 /**
@@ -30,7 +31,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-10-04T18:21:10Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:04:47Z")
 public class ZclBasicCluster extends ZclCluster {
     /**
      * The ZigBee Cluster Library Cluster ID
@@ -177,6 +178,28 @@ public class ZclBasicCluster extends ZclCluster {
      */
     public ZclBasicCluster(final ZigBeeEndpoint zigbeeEndpoint) {
         super(zigbeeEndpoint, CLUSTER_ID, CLUSTER_NAME);
+    }
+
+    /**
+     * Sends a {@link ZclBasicCommand} and returns the {@link Future} to the result which will complete when the remote
+     * device response is received, or the request times out.
+     *
+     * @param command the {@link ZclBasicCommand} to send
+     * @return the command result future
+     */
+    public Future<CommandResult> sendCommand(ZclBasicCommand command) {
+        return super.sendCommand(command);
+    }
+
+    /**
+     * Sends a response to the command. This method sets all the common elements of the response based on the command -
+     * eg transactionId, direction, address...
+     *
+     * @param command the {@link ZclBasicCommand} to which the response is being sent
+     * @param response the {@link ZclBasicCommand} to send
+     */
+    public void sendResponse(ZclBasicCommand command, ZclBasicCommand response) {
+        super.sendResponse(command, response);
     }
 
     /**
@@ -1422,6 +1445,6 @@ public class ZclBasicCluster extends ZclCluster {
      * @return the {@link Future<CommandResult>} command result future
      */
     public Future<CommandResult> resetToFactoryDefaultsCommand() {
-        return send(new ResetToFactoryDefaultsCommand());
+        return sendCommand(new ResetToFactoryDefaultsCommand());
     }
 }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclBinaryInputBasicCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclBinaryInputBasicCluster.java
@@ -28,7 +28,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-10-04T18:21:10Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T11:55:03Z")
 public class ZclBinaryInputBasicCluster extends ZclCluster {
     /**
      * The ZigBee Cluster Library Cluster ID
@@ -187,6 +187,7 @@ public class ZclBinaryInputBasicCluster extends ZclCluster {
 
         return attributeMap;
     }
+
 
     /**
      * Default constructor to create a Binary Input (Basic) cluster.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclColorControlCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclColorControlCluster.java
@@ -37,6 +37,7 @@ import com.zsmartsystems.zigbee.zcl.clusters.colorcontrol.StepColorTemperatureCo
 import com.zsmartsystems.zigbee.zcl.clusters.colorcontrol.StepHueCommand;
 import com.zsmartsystems.zigbee.zcl.clusters.colorcontrol.StepSaturationCommand;
 import com.zsmartsystems.zigbee.zcl.clusters.colorcontrol.StopMoveStepCommand;
+import com.zsmartsystems.zigbee.zcl.clusters.colorcontrol.ZclColorControlCommand;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
 /**
@@ -58,7 +59,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-10-04T18:21:10Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:04:47Z")
 public class ZclColorControlCluster extends ZclCluster {
     /**
      * The ZigBee Cluster Library Cluster ID
@@ -288,6 +289,28 @@ public class ZclColorControlCluster extends ZclCluster {
      */
     public ZclColorControlCluster(final ZigBeeEndpoint zigbeeEndpoint) {
         super(zigbeeEndpoint, CLUSTER_ID, CLUSTER_NAME);
+    }
+
+    /**
+     * Sends a {@link ZclColorControlCommand} and returns the {@link Future} to the result which will complete when the remote
+     * device response is received, or the request times out.
+     *
+     * @param command the {@link ZclColorControlCommand} to send
+     * @return the command result future
+     */
+    public Future<CommandResult> sendCommand(ZclColorControlCommand command) {
+        return super.sendCommand(command);
+    }
+
+    /**
+     * Sends a response to the command. This method sets all the common elements of the response based on the command -
+     * eg transactionId, direction, address...
+     *
+     * @param command the {@link ZclColorControlCommand} to which the response is being sent
+     * @param response the {@link ZclColorControlCommand} to send
+     */
+    public void sendResponse(ZclColorControlCommand command, ZclColorControlCommand response) {
+        super.sendResponse(command, response);
     }
 
     /**
@@ -1376,7 +1399,7 @@ public class ZclColorControlCluster extends ZclCluster {
         command.setDirection(direction);
         command.setTransitionTime(transitionTime);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -1393,7 +1416,7 @@ public class ZclColorControlCluster extends ZclCluster {
         command.setMoveMode(moveMode);
         command.setRate(rate);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -1412,7 +1435,7 @@ public class ZclColorControlCluster extends ZclCluster {
         command.setStepSize(stepSize);
         command.setTransitionTime(transitionTime);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -1429,7 +1452,7 @@ public class ZclColorControlCluster extends ZclCluster {
         command.setSaturation(saturation);
         command.setTransitionTime(transitionTime);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -1446,7 +1469,7 @@ public class ZclColorControlCluster extends ZclCluster {
         command.setMoveMode(moveMode);
         command.setRate(rate);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -1465,7 +1488,7 @@ public class ZclColorControlCluster extends ZclCluster {
         command.setStepSize(stepSize);
         command.setTransitionTime(transitionTime);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -1484,7 +1507,7 @@ public class ZclColorControlCluster extends ZclCluster {
         command.setSaturation(saturation);
         command.setTransitionTime(transitionTime);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -1503,7 +1526,7 @@ public class ZclColorControlCluster extends ZclCluster {
         command.setColorY(colorY);
         command.setTransitionTime(transitionTime);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -1520,7 +1543,7 @@ public class ZclColorControlCluster extends ZclCluster {
         command.setRateX(rateX);
         command.setRateY(rateY);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -1539,7 +1562,7 @@ public class ZclColorControlCluster extends ZclCluster {
         command.setStepY(stepY);
         command.setTransitionTime(transitionTime);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -1563,7 +1586,7 @@ public class ZclColorControlCluster extends ZclCluster {
         command.setColorTemperature(colorTemperature);
         command.setTransitionTime(transitionTime);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -1592,7 +1615,7 @@ public class ZclColorControlCluster extends ZclCluster {
         command.setDirection(direction);
         command.setTransitionTime(transitionTime);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -1616,7 +1639,7 @@ public class ZclColorControlCluster extends ZclCluster {
         command.setMoveMode(moveMode);
         command.setRate(rate);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -1638,7 +1661,7 @@ public class ZclColorControlCluster extends ZclCluster {
         command.setStepSize(stepSize);
         command.setTransitionTime(transitionTime);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -1661,7 +1684,7 @@ public class ZclColorControlCluster extends ZclCluster {
         command.setSaturation(saturation);
         command.setTransitionTime(transitionTime);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -1687,7 +1710,7 @@ public class ZclColorControlCluster extends ZclCluster {
         command.setTransitionTime(transitionTime);
         command.setStartHue(startHue);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -1704,7 +1727,7 @@ public class ZclColorControlCluster extends ZclCluster {
      * @return the {@link Future<CommandResult>} command result future
      */
     public Future<CommandResult> stopMoveStepCommand() {
-        return send(new StopMoveStepCommand());
+        return sendCommand(new StopMoveStepCommand());
     }
 
     /**
@@ -1728,7 +1751,7 @@ public class ZclColorControlCluster extends ZclCluster {
         command.setColorTemperatureMinimum(colorTemperatureMinimum);
         command.setColorTemperatureMaximum(colorTemperatureMaximum);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -1754,6 +1777,6 @@ public class ZclColorControlCluster extends ZclCluster {
         command.setColorTemperatureMinimum(colorTemperatureMinimum);
         command.setColorTemperatureMaximum(colorTemperatureMaximum);
 
-        return send(command);
+        return sendCommand(command);
     }
 }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclCommissioningCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclCommissioningCluster.java
@@ -26,6 +26,7 @@ import com.zsmartsystems.zigbee.zcl.clusters.commissioning.RestoreStartupParamet
 import com.zsmartsystems.zigbee.zcl.clusters.commissioning.RestoreStartupParametersResponse;
 import com.zsmartsystems.zigbee.zcl.clusters.commissioning.SaveStartupParametersCommand;
 import com.zsmartsystems.zigbee.zcl.clusters.commissioning.SaveStartupParametersResponse;
+import com.zsmartsystems.zigbee.zcl.clusters.commissioning.ZclCommissioningCommand;
 
 /**
  * <b>Commissioning</b> cluster implementation (<i>Cluster ID 0x0015</i>).
@@ -35,7 +36,7 @@ import com.zsmartsystems.zigbee.zcl.clusters.commissioning.SaveStartupParameters
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-10-04T18:21:10Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:04:47Z")
 public class ZclCommissioningCluster extends ZclCluster {
     /**
      * The ZigBee Cluster Library Cluster ID
@@ -95,6 +96,28 @@ public class ZclCommissioningCluster extends ZclCluster {
     }
 
     /**
+     * Sends a {@link ZclCommissioningCommand} and returns the {@link Future} to the result which will complete when the remote
+     * device response is received, or the request times out.
+     *
+     * @param command the {@link ZclCommissioningCommand} to send
+     * @return the command result future
+     */
+    public Future<CommandResult> sendCommand(ZclCommissioningCommand command) {
+        return super.sendCommand(command);
+    }
+
+    /**
+     * Sends a response to the command. This method sets all the common elements of the response based on the command -
+     * eg transactionId, direction, address...
+     *
+     * @param command the {@link ZclCommissioningCommand} to which the response is being sent
+     * @param response the {@link ZclCommissioningCommand} to send
+     */
+    public void sendResponse(ZclCommissioningCommand command, ZclCommissioningCommand response) {
+        super.sendResponse(command, response);
+    }
+
+    /**
      * The Restart Device Command
      *
      * @param option {@link Integer} Option
@@ -110,7 +133,7 @@ public class ZclCommissioningCluster extends ZclCluster {
         command.setDelay(delay);
         command.setJitter(jitter);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -127,7 +150,7 @@ public class ZclCommissioningCluster extends ZclCluster {
         command.setOption(option);
         command.setIndex(index);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -144,7 +167,7 @@ public class ZclCommissioningCluster extends ZclCluster {
         command.setOption(option);
         command.setIndex(index);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -161,7 +184,7 @@ public class ZclCommissioningCluster extends ZclCluster {
         command.setOption(option);
         command.setIndex(index);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -176,7 +199,7 @@ public class ZclCommissioningCluster extends ZclCluster {
         // Set the fields
         command.setStatus(status);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -191,7 +214,7 @@ public class ZclCommissioningCluster extends ZclCluster {
         // Set the fields
         command.setStatus(status);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -206,7 +229,7 @@ public class ZclCommissioningCluster extends ZclCluster {
         // Set the fields
         command.setStatus(status);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -221,6 +244,6 @@ public class ZclCommissioningCluster extends ZclCluster {
         // Set the fields
         command.setStatus(status);
 
-        return send(command);
+        return sendCommand(command);
     }
 }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclDehumidificationControlCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclDehumidificationControlCluster.java
@@ -26,7 +26,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-10-04T18:21:10Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T11:55:03Z")
 public class ZclDehumidificationControlCluster extends ZclCluster {
     /**
      * The ZigBee Cluster Library Cluster ID
@@ -105,6 +105,7 @@ public class ZclDehumidificationControlCluster extends ZclCluster {
 
         return attributeMap;
     }
+
 
     /**
      * Default constructor to create a Dehumidification Control cluster.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclDemandResponseAndLoadControlCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclDemandResponseAndLoadControlCluster.java
@@ -24,6 +24,7 @@ import com.zsmartsystems.zigbee.zcl.clusters.demandresponseandloadcontrol.Cancel
 import com.zsmartsystems.zigbee.zcl.clusters.demandresponseandloadcontrol.GetScheduledEvents;
 import com.zsmartsystems.zigbee.zcl.clusters.demandresponseandloadcontrol.LoadControlEventCommand;
 import com.zsmartsystems.zigbee.zcl.clusters.demandresponseandloadcontrol.ReportEventStatus;
+import com.zsmartsystems.zigbee.zcl.clusters.demandresponseandloadcontrol.ZclDemandResponseAndLoadControlCommand;
 import com.zsmartsystems.zigbee.zcl.field.ByteArray;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
@@ -45,7 +46,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-10-04T18:21:10Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:04:47Z")
 public class ZclDemandResponseAndLoadControlCluster extends ZclCluster {
     /**
      * The ZigBee Cluster Library Cluster ID
@@ -157,6 +158,28 @@ public class ZclDemandResponseAndLoadControlCluster extends ZclCluster {
     }
 
     /**
+     * Sends a {@link ZclDemandResponseAndLoadControlCommand} and returns the {@link Future} to the result which will complete when the remote
+     * device response is received, or the request times out.
+     *
+     * @param command the {@link ZclDemandResponseAndLoadControlCommand} to send
+     * @return the command result future
+     */
+    public Future<CommandResult> sendCommand(ZclDemandResponseAndLoadControlCommand command) {
+        return super.sendCommand(command);
+    }
+
+    /**
+     * Sends a response to the command. This method sets all the common elements of the response based on the command -
+     * eg transactionId, direction, address...
+     *
+     * @param command the {@link ZclDemandResponseAndLoadControlCommand} to which the response is being sent
+     * @param response the {@link ZclDemandResponseAndLoadControlCommand} to send
+     */
+    public void sendResponse(ZclDemandResponseAndLoadControlCommand command, ZclDemandResponseAndLoadControlCommand response) {
+        super.sendResponse(command, response);
+    }
+
+    /**
      * The Report Event Status
      *
      * @param issuerEventId {@link Integer} Issuer Event ID
@@ -188,7 +211,7 @@ public class ZclDemandResponseAndLoadControlCluster extends ZclCluster {
         command.setSignatureType(signatureType);
         command.setSignature(signature);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -210,7 +233,7 @@ public class ZclDemandResponseAndLoadControlCluster extends ZclCluster {
         command.setStartTime(startTime);
         command.setNumberOfEvents(numberOfEvents);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -249,7 +272,7 @@ public class ZclDemandResponseAndLoadControlCluster extends ZclCluster {
         command.setDutyCycle(dutyCycle);
         command.setEventControl(eventControl);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -272,7 +295,7 @@ public class ZclDemandResponseAndLoadControlCluster extends ZclCluster {
         command.setCancelControl(cancelControl);
         command.setEffectiveTime(effectiveTime);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -287,6 +310,6 @@ public class ZclDemandResponseAndLoadControlCluster extends ZclCluster {
         // Set the fields
         command.setCancelControl(cancelControl);
 
-        return send(command);
+        return sendCommand(command);
     }
 }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclDiagnosticsCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclDiagnosticsCluster.java
@@ -28,7 +28,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-10-04T18:21:10Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T11:55:03Z")
 public class ZclDiagnosticsCluster extends ZclCluster {
     /**
      * The ZigBee Cluster Library Cluster ID
@@ -141,6 +141,7 @@ public class ZclDiagnosticsCluster extends ZclCluster {
 
         return attributeMap;
     }
+
 
     /**
      * Default constructor to create a Diagnostics cluster.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclDoorLockCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclDoorLockCluster.java
@@ -26,6 +26,7 @@ import com.zsmartsystems.zigbee.zcl.clusters.doorlock.UnlockDoorCommand;
 import com.zsmartsystems.zigbee.zcl.clusters.doorlock.UnlockDoorResponse;
 import com.zsmartsystems.zigbee.zcl.clusters.doorlock.UnlockWithTimeout;
 import com.zsmartsystems.zigbee.zcl.clusters.doorlock.UnlockWithTimeoutResponse;
+import com.zsmartsystems.zigbee.zcl.clusters.doorlock.ZclDoorLockCommand;
 import com.zsmartsystems.zigbee.zcl.field.ByteArray;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
@@ -55,7 +56,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-10-04T18:21:10Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:04:47Z")
 public class ZclDoorLockCluster extends ZclCluster {
     /**
      * The ZigBee Cluster Library Cluster ID
@@ -400,6 +401,28 @@ public class ZclDoorLockCluster extends ZclCluster {
      */
     public ZclDoorLockCluster(final ZigBeeEndpoint zigbeeEndpoint) {
         super(zigbeeEndpoint, CLUSTER_ID, CLUSTER_NAME);
+    }
+
+    /**
+     * Sends a {@link ZclDoorLockCommand} and returns the {@link Future} to the result which will complete when the remote
+     * device response is received, or the request times out.
+     *
+     * @param command the {@link ZclDoorLockCommand} to send
+     * @return the command result future
+     */
+    public Future<CommandResult> sendCommand(ZclDoorLockCommand command) {
+        return super.sendCommand(command);
+    }
+
+    /**
+     * Sends a response to the command. This method sets all the common elements of the response based on the command -
+     * eg transactionId, direction, address...
+     *
+     * @param command the {@link ZclDoorLockCommand} to which the response is being sent
+     * @param response the {@link ZclDoorLockCommand} to send
+     */
+    public void sendResponse(ZclDoorLockCommand command, ZclDoorLockCommand response) {
+        super.sendResponse(command, response);
     }
 
     /**
@@ -3409,7 +3432,7 @@ public class ZclDoorLockCluster extends ZclCluster {
         // Set the fields
         command.setPinCode(pinCode);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -3433,7 +3456,7 @@ public class ZclDoorLockCluster extends ZclCluster {
         // Set the fields
         command.setPinCode(pinCode);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -3452,7 +3475,7 @@ public class ZclDoorLockCluster extends ZclCluster {
         // Set the fields
         command.setPin(pin);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -3476,7 +3499,7 @@ public class ZclDoorLockCluster extends ZclCluster {
         command.setTimeoutInSeconds(timeoutInSeconds);
         command.setPin(pin);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -3498,7 +3521,7 @@ public class ZclDoorLockCluster extends ZclCluster {
         // Set the fields
         command.setStatus(status);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -3520,7 +3543,7 @@ public class ZclDoorLockCluster extends ZclCluster {
         // Set the fields
         command.setStatus(status);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -3542,7 +3565,7 @@ public class ZclDoorLockCluster extends ZclCluster {
         // Set the fields
         command.setStatus(status);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -3563,6 +3586,6 @@ public class ZclDoorLockCluster extends ZclCluster {
         // Set the fields
         command.setStatus(status);
 
-        return send(command);
+        return sendCommand(command);
     }
 }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclElectricalMeasurementCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclElectricalMeasurementCluster.java
@@ -22,6 +22,7 @@ import com.zsmartsystems.zigbee.zcl.clusters.electricalmeasurement.GetMeasuremen
 import com.zsmartsystems.zigbee.zcl.clusters.electricalmeasurement.GetMeasurementProfileResponseCommand;
 import com.zsmartsystems.zigbee.zcl.clusters.electricalmeasurement.GetProfileInfoCommand;
 import com.zsmartsystems.zigbee.zcl.clusters.electricalmeasurement.GetProfileInfoResponseCommand;
+import com.zsmartsystems.zigbee.zcl.clusters.electricalmeasurement.ZclElectricalMeasurementCommand;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
 /**
@@ -41,7 +42,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-10-04T18:21:10Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:04:47Z")
 public class ZclElectricalMeasurementCluster extends ZclCluster {
     /**
      * The ZigBee Cluster Library Cluster ID
@@ -411,6 +412,28 @@ public class ZclElectricalMeasurementCluster extends ZclCluster {
      */
     public ZclElectricalMeasurementCluster(final ZigBeeEndpoint zigbeeEndpoint) {
         super(zigbeeEndpoint, CLUSTER_ID, CLUSTER_NAME);
+    }
+
+    /**
+     * Sends a {@link ZclElectricalMeasurementCommand} and returns the {@link Future} to the result which will complete when the remote
+     * device response is received, or the request times out.
+     *
+     * @param command the {@link ZclElectricalMeasurementCommand} to send
+     * @return the command result future
+     */
+    public Future<CommandResult> sendCommand(ZclElectricalMeasurementCommand command) {
+        return super.sendCommand(command);
+    }
+
+    /**
+     * Sends a response to the command. This method sets all the common elements of the response based on the command -
+     * eg transactionId, direction, address...
+     *
+     * @param command the {@link ZclElectricalMeasurementCommand} to which the response is being sent
+     * @param response the {@link ZclElectricalMeasurementCommand} to send
+     */
+    public void sendResponse(ZclElectricalMeasurementCommand command, ZclElectricalMeasurementCommand response) {
+        super.sendResponse(command, response);
     }
 
     /**
@@ -7945,7 +7968,7 @@ public class ZclElectricalMeasurementCluster extends ZclCluster {
      * @return the {@link Future<CommandResult>} command result future
      */
     public Future<CommandResult> getProfileInfoCommand() {
-        return send(new GetProfileInfoCommand());
+        return sendCommand(new GetProfileInfoCommand());
     }
 
     /**
@@ -7967,7 +7990,7 @@ public class ZclElectricalMeasurementCluster extends ZclCluster {
         command.setStartTime(startTime);
         command.setNumberOfIntervals(numberOfIntervals);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -7992,7 +8015,7 @@ public class ZclElectricalMeasurementCluster extends ZclCluster {
         command.setMaxNumberOfIntervals(maxNumberOfIntervals);
         command.setListOfAttributes(listOfAttributes);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -8021,6 +8044,6 @@ public class ZclElectricalMeasurementCluster extends ZclCluster {
         command.setAttributeId(attributeId);
         command.setIntervals(intervals);
 
-        return send(command);
+        return sendCommand(command);
     }
 }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclFanControlCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclFanControlCluster.java
@@ -27,7 +27,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-10-04T18:21:10Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T11:55:03Z")
 public class ZclFanControlCluster extends ZclCluster {
     /**
      * The ZigBee Cluster Library Cluster ID
@@ -66,6 +66,7 @@ public class ZclFanControlCluster extends ZclCluster {
 
         return attributeMap;
     }
+
 
     /**
      * Default constructor to create a Fan Control cluster.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclFlowMeasurementCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclFlowMeasurementCluster.java
@@ -27,7 +27,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-10-04T18:21:10Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T11:55:03Z")
 public class ZclFlowMeasurementCluster extends ZclCluster {
     /**
      * The ZigBee Cluster Library Cluster ID
@@ -95,6 +95,7 @@ public class ZclFlowMeasurementCluster extends ZclCluster {
 
         return attributeMap;
     }
+
 
     /**
      * Default constructor to create a Flow Measurement cluster.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclGreenPowerCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclGreenPowerCluster.java
@@ -38,6 +38,7 @@ import com.zsmartsystems.zigbee.zcl.clusters.greenpower.GpTranslationTableReques
 import com.zsmartsystems.zigbee.zcl.clusters.greenpower.GpTranslationTableUpdate;
 import com.zsmartsystems.zigbee.zcl.clusters.greenpower.GpTranslationTableUpdateTranslation;
 import com.zsmartsystems.zigbee.zcl.clusters.greenpower.GpTunnelingStop;
+import com.zsmartsystems.zigbee.zcl.clusters.greenpower.ZclGreenPowerCommand;
 import com.zsmartsystems.zigbee.zcl.field.ByteArray;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
@@ -48,7 +49,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-11-03T12:48:45Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:04:47Z")
 public class ZclGreenPowerCluster extends ZclCluster {
     /**
      * The ZigBee Cluster Library Cluster ID
@@ -276,6 +277,28 @@ public class ZclGreenPowerCluster extends ZclCluster {
      */
     public ZclGreenPowerCluster(final ZigBeeEndpoint zigbeeEndpoint) {
         super(zigbeeEndpoint, CLUSTER_ID, CLUSTER_NAME);
+    }
+
+    /**
+     * Sends a {@link ZclGreenPowerCommand} and returns the {@link Future} to the result which will complete when the remote
+     * device response is received, or the request times out.
+     *
+     * @param command the {@link ZclGreenPowerCommand} to send
+     * @return the command result future
+     */
+    public Future<CommandResult> sendCommand(ZclGreenPowerCommand command) {
+        return super.sendCommand(command);
+    }
+
+    /**
+     * Sends a response to the command. This method sets all the common elements of the response based on the command -
+     * eg transactionId, direction, address...
+     *
+     * @param command the {@link ZclGreenPowerCommand} to which the response is being sent
+     * @param response the {@link ZclGreenPowerCommand} to send
+     */
+    public void sendResponse(ZclGreenPowerCommand command, ZclGreenPowerCommand response) {
+        super.sendResponse(command, response);
     }
 
     /**
@@ -1085,7 +1108,7 @@ public class ZclGreenPowerCluster extends ZclCluster {
         command.setGppShortAddress(gppShortAddress);
         command.setGppDistance(gppDistance);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -1112,7 +1135,7 @@ public class ZclGreenPowerCluster extends ZclCluster {
         command.setGpdIeee(gpdIeee);
         command.setEndpoint(endpoint);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -1142,7 +1165,7 @@ public class ZclGreenPowerCluster extends ZclCluster {
         command.setGppShortAddress(gppShortAddress);
         command.setGppDistance(gppDistance);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -1182,7 +1205,7 @@ public class ZclGreenPowerCluster extends ZclCluster {
         command.setGppLink(gppLink);
         command.setMic(mic);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -1207,7 +1230,7 @@ public class ZclGreenPowerCluster extends ZclCluster {
         command.setGpmAddrForPairing(gpmAddrForPairing);
         command.setSinkEndpoint(sinkEndpoint);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -1232,7 +1255,7 @@ public class ZclGreenPowerCluster extends ZclCluster {
         command.setEndpoint(endpoint);
         command.setTranslations(translations);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -1250,7 +1273,7 @@ public class ZclGreenPowerCluster extends ZclCluster {
         // Set the fields
         command.setStartIndex(startIndex);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -1317,7 +1340,7 @@ public class ZclGreenPowerCluster extends ZclCluster {
         command.setClusterListServer(clusterListServer);
         command.setClusterListClient(clusterListClient);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -1343,7 +1366,7 @@ public class ZclGreenPowerCluster extends ZclCluster {
         command.setEndpoint(endpoint);
         command.setIndex(index);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -1373,7 +1396,7 @@ public class ZclGreenPowerCluster extends ZclCluster {
         command.setEntriesCount(entriesCount);
         command.setProxyTableEntries(proxyTableEntries);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -1398,7 +1421,7 @@ public class ZclGreenPowerCluster extends ZclCluster {
         command.setGpdIeee(gpdIeee);
         command.setGpdSecurityFrameCounter(gpdSecurityFrameCounter);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -1440,7 +1463,7 @@ public class ZclGreenPowerCluster extends ZclCluster {
         command.setAssignedAlias(assignedAlias);
         command.setForwardingRadius(forwardingRadius);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -1463,7 +1486,7 @@ public class ZclGreenPowerCluster extends ZclCluster {
         command.setCommissioningWindow(commissioningWindow);
         command.setChannel(channel);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -1495,7 +1518,7 @@ public class ZclGreenPowerCluster extends ZclCluster {
         command.setGpdCommandId(gpdCommandId);
         command.setGpdCommandPayload(gpdCommandPayload);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -1520,7 +1543,7 @@ public class ZclGreenPowerCluster extends ZclCluster {
         command.setSinkTableEntriesCount(sinkTableEntriesCount);
         command.setSinkTableEntries(sinkTableEntries);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -1545,6 +1568,6 @@ public class ZclGreenPowerCluster extends ZclCluster {
         command.setEndpoint(endpoint);
         command.setIndex(index);
 
-        return send(command);
+        return sendCommand(command);
     }
 }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclGroupsCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclGroupsCluster.java
@@ -29,6 +29,7 @@ import com.zsmartsystems.zigbee.zcl.clusters.groups.RemoveGroupCommand;
 import com.zsmartsystems.zigbee.zcl.clusters.groups.RemoveGroupResponse;
 import com.zsmartsystems.zigbee.zcl.clusters.groups.ViewGroupCommand;
 import com.zsmartsystems.zigbee.zcl.clusters.groups.ViewGroupResponse;
+import com.zsmartsystems.zigbee.zcl.clusters.groups.ZclGroupsCommand;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
 /**
@@ -61,7 +62,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-10-04T18:21:10Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:04:47Z")
 public class ZclGroupsCluster extends ZclCluster {
     /**
      * The ZigBee Cluster Library Cluster ID
@@ -130,6 +131,28 @@ public class ZclGroupsCluster extends ZclCluster {
      */
     public ZclGroupsCluster(final ZigBeeEndpoint zigbeeEndpoint) {
         super(zigbeeEndpoint, CLUSTER_ID, CLUSTER_NAME);
+    }
+
+    /**
+     * Sends a {@link ZclGroupsCommand} and returns the {@link Future} to the result which will complete when the remote
+     * device response is received, or the request times out.
+     *
+     * @param command the {@link ZclGroupsCommand} to send
+     * @return the command result future
+     */
+    public Future<CommandResult> sendCommand(ZclGroupsCommand command) {
+        return super.sendCommand(command);
+    }
+
+    /**
+     * Sends a response to the command. This method sets all the common elements of the response based on the command -
+     * eg transactionId, direction, address...
+     *
+     * @param command the {@link ZclGroupsCommand} to which the response is being sent
+     * @param response the {@link ZclGroupsCommand} to send
+     */
+    public void sendResponse(ZclGroupsCommand command, ZclGroupsCommand response) {
+        super.sendResponse(command, response);
     }
 
     /**
@@ -220,7 +243,7 @@ public class ZclGroupsCluster extends ZclCluster {
         command.setGroupId(groupId);
         command.setGroupName(groupName);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -239,7 +262,7 @@ public class ZclGroupsCluster extends ZclCluster {
         // Set the fields
         command.setGroupId(groupId);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -259,7 +282,7 @@ public class ZclGroupsCluster extends ZclCluster {
         command.setGroupCount(groupCount);
         command.setGroupList(groupList);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -277,7 +300,7 @@ public class ZclGroupsCluster extends ZclCluster {
         // Set the fields
         command.setGroupId(groupId);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -289,7 +312,7 @@ public class ZclGroupsCluster extends ZclCluster {
      * @return the {@link Future<CommandResult>} command result future
      */
     public Future<CommandResult> removeAllGroupsCommand() {
-        return send(new RemoveAllGroupsCommand());
+        return sendCommand(new RemoveAllGroupsCommand());
     }
 
     /**
@@ -311,7 +334,7 @@ public class ZclGroupsCluster extends ZclCluster {
         command.setGroupId(groupId);
         command.setGroupName(groupName);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -331,7 +354,7 @@ public class ZclGroupsCluster extends ZclCluster {
         command.setStatus(status);
         command.setGroupId(groupId);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -353,7 +376,7 @@ public class ZclGroupsCluster extends ZclCluster {
         command.setGroupId(groupId);
         command.setGroupName(groupName);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -375,7 +398,7 @@ public class ZclGroupsCluster extends ZclCluster {
         command.setGroupCount(groupCount);
         command.setGroupList(groupList);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -395,6 +418,6 @@ public class ZclGroupsCluster extends ZclCluster {
         command.setStatus(status);
         command.setGroupId(groupId);
 
-        return send(command);
+        return sendCommand(command);
     }
 }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclIasAceCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclIasAceCluster.java
@@ -38,6 +38,7 @@ import com.zsmartsystems.zigbee.zcl.clusters.iasace.GetZoneStatusResponse;
 import com.zsmartsystems.zigbee.zcl.clusters.iasace.PanelStatusChangedCommand;
 import com.zsmartsystems.zigbee.zcl.clusters.iasace.PanicCommand;
 import com.zsmartsystems.zigbee.zcl.clusters.iasace.SetBypassedZoneListCommand;
+import com.zsmartsystems.zigbee.zcl.clusters.iasace.ZclIasAceCommand;
 import com.zsmartsystems.zigbee.zcl.clusters.iasace.ZoneStatusChangedCommand;
 
 /**
@@ -49,7 +50,7 @@ import com.zsmartsystems.zigbee.zcl.clusters.iasace.ZoneStatusChangedCommand;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-10-04T18:21:10Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:04:47Z")
 public class ZclIasAceCluster extends ZclCluster {
     /**
      * The ZigBee Cluster Library Cluster ID
@@ -120,6 +121,28 @@ public class ZclIasAceCluster extends ZclCluster {
     }
 
     /**
+     * Sends a {@link ZclIasAceCommand} and returns the {@link Future} to the result which will complete when the remote
+     * device response is received, or the request times out.
+     *
+     * @param command the {@link ZclIasAceCommand} to send
+     * @return the command result future
+     */
+    public Future<CommandResult> sendCommand(ZclIasAceCommand command) {
+        return super.sendCommand(command);
+    }
+
+    /**
+     * Sends a response to the command. This method sets all the common elements of the response based on the command -
+     * eg transactionId, direction, address...
+     *
+     * @param command the {@link ZclIasAceCommand} to which the response is being sent
+     * @param response the {@link ZclIasAceCommand} to send
+     */
+    public void sendResponse(ZclIasAceCommand command, ZclIasAceCommand response) {
+        super.sendResponse(command, response);
+    }
+
+    /**
      * The Arm Command
      * <p>
      * On receipt of this command, the receiving device sets its arm mode according to the value
@@ -140,7 +163,7 @@ public class ZclIasAceCluster extends ZclCluster {
         command.setArmDisarmCode(armDisarmCode);
         command.setZoneId(zoneId);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -167,7 +190,7 @@ public class ZclIasAceCluster extends ZclCluster {
         command.setZoneIds(zoneIds);
         command.setArmDisarmCode(armDisarmCode);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -176,7 +199,7 @@ public class ZclIasAceCluster extends ZclCluster {
      * @return the {@link Future<CommandResult>} command result future
      */
     public Future<CommandResult> emergencyCommand() {
-        return send(new EmergencyCommand());
+        return sendCommand(new EmergencyCommand());
     }
 
     /**
@@ -185,7 +208,7 @@ public class ZclIasAceCluster extends ZclCluster {
      * @return the {@link Future<CommandResult>} command result future
      */
     public Future<CommandResult> fireCommand() {
-        return send(new FireCommand());
+        return sendCommand(new FireCommand());
     }
 
     /**
@@ -194,7 +217,7 @@ public class ZclIasAceCluster extends ZclCluster {
      * @return the {@link Future<CommandResult>} command result future
      */
     public Future<CommandResult> panicCommand() {
-        return send(new PanicCommand());
+        return sendCommand(new PanicCommand());
     }
 
     /**
@@ -203,7 +226,7 @@ public class ZclIasAceCluster extends ZclCluster {
      * @return the {@link Future<CommandResult>} command result future
      */
     public Future<CommandResult> getZoneIdMapCommand() {
-        return send(new GetZoneIdMapCommand());
+        return sendCommand(new GetZoneIdMapCommand());
     }
 
     /**
@@ -218,7 +241,7 @@ public class ZclIasAceCluster extends ZclCluster {
         // Set the fields
         command.setZoneId(zoneId);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -234,7 +257,7 @@ public class ZclIasAceCluster extends ZclCluster {
      * @return the {@link Future<CommandResult>} command result future
      */
     public Future<CommandResult> getPanelStatusCommand() {
-        return send(new GetPanelStatusCommand());
+        return sendCommand(new GetPanelStatusCommand());
     }
 
     /**
@@ -248,7 +271,7 @@ public class ZclIasAceCluster extends ZclCluster {
      * @return the {@link Future<CommandResult>} command result future
      */
     public Future<CommandResult> getBypassedZoneListCommand() {
-        return send(new GetBypassedZoneListCommand());
+        return sendCommand(new GetBypassedZoneListCommand());
     }
 
     /**
@@ -279,7 +302,7 @@ public class ZclIasAceCluster extends ZclCluster {
         command.setZoneStatusMaskFlag(zoneStatusMaskFlag);
         command.setZoneStatusMask(zoneStatusMask);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -294,7 +317,7 @@ public class ZclIasAceCluster extends ZclCluster {
         // Set the fields
         command.setArmNotification(armNotification);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -343,7 +366,7 @@ public class ZclIasAceCluster extends ZclCluster {
         command.setZoneIdMapSection14(zoneIdMapSection14);
         command.setZoneIdMapSection15(zoneIdMapSection15);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -364,7 +387,7 @@ public class ZclIasAceCluster extends ZclCluster {
         command.setIeeeAddress(ieeeAddress);
         command.setZoneLabel(zoneLabel);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -391,7 +414,7 @@ public class ZclIasAceCluster extends ZclCluster {
         command.setAudibleNotification(audibleNotification);
         command.setZoneLabel(zoneLabel);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -424,7 +447,7 @@ public class ZclIasAceCluster extends ZclCluster {
         command.setAudibleNotification(audibleNotification);
         command.setAlarmStatus(alarmStatus);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -448,7 +471,7 @@ public class ZclIasAceCluster extends ZclCluster {
         command.setAudibleNotification(audibleNotification);
         command.setAlarmStatus(alarmStatus);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -467,7 +490,7 @@ public class ZclIasAceCluster extends ZclCluster {
         // Set the fields
         command.setZoneId(zoneId);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -485,7 +508,7 @@ public class ZclIasAceCluster extends ZclCluster {
         // Set the fields
         command.setBypassResult(bypassResult);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -511,6 +534,6 @@ public class ZclIasAceCluster extends ZclCluster {
         command.setZoneId(zoneId);
         command.setZoneStatus(zoneStatus);
 
-        return send(command);
+        return sendCommand(command);
     }
 }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclIasWdCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclIasWdCluster.java
@@ -20,6 +20,7 @@ import com.zsmartsystems.zigbee.zcl.ZclCluster;
 import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.clusters.iaswd.Squawk;
 import com.zsmartsystems.zigbee.zcl.clusters.iaswd.StartWarningCommand;
+import com.zsmartsystems.zigbee.zcl.clusters.iaswd.ZclIasWdCommand;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
 /**
@@ -32,7 +33,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-10-04T18:21:10Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:04:47Z")
 public class ZclIasWdCluster extends ZclCluster {
     /**
      * The ZigBee Cluster Library Cluster ID
@@ -84,6 +85,28 @@ public class ZclIasWdCluster extends ZclCluster {
      */
     public ZclIasWdCluster(final ZigBeeEndpoint zigbeeEndpoint) {
         super(zigbeeEndpoint, CLUSTER_ID, CLUSTER_NAME);
+    }
+
+    /**
+     * Sends a {@link ZclIasWdCommand} and returns the {@link Future} to the result which will complete when the remote
+     * device response is received, or the request times out.
+     *
+     * @param command the {@link ZclIasWdCommand} to send
+     * @return the command result future
+     */
+    public Future<CommandResult> sendCommand(ZclIasWdCommand command) {
+        return super.sendCommand(command);
+    }
+
+    /**
+     * Sends a response to the command. This method sets all the common elements of the response based on the command -
+     * eg transactionId, direction, address...
+     *
+     * @param command the {@link ZclIasWdCommand} to which the response is being sent
+     * @param response the {@link ZclIasWdCommand} to send
+     */
+    public void sendResponse(ZclIasWdCommand command, ZclIasWdCommand response) {
+        super.sendResponse(command, response);
     }
 
     /**
@@ -192,7 +215,7 @@ public class ZclIasWdCluster extends ZclCluster {
         command.setHeader(header);
         command.setWarningDuration(warningDuration);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -211,6 +234,6 @@ public class ZclIasWdCluster extends ZclCluster {
         // Set the fields
         command.setSquawkInfo(squawkInfo);
 
-        return send(command);
+        return sendCommand(command);
     }
 }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclIasZoneCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclIasZoneCluster.java
@@ -21,6 +21,7 @@ import com.zsmartsystems.zigbee.zcl.ZclCluster;
 import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.clusters.iaszone.InitiateNormalOperationModeCommand;
 import com.zsmartsystems.zigbee.zcl.clusters.iaszone.InitiateTestModeCommand;
+import com.zsmartsystems.zigbee.zcl.clusters.iaszone.ZclIasZoneCommand;
 import com.zsmartsystems.zigbee.zcl.clusters.iaszone.ZoneEnrollRequestCommand;
 import com.zsmartsystems.zigbee.zcl.clusters.iaszone.ZoneEnrollResponse;
 import com.zsmartsystems.zigbee.zcl.clusters.iaszone.ZoneStatusChangeNotificationCommand;
@@ -35,7 +36,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-10-04T18:21:10Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:04:47Z")
 public class ZclIasZoneCluster extends ZclCluster {
     /**
      * The ZigBee Cluster Library Cluster ID
@@ -160,6 +161,28 @@ public class ZclIasZoneCluster extends ZclCluster {
      */
     public ZclIasZoneCluster(final ZigBeeEndpoint zigbeeEndpoint) {
         super(zigbeeEndpoint, CLUSTER_ID, CLUSTER_NAME);
+    }
+
+    /**
+     * Sends a {@link ZclIasZoneCommand} and returns the {@link Future} to the result which will complete when the remote
+     * device response is received, or the request times out.
+     *
+     * @param command the {@link ZclIasZoneCommand} to send
+     * @return the command result future
+     */
+    public Future<CommandResult> sendCommand(ZclIasZoneCommand command) {
+        return super.sendCommand(command);
+    }
+
+    /**
+     * Sends a response to the command. This method sets all the common elements of the response based on the command -
+     * eg transactionId, direction, address...
+     *
+     * @param command the {@link ZclIasZoneCommand} to which the response is being sent
+     * @param response the {@link ZclIasZoneCommand} to send
+     */
+    public void sendResponse(ZclIasZoneCommand command, ZclIasZoneCommand response) {
+        super.sendResponse(command, response);
     }
 
     /**
@@ -744,7 +767,7 @@ public class ZclIasZoneCluster extends ZclCluster {
         command.setEnrollResponseCode(enrollResponseCode);
         command.setZoneId(zoneId);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -760,7 +783,7 @@ public class ZclIasZoneCluster extends ZclCluster {
      * @return the {@link Future<CommandResult>} command result future
      */
     public Future<CommandResult> initiateNormalOperationModeCommand() {
-        return send(new InitiateNormalOperationModeCommand());
+        return sendCommand(new InitiateNormalOperationModeCommand());
     }
 
     /**
@@ -796,7 +819,7 @@ public class ZclIasZoneCluster extends ZclCluster {
         command.setTestModeDuration(testModeDuration);
         command.setCurrentZoneSensitivityLevel(currentZoneSensitivityLevel);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -820,7 +843,7 @@ public class ZclIasZoneCluster extends ZclCluster {
         command.setZoneId(zoneId);
         command.setDelay(delay);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -841,6 +864,6 @@ public class ZclIasZoneCluster extends ZclCluster {
         command.setZoneType(zoneType);
         command.setManufacturerCode(manufacturerCode);
 
-        return send(command);
+        return sendCommand(command);
     }
 }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclIdentifyCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclIdentifyCluster.java
@@ -21,6 +21,7 @@ import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.clusters.identify.IdentifyCommand;
 import com.zsmartsystems.zigbee.zcl.clusters.identify.IdentifyQueryCommand;
 import com.zsmartsystems.zigbee.zcl.clusters.identify.IdentifyQueryResponse;
+import com.zsmartsystems.zigbee.zcl.clusters.identify.ZclIdentifyCommand;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
 /**
@@ -35,7 +36,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-10-04T18:21:10Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:04:47Z")
 public class ZclIdentifyCluster extends ZclCluster {
     /**
      * The ZigBee Cluster Library Cluster ID
@@ -104,6 +105,28 @@ public class ZclIdentifyCluster extends ZclCluster {
      */
     public ZclIdentifyCluster(final ZigBeeEndpoint zigbeeEndpoint) {
         super(zigbeeEndpoint, CLUSTER_ID, CLUSTER_NAME);
+    }
+
+    /**
+     * Sends a {@link ZclIdentifyCommand} and returns the {@link Future} to the result which will complete when the remote
+     * device response is received, or the request times out.
+     *
+     * @param command the {@link ZclIdentifyCommand} to send
+     * @return the command result future
+     */
+    public Future<CommandResult> sendCommand(ZclIdentifyCommand command) {
+        return super.sendCommand(command);
+    }
+
+    /**
+     * Sends a response to the command. This method sets all the common elements of the response based on the command -
+     * eg transactionId, direction, address...
+     *
+     * @param command the {@link ZclIdentifyCommand} to which the response is being sent
+     * @param response the {@link ZclIdentifyCommand} to send
+     */
+    public void sendResponse(ZclIdentifyCommand command, ZclIdentifyCommand response) {
+        super.sendResponse(command, response);
     }
 
     /**
@@ -240,7 +263,7 @@ public class ZclIdentifyCluster extends ZclCluster {
         // Set the fields
         command.setIdentifyTime(identifyTime);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -249,7 +272,7 @@ public class ZclIdentifyCluster extends ZclCluster {
      * @return the {@link Future<CommandResult>} command result future
      */
     public Future<CommandResult> identifyQueryCommand() {
-        return send(new IdentifyQueryCommand());
+        return sendCommand(new IdentifyQueryCommand());
     }
 
     /**
@@ -267,6 +290,6 @@ public class ZclIdentifyCluster extends ZclCluster {
         // Set the fields
         command.setIdentifyTime(identifyTime);
 
-        return send(command);
+        return sendCommand(command);
     }
 }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclIlluminanceLevelSensingCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclIlluminanceLevelSensingCluster.java
@@ -28,7 +28,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-10-04T18:21:10Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T11:55:03Z")
 public class ZclIlluminanceLevelSensingCluster extends ZclCluster {
     /**
      * The ZigBee Cluster Library Cluster ID
@@ -86,6 +86,7 @@ public class ZclIlluminanceLevelSensingCluster extends ZclCluster {
 
         return attributeMap;
     }
+
 
     /**
      * Default constructor to create a Illuminance Level Sensing cluster.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclIlluminanceMeasurementCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclIlluminanceMeasurementCluster.java
@@ -27,7 +27,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-10-04T18:21:10Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T11:55:03Z")
 public class ZclIlluminanceMeasurementCluster extends ZclCluster {
     /**
      * The ZigBee Cluster Library Cluster ID
@@ -97,6 +97,7 @@ public class ZclIlluminanceMeasurementCluster extends ZclCluster {
 
         return attributeMap;
     }
+
 
     /**
      * Default constructor to create a Illuminance Measurement cluster.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclKeyEstablishmentCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclKeyEstablishmentCluster.java
@@ -25,6 +25,7 @@ import com.zsmartsystems.zigbee.zcl.clusters.keyestablishment.EphemeralDataRespo
 import com.zsmartsystems.zigbee.zcl.clusters.keyestablishment.InitiateKeyEstablishmentRequestCommand;
 import com.zsmartsystems.zigbee.zcl.clusters.keyestablishment.InitiateKeyEstablishmentResponse;
 import com.zsmartsystems.zigbee.zcl.clusters.keyestablishment.TerminateKeyEstablishment;
+import com.zsmartsystems.zigbee.zcl.clusters.keyestablishment.ZclKeyEstablishmentCommand;
 import com.zsmartsystems.zigbee.zcl.field.ByteArray;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
@@ -62,7 +63,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-10-04T18:21:10Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:04:47Z")
 public class ZclKeyEstablishmentCluster extends ZclCluster {
     /**
      * The ZigBee Cluster Library Cluster ID
@@ -94,8 +95,7 @@ public class ZclKeyEstablishmentCluster extends ZclCluster {
     protected Map<Integer, ZclAttribute> initializeClientAttributes() {
         Map<Integer, ZclAttribute> attributeMap = new ConcurrentSkipListMap<>();
 
-        attributeMap.put(ATTR_CLIENTKEYESTABLISHMENTSUITE, new ZclAttribute(this, ATTR_CLIENTKEYESTABLISHMENTSUITE,
-                "Client Key Establishment Suite", ZclDataType.ENUMERATION_16_BIT, true, true, false, false));
+        attributeMap.put(ATTR_CLIENTKEYESTABLISHMENTSUITE, new ZclAttribute(this, ATTR_CLIENTKEYESTABLISHMENTSUITE, "Client Key Establishment Suite", ZclDataType.ENUMERATION_16_BIT, true, true, false, false));
 
         return attributeMap;
     }
@@ -104,8 +104,7 @@ public class ZclKeyEstablishmentCluster extends ZclCluster {
     protected Map<Integer, ZclAttribute> initializeServerAttributes() {
         Map<Integer, ZclAttribute> attributeMap = new ConcurrentSkipListMap<>();
 
-        attributeMap.put(ATTR_SERVERKEYESTABLISHMENTSUITE, new ZclAttribute(this, ATTR_SERVERKEYESTABLISHMENTSUITE,
-                "Server Key Establishment Suite", ZclDataType.ENUMERATION_16_BIT, true, true, false, false));
+        attributeMap.put(ATTR_SERVERKEYESTABLISHMENTSUITE, new ZclAttribute(this, ATTR_SERVERKEYESTABLISHMENTSUITE, "Server Key Establishment Suite", ZclDataType.ENUMERATION_16_BIT, true, true, false, false));
 
         return attributeMap;
     }
@@ -140,6 +139,28 @@ public class ZclKeyEstablishmentCluster extends ZclCluster {
      */
     public ZclKeyEstablishmentCluster(final ZigBeeEndpoint zigbeeEndpoint) {
         super(zigbeeEndpoint, CLUSTER_ID, CLUSTER_NAME);
+    }
+
+    /**
+     * Sends a {@link ZclKeyEstablishmentCommand} and returns the {@link Future} to the result which will complete when the remote
+     * device response is received, or the request times out.
+     *
+     * @param command the {@link ZclKeyEstablishmentCommand} to send
+     * @return the command result future
+     */
+    public Future<CommandResult> sendCommand(ZclKeyEstablishmentCommand command) {
+        return super.sendCommand(command);
+    }
+
+    /**
+     * Sends a response to the command. This method sets all the common elements of the response based on the command -
+     * eg transactionId, direction, address...
+     *
+     * @param command the {@link ZclKeyEstablishmentCommand} to which the response is being sent
+     * @param response the {@link ZclKeyEstablishmentCommand} to send
+     */
+    public void sendResponse(ZclKeyEstablishmentCommand command, ZclKeyEstablishmentCommand response) {
+        super.sendResponse(command, response);
     }
 
     /**
@@ -209,8 +230,7 @@ public class ZclKeyEstablishmentCluster extends ZclCluster {
      * @param minInterval minimum reporting period
      * @param maxInterval maximum reporting period
      * @return the {@link Future<CommandResult>} command result future
-     * @deprecated As of release 1.2.0, replaced by
-     *             {@link #setReporting(int attributeId, int minInterval, int maxInterval)}
+     * @deprecated As of release 1.2.0, replaced by {@link #setReporting(int attributeId, int minInterval, int maxInterval)}
      */
     @Deprecated
     public Future<CommandResult> setServerKeyEstablishmentSuiteReporting(final int minInterval, final int maxInterval) {
@@ -247,8 +267,7 @@ public class ZclKeyEstablishmentCluster extends ZclCluster {
      * @param identity {@link ByteArray} Identity
      * @return the {@link Future<CommandResult>} command result future
      */
-    public Future<CommandResult> initiateKeyEstablishmentRequestCommand(Integer keyEstablishmentSuite,
-            Integer ephemeralDataGenerateTime, Integer confirmKeyGenerateTime, ByteArray identity) {
+    public Future<CommandResult> initiateKeyEstablishmentRequestCommand(Integer keyEstablishmentSuite, Integer ephemeralDataGenerateTime, Integer confirmKeyGenerateTime, ByteArray identity) {
         InitiateKeyEstablishmentRequestCommand command = new InitiateKeyEstablishmentRequestCommand();
 
         // Set the fields
@@ -256,9 +275,8 @@ public class ZclKeyEstablishmentCluster extends ZclCluster {
         command.setEphemeralDataGenerateTime(ephemeralDataGenerateTime);
         command.setConfirmKeyGenerateTime(confirmKeyGenerateTime);
         command.setIdentity(identity);
-        command.setDisableDefaultResponse(true);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -275,9 +293,8 @@ public class ZclKeyEstablishmentCluster extends ZclCluster {
 
         // Set the fields
         command.setEphemeralData(ephemeralData);
-        command.setDisableDefaultResponse(true);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -296,9 +313,8 @@ public class ZclKeyEstablishmentCluster extends ZclCluster {
 
         // Set the fields
         command.setSecureMessageAuthenticationCode(secureMessageAuthenticationCode);
-        command.setDisableDefaultResponse(true);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -315,8 +331,7 @@ public class ZclKeyEstablishmentCluster extends ZclCluster {
      * @param identity {@link ByteArray} Identity
      * @return the {@link Future<CommandResult>} command result future
      */
-    public Future<CommandResult> initiateKeyEstablishmentResponse(Integer requestedKeyEstablishmentSuite,
-            Integer ephemeralDataGenerateTime, Integer confirmKeyGenerateTime, ByteArray identity) {
+    public Future<CommandResult> initiateKeyEstablishmentResponse(Integer requestedKeyEstablishmentSuite, Integer ephemeralDataGenerateTime, Integer confirmKeyGenerateTime, ByteArray identity) {
         InitiateKeyEstablishmentResponse command = new InitiateKeyEstablishmentResponse();
 
         // Set the fields
@@ -324,9 +339,8 @@ public class ZclKeyEstablishmentCluster extends ZclCluster {
         command.setEphemeralDataGenerateTime(ephemeralDataGenerateTime);
         command.setConfirmKeyGenerateTime(confirmKeyGenerateTime);
         command.setIdentity(identity);
-        command.setDisableDefaultResponse(true);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -343,9 +357,8 @@ public class ZclKeyEstablishmentCluster extends ZclCluster {
 
         // Set the fields
         command.setEphemeralData(ephemeralData);
-        command.setDisableDefaultResponse(true);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -364,9 +377,8 @@ public class ZclKeyEstablishmentCluster extends ZclCluster {
 
         // Set the fields
         command.setSecureMessageAuthenticationCode(secureMessageAuthenticationCode);
-        command.setDisableDefaultResponse(true);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -380,16 +392,14 @@ public class ZclKeyEstablishmentCluster extends ZclCluster {
      * @param keyEstablishmentSuite {@link Integer} Key Establishment Suite
      * @return the {@link Future<CommandResult>} command result future
      */
-    public Future<CommandResult> terminateKeyEstablishment(Integer statusCode, Integer waitTime,
-            Integer keyEstablishmentSuite) {
+    public Future<CommandResult> terminateKeyEstablishment(Integer statusCode, Integer waitTime, Integer keyEstablishmentSuite) {
         TerminateKeyEstablishment command = new TerminateKeyEstablishment();
 
         // Set the fields
         command.setStatusCode(statusCode);
         command.setWaitTime(waitTime);
         command.setKeyEstablishmentSuite(keyEstablishmentSuite);
-        command.setDisableDefaultResponse(true);
 
-        return send(command);
+        return sendCommand(command);
     }
 }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclLevelControlCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclLevelControlCluster.java
@@ -26,6 +26,7 @@ import com.zsmartsystems.zigbee.zcl.clusters.levelcontrol.StepCommand;
 import com.zsmartsystems.zigbee.zcl.clusters.levelcontrol.StepWithOnOffCommand;
 import com.zsmartsystems.zigbee.zcl.clusters.levelcontrol.StopCommand;
 import com.zsmartsystems.zigbee.zcl.clusters.levelcontrol.StopWithOnOffCommand;
+import com.zsmartsystems.zigbee.zcl.clusters.levelcontrol.ZclLevelControlCommand;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
 /**
@@ -51,7 +52,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T17:34:01Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T17:52:58Z")
 public class ZclLevelControlCluster extends ZclCluster {
     /**
      * The ZigBee Cluster Library Cluster ID
@@ -161,6 +162,28 @@ public class ZclLevelControlCluster extends ZclCluster {
      */
     public ZclLevelControlCluster(final ZigBeeEndpoint zigbeeEndpoint) {
         super(zigbeeEndpoint, CLUSTER_ID, CLUSTER_NAME);
+    }
+
+    /**
+     * Sends a {@link ZclLevelControlCommand} and returns the {@link Future} to the result which will complete when the remote
+     * device response is received, or the request times out.
+     *
+     * @param command the {@link ZclLevelControlCommand} to send
+     * @return the command result future
+     */
+    public Future<CommandResult> sendCommand(ZclLevelControlCommand command) {
+        return super.sendCommand(command);
+    }
+
+    /**
+     * Sends a response to the command. This method sets all the common elements of the response based on the command -
+     * eg transactionId, direction, address...
+     *
+     * @param command the {@link ZclLevelControlCommand} to which the response is being sent
+     * @param response the {@link ZclLevelControlCommand} to send
+     */
+    public void sendResponse(ZclLevelControlCommand command, ZclLevelControlCommand response) {
+        super.sendResponse(command, response);
     }
 
     /**
@@ -775,7 +798,7 @@ public class ZclLevelControlCluster extends ZclCluster {
         command.setLevel(level);
         command.setTransitionTime(transitionTime);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -792,7 +815,7 @@ public class ZclLevelControlCluster extends ZclCluster {
         command.setMoveMode(moveMode);
         command.setRate(rate);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -811,7 +834,7 @@ public class ZclLevelControlCluster extends ZclCluster {
         command.setStepSize(stepSize);
         command.setTransitionTime(transitionTime);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -825,7 +848,7 @@ public class ZclLevelControlCluster extends ZclCluster {
      * @return the {@link Future<CommandResult>} command result future
      */
     public Future<CommandResult> stopCommand() {
-        return send(new StopCommand());
+        return sendCommand(new StopCommand());
     }
 
     /**
@@ -852,7 +875,7 @@ public class ZclLevelControlCluster extends ZclCluster {
         command.setLevel(level);
         command.setTransitionTime(transitionTime);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -869,7 +892,7 @@ public class ZclLevelControlCluster extends ZclCluster {
         command.setMoveMode(moveMode);
         command.setRate(rate);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -888,7 +911,7 @@ public class ZclLevelControlCluster extends ZclCluster {
         command.setStepSize(stepSize);
         command.setTransitionTime(transitionTime);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -897,6 +920,6 @@ public class ZclLevelControlCluster extends ZclCluster {
      * @return the {@link Future<CommandResult>} command result future
      */
     public Future<CommandResult> stopWithOnOffCommand() {
-        return send(new StopWithOnOffCommand());
+        return sendCommand(new StopWithOnOffCommand());
     }
 }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclMessagingCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclMessagingCluster.java
@@ -27,6 +27,7 @@ import com.zsmartsystems.zigbee.zcl.clusters.messaging.DisplayProtectedMessageCo
 import com.zsmartsystems.zigbee.zcl.clusters.messaging.GetLastMessage;
 import com.zsmartsystems.zigbee.zcl.clusters.messaging.GetMessageCancellation;
 import com.zsmartsystems.zigbee.zcl.clusters.messaging.MessageConfirmation;
+import com.zsmartsystems.zigbee.zcl.clusters.messaging.ZclMessagingCommand;
 import com.zsmartsystems.zigbee.zcl.field.ByteArray;
 
 /**
@@ -40,7 +41,7 @@ import com.zsmartsystems.zigbee.zcl.field.ByteArray;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-10-04T18:21:10Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:04:47Z")
 public class ZclMessagingCluster extends ZclCluster {
     /**
      * The ZigBee Cluster Library Cluster ID
@@ -100,6 +101,28 @@ public class ZclMessagingCluster extends ZclCluster {
     }
 
     /**
+     * Sends a {@link ZclMessagingCommand} and returns the {@link Future} to the result which will complete when the remote
+     * device response is received, or the request times out.
+     *
+     * @param command the {@link ZclMessagingCommand} to send
+     * @return the command result future
+     */
+    public Future<CommandResult> sendCommand(ZclMessagingCommand command) {
+        return super.sendCommand(command);
+    }
+
+    /**
+     * Sends a response to the command. This method sets all the common elements of the response based on the command -
+     * eg transactionId, direction, address...
+     *
+     * @param command the {@link ZclMessagingCommand} to which the response is being sent
+     * @param response the {@link ZclMessagingCommand} to send
+     */
+    public void sendResponse(ZclMessagingCommand command, ZclMessagingCommand response) {
+        super.sendResponse(command, response);
+    }
+
+    /**
      * The Display Message Command
      *
      * @param messageId {@link Integer} Message ID
@@ -121,7 +144,7 @@ public class ZclMessagingCluster extends ZclCluster {
         command.setMessage(message);
         command.setExtendedMessageControl(extendedMessageControl);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -143,7 +166,7 @@ public class ZclMessagingCluster extends ZclCluster {
         command.setMessageId(messageId);
         command.setMessageControl(messageControl);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -171,7 +194,7 @@ public class ZclMessagingCluster extends ZclCluster {
         command.setMessage(message);
         command.setExtendedMessageControl(extendedMessageControl);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -189,7 +212,7 @@ public class ZclMessagingCluster extends ZclCluster {
         // Set the fields
         command.setImplementationTime(implementationTime);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -218,7 +241,7 @@ public class ZclMessagingCluster extends ZclCluster {
         command.setMessage(message);
         command.setOptionalExtendedMessageControl(optionalExtendedMessageControl);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -244,7 +267,7 @@ public class ZclMessagingCluster extends ZclCluster {
         command.setMessageConfirmationControl(messageConfirmationControl);
         command.setMessageConfirmationResponse(messageConfirmationResponse);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -263,7 +286,7 @@ public class ZclMessagingCluster extends ZclCluster {
         // Set the fields
         command.setEarliestImplementationTime(earliestImplementationTime);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -281,6 +304,6 @@ public class ZclMessagingCluster extends ZclCluster {
         // Set the fields
         command.setImplementationDateTime(implementationDateTime);
 
-        return send(command);
+        return sendCommand(command);
     }
 }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclMeteringCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclMeteringCluster.java
@@ -51,6 +51,7 @@ import com.zsmartsystems.zigbee.zcl.clusters.metering.StartSamplingResponse;
 import com.zsmartsystems.zigbee.zcl.clusters.metering.SupplyStatusResponse;
 import com.zsmartsystems.zigbee.zcl.clusters.metering.TakeSnapshot;
 import com.zsmartsystems.zigbee.zcl.clusters.metering.TakeSnapshotResponse;
+import com.zsmartsystems.zigbee.zcl.clusters.metering.ZclMeteringCommand;
 import com.zsmartsystems.zigbee.zcl.field.ByteArray;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
@@ -66,7 +67,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-10-04T18:21:10Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:04:47Z")
 public class ZclMeteringCluster extends ZclCluster {
     /**
      * The ZigBee Cluster Library Cluster ID
@@ -3583,6 +3584,28 @@ public class ZclMeteringCluster extends ZclCluster {
      */
     public ZclMeteringCluster(final ZigBeeEndpoint zigbeeEndpoint) {
         super(zigbeeEndpoint, CLUSTER_ID, CLUSTER_NAME);
+    }
+
+    /**
+     * Sends a {@link ZclMeteringCommand} and returns the {@link Future} to the result which will complete when the remote
+     * device response is received, or the request times out.
+     *
+     * @param command the {@link ZclMeteringCommand} to send
+     * @return the command result future
+     */
+    public Future<CommandResult> sendCommand(ZclMeteringCommand command) {
+        return super.sendCommand(command);
+    }
+
+    /**
+     * Sends a response to the command. This method sets all the common elements of the response based on the command -
+     * eg transactionId, direction, address...
+     *
+     * @param command the {@link ZclMeteringCommand} to which the response is being sent
+     * @param response the {@link ZclMeteringCommand} to send
+     */
+    public void sendResponse(ZclMeteringCommand command, ZclMeteringCommand response) {
+        super.sendResponse(command, response);
     }
 
     /**
@@ -17124,7 +17147,7 @@ public class ZclMeteringCluster extends ZclCluster {
         command.setEndTime(endTime);
         command.setNumberOfPeriods(numberOfPeriods);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -17142,7 +17165,7 @@ public class ZclMeteringCluster extends ZclCluster {
         // Set the fields
         command.setEndpointId(endpointId);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -17160,7 +17183,7 @@ public class ZclMeteringCluster extends ZclCluster {
         // Set the fields
         command.setRemovedEndpointId(removedEndpointId);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -17180,7 +17203,7 @@ public class ZclMeteringCluster extends ZclCluster {
         command.setFastPollUpdatePeriod(fastPollUpdatePeriod);
         command.setDuration(duration);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -17203,7 +17226,7 @@ public class ZclMeteringCluster extends ZclCluster {
         command.setTotalNumberOfCommands(totalNumberOfCommands);
         command.setSnapshotSchedulePayload(snapshotSchedulePayload);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -17220,7 +17243,7 @@ public class ZclMeteringCluster extends ZclCluster {
         // Set the fields
         command.setSnapshotCause(snapshotCause);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -17243,7 +17266,7 @@ public class ZclMeteringCluster extends ZclCluster {
         command.setSnapshotOffset(snapshotOffset);
         command.setSnapshotCause(snapshotCause);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -17271,7 +17294,7 @@ public class ZclMeteringCluster extends ZclCluster {
         command.setSampleRequestInterval(sampleRequestInterval);
         command.setMaxNumberOfSamples(maxNumberOfSamples);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -17296,7 +17319,7 @@ public class ZclMeteringCluster extends ZclCluster {
         command.setSampleType(sampleType);
         command.setNumberOfSamples(numberOfSamples);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -17316,7 +17339,7 @@ public class ZclMeteringCluster extends ZclCluster {
         command.setNotificationScheme(notificationScheme);
         command.setNotificationFlags(notificationFlags);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -17336,7 +17359,7 @@ public class ZclMeteringCluster extends ZclCluster {
         command.setProviderId(providerId);
         command.setIssuerEventId(issuerEventId);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -17364,7 +17387,7 @@ public class ZclMeteringCluster extends ZclCluster {
         command.setProposedSupplyStatus(proposedSupplyStatus);
         command.setSupplyControlBits(supplyControlBits);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -17384,7 +17407,7 @@ public class ZclMeteringCluster extends ZclCluster {
         // Set the fields
         command.setProposedSupplyStatus(proposedSupplyStatus);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -17410,7 +17433,7 @@ public class ZclMeteringCluster extends ZclCluster {
         command.setSupplyUncontrolledFlowState(supplyUncontrolledFlowState);
         command.setLoadLimitSupplyState(loadLimitSupplyState);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -17442,7 +17465,7 @@ public class ZclMeteringCluster extends ZclCluster {
         command.setStabilisationPeriod(stabilisationPeriod);
         command.setMeasurementPeriod(measurementPeriod);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -17467,7 +17490,7 @@ public class ZclMeteringCluster extends ZclCluster {
         command.setNumberOfPeriodsDelivered(numberOfPeriodsDelivered);
         command.setIntervals(intervals);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -17478,7 +17501,7 @@ public class ZclMeteringCluster extends ZclCluster {
      * @return the {@link Future<CommandResult>} command result future
      */
     public Future<CommandResult> requestMirror() {
-        return send(new RequestMirror());
+        return sendCommand(new RequestMirror());
     }
 
     /**
@@ -17489,7 +17512,7 @@ public class ZclMeteringCluster extends ZclCluster {
      * @return the {@link Future<CommandResult>} command result future
      */
     public Future<CommandResult> removeMirror() {
-        return send(new RemoveMirror());
+        return sendCommand(new RemoveMirror());
     }
 
     /**
@@ -17508,7 +17531,7 @@ public class ZclMeteringCluster extends ZclCluster {
         command.setAppliedUpdatePeriod(appliedUpdatePeriod);
         command.setFastPollModeEndtime(fastPollModeEndtime);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -17528,7 +17551,7 @@ public class ZclMeteringCluster extends ZclCluster {
         command.setIssuerEventId(issuerEventId);
         command.setSnapshotResponsePayload(snapshotResponsePayload);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -17548,7 +17571,7 @@ public class ZclMeteringCluster extends ZclCluster {
         command.setSnapshotId(snapshotId);
         command.setSnapshotConfirmation(snapshotConfirmation);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -17580,7 +17603,7 @@ public class ZclMeteringCluster extends ZclCluster {
         command.setSnapshotPayloadType(snapshotPayloadType);
         command.setSnapshotPayload(snapshotPayload);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -17608,7 +17631,7 @@ public class ZclMeteringCluster extends ZclCluster {
         command.setNumberOfSamples(numberOfSamples);
         command.setSamples(samples);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -17632,7 +17655,7 @@ public class ZclMeteringCluster extends ZclCluster {
         command.setMirrorNotificationReporting(mirrorNotificationReporting);
         command.setNotificationScheme(notificationScheme);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -17655,7 +17678,7 @@ public class ZclMeteringCluster extends ZclCluster {
         command.setNotificationScheme(notificationScheme);
         command.setNotificationFlagOrder(notificationFlagOrder);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -17679,7 +17702,7 @@ public class ZclMeteringCluster extends ZclCluster {
         command.setNotificationFlagAttributeId(notificationFlagAttributeId);
         command.setSubPayload(subPayload);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -17703,7 +17726,7 @@ public class ZclMeteringCluster extends ZclCluster {
         command.setNotificationFlagAttributeId(notificationFlagAttributeId);
         command.setNotificationFlagsN(notificationFlagsN);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -17726,7 +17749,7 @@ public class ZclMeteringCluster extends ZclCluster {
         command.setImplementationDateTime(implementationDateTime);
         command.setSupplyStatus(supplyStatus);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -17744,6 +17767,6 @@ public class ZclMeteringCluster extends ZclCluster {
         // Set the fields
         command.setSampleId(sampleId);
 
-        return send(command);
+        return sendCommand(command);
     }
 }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclMultistateInputBasicCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclMultistateInputBasicCluster.java
@@ -29,7 +29,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-10-04T18:21:10Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T11:55:03Z")
 public class ZclMultistateInputBasicCluster extends ZclCluster {
     /**
      * The ZigBee Cluster Library Cluster ID
@@ -168,6 +168,7 @@ public class ZclMultistateInputBasicCluster extends ZclCluster {
 
         return attributeMap;
     }
+
 
     /**
      * Default constructor to create a Multistate Input (Basic) cluster.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclMultistateOutputBasicCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclMultistateOutputBasicCluster.java
@@ -28,7 +28,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-10-04T18:21:10Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T11:55:03Z")
 public class ZclMultistateOutputBasicCluster extends ZclCluster {
     /**
      * The ZigBee Cluster Library Cluster ID
@@ -173,6 +173,7 @@ public class ZclMultistateOutputBasicCluster extends ZclCluster {
 
         return attributeMap;
     }
+
 
     /**
      * Default constructor to create a Multistate Output (Basic) cluster.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclMultistateValueBasicCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclMultistateValueBasicCluster.java
@@ -27,7 +27,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-10-04T18:21:10Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T11:55:03Z")
 public class ZclMultistateValueBasicCluster extends ZclCluster {
     /**
      * The ZigBee Cluster Library Cluster ID
@@ -172,6 +172,7 @@ public class ZclMultistateValueBasicCluster extends ZclCluster {
 
         return attributeMap;
     }
+
 
     /**
      * Default constructor to create a Multistate Value (Basic) cluster.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclOccupancySensingCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclOccupancySensingCluster.java
@@ -27,7 +27,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-10-04T18:21:10Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T11:55:03Z")
 public class ZclOccupancySensingCluster extends ZclCluster {
     /**
      * The ZigBee Cluster Library Cluster ID
@@ -118,6 +118,7 @@ public class ZclOccupancySensingCluster extends ZclCluster {
 
         return attributeMap;
     }
+
 
     /**
      * Default constructor to create a Occupancy Sensing cluster.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclOnOffCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclOnOffCluster.java
@@ -24,6 +24,7 @@ import com.zsmartsystems.zigbee.zcl.clusters.onoff.OnCommand;
 import com.zsmartsystems.zigbee.zcl.clusters.onoff.OnWithRecallGlobalSceneCommand;
 import com.zsmartsystems.zigbee.zcl.clusters.onoff.OnWithTimedOffCommand;
 import com.zsmartsystems.zigbee.zcl.clusters.onoff.ToggleCommand;
+import com.zsmartsystems.zigbee.zcl.clusters.onoff.ZclOnOffCommand;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
 /**
@@ -33,7 +34,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-10-26T17:06:24Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:04:47Z")
 public class ZclOnOffCluster extends ZclCluster {
     /**
      * The ZigBee Cluster Library Cluster ID
@@ -127,6 +128,28 @@ public class ZclOnOffCluster extends ZclCluster {
      */
     public ZclOnOffCluster(final ZigBeeEndpoint zigbeeEndpoint) {
         super(zigbeeEndpoint, CLUSTER_ID, CLUSTER_NAME);
+    }
+
+    /**
+     * Sends a {@link ZclOnOffCommand} and returns the {@link Future} to the result which will complete when the remote
+     * device response is received, or the request times out.
+     *
+     * @param command the {@link ZclOnOffCommand} to send
+     * @return the command result future
+     */
+    public Future<CommandResult> sendCommand(ZclOnOffCommand command) {
+        return super.sendCommand(command);
+    }
+
+    /**
+     * Sends a response to the command. This method sets all the common elements of the response based on the command -
+     * eg transactionId, direction, address...
+     *
+     * @param command the {@link ZclOnOffCommand} to which the response is being sent
+     * @param response the {@link ZclOnOffCommand} to send
+     */
+    public void sendResponse(ZclOnOffCommand command, ZclOnOffCommand response) {
+        super.sendResponse(command, response);
     }
 
     /**
@@ -568,7 +591,7 @@ public class ZclOnOffCluster extends ZclCluster {
      * @return the {@link Future<CommandResult>} command result future
      */
     public Future<CommandResult> offCommand() {
-        return send(new OffCommand());
+        return sendCommand(new OffCommand());
     }
 
     /**
@@ -582,7 +605,7 @@ public class ZclOnOffCluster extends ZclCluster {
      * @return the {@link Future<CommandResult>} command result future
      */
     public Future<CommandResult> onCommand() {
-        return send(new OnCommand());
+        return sendCommand(new OnCommand());
     }
 
     /**
@@ -598,7 +621,7 @@ public class ZclOnOffCluster extends ZclCluster {
      * @return the {@link Future<CommandResult>} command result future
      */
     public Future<CommandResult> toggleCommand() {
-        return send(new ToggleCommand());
+        return sendCommand(new ToggleCommand());
     }
 
     /**
@@ -618,7 +641,7 @@ public class ZclOnOffCluster extends ZclCluster {
         command.setEffectIdentifier(effectIdentifier);
         command.setEffectVariant(effectVariant);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -630,7 +653,7 @@ public class ZclOnOffCluster extends ZclCluster {
      * @return the {@link Future<CommandResult>} command result future
      */
     public Future<CommandResult> onWithRecallGlobalSceneCommand() {
-        return send(new OnWithRecallGlobalSceneCommand());
+        return sendCommand(new OnWithRecallGlobalSceneCommand());
     }
 
     /**
@@ -655,6 +678,6 @@ public class ZclOnOffCluster extends ZclCluster {
         command.setOnTime(onTime);
         command.setOffWaitTime(offWaitTime);
 
-        return send(command);
+        return sendCommand(command);
     }
 }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclOnOffSwitchConfigurationCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclOnOffSwitchConfigurationCluster.java
@@ -26,7 +26,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-10-04T18:21:10Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T11:55:03Z")
 public class ZclOnOffSwitchConfigurationCluster extends ZclCluster {
     /**
      * The ZigBee Cluster Library Cluster ID
@@ -66,6 +66,7 @@ public class ZclOnOffSwitchConfigurationCluster extends ZclCluster {
 
         return attributeMap;
     }
+
 
     /**
      * Default constructor to create a On / Off Switch Configuration cluster.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclOtaUpgradeCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclOtaUpgradeCluster.java
@@ -30,6 +30,7 @@ import com.zsmartsystems.zigbee.zcl.clusters.otaupgrade.QuerySpecificFileCommand
 import com.zsmartsystems.zigbee.zcl.clusters.otaupgrade.QuerySpecificFileResponse;
 import com.zsmartsystems.zigbee.zcl.clusters.otaupgrade.UpgradeEndCommand;
 import com.zsmartsystems.zigbee.zcl.clusters.otaupgrade.UpgradeEndResponse;
+import com.zsmartsystems.zigbee.zcl.clusters.otaupgrade.ZclOtaUpgradeCommand;
 import com.zsmartsystems.zigbee.zcl.field.ByteArray;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
@@ -63,7 +64,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-10-04T18:21:10Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:04:47Z")
 public class ZclOtaUpgradeCluster extends ZclCluster {
     /**
      * The ZigBee Cluster Library Cluster ID
@@ -221,6 +222,28 @@ public class ZclOtaUpgradeCluster extends ZclCluster {
     }
 
     /**
+     * Sends a {@link ZclOtaUpgradeCommand} and returns the {@link Future} to the result which will complete when the remote
+     * device response is received, or the request times out.
+     *
+     * @param command the {@link ZclOtaUpgradeCommand} to send
+     * @return the command result future
+     */
+    public Future<CommandResult> sendCommand(ZclOtaUpgradeCommand command) {
+        return super.sendCommand(command);
+    }
+
+    /**
+     * Sends a response to the command. This method sets all the common elements of the response based on the command -
+     * eg transactionId, direction, address...
+     *
+     * @param command the {@link ZclOtaUpgradeCommand} to which the response is being sent
+     * @param response the {@link ZclOtaUpgradeCommand} to send
+     */
+    public void sendResponse(ZclOtaUpgradeCommand command, ZclOtaUpgradeCommand response) {
+        super.sendResponse(command, response);
+    }
+
+    /**
      * The Image Notify Command
      * <p>
      * The purpose of sending Image Notify command is so the server has a way to notify client
@@ -254,7 +277,7 @@ public class ZclOtaUpgradeCluster extends ZclCluster {
         command.setImageType(imageType);
         command.setNewFileVersion(newFileVersion);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -292,7 +315,7 @@ public class ZclOtaUpgradeCluster extends ZclCluster {
         command.setFileVersion(fileVersion);
         command.setHardwareVersion(hardwareVersion);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -327,7 +350,7 @@ public class ZclOtaUpgradeCluster extends ZclCluster {
         command.setFileVersion(fileVersion);
         command.setImageSize(imageSize);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -370,7 +393,7 @@ public class ZclOtaUpgradeCluster extends ZclCluster {
         command.setRequestNodeAddress(requestNodeAddress);
         command.setBlockRequestDelay(blockRequestDelay);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -417,7 +440,7 @@ public class ZclOtaUpgradeCluster extends ZclCluster {
         command.setResponseSpacing(responseSpacing);
         command.setRequestNodeAddress(requestNodeAddress);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -462,7 +485,7 @@ public class ZclOtaUpgradeCluster extends ZclCluster {
         command.setFileOffset(fileOffset);
         command.setImageData(imageData);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -501,7 +524,7 @@ public class ZclOtaUpgradeCluster extends ZclCluster {
         command.setImageType(imageType);
         command.setFileVersion(fileVersion);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -536,7 +559,7 @@ public class ZclOtaUpgradeCluster extends ZclCluster {
         command.setCurrentTime(currentTime);
         command.setUpgradeTime(upgradeTime);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -567,7 +590,7 @@ public class ZclOtaUpgradeCluster extends ZclCluster {
         command.setFileVersion(fileVersion);
         command.setZigbeeStackVersion(zigbeeStackVersion);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -600,6 +623,6 @@ public class ZclOtaUpgradeCluster extends ZclCluster {
         command.setFileVersion(fileVersion);
         command.setImageSize(imageSize);
 
-        return send(command);
+        return sendCommand(command);
     }
 }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclPollControlCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclPollControlCluster.java
@@ -23,6 +23,7 @@ import com.zsmartsystems.zigbee.zcl.clusters.pollcontrol.CheckInResponse;
 import com.zsmartsystems.zigbee.zcl.clusters.pollcontrol.FastPollStopCommand;
 import com.zsmartsystems.zigbee.zcl.clusters.pollcontrol.SetLongPollIntervalCommand;
 import com.zsmartsystems.zigbee.zcl.clusters.pollcontrol.SetShortPollIntervalCommand;
+import com.zsmartsystems.zigbee.zcl.clusters.pollcontrol.ZclPollControlCommand;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
 /**
@@ -44,7 +45,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-10-04T18:21:10Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:04:47Z")
 public class ZclPollControlCluster extends ZclCluster {
     /**
      * The ZigBee Cluster Library Cluster ID
@@ -181,6 +182,28 @@ public class ZclPollControlCluster extends ZclCluster {
      */
     public ZclPollControlCluster(final ZigBeeEndpoint zigbeeEndpoint) {
         super(zigbeeEndpoint, CLUSTER_ID, CLUSTER_NAME);
+    }
+
+    /**
+     * Sends a {@link ZclPollControlCommand} and returns the {@link Future} to the result which will complete when the remote
+     * device response is received, or the request times out.
+     *
+     * @param command the {@link ZclPollControlCommand} to send
+     * @return the command result future
+     */
+    public Future<CommandResult> sendCommand(ZclPollControlCommand command) {
+        return super.sendCommand(command);
+    }
+
+    /**
+     * Sends a response to the command. This method sets all the common elements of the response based on the command -
+     * eg transactionId, direction, address...
+     *
+     * @param command the {@link ZclPollControlCommand} to which the response is being sent
+     * @param response the {@link ZclPollControlCommand} to send
+     */
+    public void sendResponse(ZclPollControlCommand command, ZclPollControlCommand response) {
+        super.sendResponse(command, response);
     }
 
     /**
@@ -843,7 +866,7 @@ public class ZclPollControlCluster extends ZclCluster {
         command.setStartFastPolling(startFastPolling);
         command.setFastPollTimeout(fastPollTimeout);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -863,7 +886,7 @@ public class ZclPollControlCluster extends ZclCluster {
      * @return the {@link Future<CommandResult>} command result future
      */
     public Future<CommandResult> fastPollStopCommand() {
-        return send(new FastPollStopCommand());
+        return sendCommand(new FastPollStopCommand());
     }
 
     /**
@@ -886,7 +909,7 @@ public class ZclPollControlCluster extends ZclCluster {
         // Set the fields
         command.setNewLongPollInterval(newLongPollInterval);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -909,7 +932,7 @@ public class ZclPollControlCluster extends ZclCluster {
         // Set the fields
         command.setNewShortPollInterval(newShortPollInterval);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -928,6 +951,6 @@ public class ZclPollControlCluster extends ZclCluster {
      * @return the {@link Future<CommandResult>} command result future
      */
     public Future<CommandResult> checkInCommand() {
-        return send(new CheckInCommand());
+        return sendCommand(new CheckInCommand());
     }
 }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclPowerConfigurationCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclPowerConfigurationCluster.java
@@ -27,7 +27,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-10-04T18:21:10Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T11:55:03Z")
 public class ZclPowerConfigurationCluster extends ZclCluster {
     /**
      * The ZigBee Cluster Library Cluster ID
@@ -237,6 +237,7 @@ public class ZclPowerConfigurationCluster extends ZclCluster {
 
         return attributeMap;
     }
+
 
     /**
      * Default constructor to create a Power Configuration cluster.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclPrepaymentCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclPrepaymentCluster.java
@@ -38,6 +38,7 @@ import com.zsmartsystems.zigbee.zcl.clusters.prepayment.SetLowCreditWarningLevel
 import com.zsmartsystems.zigbee.zcl.clusters.prepayment.SetMaximumCreditLimit;
 import com.zsmartsystems.zigbee.zcl.clusters.prepayment.SetOverallDebtCap;
 import com.zsmartsystems.zigbee.zcl.clusters.prepayment.TopUpPayload;
+import com.zsmartsystems.zigbee.zcl.clusters.prepayment.ZclPrepaymentCommand;
 import com.zsmartsystems.zigbee.zcl.field.ByteArray;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
@@ -64,7 +65,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-10-04T18:21:10Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:04:47Z")
 public class ZclPrepaymentCluster extends ZclCluster {
     /**
      * The ZigBee Cluster Library Cluster ID
@@ -788,6 +789,28 @@ public class ZclPrepaymentCluster extends ZclCluster {
      */
     public ZclPrepaymentCluster(final ZigBeeEndpoint zigbeeEndpoint) {
         super(zigbeeEndpoint, CLUSTER_ID, CLUSTER_NAME);
+    }
+
+    /**
+     * Sends a {@link ZclPrepaymentCommand} and returns the {@link Future} to the result which will complete when the remote
+     * device response is received, or the request times out.
+     *
+     * @param command the {@link ZclPrepaymentCommand} to send
+     * @return the command result future
+     */
+    public Future<CommandResult> sendCommand(ZclPrepaymentCommand command) {
+        return super.sendCommand(command);
+    }
+
+    /**
+     * Sends a response to the command. This method sets all the common elements of the response based on the command -
+     * eg transactionId, direction, address...
+     *
+     * @param command the {@link ZclPrepaymentCommand} to which the response is being sent
+     * @param response the {@link ZclPrepaymentCommand} to send
+     */
+    public void sendResponse(ZclPrepaymentCommand command, ZclPrepaymentCommand response) {
+        super.sendResponse(command, response);
     }
 
     /**
@@ -9421,7 +9444,7 @@ public class ZclPrepaymentCluster extends ZclCluster {
         command.setSiteId(siteId);
         command.setMeterSerialNumber(meterSerialNumber);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -9457,7 +9480,7 @@ public class ZclPrepaymentCluster extends ZclCluster {
         command.setDebtRecoveryAmount(debtRecoveryAmount);
         command.setDebtRecoveryBalancePercentage(debtRecoveryBalancePercentage);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -9480,7 +9503,7 @@ public class ZclPrepaymentCluster extends ZclCluster {
         command.setEmergencyCreditLimit(emergencyCreditLimit);
         command.setEmergencyCreditThreshold(emergencyCreditThreshold);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -9500,7 +9523,7 @@ public class ZclPrepaymentCluster extends ZclCluster {
         command.setOriginatingDevice(originatingDevice);
         command.setTopUpCode(topUpCode);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -9524,7 +9547,7 @@ public class ZclPrepaymentCluster extends ZclCluster {
         command.setCreditAdjustmentType(creditAdjustmentType);
         command.setCreditAdjustmentValue(creditAdjustmentValue);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -9550,7 +9573,7 @@ public class ZclPrepaymentCluster extends ZclCluster {
         command.setProposedPaymentControlConfiguration(proposedPaymentControlConfiguration);
         command.setCutOffValue(cutOffValue);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -9573,7 +9596,7 @@ public class ZclPrepaymentCluster extends ZclCluster {
         command.setSnapshotOffset(snapshotOffset);
         command.setSnapshotCause(snapshotCause);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -9593,7 +9616,7 @@ public class ZclPrepaymentCluster extends ZclCluster {
         command.setLatestEndTime(latestEndTime);
         command.setNumberOfRecords(numberOfRecords);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -9611,7 +9634,7 @@ public class ZclPrepaymentCluster extends ZclCluster {
         // Set the fields
         command.setLowCreditWarningLevel(lowCreditWarningLevel);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -9632,7 +9655,7 @@ public class ZclPrepaymentCluster extends ZclCluster {
         command.setNumberOfDebts(numberOfDebts);
         command.setDebtType(debtType);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -9658,7 +9681,7 @@ public class ZclPrepaymentCluster extends ZclCluster {
         command.setMaximumCreditLevel(maximumCreditLevel);
         command.setMaximumCreditPerTopUp(maximumCreditPerTopUp);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -9682,7 +9705,7 @@ public class ZclPrepaymentCluster extends ZclCluster {
         command.setImplementationDateTime(implementationDateTime);
         command.setOverallDebtCap(overallDebtCap);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -9714,7 +9737,7 @@ public class ZclPrepaymentCluster extends ZclCluster {
         command.setSnapshotPayloadType(snapshotPayloadType);
         command.setSnapshotPayload(snapshotPayload);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -9737,7 +9760,7 @@ public class ZclPrepaymentCluster extends ZclCluster {
         command.setEmergencyCreditLimit(emergencyCreditLimit);
         command.setEmergencyCreditThreshold(emergencyCreditThreshold);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -9760,7 +9783,7 @@ public class ZclPrepaymentCluster extends ZclCluster {
         command.setSourceOfTopUp(sourceOfTopUp);
         command.setCreditRemaining(creditRemaining);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -9781,7 +9804,7 @@ public class ZclPrepaymentCluster extends ZclCluster {
         command.setTotalNumberOfCommands(totalNumberOfCommands);
         command.setTopUpPayload(topUpPayload);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -9802,6 +9825,6 @@ public class ZclPrepaymentCluster extends ZclCluster {
         command.setTotalNumberOfCommands(totalNumberOfCommands);
         command.setDebtPayload(debtPayload);
 
-        return send(command);
+        return sendCommand(command);
     }
 }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclPressureMeasurementCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclPressureMeasurementCluster.java
@@ -27,7 +27,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-10-04T18:21:10Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T11:55:03Z")
 public class ZclPressureMeasurementCluster extends ZclCluster {
     /**
      * The ZigBee Cluster Library Cluster ID
@@ -123,6 +123,7 @@ public class ZclPressureMeasurementCluster extends ZclCluster {
 
         return attributeMap;
     }
+
 
     /**
      * Default constructor to create a Pressure Measurement cluster.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclPriceCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclPriceCluster.java
@@ -53,6 +53,7 @@ import com.zsmartsystems.zigbee.zcl.clusters.price.PublishPriceCommand;
 import com.zsmartsystems.zigbee.zcl.clusters.price.PublishPriceMatrixCommand;
 import com.zsmartsystems.zigbee.zcl.clusters.price.PublishTariffInformationCommand;
 import com.zsmartsystems.zigbee.zcl.clusters.price.PublishTierLabelsCommand;
+import com.zsmartsystems.zigbee.zcl.clusters.price.ZclPriceCommand;
 import com.zsmartsystems.zigbee.zcl.field.ByteArray;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
@@ -71,7 +72,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-10-04T18:21:10Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:04:47Z")
 public class ZclPriceCluster extends ZclCluster {
     /**
      * The ZigBee Cluster Library Cluster ID
@@ -4778,6 +4779,28 @@ public class ZclPriceCluster extends ZclCluster {
      */
     public ZclPriceCluster(final ZigBeeEndpoint zigbeeEndpoint) {
         super(zigbeeEndpoint, CLUSTER_ID, CLUSTER_NAME);
+    }
+
+    /**
+     * Sends a {@link ZclPriceCommand} and returns the {@link Future} to the result which will complete when the remote
+     * device response is received, or the request times out.
+     *
+     * @param command the {@link ZclPriceCommand} to send
+     * @return the command result future
+     */
+    public Future<CommandResult> sendCommand(ZclPriceCommand command) {
+        return super.sendCommand(command);
+    }
+
+    /**
+     * Sends a response to the command. This method sets all the common elements of the response based on the command -
+     * eg transactionId, direction, address...
+     *
+     * @param command the {@link ZclPriceCommand} to which the response is being sent
+     * @param response the {@link ZclPriceCommand} to send
+     */
+    public void sendResponse(ZclPriceCommand command, ZclPriceCommand response) {
+        super.sendResponse(command, response);
     }
 
     /**
@@ -11410,7 +11433,7 @@ public class ZclPriceCluster extends ZclCluster {
         // Set the fields
         command.setCommandOptions(commandOptions);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -11432,7 +11455,7 @@ public class ZclPriceCluster extends ZclCluster {
         command.setStartTime(startTime);
         command.setNumberOfEvents(numberOfEvents);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -11457,7 +11480,7 @@ public class ZclPriceCluster extends ZclCluster {
         command.setPriceAckTime(priceAckTime);
         command.setControl(control);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -11481,7 +11504,7 @@ public class ZclPriceCluster extends ZclCluster {
         command.setNumberOfEvents(numberOfEvents);
         command.setTariffType(tariffType);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -11506,7 +11529,7 @@ public class ZclPriceCluster extends ZclCluster {
         command.setMinIssuerEventId(minIssuerEventId);
         command.setNumberOfCommands(numberOfCommands);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -11531,7 +11554,7 @@ public class ZclPriceCluster extends ZclCluster {
         command.setMinIssuerEventId(minIssuerEventId);
         command.setNumberOfCommands(numberOfCommands);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -11560,7 +11583,7 @@ public class ZclPriceCluster extends ZclCluster {
         command.setNumberOfCommands(numberOfCommands);
         command.setTariffType(tariffType);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -11580,7 +11603,7 @@ public class ZclPriceCluster extends ZclCluster {
         // Set the fields
         command.setIssuerTariffId(issuerTariffId);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -11600,7 +11623,7 @@ public class ZclPriceCluster extends ZclCluster {
         // Set the fields
         command.setIssuerTariffId(issuerTariffId);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -11625,7 +11648,7 @@ public class ZclPriceCluster extends ZclCluster {
         command.setNumberOfCommands(numberOfCommands);
         command.setTariffType(tariffType);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -11643,7 +11666,7 @@ public class ZclPriceCluster extends ZclCluster {
         // Set the fields
         command.setIssuerTariffId(issuerTariffId);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -11667,7 +11690,7 @@ public class ZclPriceCluster extends ZclCluster {
         command.setNumberOfCommands(numberOfCommands);
         command.setTariffType(tariffType);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -11691,7 +11714,7 @@ public class ZclPriceCluster extends ZclCluster {
         command.setNumberOfCommands(numberOfCommands);
         command.setTariffType(tariffType);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -11711,7 +11734,7 @@ public class ZclPriceCluster extends ZclCluster {
         command.setIssuerEventId(issuerEventId);
         command.setCppAuth(cppAuth);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -11731,7 +11754,7 @@ public class ZclPriceCluster extends ZclCluster {
         command.setLatestEndTime(latestEndTime);
         command.setNumberOfRecords(numberOfRecords);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -11745,7 +11768,7 @@ public class ZclPriceCluster extends ZclCluster {
      * @return the {@link Future<CommandResult>} command result future
      */
     public Future<CommandResult> getCurrencyConversionCommand() {
-        return send(new GetCurrencyConversionCommand());
+        return sendCommand(new GetCurrencyConversionCommand());
     }
 
     /**
@@ -11758,7 +11781,7 @@ public class ZclPriceCluster extends ZclCluster {
      * @return the {@link Future<CommandResult>} command result future
      */
     public Future<CommandResult> getTariffCancellationCommand() {
-        return send(new GetTariffCancellationCommand());
+        return sendCommand(new GetTariffCancellationCommand());
     }
 
     /**
@@ -11842,7 +11865,7 @@ public class ZclPriceCluster extends ZclCluster {
         command.setExtendedPriceTier(extendedPriceTier);
         command.setExtendedRegisterTier(extendedRegisterTier);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -11884,7 +11907,7 @@ public class ZclPriceCluster extends ZclCluster {
         command.setTariffType(tariffType);
         command.setTariffResolutionPeriod(tariffResolutionPeriod);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -11910,7 +11933,7 @@ public class ZclPriceCluster extends ZclCluster {
         command.setConversionFactor(conversionFactor);
         command.setConversionFactorTrailingDigit(conversionFactorTrailingDigit);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -11937,7 +11960,7 @@ public class ZclPriceCluster extends ZclCluster {
         command.setCalorificValueUnit(calorificValueUnit);
         command.setCalorificValueTrailingDigit(calorificValueTrailingDigit);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -11990,7 +12013,7 @@ public class ZclPriceCluster extends ZclCluster {
         command.setBlockThresholdMultiplier(blockThresholdMultiplier);
         command.setBlockThresholdDivisor(blockThresholdDivisor);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -12035,7 +12058,7 @@ public class ZclPriceCluster extends ZclCluster {
         command.setSubPayloadControl(subPayloadControl);
         command.setPriceMatrixSubPayload(priceMatrixSubPayload);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -12078,7 +12101,7 @@ public class ZclPriceCluster extends ZclCluster {
         command.setSubPayloadControl(subPayloadControl);
         command.setBlockThresholdSubPayload(blockThresholdSubPayload);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -12109,7 +12132,7 @@ public class ZclPriceCluster extends ZclCluster {
         command.setCo2ValueUnit(co2ValueUnit);
         command.setCo2ValueTrailingDigit(co2ValueTrailingDigit);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -12141,7 +12164,7 @@ public class ZclPriceCluster extends ZclCluster {
         command.setTierId(tierId);
         command.setTierLabel(tierLabel);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -12174,7 +12197,7 @@ public class ZclPriceCluster extends ZclCluster {
         command.setBillingPeriodDurationType(billingPeriodDurationType);
         command.setTariffType(tariffType);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -12214,7 +12237,7 @@ public class ZclPriceCluster extends ZclCluster {
         command.setCurrency(currency);
         command.setBillTrailingDigit(billTrailingDigit);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -12250,7 +12273,7 @@ public class ZclPriceCluster extends ZclCluster {
         command.setCppPriceTier(cppPriceTier);
         command.setCppAuth(cppAuth);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -12285,7 +12308,7 @@ public class ZclPriceCluster extends ZclCluster {
         command.setCreditPaymentDate(creditPaymentDate);
         command.setCreditPaymentRef(creditPaymentRef);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -12317,7 +12340,7 @@ public class ZclPriceCluster extends ZclCluster {
         command.setConversionFactorTrailingDigit(conversionFactorTrailingDigit);
         command.setCurrencyChangeControlFlags(currencyChangeControlFlags);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -12343,6 +12366,6 @@ public class ZclPriceCluster extends ZclCluster {
         command.setIssuerTariffId(issuerTariffId);
         command.setTariffType(tariffType);
 
-        return send(command);
+        return sendCommand(command);
     }
 }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclRelativeHumidityMeasurementCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclRelativeHumidityMeasurementCluster.java
@@ -28,7 +28,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-10-04T18:21:10Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T11:55:03Z")
 public class ZclRelativeHumidityMeasurementCluster extends ZclCluster {
     /**
      * The ZigBee Cluster Library Cluster ID
@@ -95,6 +95,7 @@ public class ZclRelativeHumidityMeasurementCluster extends ZclCluster {
 
         return attributeMap;
     }
+
 
     /**
      * Default constructor to create a Relative Humidity Measurement cluster.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclRssiLocationCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclRssiLocationCluster.java
@@ -35,6 +35,7 @@ import com.zsmartsystems.zigbee.zcl.clusters.rssilocation.RssiResponse;
 import com.zsmartsystems.zigbee.zcl.clusters.rssilocation.SendPingsCommand;
 import com.zsmartsystems.zigbee.zcl.clusters.rssilocation.SetAbsoluteLocationCommand;
 import com.zsmartsystems.zigbee.zcl.clusters.rssilocation.SetDeviceConfigurationCommand;
+import com.zsmartsystems.zigbee.zcl.clusters.rssilocation.ZclRssiLocationCommand;
 import com.zsmartsystems.zigbee.zcl.field.NeighborInformation;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
@@ -47,7 +48,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-10-04T18:21:10Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:04:47Z")
 public class ZclRssiLocationCluster extends ZclCluster {
     /**
      * The ZigBee Cluster Library Cluster ID
@@ -227,6 +228,28 @@ public class ZclRssiLocationCluster extends ZclCluster {
      */
     public ZclRssiLocationCluster(final ZigBeeEndpoint zigbeeEndpoint) {
         super(zigbeeEndpoint, CLUSTER_ID, CLUSTER_NAME);
+    }
+
+    /**
+     * Sends a {@link ZclRssiLocationCommand} and returns the {@link Future} to the result which will complete when the remote
+     * device response is received, or the request times out.
+     *
+     * @param command the {@link ZclRssiLocationCommand} to send
+     * @return the command result future
+     */
+    public Future<CommandResult> sendCommand(ZclRssiLocationCommand command) {
+        return super.sendCommand(command);
+    }
+
+    /**
+     * Sends a response to the command. This method sets all the common elements of the response based on the command -
+     * eg transactionId, direction, address...
+     *
+     * @param command the {@link ZclRssiLocationCommand} to which the response is being sent
+     * @param response the {@link ZclRssiLocationCommand} to send
+     */
+    public void sendResponse(ZclRssiLocationCommand command, ZclRssiLocationCommand response) {
+        super.sendResponse(command, response);
     }
 
     /**
@@ -1271,7 +1294,7 @@ public class ZclRssiLocationCluster extends ZclCluster {
         command.setPower(power);
         command.setPathLossExponent(pathLossExponent);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -1294,7 +1317,7 @@ public class ZclRssiLocationCluster extends ZclCluster {
         command.setNumberRssiMeasurements(numberRssiMeasurements);
         command.setReportingPeriod(reportingPeriod);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -1309,7 +1332,7 @@ public class ZclRssiLocationCluster extends ZclCluster {
         // Set the fields
         command.setTargetAddress(targetAddress);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -1328,7 +1351,7 @@ public class ZclRssiLocationCluster extends ZclCluster {
         command.setNumberResponses(numberResponses);
         command.setTargetAddress(targetAddress);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -1353,7 +1376,7 @@ public class ZclRssiLocationCluster extends ZclCluster {
         command.setRssi(rssi);
         command.setNumberRssiMeasurements(numberRssiMeasurements);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -1372,7 +1395,7 @@ public class ZclRssiLocationCluster extends ZclCluster {
         command.setNumberRssiMeasurements(numberRssiMeasurements);
         command.setCalculationPeriod(calculationPeriod);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -1393,7 +1416,7 @@ public class ZclRssiLocationCluster extends ZclCluster {
         command.setCoordinate2(coordinate2);
         command.setCoordinate3(coordinate3);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -1418,7 +1441,7 @@ public class ZclRssiLocationCluster extends ZclCluster {
         command.setNumberRssiMeasurements(numberRssiMeasurements);
         command.setReportingPeriod(reportingPeriod);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -1451,7 +1474,7 @@ public class ZclRssiLocationCluster extends ZclCluster {
         command.setQualityMeasure(qualityMeasure);
         command.setLocationAge(locationAge);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -1482,7 +1505,7 @@ public class ZclRssiLocationCluster extends ZclCluster {
         command.setQualityMeasure(qualityMeasure);
         command.setLocationAge(locationAge);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -1491,7 +1514,7 @@ public class ZclRssiLocationCluster extends ZclCluster {
      * @return the {@link Future<CommandResult>} command result future
      */
     public Future<CommandResult> compactLocationDataNotificationCommand() {
-        return send(new CompactLocationDataNotificationCommand());
+        return sendCommand(new CompactLocationDataNotificationCommand());
     }
 
     /**
@@ -1506,7 +1529,7 @@ public class ZclRssiLocationCluster extends ZclCluster {
         // Set the fields
         command.setLocationType(locationType);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -1515,7 +1538,7 @@ public class ZclRssiLocationCluster extends ZclCluster {
      * @return the {@link Future<CommandResult>} command result future
      */
     public Future<CommandResult> rssiRequestCommand() {
-        return send(new RssiRequestCommand());
+        return sendCommand(new RssiRequestCommand());
     }
 
     /**
@@ -1534,7 +1557,7 @@ public class ZclRssiLocationCluster extends ZclCluster {
         command.setNumberOfNeighbors(numberOfNeighbors);
         command.setNeighborsInformation(neighborsInformation);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -1549,6 +1572,6 @@ public class ZclRssiLocationCluster extends ZclCluster {
         // Set the fields
         command.setRequestingAddress(requestingAddress);
 
-        return send(command);
+        return sendCommand(command);
     }
 }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclScenesCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclScenesCluster.java
@@ -39,6 +39,7 @@ import com.zsmartsystems.zigbee.zcl.clusters.scenes.StoreSceneCommand;
 import com.zsmartsystems.zigbee.zcl.clusters.scenes.StoreSceneResponse;
 import com.zsmartsystems.zigbee.zcl.clusters.scenes.ViewSceneCommand;
 import com.zsmartsystems.zigbee.zcl.clusters.scenes.ViewSceneResponse;
+import com.zsmartsystems.zigbee.zcl.clusters.scenes.ZclScenesCommand;
 import com.zsmartsystems.zigbee.zcl.field.ExtensionFieldSet;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
@@ -56,7 +57,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-11-16T08:52:33Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:04:47Z")
 public class ZclScenesCluster extends ZclCluster {
     /**
      * The ZigBee Cluster Library Cluster ID
@@ -171,6 +172,28 @@ public class ZclScenesCluster extends ZclCluster {
      */
     public ZclScenesCluster(final ZigBeeEndpoint zigbeeEndpoint) {
         super(zigbeeEndpoint, CLUSTER_ID, CLUSTER_NAME);
+    }
+
+    /**
+     * Sends a {@link ZclScenesCommand} and returns the {@link Future} to the result which will complete when the remote
+     * device response is received, or the request times out.
+     *
+     * @param command the {@link ZclScenesCommand} to send
+     * @return the command result future
+     */
+    public Future<CommandResult> sendCommand(ZclScenesCommand command) {
+        return super.sendCommand(command);
+    }
+
+    /**
+     * Sends a response to the command. This method sets all the common elements of the response based on the command -
+     * eg transactionId, direction, address...
+     *
+     * @param command the {@link ZclScenesCommand} to which the response is being sent
+     * @param response the {@link ZclScenesCommand} to send
+     */
+    public void sendResponse(ZclScenesCommand command, ZclScenesCommand response) {
+        super.sendResponse(command, response);
     }
 
     /**
@@ -607,7 +630,7 @@ public class ZclScenesCluster extends ZclCluster {
         command.setSceneName(sceneName);
         command.setExtensionFieldSets(extensionFieldSets);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -626,7 +649,7 @@ public class ZclScenesCluster extends ZclCluster {
         command.setGroupId(groupId);
         command.setSceneId(sceneId);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -645,7 +668,7 @@ public class ZclScenesCluster extends ZclCluster {
         command.setGroupId(groupId);
         command.setSceneId(sceneId);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -662,7 +685,7 @@ public class ZclScenesCluster extends ZclCluster {
         // Set the fields
         command.setGroupId(groupId);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -681,7 +704,7 @@ public class ZclScenesCluster extends ZclCluster {
         command.setGroupId(groupId);
         command.setSceneId(sceneId);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -700,7 +723,7 @@ public class ZclScenesCluster extends ZclCluster {
         command.setGroupId(groupId);
         command.setSceneId(sceneId);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -719,7 +742,7 @@ public class ZclScenesCluster extends ZclCluster {
         // Set the fields
         command.setGroupId(groupId);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -745,7 +768,7 @@ public class ZclScenesCluster extends ZclCluster {
         command.setSceneName(sceneName);
         command.setExtensionFieldSets(extensionFieldSets);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -765,7 +788,7 @@ public class ZclScenesCluster extends ZclCluster {
         command.setGroupId(groupId);
         command.setSceneId(sceneId);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -791,7 +814,7 @@ public class ZclScenesCluster extends ZclCluster {
         command.setGroupIdTo(groupIdTo);
         command.setSceneIdTo(sceneIdTo);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -810,7 +833,7 @@ public class ZclScenesCluster extends ZclCluster {
         command.setGroupId(groupId);
         command.setSceneId(sceneId);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -835,7 +858,7 @@ public class ZclScenesCluster extends ZclCluster {
         command.setSceneName(sceneName);
         command.setExtensionFieldSets(extensionFieldSets);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -854,7 +877,7 @@ public class ZclScenesCluster extends ZclCluster {
         command.setGroupId(groupId);
         command.setSceneId(sceneId);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -871,7 +894,7 @@ public class ZclScenesCluster extends ZclCluster {
         command.setStatus(status);
         command.setGroupId(groupId);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -890,7 +913,7 @@ public class ZclScenesCluster extends ZclCluster {
         command.setGroupId(groupId);
         command.setSceneId(sceneId);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -913,7 +936,7 @@ public class ZclScenesCluster extends ZclCluster {
         command.setSceneCount(sceneCount);
         command.setSceneList(sceneList);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -932,7 +955,7 @@ public class ZclScenesCluster extends ZclCluster {
         command.setGroupId(groupId);
         command.setSceneId(sceneId);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -957,7 +980,7 @@ public class ZclScenesCluster extends ZclCluster {
         command.setSceneName(sceneName);
         command.setExtensionFieldSets(extensionFieldSets);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -976,6 +999,6 @@ public class ZclScenesCluster extends ZclCluster {
         command.setGroupId(groupId);
         command.setSceneId(sceneId);
 
-        return send(command);
+        return sendCommand(command);
     }
 }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclSmartEnergyTunnelingCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclSmartEnergyTunnelingCluster.java
@@ -33,6 +33,7 @@ import com.zsmartsystems.zigbee.zcl.clusters.smartenergytunneling.TransferDataEr
 import com.zsmartsystems.zigbee.zcl.clusters.smartenergytunneling.TransferDataErrorServerToClient;
 import com.zsmartsystems.zigbee.zcl.clusters.smartenergytunneling.TransferDataServerToClient;
 import com.zsmartsystems.zigbee.zcl.clusters.smartenergytunneling.TunnelClosureNotification;
+import com.zsmartsystems.zigbee.zcl.clusters.smartenergytunneling.ZclSmartEnergyTunnelingCommand;
 import com.zsmartsystems.zigbee.zcl.field.ByteArray;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
@@ -65,7 +66,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-10-04T18:21:10Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:04:47Z")
 public class ZclSmartEnergyTunnelingCluster extends ZclCluster {
     /**
      * The ZigBee Cluster Library Cluster ID
@@ -139,6 +140,28 @@ public class ZclSmartEnergyTunnelingCluster extends ZclCluster {
      */
     public ZclSmartEnergyTunnelingCluster(final ZigBeeEndpoint zigbeeEndpoint) {
         super(zigbeeEndpoint, CLUSTER_ID, CLUSTER_NAME);
+    }
+
+    /**
+     * Sends a {@link ZclSmartEnergyTunnelingCommand} and returns the {@link Future} to the result which will complete when the remote
+     * device response is received, or the request times out.
+     *
+     * @param command the {@link ZclSmartEnergyTunnelingCommand} to send
+     * @return the command result future
+     */
+    public Future<CommandResult> sendCommand(ZclSmartEnergyTunnelingCommand command) {
+        return super.sendCommand(command);
+    }
+
+    /**
+     * Sends a response to the command. This method sets all the common elements of the response based on the command -
+     * eg transactionId, direction, address...
+     *
+     * @param command the {@link ZclSmartEnergyTunnelingCommand} to which the response is being sent
+     * @param response the {@link ZclSmartEnergyTunnelingCommand} to send
+     */
+    public void sendResponse(ZclSmartEnergyTunnelingCommand command, ZclSmartEnergyTunnelingCommand response) {
+        super.sendResponse(command, response);
     }
 
     /**
@@ -239,7 +262,7 @@ public class ZclSmartEnergyTunnelingCluster extends ZclCluster {
         command.setFlowControlSupport(flowControlSupport);
         command.setMaximumIncomingTransferSize(maximumIncomingTransferSize);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -259,7 +282,7 @@ public class ZclSmartEnergyTunnelingCluster extends ZclCluster {
         // Set the fields
         command.setTunnelId(tunnelId);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -279,7 +302,7 @@ public class ZclSmartEnergyTunnelingCluster extends ZclCluster {
         command.setTunnelId(tunnelId);
         command.setData(data);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -311,7 +334,7 @@ public class ZclSmartEnergyTunnelingCluster extends ZclCluster {
         command.setTunnelId(tunnelId);
         command.setTransferDataStatus(transferDataStatus);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -333,7 +356,7 @@ public class ZclSmartEnergyTunnelingCluster extends ZclCluster {
         command.setTunnelId(tunnelId);
         command.setNumberOfBytesLeft(numberOfBytesLeft);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -356,7 +379,7 @@ public class ZclSmartEnergyTunnelingCluster extends ZclCluster {
         command.setTunnelId(tunnelId);
         command.setNumberOfOctetsLeft(numberOfOctetsLeft);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -374,7 +397,7 @@ public class ZclSmartEnergyTunnelingCluster extends ZclCluster {
         // Set the fields
         command.setProtocolOffset(protocolOffset);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -398,7 +421,7 @@ public class ZclSmartEnergyTunnelingCluster extends ZclCluster {
         command.setTunnelStatus(tunnelStatus);
         command.setMaximumIncomingTransferSize(maximumIncomingTransferSize);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -418,7 +441,7 @@ public class ZclSmartEnergyTunnelingCluster extends ZclCluster {
         command.setTunnelId(tunnelId);
         command.setData(data);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -450,7 +473,7 @@ public class ZclSmartEnergyTunnelingCluster extends ZclCluster {
         command.setTunnelId(tunnelId);
         command.setTransferDataStatus(transferDataStatus);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -472,7 +495,7 @@ public class ZclSmartEnergyTunnelingCluster extends ZclCluster {
         command.setTunnelId(tunnelId);
         command.setNumberOfBytesLeft(numberOfBytesLeft);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -495,7 +518,7 @@ public class ZclSmartEnergyTunnelingCluster extends ZclCluster {
         command.setTunnelId(tunnelId);
         command.setNumberOfOctetsLeft(numberOfOctetsLeft);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -519,7 +542,7 @@ public class ZclSmartEnergyTunnelingCluster extends ZclCluster {
         command.setProtocolCount(protocolCount);
         command.setProtocolList(protocolList);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -541,6 +564,6 @@ public class ZclSmartEnergyTunnelingCluster extends ZclCluster {
         // Set the fields
         command.setTunnelId(tunnelId);
 
-        return send(command);
+        return sendCommand(command);
     }
 }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclTemperatureMeasurementCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclTemperatureMeasurementCluster.java
@@ -27,7 +27,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-10-04T18:21:10Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T11:55:03Z")
 public class ZclTemperatureMeasurementCluster extends ZclCluster {
     /**
      * The ZigBee Cluster Library Cluster ID
@@ -96,6 +96,7 @@ public class ZclTemperatureMeasurementCluster extends ZclCluster {
 
         return attributeMap;
     }
+
 
     /**
      * Default constructor to create a Temperature Measurement cluster.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclThermostatCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclThermostatCluster.java
@@ -25,6 +25,7 @@ import com.zsmartsystems.zigbee.zcl.clusters.thermostat.GetWeeklySchedule;
 import com.zsmartsystems.zigbee.zcl.clusters.thermostat.GetWeeklyScheduleResponse;
 import com.zsmartsystems.zigbee.zcl.clusters.thermostat.SetWeeklySchedule;
 import com.zsmartsystems.zigbee.zcl.clusters.thermostat.SetpointRaiseLowerCommand;
+import com.zsmartsystems.zigbee.zcl.clusters.thermostat.ZclThermostatCommand;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
 /**
@@ -34,7 +35,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-10-04T18:21:10Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:04:47Z")
 public class ZclThermostatCluster extends ZclCluster {
     /**
      * The ZigBee Cluster Library Cluster ID
@@ -180,6 +181,28 @@ public class ZclThermostatCluster extends ZclCluster {
      */
     public ZclThermostatCluster(final ZigBeeEndpoint zigbeeEndpoint) {
         super(zigbeeEndpoint, CLUSTER_ID, CLUSTER_NAME);
+    }
+
+    /**
+     * Sends a {@link ZclThermostatCommand} and returns the {@link Future} to the result which will complete when the remote
+     * device response is received, or the request times out.
+     *
+     * @param command the {@link ZclThermostatCommand} to send
+     * @return the command result future
+     */
+    public Future<CommandResult> sendCommand(ZclThermostatCommand command) {
+        return super.sendCommand(command);
+    }
+
+    /**
+     * Sends a response to the command. This method sets all the common elements of the response based on the command -
+     * eg transactionId, direction, address...
+     *
+     * @param command the {@link ZclThermostatCommand} to which the response is being sent
+     * @param response the {@link ZclThermostatCommand} to send
+     */
+    public void sendResponse(ZclThermostatCommand command, ZclThermostatCommand response) {
+        super.sendResponse(command, response);
     }
 
     /**
@@ -1393,7 +1416,7 @@ public class ZclThermostatCluster extends ZclCluster {
         command.setMode(mode);
         command.setAmount(amount);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -1428,7 +1451,7 @@ public class ZclThermostatCluster extends ZclCluster {
         command.setHeatSet(heatSet);
         command.setCoolSet(coolSet);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -1445,7 +1468,7 @@ public class ZclThermostatCluster extends ZclCluster {
         command.setDaysToReturn(daysToReturn);
         command.setModeToReturn(modeToReturn);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -1454,7 +1477,7 @@ public class ZclThermostatCluster extends ZclCluster {
      * @return the {@link Future<CommandResult>} command result future
      */
     public Future<CommandResult> clearWeeklySchedule() {
-        return send(new ClearWeeklySchedule());
+        return sendCommand(new ClearWeeklySchedule());
     }
 
     /**
@@ -1477,7 +1500,7 @@ public class ZclThermostatCluster extends ZclCluster {
      * @return the {@link Future<CommandResult>} command result future
      */
     public Future<CommandResult> getRelayStatusLog() {
-        return send(new GetRelayStatusLog());
+        return sendCommand(new GetRelayStatusLog());
     }
 
     /**
@@ -1502,7 +1525,7 @@ public class ZclThermostatCluster extends ZclCluster {
         command.setHeatSet(heatSet);
         command.setCoolSet(coolSet);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -1527,6 +1550,6 @@ public class ZclThermostatCluster extends ZclCluster {
         command.setSetpoint(setpoint);
         command.setUnreadEntries(unreadEntries);
 
-        return send(command);
+        return sendCommand(command);
     }
 }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclThermostatUserInterfaceConfigurationCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclThermostatUserInterfaceConfigurationCluster.java
@@ -27,7 +27,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-10-04T18:21:10Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T11:55:03Z")
 public class ZclThermostatUserInterfaceConfigurationCluster extends ZclCluster {
     /**
      * The ZigBee Cluster Library Cluster ID
@@ -80,6 +80,7 @@ public class ZclThermostatUserInterfaceConfigurationCluster extends ZclCluster {
 
         return attributeMap;
     }
+
 
     /**
      * Default constructor to create a Thermostat User Interface Configuration cluster.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclTimeCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclTimeCluster.java
@@ -30,7 +30,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-10-04T18:21:10Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T11:55:03Z")
 public class ZclTimeCluster extends ZclCluster {
     /**
      * The ZigBee Cluster Library Cluster ID
@@ -146,6 +146,7 @@ public class ZclTimeCluster extends ZclCluster {
 
         return attributeMap;
     }
+
 
     /**
      * Default constructor to create a Time cluster.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclWindowCoveringCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclWindowCoveringCluster.java
@@ -25,6 +25,7 @@ import com.zsmartsystems.zigbee.zcl.clusters.windowcovering.WindowCoveringGoToTi
 import com.zsmartsystems.zigbee.zcl.clusters.windowcovering.WindowCoveringGoToTiltValue;
 import com.zsmartsystems.zigbee.zcl.clusters.windowcovering.WindowCoveringStop;
 import com.zsmartsystems.zigbee.zcl.clusters.windowcovering.WindowCoveringUpOpen;
+import com.zsmartsystems.zigbee.zcl.clusters.windowcovering.ZclWindowCoveringCommand;
 import com.zsmartsystems.zigbee.zcl.field.ByteArray;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
@@ -35,7 +36,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-10-04T18:21:10Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:04:47Z")
 public class ZclWindowCoveringCluster extends ZclCluster {
     /**
      * The ZigBee Cluster Library Cluster ID
@@ -231,6 +232,28 @@ public class ZclWindowCoveringCluster extends ZclCluster {
      */
     public ZclWindowCoveringCluster(final ZigBeeEndpoint zigbeeEndpoint) {
         super(zigbeeEndpoint, CLUSTER_ID, CLUSTER_NAME);
+    }
+
+    /**
+     * Sends a {@link ZclWindowCoveringCommand} and returns the {@link Future} to the result which will complete when the remote
+     * device response is received, or the request times out.
+     *
+     * @param command the {@link ZclWindowCoveringCommand} to send
+     * @return the command result future
+     */
+    public Future<CommandResult> sendCommand(ZclWindowCoveringCommand command) {
+        return super.sendCommand(command);
+    }
+
+    /**
+     * Sends a response to the command. This method sets all the common elements of the response based on the command -
+     * eg transactionId, direction, address...
+     *
+     * @param command the {@link ZclWindowCoveringCommand} to which the response is being sent
+     * @param response the {@link ZclWindowCoveringCommand} to send
+     */
+    public void sendResponse(ZclWindowCoveringCommand command, ZclWindowCoveringCommand response) {
+        super.sendResponse(command, response);
     }
 
     /**
@@ -1682,7 +1705,7 @@ public class ZclWindowCoveringCluster extends ZclCluster {
      * @return the {@link Future<CommandResult>} command result future
      */
     public Future<CommandResult> windowCoveringUpOpen() {
-        return send(new WindowCoveringUpOpen());
+        return sendCommand(new WindowCoveringUpOpen());
     }
 
     /**
@@ -1693,7 +1716,7 @@ public class ZclWindowCoveringCluster extends ZclCluster {
      * @return the {@link Future<CommandResult>} command result future
      */
     public Future<CommandResult> windowCoveringDownClose() {
-        return send(new WindowCoveringDownClose());
+        return sendCommand(new WindowCoveringDownClose());
     }
 
     /**
@@ -1704,7 +1727,7 @@ public class ZclWindowCoveringCluster extends ZclCluster {
      * @return the {@link Future<CommandResult>} command result future
      */
     public Future<CommandResult> windowCoveringStop() {
-        return send(new WindowCoveringStop());
+        return sendCommand(new WindowCoveringStop());
     }
 
     /**
@@ -1721,7 +1744,7 @@ public class ZclWindowCoveringCluster extends ZclCluster {
         // Set the fields
         command.setLiftValue(liftValue);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -1738,7 +1761,7 @@ public class ZclWindowCoveringCluster extends ZclCluster {
         // Set the fields
         command.setPercentageLiftValue(percentageLiftValue);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -1755,7 +1778,7 @@ public class ZclWindowCoveringCluster extends ZclCluster {
         // Set the fields
         command.setTiltValue(tiltValue);
 
-        return send(command);
+        return sendCommand(command);
     }
 
     /**
@@ -1772,6 +1795,6 @@ public class ZclWindowCoveringCluster extends ZclCluster {
         // Set the fields
         command.setPercentageTiltValue(percentageTiltValue);
 
-        return send(command);
+        return sendCommand(command);
     }
 }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/alarms/AlarmCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/alarms/AlarmCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.alarms;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -28,8 +27,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class AlarmCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class AlarmCommand extends ZclAlarmsCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/alarms/GetAlarmCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/alarms/GetAlarmCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.alarms;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 
 /**
@@ -25,8 +24,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class GetAlarmCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class GetAlarmCommand extends ZclAlarmsCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/alarms/GetAlarmResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/alarms/GetAlarmResponse.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.alarms;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -29,8 +28,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class GetAlarmResponse extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class GetAlarmResponse extends ZclAlarmsCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/alarms/ResetAlarmCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/alarms/ResetAlarmCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.alarms;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -27,8 +26,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class ResetAlarmCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class ResetAlarmCommand extends ZclAlarmsCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/alarms/ResetAlarmLogCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/alarms/ResetAlarmLogCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.alarms;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 
 /**
@@ -22,8 +21,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class ResetAlarmLogCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class ResetAlarmLogCommand extends ZclAlarmsCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/alarms/ResetAllAlarmsCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/alarms/ResetAllAlarmsCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.alarms;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 
 /**
@@ -24,8 +23,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class ResetAllAlarmsCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class ResetAllAlarmsCommand extends ZclAlarmsCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/alarms/ZclAlarmsCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/alarms/ZclAlarmsCommand.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2016-2020 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.zcl.clusters.alarms;
+
+import javax.annotation.Generated;
+
+import com.zsmartsystems.zigbee.zcl.ZclCommand;
+/**
+ * Abstract base command class for all commands in the <b>Alarms</b> cluster (<i>Cluster ID 0x0009</i>).
+ * All commands sent through the {@link ZclAlarmsCluster} must extend this class.
+ * <p>
+ * Code is auto-generated. Modifications may be overwritten!
+ */
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T10:29:23Z")
+public abstract class ZclAlarmsCommand extends ZclCommand {
+}

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/basic/ResetToFactoryDefaultsCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/basic/ResetToFactoryDefaultsCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.basic;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 
 /**
@@ -24,8 +23,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class ResetToFactoryDefaultsCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class ResetToFactoryDefaultsCommand extends ZclBasicCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/basic/ZclBasicCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/basic/ZclBasicCommand.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2016-2020 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.zcl.clusters.basic;
+
+import javax.annotation.Generated;
+
+import com.zsmartsystems.zigbee.zcl.ZclCommand;
+/**
+ * Abstract base command class for all commands in the <b>Basic</b> cluster (<i>Cluster ID 0x0000</i>).
+ * All commands sent through the {@link ZclBasicCluster} must extend this class.
+ * <p>
+ * Code is auto-generated. Modifications may be overwritten!
+ */
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T10:29:23Z")
+public abstract class ZclBasicCommand extends ZclCommand {
+}

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/ColorLoopSetCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/ColorLoopSetCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.colorcontrol;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -26,8 +25,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class ColorLoopSetCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class ColorLoopSetCommand extends ZclColorControlCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/EnhancedMoveHueCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/EnhancedMoveHueCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.colorcontrol;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -30,8 +29,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class EnhancedMoveHueCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class EnhancedMoveHueCommand extends ZclColorControlCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/EnhancedMoveToHueAndSaturationCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/EnhancedMoveToHueAndSaturationCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.colorcontrol;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -27,8 +26,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class EnhancedMoveToHueAndSaturationCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class EnhancedMoveToHueAndSaturationCommand extends ZclColorControlCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/EnhancedMoveToHueCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/EnhancedMoveToHueCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.colorcontrol;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -33,8 +32,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class EnhancedMoveToHueCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class EnhancedMoveToHueCommand extends ZclColorControlCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/EnhancedStepHueCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/EnhancedStepHueCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.colorcontrol;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -26,8 +25,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class EnhancedStepHueCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class EnhancedStepHueCommand extends ZclColorControlCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/MoveColorCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/MoveColorCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.colorcontrol;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -23,8 +22,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class MoveColorCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class MoveColorCommand extends ZclColorControlCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/MoveColorTemperatureCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/MoveColorTemperatureCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.colorcontrol;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -26,8 +25,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class MoveColorTemperatureCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class MoveColorTemperatureCommand extends ZclColorControlCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/MoveHueCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/MoveHueCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.colorcontrol;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -23,8 +22,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class MoveHueCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class MoveHueCommand extends ZclColorControlCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/MoveSaturationCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/MoveSaturationCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.colorcontrol;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -23,8 +22,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class MoveSaturationCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class MoveSaturationCommand extends ZclColorControlCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/MoveToColorCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/MoveToColorCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.colorcontrol;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -23,8 +22,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class MoveToColorCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class MoveToColorCommand extends ZclColorControlCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/MoveToColorTemperatureCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/MoveToColorTemperatureCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.colorcontrol;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -30,8 +29,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class MoveToColorTemperatureCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class MoveToColorTemperatureCommand extends ZclColorControlCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/MoveToHueAndSaturationCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/MoveToHueAndSaturationCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.colorcontrol;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -23,8 +22,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class MoveToHueAndSaturationCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class MoveToHueAndSaturationCommand extends ZclColorControlCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/MoveToHueCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/MoveToHueCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.colorcontrol;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -23,8 +22,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class MoveToHueCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class MoveToHueCommand extends ZclColorControlCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/MoveToSaturationCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/MoveToSaturationCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.colorcontrol;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -23,8 +22,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class MoveToSaturationCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class MoveToSaturationCommand extends ZclColorControlCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/StepColorCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/StepColorCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.colorcontrol;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -23,8 +22,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class StepColorCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class StepColorCommand extends ZclColorControlCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/StepColorTemperatureCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/StepColorTemperatureCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.colorcontrol;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -26,8 +25,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class StepColorTemperatureCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class StepColorTemperatureCommand extends ZclColorControlCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/StepHueCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/StepHueCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.colorcontrol;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -23,8 +22,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class StepHueCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class StepHueCommand extends ZclColorControlCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/StepSaturationCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/StepSaturationCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.colorcontrol;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -23,8 +22,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class StepSaturationCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class StepSaturationCommand extends ZclColorControlCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/StopMoveStepCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/StopMoveStepCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.colorcontrol;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 
 /**
@@ -28,8 +27,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class StopMoveStepCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class StopMoveStepCommand extends ZclColorControlCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/ZclColorControlCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/ZclColorControlCommand.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2016-2020 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.zcl.clusters.colorcontrol;
+
+import javax.annotation.Generated;
+
+import com.zsmartsystems.zigbee.zcl.ZclCommand;
+/**
+ * Abstract base command class for all commands in the <b>Color Control</b> cluster (<i>Cluster ID 0x0300</i>).
+ * All commands sent through the {@link ZclColorControlCluster} must extend this class.
+ * <p>
+ * Code is auto-generated. Modifications may be overwritten!
+ */
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T10:29:23Z")
+public abstract class ZclColorControlCommand extends ZclCommand {
+}

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/commissioning/ResetStartupParametersCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/commissioning/ResetStartupParametersCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.commissioning;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -23,8 +22,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-06-15T20:20:47Z")
-public class ResetStartupParametersCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class ResetStartupParametersCommand extends ZclCommissioningCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/commissioning/ResetStartupParametersResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/commissioning/ResetStartupParametersResponse.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.commissioning;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -23,8 +22,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-06-15T20:20:47Z")
-public class ResetStartupParametersResponse extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class ResetStartupParametersResponse extends ZclCommissioningCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/commissioning/RestartDeviceCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/commissioning/RestartDeviceCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.commissioning;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -23,8 +22,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-06-15T20:20:47Z")
-public class RestartDeviceCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class RestartDeviceCommand extends ZclCommissioningCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/commissioning/RestartDeviceResponseResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/commissioning/RestartDeviceResponseResponse.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.commissioning;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -23,8 +22,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-06-15T20:20:47Z")
-public class RestartDeviceResponseResponse extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class RestartDeviceResponseResponse extends ZclCommissioningCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/commissioning/RestoreStartupParametersCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/commissioning/RestoreStartupParametersCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.commissioning;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -23,8 +22,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-06-15T20:20:47Z")
-public class RestoreStartupParametersCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class RestoreStartupParametersCommand extends ZclCommissioningCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/commissioning/RestoreStartupParametersResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/commissioning/RestoreStartupParametersResponse.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.commissioning;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -23,8 +22,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-06-15T20:20:47Z")
-public class RestoreStartupParametersResponse extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class RestoreStartupParametersResponse extends ZclCommissioningCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/commissioning/SaveStartupParametersCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/commissioning/SaveStartupParametersCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.commissioning;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -23,8 +22,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-06-15T20:20:47Z")
-public class SaveStartupParametersCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class SaveStartupParametersCommand extends ZclCommissioningCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/commissioning/SaveStartupParametersResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/commissioning/SaveStartupParametersResponse.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.commissioning;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -23,8 +22,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-06-15T20:20:47Z")
-public class SaveStartupParametersResponse extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class SaveStartupParametersResponse extends ZclCommissioningCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/commissioning/ZclCommissioningCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/commissioning/ZclCommissioningCommand.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2016-2020 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.zcl.clusters.commissioning;
+
+import javax.annotation.Generated;
+
+import com.zsmartsystems.zigbee.zcl.ZclCommand;
+/**
+ * Abstract base command class for all commands in the <b>Commissioning</b> cluster (<i>Cluster ID 0x0015</i>).
+ * All commands sent through the {@link ZclCommissioningCluster} must extend this class.
+ * <p>
+ * Code is auto-generated. Modifications may be overwritten!
+ */
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T10:29:23Z")
+public abstract class ZclCommissioningCommand extends ZclCommand {
+}

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/demandresponseandloadcontrol/CancelAllLoadControlEvents.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/demandresponseandloadcontrol/CancelAllLoadControlEvents.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.demandresponseandloadcontrol;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -23,8 +22,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class CancelAllLoadControlEvents extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class CancelAllLoadControlEvents extends ZclDemandResponseAndLoadControlCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/demandresponseandloadcontrol/CancelLoadControlEvent.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/demandresponseandloadcontrol/CancelLoadControlEvent.java
@@ -11,7 +11,6 @@ import java.util.Calendar;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -25,8 +24,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class CancelLoadControlEvent extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class CancelLoadControlEvent extends ZclDemandResponseAndLoadControlCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/demandresponseandloadcontrol/GetScheduledEvents.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/demandresponseandloadcontrol/GetScheduledEvents.java
@@ -11,7 +11,6 @@ import java.util.Calendar;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -30,8 +29,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class GetScheduledEvents extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class GetScheduledEvents extends ZclDemandResponseAndLoadControlCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/demandresponseandloadcontrol/LoadControlEventCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/demandresponseandloadcontrol/LoadControlEventCommand.java
@@ -11,7 +11,6 @@ import java.util.Calendar;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -25,8 +24,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class LoadControlEventCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class LoadControlEventCommand extends ZclDemandResponseAndLoadControlCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/demandresponseandloadcontrol/ReportEventStatus.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/demandresponseandloadcontrol/ReportEventStatus.java
@@ -11,7 +11,6 @@ import java.util.Calendar;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.field.ByteArray;
@@ -26,8 +25,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class ReportEventStatus extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class ReportEventStatus extends ZclDemandResponseAndLoadControlCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/demandresponseandloadcontrol/ZclDemandResponseAndLoadControlCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/demandresponseandloadcontrol/ZclDemandResponseAndLoadControlCommand.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2016-2020 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.zcl.clusters.demandresponseandloadcontrol;
+
+import javax.annotation.Generated;
+
+import com.zsmartsystems.zigbee.zcl.ZclCommand;
+/**
+ * Abstract base command class for all commands in the <b>Demand Response And Load Control</b> cluster (<i>Cluster ID 0x0701</i>).
+ * All commands sent through the {@link ZclDemandResponseAndLoadControlCluster} must extend this class.
+ * <p>
+ * Code is auto-generated. Modifications may be overwritten!
+ */
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T10:29:23Z")
+public abstract class ZclDemandResponseAndLoadControlCommand extends ZclCommand {
+}

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/doorlock/LockDoorCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/doorlock/LockDoorCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.doorlock;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.field.ByteArray;
@@ -28,8 +27,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class LockDoorCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class LockDoorCommand extends ZclDoorLockCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/doorlock/LockDoorResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/doorlock/LockDoorResponse.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.doorlock;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -30,8 +29,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class LockDoorResponse extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class LockDoorResponse extends ZclDoorLockCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/doorlock/Toggle.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/doorlock/Toggle.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.doorlock;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -27,8 +26,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class Toggle extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class Toggle extends ZclDoorLockCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/doorlock/ToggleResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/doorlock/ToggleResponse.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.doorlock;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -30,8 +29,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class ToggleResponse extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class ToggleResponse extends ZclDoorLockCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/doorlock/UnlockDoorCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/doorlock/UnlockDoorCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.doorlock;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.field.ByteArray;
@@ -32,8 +31,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class UnlockDoorCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class UnlockDoorCommand extends ZclDoorLockCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/doorlock/UnlockDoorResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/doorlock/UnlockDoorResponse.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.doorlock;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -30,8 +29,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class UnlockDoorResponse extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class UnlockDoorResponse extends ZclDoorLockCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/doorlock/UnlockWithTimeout.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/doorlock/UnlockWithTimeout.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.doorlock;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -30,8 +29,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class UnlockWithTimeout extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class UnlockWithTimeout extends ZclDoorLockCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/doorlock/UnlockWithTimeoutResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/doorlock/UnlockWithTimeoutResponse.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.doorlock;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -29,8 +28,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class UnlockWithTimeoutResponse extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class UnlockWithTimeoutResponse extends ZclDoorLockCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/doorlock/ZclDoorLockCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/doorlock/ZclDoorLockCommand.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2016-2020 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.zcl.clusters.doorlock;
+
+import javax.annotation.Generated;
+
+import com.zsmartsystems.zigbee.zcl.ZclCommand;
+/**
+ * Abstract base command class for all commands in the <b>Door Lock</b> cluster (<i>Cluster ID 0x0101</i>).
+ * All commands sent through the {@link ZclDoorLockCluster} must extend this class.
+ * <p>
+ * Code is auto-generated. Modifications may be overwritten!
+ */
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T10:29:23Z")
+public abstract class ZclDoorLockCommand extends ZclCommand {
+}

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/electricalmeasurement/GetMeasurementProfileCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/electricalmeasurement/GetMeasurementProfileCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.electricalmeasurement;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -26,8 +25,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class GetMeasurementProfileCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class GetMeasurementProfileCommand extends ZclElectricalMeasurementCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/electricalmeasurement/GetMeasurementProfileResponseCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/electricalmeasurement/GetMeasurementProfileResponseCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.electricalmeasurement;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -27,8 +26,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class GetMeasurementProfileResponseCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class GetMeasurementProfileResponseCommand extends ZclElectricalMeasurementCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/electricalmeasurement/GetProfileInfoCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/electricalmeasurement/GetProfileInfoCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.electricalmeasurement;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 
 /**
@@ -22,8 +21,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class GetProfileInfoCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class GetProfileInfoCommand extends ZclElectricalMeasurementCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/electricalmeasurement/GetProfileInfoResponseCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/electricalmeasurement/GetProfileInfoResponseCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.electricalmeasurement;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -27,8 +26,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class GetProfileInfoResponseCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class GetProfileInfoResponseCommand extends ZclElectricalMeasurementCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/electricalmeasurement/ZclElectricalMeasurementCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/electricalmeasurement/ZclElectricalMeasurementCommand.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2016-2020 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.zcl.clusters.electricalmeasurement;
+
+import javax.annotation.Generated;
+
+import com.zsmartsystems.zigbee.zcl.ZclCommand;
+/**
+ * Abstract base command class for all commands in the <b>Electrical Measurement</b> cluster (<i>Cluster ID 0x0B04</i>).
+ * All commands sent through the {@link ZclElectricalMeasurementCluster} must extend this class.
+ * <p>
+ * Code is auto-generated. Modifications may be overwritten!
+ */
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T10:29:23Z")
+public abstract class ZclElectricalMeasurementCommand extends ZclCommand {
+}

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/ConfigureReportingCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/ConfigureReportingCommand.java
@@ -11,7 +11,6 @@ import java.util.List;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.field.AttributeReportingConfigurationRecord;
@@ -31,8 +30,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class ConfigureReportingCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class ConfigureReportingCommand extends ZclGeneralCommand {
     /**
      * The command ID.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/ConfigureReportingResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/ConfigureReportingResponse.java
@@ -11,7 +11,6 @@ import java.util.List;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.ZclStatus;
@@ -30,8 +29,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class ConfigureReportingResponse extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class ConfigureReportingResponse extends ZclGeneralCommand {
     /**
      * The command ID.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/DefaultResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/DefaultResponse.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.general;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.ZclStatus;
@@ -28,8 +27,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class DefaultResponse extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class DefaultResponse extends ZclGeneralCommand {
     /**
      * The command ID.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/DiscoverAttributesCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/DiscoverAttributesCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.general;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -27,8 +26,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class DiscoverAttributesCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class DiscoverAttributesCommand extends ZclGeneralCommand {
     /**
      * The command ID.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/DiscoverAttributesExtended.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/DiscoverAttributesExtended.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.general;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -28,8 +27,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class DiscoverAttributesExtended extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class DiscoverAttributesExtended extends ZclGeneralCommand {
     /**
      * The command ID.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/DiscoverAttributesExtendedResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/DiscoverAttributesExtendedResponse.java
@@ -11,7 +11,6 @@ import java.util.List;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.field.ExtendedAttributeInformation;
@@ -29,8 +28,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class DiscoverAttributesExtendedResponse extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class DiscoverAttributesExtendedResponse extends ZclGeneralCommand {
     /**
      * The command ID.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/DiscoverAttributesResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/DiscoverAttributesResponse.java
@@ -11,7 +11,6 @@ import java.util.List;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.field.AttributeInformation;
@@ -29,8 +28,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class DiscoverAttributesResponse extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class DiscoverAttributesResponse extends ZclGeneralCommand {
     /**
      * The command ID.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/DiscoverCommandsGenerated.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/DiscoverCommandsGenerated.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.general;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -27,8 +26,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class DiscoverCommandsGenerated extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class DiscoverCommandsGenerated extends ZclGeneralCommand {
     /**
      * The command ID.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/DiscoverCommandsGeneratedResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/DiscoverCommandsGeneratedResponse.java
@@ -11,7 +11,6 @@ import java.util.List;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -28,8 +27,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class DiscoverCommandsGeneratedResponse extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class DiscoverCommandsGeneratedResponse extends ZclGeneralCommand {
     /**
      * The command ID.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/DiscoverCommandsReceived.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/DiscoverCommandsReceived.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.general;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -26,8 +25,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class DiscoverCommandsReceived extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class DiscoverCommandsReceived extends ZclGeneralCommand {
     /**
      * The command ID.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/DiscoverCommandsReceivedResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/DiscoverCommandsReceivedResponse.java
@@ -11,7 +11,6 @@ import java.util.List;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -28,8 +27,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class DiscoverCommandsReceivedResponse extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class DiscoverCommandsReceivedResponse extends ZclGeneralCommand {
     /**
      * The command ID.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/ReadAttributesCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/ReadAttributesCommand.java
@@ -11,7 +11,6 @@ import java.util.List;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -29,8 +28,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class ReadAttributesCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class ReadAttributesCommand extends ZclGeneralCommand {
     /**
      * The command ID.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/ReadAttributesResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/ReadAttributesResponse.java
@@ -11,7 +11,6 @@ import java.util.List;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.field.ReadAttributeStatusRecord;
@@ -33,8 +32,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class ReadAttributesResponse extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class ReadAttributesResponse extends ZclGeneralCommand {
     /**
      * The command ID.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/ReadAttributesStructuredCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/ReadAttributesStructuredCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.general;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -27,8 +26,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class ReadAttributesStructuredCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class ReadAttributesStructuredCommand extends ZclGeneralCommand {
     /**
      * The command ID.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/ReadReportingConfigurationCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/ReadReportingConfigurationCommand.java
@@ -11,7 +11,6 @@ import java.util.List;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.field.AttributeRecord;
@@ -29,8 +28,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class ReadReportingConfigurationCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class ReadReportingConfigurationCommand extends ZclGeneralCommand {
     /**
      * The command ID.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/ReadReportingConfigurationResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/ReadReportingConfigurationResponse.java
@@ -11,7 +11,6 @@ import java.util.List;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.field.AttributeReportingStatusRecord;
@@ -29,8 +28,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-08-15T18:28:04Z")
-public class ReadReportingConfigurationResponse extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class ReadReportingConfigurationResponse extends ZclGeneralCommand {
     /**
      * The command ID.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/ReportAttributesCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/ReportAttributesCommand.java
@@ -11,7 +11,6 @@ import java.util.List;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.field.AttributeReport;
@@ -30,8 +29,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class ReportAttributesCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class ReportAttributesCommand extends ZclGeneralCommand {
     /**
      * The command ID.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/WriteAttributesCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/WriteAttributesCommand.java
@@ -11,7 +11,6 @@ import java.util.List;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.field.WriteAttributeRecord;
@@ -30,8 +29,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class WriteAttributesCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class WriteAttributesCommand extends ZclGeneralCommand {
     /**
      * The command ID.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/WriteAttributesNoResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/WriteAttributesNoResponse.java
@@ -11,7 +11,6 @@ import java.util.List;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.field.WriteAttributeRecord;
@@ -31,8 +30,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class WriteAttributesNoResponse extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class WriteAttributesNoResponse extends ZclGeneralCommand {
     /**
      * The command ID.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/WriteAttributesResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/WriteAttributesResponse.java
@@ -11,7 +11,6 @@ import java.util.List;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.field.WriteAttributeStatusRecord;
@@ -29,8 +28,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class WriteAttributesResponse extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class WriteAttributesResponse extends ZclGeneralCommand {
     /**
      * The command ID.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/WriteAttributesStructuredCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/WriteAttributesStructuredCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.general;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.ZclStatus;
@@ -29,8 +28,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class WriteAttributesStructuredCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class WriteAttributesStructuredCommand extends ZclGeneralCommand {
     /**
      * The command ID.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/WriteAttributesStructuredResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/WriteAttributesStructuredResponse.java
@@ -11,7 +11,6 @@ import java.util.List;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.ZclStatus;
@@ -30,8 +29,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class WriteAttributesStructuredResponse extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class WriteAttributesStructuredResponse extends ZclGeneralCommand {
     /**
      * The command ID.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/WriteAttributesUndividedCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/WriteAttributesUndividedCommand.java
@@ -11,7 +11,6 @@ import java.util.List;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.field.WriteAttributeRecord;
@@ -34,8 +33,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class WriteAttributesUndividedCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class WriteAttributesUndividedCommand extends ZclGeneralCommand {
     /**
      * The command ID.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/ZclGeneralCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/ZclGeneralCommand.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2016-2020 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.zcl.clusters.general;
+
+import javax.annotation.Generated;
+
+import com.zsmartsystems.zigbee.zcl.ZclCommand;
+/**
+ * Abstract base command class for all commands in the <b>General</b> cluster (<i>Cluster ID 0xFFFF</i>).
+ * All commands sent through the {@link ZclGeneralCluster} must extend this class.
+ * <p>
+ * Code is auto-generated. Modifications may be overwritten!
+ */
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T10:29:23Z")
+public abstract class ZclGeneralCommand extends ZclCommand {
+}

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpCommissioningNotification.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpCommissioningNotification.java
@@ -10,7 +10,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.greenpower;
 import javax.annotation.Generated;
 
 import com.zsmartsystems.zigbee.IeeeAddress;
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.field.ByteArray;
@@ -32,8 +31,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-11-03T12:48:45Z")
-public class GpCommissioningNotification extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class GpCommissioningNotification extends ZclGreenPowerCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpNotification.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpNotification.java
@@ -10,7 +10,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.greenpower;
 import javax.annotation.Generated;
 
 import com.zsmartsystems.zigbee.IeeeAddress;
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.field.ByteArray;
@@ -32,8 +31,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-11-03T12:48:45Z")
-public class GpNotification extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class GpNotification extends ZclGreenPowerCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpNotificationResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpNotificationResponse.java
@@ -10,7 +10,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.greenpower;
 import javax.annotation.Generated;
 
 import com.zsmartsystems.zigbee.IeeeAddress;
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -28,8 +27,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-11-03T12:48:45Z")
-public class GpNotificationResponse extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class GpNotificationResponse extends ZclGreenPowerCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpPairing.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpPairing.java
@@ -11,7 +11,6 @@ import javax.annotation.Generated;
 
 import com.zsmartsystems.zigbee.IeeeAddress;
 import com.zsmartsystems.zigbee.security.ZigBeeKey;
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -29,8 +28,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-11-03T12:48:45Z")
-public class GpPairing extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class GpPairing extends ZclGreenPowerCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpPairingConfiguration.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpPairingConfiguration.java
@@ -11,7 +11,6 @@ import javax.annotation.Generated;
 
 import com.zsmartsystems.zigbee.IeeeAddress;
 import com.zsmartsystems.zigbee.security.ZigBeeKey;
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.clusters.greenpower.GpPairingConfigurationGroupList;
@@ -34,8 +33,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-11-03T12:48:45Z")
-public class GpPairingConfiguration extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class GpPairingConfiguration extends ZclGreenPowerCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpPairingSearch.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpPairingSearch.java
@@ -10,7 +10,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.greenpower;
 import javax.annotation.Generated;
 
 import com.zsmartsystems.zigbee.IeeeAddress;
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -30,8 +29,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-11-03T12:48:45Z")
-public class GpPairingSearch extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class GpPairingSearch extends ZclGreenPowerCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpProxyCommissioningMode.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpProxyCommissioningMode.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.greenpower;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -27,8 +26,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-11-03T12:48:45Z")
-public class GpProxyCommissioningMode extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class GpProxyCommissioningMode extends ZclGreenPowerCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpProxyTableRequest.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpProxyTableRequest.java
@@ -10,7 +10,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.greenpower;
 import javax.annotation.Generated;
 
 import com.zsmartsystems.zigbee.IeeeAddress;
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -26,8 +25,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-07-04T22:00:57Z")
-public class GpProxyTableRequest extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class GpProxyTableRequest extends ZclGreenPowerCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpProxyTableResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpProxyTableResponse.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.greenpower;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -30,8 +29,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-11-03T12:48:45Z")
-public class GpProxyTableResponse extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class GpProxyTableResponse extends ZclGreenPowerCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpResponse.java
@@ -10,7 +10,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.greenpower;
 import javax.annotation.Generated;
 
 import com.zsmartsystems.zigbee.IeeeAddress;
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.field.ByteArray;
@@ -28,8 +27,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-11-03T12:48:45Z")
-public class GpResponse extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class GpResponse extends ZclGreenPowerCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpSinkCommissioningMode.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpSinkCommissioningMode.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.greenpower;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -26,8 +25,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-11-03T12:48:45Z")
-public class GpSinkCommissioningMode extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class GpSinkCommissioningMode extends ZclGreenPowerCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpSinkTableRequest.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpSinkTableRequest.java
@@ -10,7 +10,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.greenpower;
 import javax.annotation.Generated;
 
 import com.zsmartsystems.zigbee.IeeeAddress;
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -27,8 +26,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-11-03T12:48:45Z")
-public class GpSinkTableRequest extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class GpSinkTableRequest extends ZclGreenPowerCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpSinkTableResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpSinkTableResponse.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.greenpower;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -25,8 +24,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-07-04T21:54:11Z")
-public class GpSinkTableResponse extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class GpSinkTableResponse extends ZclGreenPowerCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpTranslationTableRequest.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpTranslationTableRequest.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.greenpower;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -26,8 +25,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-11-03T12:48:45Z")
-public class GpTranslationTableRequest extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class GpTranslationTableRequest extends ZclGreenPowerCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpTranslationTableUpdate.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpTranslationTableUpdate.java
@@ -10,7 +10,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.greenpower;
 import javax.annotation.Generated;
 
 import com.zsmartsystems.zigbee.IeeeAddress;
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.clusters.greenpower.GpTranslationTableUpdateTranslation;
@@ -27,8 +26,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-11-03T12:48:45Z")
-public class GpTranslationTableUpdate extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class GpTranslationTableUpdate extends ZclGreenPowerCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpTunnelingStop.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpTunnelingStop.java
@@ -10,7 +10,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.greenpower;
 import javax.annotation.Generated;
 
 import com.zsmartsystems.zigbee.IeeeAddress;
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -27,8 +26,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-11-03T12:48:45Z")
-public class GpTunnelingStop extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class GpTunnelingStop extends ZclGreenPowerCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/ZclGreenPowerCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/ZclGreenPowerCommand.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2016-2020 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.zcl.clusters.greenpower;
+
+import javax.annotation.Generated;
+
+import com.zsmartsystems.zigbee.zcl.ZclCommand;
+/**
+ * Abstract base command class for all commands in the <b>Green Power</b> cluster (<i>Cluster ID 0x0021</i>).
+ * All commands sent through the {@link ZclGreenPowerCluster} must extend this class.
+ * <p>
+ * Code is auto-generated. Modifications may be overwritten!
+ */
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T10:29:23Z")
+public abstract class ZclGreenPowerCommand extends ZclCommand {
+}

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/groups/AddGroupCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/groups/AddGroupCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.groups;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -26,8 +25,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class AddGroupCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class AddGroupCommand extends ZclGroupsCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/groups/AddGroupIfIdentifyingCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/groups/AddGroupIfIdentifyingCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.groups;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -27,8 +26,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class AddGroupIfIdentifyingCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class AddGroupIfIdentifyingCommand extends ZclGroupsCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/groups/AddGroupResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/groups/AddGroupResponse.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.groups;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -26,8 +25,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class AddGroupResponse extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class AddGroupResponse extends ZclGroupsCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/groups/GetGroupMembershipCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/groups/GetGroupMembershipCommand.java
@@ -11,7 +11,6 @@ import java.util.List;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -28,8 +27,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class GetGroupMembershipCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class GetGroupMembershipCommand extends ZclGroupsCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/groups/GetGroupMembershipResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/groups/GetGroupMembershipResponse.java
@@ -11,7 +11,6 @@ import java.util.List;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -28,8 +27,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class GetGroupMembershipResponse extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class GetGroupMembershipResponse extends ZclGroupsCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/groups/RemoveAllGroupsCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/groups/RemoveAllGroupsCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.groups;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 
 /**
@@ -23,8 +22,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class RemoveAllGroupsCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class RemoveAllGroupsCommand extends ZclGroupsCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/groups/RemoveGroupCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/groups/RemoveGroupCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.groups;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -26,8 +25,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class RemoveGroupCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class RemoveGroupCommand extends ZclGroupsCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/groups/RemoveGroupResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/groups/RemoveGroupResponse.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.groups;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -26,8 +25,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class RemoveGroupResponse extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class RemoveGroupResponse extends ZclGroupsCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/groups/ViewGroupCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/groups/ViewGroupCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.groups;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -27,8 +26,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class ViewGroupCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class ViewGroupCommand extends ZclGroupsCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/groups/ViewGroupResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/groups/ViewGroupResponse.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.groups;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -26,8 +25,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class ViewGroupResponse extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class ViewGroupResponse extends ZclGroupsCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/groups/ZclGroupsCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/groups/ZclGroupsCommand.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2016-2020 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.zcl.clusters.groups;
+
+import javax.annotation.Generated;
+
+import com.zsmartsystems.zigbee.zcl.ZclCommand;
+/**
+ * Abstract base command class for all commands in the <b>Groups</b> cluster (<i>Cluster ID 0x0004</i>).
+ * All commands sent through the {@link ZclGroupsCluster} must extend this class.
+ * <p>
+ * Code is auto-generated. Modifications may be overwritten!
+ */
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T10:29:23Z")
+public abstract class ZclGroupsCommand extends ZclCommand {
+}

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/ArmCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/ArmCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.iasace;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -28,8 +27,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class ArmCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class ArmCommand extends ZclIasAceCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/ArmResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/ArmResponse.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.iasace;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -23,8 +22,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class ArmResponse extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class ArmResponse extends ZclIasAceCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/BypassCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/BypassCommand.java
@@ -11,7 +11,6 @@ import java.util.List;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -33,8 +32,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class BypassCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class BypassCommand extends ZclIasAceCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/BypassResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/BypassResponse.java
@@ -11,7 +11,6 @@ import java.util.List;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -28,8 +27,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class BypassResponse extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class BypassResponse extends ZclIasAceCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/EmergencyCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/EmergencyCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.iasace;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 
 /**
@@ -20,8 +19,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class EmergencyCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class EmergencyCommand extends ZclIasAceCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/FireCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/FireCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.iasace;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 
 /**
@@ -20,8 +19,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class FireCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class FireCommand extends ZclIasAceCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/GetBypassedZoneListCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/GetBypassedZoneListCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.iasace;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 
 /**
@@ -25,8 +24,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class GetBypassedZoneListCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class GetBypassedZoneListCommand extends ZclIasAceCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/GetPanelStatusCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/GetPanelStatusCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.iasace;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 
 /**
@@ -26,8 +25,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class GetPanelStatusCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class GetPanelStatusCommand extends ZclIasAceCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/GetPanelStatusResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/GetPanelStatusResponse.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.iasace;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -26,8 +25,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class GetPanelStatusResponse extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class GetPanelStatusResponse extends ZclIasAceCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/GetZoneIdMapCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/GetZoneIdMapCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.iasace;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 
 /**
@@ -20,8 +19,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class GetZoneIdMapCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class GetZoneIdMapCommand extends ZclIasAceCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/GetZoneIdMapResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/GetZoneIdMapResponse.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.iasace;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -27,8 +26,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class GetZoneIdMapResponse extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class GetZoneIdMapResponse extends ZclIasAceCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/GetZoneInformationCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/GetZoneInformationCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.iasace;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -23,8 +22,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class GetZoneInformationCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class GetZoneInformationCommand extends ZclIasAceCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/GetZoneInformationResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/GetZoneInformationResponse.java
@@ -10,7 +10,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.iasace;
 import javax.annotation.Generated;
 
 import com.zsmartsystems.zigbee.IeeeAddress;
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -24,8 +23,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class GetZoneInformationResponse extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class GetZoneInformationResponse extends ZclIasAceCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/GetZoneStatusCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/GetZoneStatusCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.iasace;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -32,8 +31,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class GetZoneStatusCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class GetZoneStatusCommand extends ZclIasAceCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/GetZoneStatusResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/GetZoneStatusResponse.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.iasace;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -26,8 +25,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class GetZoneStatusResponse extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class GetZoneStatusResponse extends ZclIasAceCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/PanelStatusChangedCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/PanelStatusChangedCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.iasace;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -35,8 +34,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class PanelStatusChangedCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class PanelStatusChangedCommand extends ZclIasAceCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/PanicCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/PanicCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.iasace;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 
 /**
@@ -20,8 +19,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class PanicCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class PanicCommand extends ZclIasAceCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/SetBypassedZoneListCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/SetBypassedZoneListCommand.java
@@ -11,7 +11,6 @@ import java.util.List;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -29,8 +28,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class SetBypassedZoneListCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class SetBypassedZoneListCommand extends ZclIasAceCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/ZclIasAceCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/ZclIasAceCommand.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2016-2020 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.zcl.clusters.iasace;
+
+import javax.annotation.Generated;
+
+import com.zsmartsystems.zigbee.zcl.ZclCommand;
+/**
+ * Abstract base command class for all commands in the <b>IAS ACE</b> cluster (<i>Cluster ID 0x0501</i>).
+ * All commands sent through the {@link ZclIasAceCluster} must extend this class.
+ * <p>
+ * Code is auto-generated. Modifications may be overwritten!
+ */
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T10:29:23Z")
+public abstract class ZclIasAceCommand extends ZclCommand {
+}

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/ZoneStatusChangedCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/ZoneStatusChangedCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.iasace;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -29,8 +28,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class ZoneStatusChangedCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class ZoneStatusChangedCommand extends ZclIasAceCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iaswd/Squawk.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iaswd/Squawk.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.iaswd;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -27,8 +26,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class Squawk extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class Squawk extends ZclIasWdCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iaswd/StartWarningCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iaswd/StartWarningCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.iaswd;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -27,8 +26,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class StartWarningCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class StartWarningCommand extends ZclIasWdCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iaswd/ZclIasWdCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iaswd/ZclIasWdCommand.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2016-2020 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.zcl.clusters.iaswd;
+
+import javax.annotation.Generated;
+
+import com.zsmartsystems.zigbee.zcl.ZclCommand;
+/**
+ * Abstract base command class for all commands in the <b>IAS WD</b> cluster (<i>Cluster ID 0x0502</i>).
+ * All commands sent through the {@link ZclIasWdCluster} must extend this class.
+ * <p>
+ * Code is auto-generated. Modifications may be overwritten!
+ */
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T10:29:23Z")
+public abstract class ZclIasWdCommand extends ZclCommand {
+}

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iaszone/InitiateNormalOperationModeCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iaszone/InitiateNormalOperationModeCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.iaszone;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 
 /**
@@ -27,8 +26,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class InitiateNormalOperationModeCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class InitiateNormalOperationModeCommand extends ZclIasZoneCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iaszone/InitiateTestModeCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iaszone/InitiateTestModeCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.iaszone;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -41,8 +40,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class InitiateTestModeCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class InitiateTestModeCommand extends ZclIasZoneCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iaszone/ZclIasZoneCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iaszone/ZclIasZoneCommand.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2016-2020 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.zcl.clusters.iaszone;
+
+import javax.annotation.Generated;
+
+import com.zsmartsystems.zigbee.zcl.ZclCommand;
+/**
+ * Abstract base command class for all commands in the <b>IAS Zone</b> cluster (<i>Cluster ID 0x0500</i>).
+ * All commands sent through the {@link ZclIasZoneCluster} must extend this class.
+ * <p>
+ * Code is auto-generated. Modifications may be overwritten!
+ */
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T10:29:23Z")
+public abstract class ZclIasZoneCommand extends ZclCommand {
+}

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iaszone/ZoneEnrollRequestCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iaszone/ZoneEnrollRequestCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.iaszone;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -27,8 +26,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class ZoneEnrollRequestCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class ZoneEnrollRequestCommand extends ZclIasZoneCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iaszone/ZoneEnrollResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iaszone/ZoneEnrollResponse.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.iaszone;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -23,8 +22,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class ZoneEnrollResponse extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class ZoneEnrollResponse extends ZclIasZoneCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iaszone/ZoneStatusChangeNotificationCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iaszone/ZoneStatusChangeNotificationCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.iaszone;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -26,8 +25,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class ZoneStatusChangeNotificationCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class ZoneStatusChangeNotificationCommand extends ZclIasZoneCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/identify/IdentifyCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/identify/IdentifyCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.identify;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -25,8 +24,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class IdentifyCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class IdentifyCommand extends ZclIdentifyCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/identify/IdentifyQueryCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/identify/IdentifyQueryCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.identify;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 
 /**
@@ -20,8 +19,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class IdentifyQueryCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class IdentifyQueryCommand extends ZclIdentifyCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/identify/IdentifyQueryResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/identify/IdentifyQueryResponse.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.identify;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -26,8 +25,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class IdentifyQueryResponse extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class IdentifyQueryResponse extends ZclIdentifyCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/identify/ZclIdentifyCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/identify/ZclIdentifyCommand.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2016-2020 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.zcl.clusters.identify;
+
+import javax.annotation.Generated;
+
+import com.zsmartsystems.zigbee.zcl.ZclCommand;
+/**
+ * Abstract base command class for all commands in the <b>Identify</b> cluster (<i>Cluster ID 0x0003</i>).
+ * All commands sent through the {@link ZclIdentifyCluster} must extend this class.
+ * <p>
+ * Code is auto-generated. Modifications may be overwritten!
+ */
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T10:29:23Z")
+public abstract class ZclIdentifyCommand extends ZclCommand {
+}

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/keyestablishment/ConfirmKeyDataRequestCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/keyestablishment/ConfirmKeyDataRequestCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.keyestablishment;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.field.ByteArray;
@@ -29,8 +28,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class ConfirmKeyDataRequestCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class ConfirmKeyDataRequestCommand extends ZclKeyEstablishmentCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/keyestablishment/ConfirmKeyResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/keyestablishment/ConfirmKeyResponse.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.keyestablishment;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.field.ByteArray;
@@ -28,8 +27,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class ConfirmKeyResponse extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class ConfirmKeyResponse extends ZclKeyEstablishmentCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/keyestablishment/EphemeralDataRequestCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/keyestablishment/EphemeralDataRequestCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.keyestablishment;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.field.ByteArray;
@@ -27,8 +26,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class EphemeralDataRequestCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class EphemeralDataRequestCommand extends ZclKeyEstablishmentCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/keyestablishment/EphemeralDataResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/keyestablishment/EphemeralDataResponse.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.keyestablishment;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.field.ByteArray;
@@ -27,8 +26,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class EphemeralDataResponse extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class EphemeralDataResponse extends ZclKeyEstablishmentCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/keyestablishment/InitiateKeyEstablishmentRequestCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/keyestablishment/InitiateKeyEstablishmentRequestCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.keyestablishment;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.field.ByteArray;
@@ -44,8 +43,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class InitiateKeyEstablishmentRequestCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class InitiateKeyEstablishmentRequestCommand extends ZclKeyEstablishmentCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/keyestablishment/InitiateKeyEstablishmentResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/keyestablishment/InitiateKeyEstablishmentResponse.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.keyestablishment;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.field.ByteArray;
@@ -28,8 +27,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class InitiateKeyEstablishmentResponse extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class InitiateKeyEstablishmentResponse extends ZclKeyEstablishmentCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/keyestablishment/TerminateKeyEstablishment.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/keyestablishment/TerminateKeyEstablishment.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.keyestablishment;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -26,8 +25,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class TerminateKeyEstablishment extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class TerminateKeyEstablishment extends ZclKeyEstablishmentCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/keyestablishment/ZclKeyEstablishmentCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/keyestablishment/ZclKeyEstablishmentCommand.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2016-2020 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.zcl.clusters.keyestablishment;
+
+import javax.annotation.Generated;
+
+import com.zsmartsystems.zigbee.zcl.ZclCommand;
+/**
+ * Abstract base command class for all commands in the <b>Key Establishment</b> cluster (<i>Cluster ID 0x0800</i>).
+ * All commands sent through the {@link ZclKeyEstablishmentCluster} must extend this class.
+ * <p>
+ * Code is auto-generated. Modifications may be overwritten!
+ */
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T10:29:23Z")
+public abstract class ZclKeyEstablishmentCommand extends ZclCommand {
+}

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/levelcontrol/MoveCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/levelcontrol/MoveCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.levelcontrol;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -23,8 +22,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class MoveCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class MoveCommand extends ZclLevelControlCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/levelcontrol/MoveToLevelCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/levelcontrol/MoveToLevelCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.levelcontrol;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -33,8 +32,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class MoveToLevelCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class MoveToLevelCommand extends ZclLevelControlCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/levelcontrol/MoveToLevelWithOnOffCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/levelcontrol/MoveToLevelWithOnOffCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.levelcontrol;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -33,8 +32,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class MoveToLevelWithOnOffCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class MoveToLevelWithOnOffCommand extends ZclLevelControlCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/levelcontrol/MoveWithOnOffCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/levelcontrol/MoveWithOnOffCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.levelcontrol;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -23,8 +22,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class MoveWithOnOffCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class MoveWithOnOffCommand extends ZclLevelControlCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/levelcontrol/StepCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/levelcontrol/StepCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.levelcontrol;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -23,8 +22,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class StepCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class StepCommand extends ZclLevelControlCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/levelcontrol/StepWithOnOffCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/levelcontrol/StepWithOnOffCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.levelcontrol;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -23,8 +22,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class StepWithOnOffCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class StepWithOnOffCommand extends ZclLevelControlCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/levelcontrol/StopCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/levelcontrol/StopCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.levelcontrol;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 
 /**
@@ -24,8 +23,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class StopCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class StopCommand extends ZclLevelControlCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/levelcontrol/StopWithOnOffCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/levelcontrol/StopWithOnOffCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.levelcontrol;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 
 /**
@@ -20,8 +19,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-09-24T18:34:07Z")
-public class StopWithOnOffCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T17:52:58Z")
+public class StopWithOnOffCommand extends ZclLevelControlCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/levelcontrol/ZclLevelControlCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/levelcontrol/ZclLevelControlCommand.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2016-2020 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.zcl.clusters.levelcontrol;
+
+import javax.annotation.Generated;
+
+import com.zsmartsystems.zigbee.zcl.ZclCommand;
+/**
+ * Abstract base command class for all commands in the <b>Level Control</b> cluster (<i>Cluster ID 0x0008</i>).
+ * All commands sent through the {@link ZclLevelControlCluster} must extend this class.
+ * <p>
+ * Code is auto-generated. Modifications may be overwritten!
+ */
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T10:29:23Z")
+public abstract class ZclLevelControlCommand extends ZclCommand {
+}

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/messaging/CancelAllMessages.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/messaging/CancelAllMessages.java
@@ -11,7 +11,6 @@ import java.util.Calendar;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -28,8 +27,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class CancelAllMessages extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class CancelAllMessages extends ZclMessagingCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/messaging/CancelAllMessagesCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/messaging/CancelAllMessagesCommand.java
@@ -11,7 +11,6 @@ import java.util.Calendar;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -28,8 +27,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class CancelAllMessagesCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class CancelAllMessagesCommand extends ZclMessagingCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/messaging/CancelMessageCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/messaging/CancelMessageCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.messaging;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -28,8 +27,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class CancelMessageCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class CancelMessageCommand extends ZclMessagingCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/messaging/DisplayMessageCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/messaging/DisplayMessageCommand.java
@@ -11,7 +11,6 @@ import java.util.Calendar;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -25,8 +24,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class DisplayMessageCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class DisplayMessageCommand extends ZclMessagingCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/messaging/DisplayProtectedMessageCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/messaging/DisplayProtectedMessageCommand.java
@@ -11,7 +11,6 @@ import java.util.Calendar;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -28,8 +27,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class DisplayProtectedMessageCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class DisplayProtectedMessageCommand extends ZclMessagingCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/messaging/GetLastMessage.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/messaging/GetLastMessage.java
@@ -11,7 +11,6 @@ import java.util.Calendar;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -29,8 +28,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class GetLastMessage extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class GetLastMessage extends ZclMessagingCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/messaging/GetMessageCancellation.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/messaging/GetMessageCancellation.java
@@ -11,7 +11,6 @@ import java.util.Calendar;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -29,8 +28,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class GetMessageCancellation extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class GetMessageCancellation extends ZclMessagingCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/messaging/MessageConfirmation.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/messaging/MessageConfirmation.java
@@ -11,7 +11,6 @@ import java.util.Calendar;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.field.ByteArray;
@@ -31,8 +30,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class MessageConfirmation extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class MessageConfirmation extends ZclMessagingCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/messaging/ZclMessagingCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/messaging/ZclMessagingCommand.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2016-2020 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.zcl.clusters.messaging;
+
+import javax.annotation.Generated;
+
+import com.zsmartsystems.zigbee.zcl.ZclCommand;
+/**
+ * Abstract base command class for all commands in the <b>Messaging</b> cluster (<i>Cluster ID 0x0703</i>).
+ * All commands sent through the {@link ZclMessagingCluster} must extend this class.
+ * <p>
+ * Code is auto-generated. Modifications may be overwritten!
+ */
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T10:29:23Z")
+public abstract class ZclMessagingCommand extends ZclCommand {
+}

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/ChangeSupply.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/ChangeSupply.java
@@ -11,7 +11,6 @@ import java.util.Calendar;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -28,8 +27,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class ChangeSupply extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class ChangeSupply extends ZclMeteringCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/ConfigureMirror.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/ConfigureMirror.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.metering;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -26,8 +25,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class ConfigureMirror extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class ConfigureMirror extends ZclMeteringCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/ConfigureNotificationFlags.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/ConfigureNotificationFlags.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.metering;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.clusters.metering.NotificationCommandSubPayload;
@@ -27,8 +26,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class ConfigureNotificationFlags extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class ConfigureNotificationFlags extends ZclMeteringCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/ConfigureNotificationScheme.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/ConfigureNotificationScheme.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.metering;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -27,8 +26,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class ConfigureNotificationScheme extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class ConfigureNotificationScheme extends ZclMeteringCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/GetNotifiedMessage.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/GetNotifiedMessage.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.metering;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -28,8 +27,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class GetNotifiedMessage extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class GetNotifiedMessage extends ZclMeteringCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/GetProfile.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/GetProfile.java
@@ -11,7 +11,6 @@ import java.util.Calendar;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -28,8 +27,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class GetProfile extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class GetProfile extends ZclMeteringCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/GetProfileResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/GetProfileResponse.java
@@ -11,7 +11,6 @@ import java.util.Calendar;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -27,8 +26,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class GetProfileResponse extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class GetProfileResponse extends ZclMeteringCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/GetSampledData.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/GetSampledData.java
@@ -11,7 +11,6 @@ import java.util.Calendar;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -29,8 +28,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class GetSampledData extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class GetSampledData extends ZclMeteringCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/GetSampledDataResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/GetSampledDataResponse.java
@@ -11,7 +11,6 @@ import java.util.Calendar;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -28,8 +27,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class GetSampledDataResponse extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class GetSampledDataResponse extends ZclMeteringCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/GetSnapshot.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/GetSnapshot.java
@@ -11,7 +11,6 @@ import java.util.Calendar;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -27,8 +26,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class GetSnapshot extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class GetSnapshot extends ZclMeteringCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/LocalChangeSupply.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/LocalChangeSupply.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.metering;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -27,8 +26,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class LocalChangeSupply extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class LocalChangeSupply extends ZclMeteringCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/MirrorRemoved.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/MirrorRemoved.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.metering;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -26,8 +25,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class MirrorRemoved extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class MirrorRemoved extends ZclMeteringCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/MirrorReportAttributeResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/MirrorReportAttributeResponse.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.metering;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -26,8 +25,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class MirrorReportAttributeResponse extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class MirrorReportAttributeResponse extends ZclMeteringCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/PublishSnapshot.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/PublishSnapshot.java
@@ -11,7 +11,6 @@ import java.util.Calendar;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -28,8 +27,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class PublishSnapshot extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class PublishSnapshot extends ZclMeteringCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/RemoveMirror.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/RemoveMirror.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.metering;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 
 /**
@@ -22,8 +21,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class RemoveMirror extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class RemoveMirror extends ZclMeteringCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/RequestFastPollMode.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/RequestFastPollMode.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.metering;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -26,8 +25,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class RequestFastPollMode extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class RequestFastPollMode extends ZclMeteringCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/RequestFastPollModeResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/RequestFastPollModeResponse.java
@@ -11,7 +11,6 @@ import java.util.Calendar;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -27,8 +26,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class RequestFastPollModeResponse extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class RequestFastPollModeResponse extends ZclMeteringCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/RequestMirror.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/RequestMirror.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.metering;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 
 /**
@@ -22,8 +21,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class RequestMirror extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class RequestMirror extends ZclMeteringCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/RequestMirrorResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/RequestMirrorResponse.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.metering;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -26,8 +25,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class RequestMirrorResponse extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class RequestMirrorResponse extends ZclMeteringCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/ResetLoadLimitCounter.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/ResetLoadLimitCounter.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.metering;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -26,8 +25,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class ResetLoadLimitCounter extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class ResetLoadLimitCounter extends ZclMeteringCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/ScheduleSnapshot.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/ScheduleSnapshot.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.metering;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.clusters.metering.SnapshotSchedulePayload;
@@ -26,8 +25,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class ScheduleSnapshot extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class ScheduleSnapshot extends ZclMeteringCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/ScheduleSnapshotResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/ScheduleSnapshotResponse.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.metering;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.clusters.metering.SnapshotResponsePayload;
@@ -27,8 +26,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class ScheduleSnapshotResponse extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class ScheduleSnapshotResponse extends ZclMeteringCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/SetSupplyStatus.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/SetSupplyStatus.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.metering;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -26,8 +25,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class SetSupplyStatus extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class SetSupplyStatus extends ZclMeteringCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/SetUncontrolledFlowThreshold.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/SetUncontrolledFlowThreshold.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.metering;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -26,8 +25,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class SetUncontrolledFlowThreshold extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class SetUncontrolledFlowThreshold extends ZclMeteringCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/StartSampling.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/StartSampling.java
@@ -11,7 +11,6 @@ import java.util.Calendar;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -30,8 +29,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class StartSampling extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class StartSampling extends ZclMeteringCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/StartSamplingResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/StartSamplingResponse.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.metering;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -25,8 +24,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class StartSamplingResponse extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class StartSamplingResponse extends ZclMeteringCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/SupplyStatusResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/SupplyStatusResponse.java
@@ -11,7 +11,6 @@ import java.util.Calendar;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -27,8 +26,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class SupplyStatusResponse extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class SupplyStatusResponse extends ZclMeteringCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/TakeSnapshot.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/TakeSnapshot.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.metering;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -25,8 +24,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class TakeSnapshot extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class TakeSnapshot extends ZclMeteringCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/TakeSnapshotResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/TakeSnapshotResponse.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.metering;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -26,8 +25,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class TakeSnapshotResponse extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class TakeSnapshotResponse extends ZclMeteringCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/ZclMeteringCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/ZclMeteringCommand.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2016-2020 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.zcl.clusters.metering;
+
+import javax.annotation.Generated;
+
+import com.zsmartsystems.zigbee.zcl.ZclCommand;
+/**
+ * Abstract base command class for all commands in the <b>Metering</b> cluster (<i>Cluster ID 0x0702</i>).
+ * All commands sent through the {@link ZclMeteringCluster} must extend this class.
+ * <p>
+ * Code is auto-generated. Modifications may be overwritten!
+ */
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T10:29:23Z")
+public abstract class ZclMeteringCommand extends ZclCommand {
+}

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/onoff/OffCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/onoff/OffCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.onoff;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 
 /**
@@ -24,8 +23,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class OffCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class OffCommand extends ZclOnOffCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/onoff/OffWithEffectCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/onoff/OffWithEffectCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.onoff;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -25,8 +24,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class OffWithEffectCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class OffWithEffectCommand extends ZclOnOffCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/onoff/OnCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/onoff/OnCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.onoff;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 
 /**
@@ -25,8 +24,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class OnCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class OnCommand extends ZclOnOffCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/onoff/OnWithRecallGlobalSceneCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/onoff/OnWithRecallGlobalSceneCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.onoff;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 
 /**
@@ -23,8 +22,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class OnWithRecallGlobalSceneCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class OnWithRecallGlobalSceneCommand extends ZclOnOffCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/onoff/OnWithTimedOffCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/onoff/OnWithTimedOffCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.onoff;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -29,8 +28,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class OnWithTimedOffCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class OnWithTimedOffCommand extends ZclOnOffCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/onoff/ToggleCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/onoff/ToggleCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.onoff;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 
 /**
@@ -26,8 +25,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class ToggleCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class ToggleCommand extends ZclOnOffCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/onoff/ZclOnOffCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/onoff/ZclOnOffCommand.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2016-2020 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.zcl.clusters.onoff;
+
+import javax.annotation.Generated;
+
+import com.zsmartsystems.zigbee.zcl.ZclCommand;
+/**
+ * Abstract base command class for all commands in the <b>On/Off</b> cluster (<i>Cluster ID 0x0006</i>).
+ * All commands sent through the {@link ZclOnOffCluster} must extend this class.
+ * <p>
+ * Code is auto-generated. Modifications may be overwritten!
+ */
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T10:29:23Z")
+public abstract class ZclOnOffCommand extends ZclCommand {
+}

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/otaupgrade/ImageBlockCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/otaupgrade/ImageBlockCommand.java
@@ -10,7 +10,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.otaupgrade;
 import javax.annotation.Generated;
 
 import com.zsmartsystems.zigbee.IeeeAddress;
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -37,8 +36,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class ImageBlockCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class ImageBlockCommand extends ZclOtaUpgradeCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/otaupgrade/ImageBlockResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/otaupgrade/ImageBlockResponse.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.otaupgrade;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.ZclStatus;
@@ -44,8 +43,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class ImageBlockResponse extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class ImageBlockResponse extends ZclOtaUpgradeCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/otaupgrade/ImageNotifyCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/otaupgrade/ImageNotifyCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.otaupgrade;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -37,8 +36,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class ImageNotifyCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class ImageNotifyCommand extends ZclOtaUpgradeCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/otaupgrade/ImagePageCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/otaupgrade/ImagePageCommand.java
@@ -10,7 +10,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.otaupgrade;
 import javax.annotation.Generated;
 
 import com.zsmartsystems.zigbee.IeeeAddress;
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -39,8 +38,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class ImagePageCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class ImagePageCommand extends ZclOtaUpgradeCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/otaupgrade/QueryNextImageCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/otaupgrade/QueryNextImageCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.otaupgrade;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -37,8 +36,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class QueryNextImageCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class QueryNextImageCommand extends ZclOtaUpgradeCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/otaupgrade/QueryNextImageResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/otaupgrade/QueryNextImageResponse.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.otaupgrade;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.ZclStatus;
@@ -36,8 +35,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class QueryNextImageResponse extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class QueryNextImageResponse extends ZclOtaUpgradeCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/otaupgrade/QuerySpecificFileCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/otaupgrade/QuerySpecificFileCommand.java
@@ -10,7 +10,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.otaupgrade;
 import javax.annotation.Generated;
 
 import com.zsmartsystems.zigbee.IeeeAddress;
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -32,8 +31,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class QuerySpecificFileCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class QuerySpecificFileCommand extends ZclOtaUpgradeCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/otaupgrade/QuerySpecificFileResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/otaupgrade/QuerySpecificFileResponse.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.otaupgrade;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.ZclStatus;
@@ -34,8 +33,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class QuerySpecificFileResponse extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class QuerySpecificFileResponse extends ZclOtaUpgradeCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/otaupgrade/UpgradeEndCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/otaupgrade/UpgradeEndCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.otaupgrade;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.ZclStatus;
@@ -41,8 +40,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class UpgradeEndCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class UpgradeEndCommand extends ZclOtaUpgradeCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/otaupgrade/UpgradeEndResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/otaupgrade/UpgradeEndResponse.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.otaupgrade;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -35,8 +34,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class UpgradeEndResponse extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class UpgradeEndResponse extends ZclOtaUpgradeCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/otaupgrade/ZclOtaUpgradeCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/otaupgrade/ZclOtaUpgradeCommand.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2016-2020 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.zcl.clusters.otaupgrade;
+
+import javax.annotation.Generated;
+
+import com.zsmartsystems.zigbee.zcl.ZclCommand;
+/**
+ * Abstract base command class for all commands in the <b>Ota Upgrade</b> cluster (<i>Cluster ID 0x0019</i>).
+ * All commands sent through the {@link ZclOtaUpgradeCluster} must extend this class.
+ * <p>
+ * Code is auto-generated. Modifications may be overwritten!
+ */
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T10:19:19Z")
+public abstract class ZclOtaUpgradeCommand extends ZclCommand {
+}

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/pollcontrol/CheckInCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/pollcontrol/CheckInCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.pollcontrol;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 
 /**
@@ -30,8 +29,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class CheckInCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class CheckInCommand extends ZclPollControlCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/pollcontrol/CheckInResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/pollcontrol/CheckInResponse.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.pollcontrol;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -38,8 +37,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class CheckInResponse extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class CheckInResponse extends ZclPollControlCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/pollcontrol/FastPollStopCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/pollcontrol/FastPollStopCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.pollcontrol;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 
 /**
@@ -31,8 +30,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class FastPollStopCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class FastPollStopCommand extends ZclPollControlCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/pollcontrol/SetLongPollIntervalCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/pollcontrol/SetLongPollIntervalCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.pollcontrol;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -31,8 +30,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class SetLongPollIntervalCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class SetLongPollIntervalCommand extends ZclPollControlCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/pollcontrol/SetShortPollIntervalCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/pollcontrol/SetShortPollIntervalCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.pollcontrol;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -31,8 +30,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class SetShortPollIntervalCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class SetShortPollIntervalCommand extends ZclPollControlCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/pollcontrol/ZclPollControlCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/pollcontrol/ZclPollControlCommand.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2016-2020 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.zcl.clusters.pollcontrol;
+
+import javax.annotation.Generated;
+
+import com.zsmartsystems.zigbee.zcl.ZclCommand;
+/**
+ * Abstract base command class for all commands in the <b>Poll Control</b> cluster (<i>Cluster ID 0x0020</i>).
+ * All commands sent through the {@link ZclPollControlCluster} must extend this class.
+ * <p>
+ * Code is auto-generated. Modifications may be overwritten!
+ */
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T10:29:23Z")
+public abstract class ZclPollControlCommand extends ZclCommand {
+}

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/ChangeDebt.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/ChangeDebt.java
@@ -11,7 +11,6 @@ import java.util.Calendar;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.field.ByteArray;
@@ -29,8 +28,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class ChangeDebt extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class ChangeDebt extends ZclPrepaymentCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/ChangePaymentMode.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/ChangePaymentMode.java
@@ -11,7 +11,6 @@ import java.util.Calendar;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -28,8 +27,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class ChangePaymentMode extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class ChangePaymentMode extends ZclPrepaymentCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/ChangePaymentModeResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/ChangePaymentModeResponse.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.prepayment;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -25,8 +24,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class ChangePaymentModeResponse extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class ChangePaymentModeResponse extends ZclPrepaymentCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/ConsumerTopUp.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/ConsumerTopUp.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.prepayment;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.field.ByteArray;
@@ -27,8 +26,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class ConsumerTopUp extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class ConsumerTopUp extends ZclPrepaymentCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/ConsumerTopUpResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/ConsumerTopUpResponse.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.prepayment;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -25,8 +24,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class ConsumerTopUpResponse extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class ConsumerTopUpResponse extends ZclPrepaymentCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/CreditAdjustment.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/CreditAdjustment.java
@@ -11,7 +11,6 @@ import java.util.Calendar;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -28,8 +27,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class CreditAdjustment extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class CreditAdjustment extends ZclPrepaymentCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/EmergencyCreditSetup.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/EmergencyCreditSetup.java
@@ -11,7 +11,6 @@ import java.util.Calendar;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -27,8 +26,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class EmergencyCreditSetup extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class EmergencyCreditSetup extends ZclPrepaymentCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/GetDebtRepaymentLog.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/GetDebtRepaymentLog.java
@@ -11,7 +11,6 @@ import java.util.Calendar;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -27,8 +26,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class GetDebtRepaymentLog extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class GetDebtRepaymentLog extends ZclPrepaymentCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/GetPrepaySnapshot.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/GetPrepaySnapshot.java
@@ -11,7 +11,6 @@ import java.util.Calendar;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -27,8 +26,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class GetPrepaySnapshot extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class GetPrepaySnapshot extends ZclPrepaymentCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/GetTopUpLog.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/GetTopUpLog.java
@@ -11,7 +11,6 @@ import java.util.Calendar;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -28,8 +27,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class GetTopUpLog extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class GetTopUpLog extends ZclPrepaymentCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/PublishDebtLog.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/PublishDebtLog.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.prepayment;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.clusters.prepayment.DebtPayload;
@@ -26,8 +25,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class PublishDebtLog extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class PublishDebtLog extends ZclPrepaymentCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/PublishPrepaySnapshot.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/PublishPrepaySnapshot.java
@@ -11,7 +11,6 @@ import java.util.Calendar;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -28,8 +27,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class PublishPrepaySnapshot extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class PublishPrepaySnapshot extends ZclPrepaymentCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/PublishTopUpLog.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/PublishTopUpLog.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.prepayment;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.clusters.prepayment.TopUpPayload;
@@ -26,8 +25,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class PublishTopUpLog extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class PublishTopUpLog extends ZclPrepaymentCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/SelectAvailableEmergencyCredit.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/SelectAvailableEmergencyCredit.java
@@ -11,7 +11,6 @@ import java.util.Calendar;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.field.ByteArray;
@@ -29,8 +28,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class SelectAvailableEmergencyCredit extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class SelectAvailableEmergencyCredit extends ZclPrepaymentCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/SetLowCreditWarningLevel.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/SetLowCreditWarningLevel.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.prepayment;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -26,8 +25,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class SetLowCreditWarningLevel extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class SetLowCreditWarningLevel extends ZclPrepaymentCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/SetMaximumCreditLimit.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/SetMaximumCreditLimit.java
@@ -11,7 +11,6 @@ import java.util.Calendar;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -28,8 +27,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class SetMaximumCreditLimit extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class SetMaximumCreditLimit extends ZclPrepaymentCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/SetOverallDebtCap.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/SetOverallDebtCap.java
@@ -11,7 +11,6 @@ import java.util.Calendar;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -28,8 +27,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class SetOverallDebtCap extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class SetOverallDebtCap extends ZclPrepaymentCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/ZclPrepaymentCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/ZclPrepaymentCommand.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2016-2020 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.zcl.clusters.prepayment;
+
+import javax.annotation.Generated;
+
+import com.zsmartsystems.zigbee.zcl.ZclCommand;
+/**
+ * Abstract base command class for all commands in the <b>Prepayment</b> cluster (<i>Cluster ID 0x0705</i>).
+ * All commands sent through the {@link ZclPrepaymentCluster} must extend this class.
+ * <p>
+ * Code is auto-generated. Modifications may be overwritten!
+ */
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T10:29:23Z")
+public abstract class ZclPrepaymentCommand extends ZclCommand {
+}

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/CancelTariffCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/CancelTariffCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.price;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -29,8 +28,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class CancelTariffCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class CancelTariffCommand extends ZclPriceCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/CppEventResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/CppEventResponse.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.price;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -26,8 +25,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class CppEventResponse extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class CppEventResponse extends ZclPriceCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/GetBillingPeriodCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/GetBillingPeriodCommand.java
@@ -11,7 +11,6 @@ import java.util.Calendar;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -28,8 +27,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class GetBillingPeriodCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class GetBillingPeriodCommand extends ZclPriceCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/GetBlockPeriodCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/GetBlockPeriodCommand.java
@@ -11,7 +11,6 @@ import java.util.Calendar;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -30,8 +29,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class GetBlockPeriodCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class GetBlockPeriodCommand extends ZclPriceCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/GetBlockThresholdsCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/GetBlockThresholdsCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.price;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -28,8 +27,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class GetBlockThresholdsCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class GetBlockThresholdsCommand extends ZclPriceCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/GetCalorificValueCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/GetCalorificValueCommand.java
@@ -11,7 +11,6 @@ import java.util.Calendar;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -30,8 +29,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class GetCalorificValueCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class GetCalorificValueCommand extends ZclPriceCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/GetCo2ValueCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/GetCo2ValueCommand.java
@@ -11,7 +11,6 @@ import java.util.Calendar;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -29,8 +28,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class GetCo2ValueCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class GetCo2ValueCommand extends ZclPriceCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/GetConsolidatedBillCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/GetConsolidatedBillCommand.java
@@ -11,7 +11,6 @@ import java.util.Calendar;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -28,8 +27,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class GetConsolidatedBillCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class GetConsolidatedBillCommand extends ZclPriceCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/GetConversionFactorCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/GetConversionFactorCommand.java
@@ -11,7 +11,6 @@ import java.util.Calendar;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -31,8 +30,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class GetConversionFactorCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class GetConversionFactorCommand extends ZclPriceCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/GetCreditPaymentCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/GetCreditPaymentCommand.java
@@ -11,7 +11,6 @@ import java.util.Calendar;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -28,8 +27,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class GetCreditPaymentCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class GetCreditPaymentCommand extends ZclPriceCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/GetCurrencyConversionCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/GetCurrencyConversionCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.price;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 
 /**
@@ -25,8 +24,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class GetCurrencyConversionCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class GetCurrencyConversionCommand extends ZclPriceCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/GetCurrentPriceCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/GetCurrentPriceCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.price;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -26,8 +25,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class GetCurrentPriceCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class GetCurrentPriceCommand extends ZclPriceCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/GetPriceMatrixCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/GetPriceMatrixCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.price;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -28,8 +27,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class GetPriceMatrixCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class GetPriceMatrixCommand extends ZclPriceCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/GetScheduledPricesCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/GetScheduledPricesCommand.java
@@ -11,7 +11,6 @@ import java.util.Calendar;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -29,8 +28,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class GetScheduledPricesCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class GetScheduledPricesCommand extends ZclPriceCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/GetTariffCancellationCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/GetTariffCancellationCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.price;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 
 /**
@@ -24,8 +23,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class GetTariffCancellationCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class GetTariffCancellationCommand extends ZclPriceCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/GetTariffInformationCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/GetTariffInformationCommand.java
@@ -11,7 +11,6 @@ import java.util.Calendar;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -32,8 +31,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class GetTariffInformationCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class GetTariffInformationCommand extends ZclPriceCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/GetTierLabelsCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/GetTierLabelsCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.price;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -26,8 +25,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class GetTierLabelsCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class GetTierLabelsCommand extends ZclPriceCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PriceAcknowledgementCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PriceAcknowledgementCommand.java
@@ -11,7 +11,6 @@ import java.util.Calendar;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -29,8 +28,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class PriceAcknowledgementCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class PriceAcknowledgementCommand extends ZclPriceCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishBillingPeriodCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishBillingPeriodCommand.java
@@ -11,7 +11,6 @@ import java.util.Calendar;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -33,8 +32,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class PublishBillingPeriodCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class PublishBillingPeriodCommand extends ZclPriceCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishBlockPeriodCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishBlockPeriodCommand.java
@@ -11,7 +11,6 @@ import java.util.Calendar;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -37,8 +36,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class PublishBlockPeriodCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class PublishBlockPeriodCommand extends ZclPriceCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishBlockThresholdsCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishBlockThresholdsCommand.java
@@ -11,7 +11,6 @@ import java.util.Calendar;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.clusters.price.BlockThresholdSubPayload;
@@ -39,8 +38,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class PublishBlockThresholdsCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class PublishBlockThresholdsCommand extends ZclPriceCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishCalorificValueCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishCalorificValueCommand.java
@@ -11,7 +11,6 @@ import java.util.Calendar;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -29,8 +28,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class PublishCalorificValueCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class PublishCalorificValueCommand extends ZclPriceCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishCo2ValueCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishCo2ValueCommand.java
@@ -11,7 +11,6 @@ import java.util.Calendar;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -29,8 +28,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class PublishCo2ValueCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class PublishCo2ValueCommand extends ZclPriceCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishConsolidatedBillCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishConsolidatedBillCommand.java
@@ -11,7 +11,6 @@ import java.util.Calendar;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -34,8 +33,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class PublishConsolidatedBillCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class PublishConsolidatedBillCommand extends ZclPriceCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishConversionFactorCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishConversionFactorCommand.java
@@ -11,7 +11,6 @@ import java.util.Calendar;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -29,8 +28,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class PublishConversionFactorCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class PublishConversionFactorCommand extends ZclPriceCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishCppEventCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishCppEventCommand.java
@@ -11,7 +11,6 @@ import java.util.Calendar;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -34,8 +33,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class PublishCppEventCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class PublishCppEventCommand extends ZclPriceCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishCreditPaymentCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishCreditPaymentCommand.java
@@ -11,7 +11,6 @@ import java.util.Calendar;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.field.ByteArray;
@@ -32,8 +31,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class PublishCreditPaymentCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class PublishCreditPaymentCommand extends ZclPriceCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishCurrencyConversionCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishCurrencyConversionCommand.java
@@ -11,7 +11,6 @@ import java.util.Calendar;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -28,8 +27,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class PublishCurrencyConversionCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class PublishCurrencyConversionCommand extends ZclPriceCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishPriceCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishPriceCommand.java
@@ -11,7 +11,6 @@ import java.util.Calendar;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.field.ByteArray;
@@ -47,8 +46,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class PublishPriceCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class PublishPriceCommand extends ZclPriceCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishPriceMatrixCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishPriceMatrixCommand.java
@@ -11,7 +11,6 @@ import java.util.Calendar;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.clusters.price.PriceMatrixSubPayload;
@@ -42,8 +41,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class PublishPriceMatrixCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class PublishPriceMatrixCommand extends ZclPriceCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishTariffInformationCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishTariffInformationCommand.java
@@ -11,7 +11,6 @@ import java.util.Calendar;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.field.ByteArray;
@@ -35,8 +34,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class PublishTariffInformationCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class PublishTariffInformationCommand extends ZclPriceCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishTierLabelsCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishTierLabelsCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.price;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.field.ByteArray;
@@ -27,8 +26,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class PublishTierLabelsCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class PublishTierLabelsCommand extends ZclPriceCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/ZclPriceCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/ZclPriceCommand.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2016-2020 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.zcl.clusters.price;
+
+import javax.annotation.Generated;
+
+import com.zsmartsystems.zigbee.zcl.ZclCommand;
+/**
+ * Abstract base command class for all commands in the <b>Price</b> cluster (<i>Cluster ID 0x0700</i>).
+ * All commands sent through the {@link ZclPriceCluster} must extend this class.
+ * <p>
+ * Code is auto-generated. Modifications may be overwritten!
+ */
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T10:29:23Z")
+public abstract class ZclPriceCommand extends ZclCommand {
+}

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/rssilocation/AnchorNodeAnnounceCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/rssilocation/AnchorNodeAnnounceCommand.java
@@ -10,7 +10,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.rssilocation;
 import javax.annotation.Generated;
 
 import com.zsmartsystems.zigbee.IeeeAddress;
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -24,8 +23,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class AnchorNodeAnnounceCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class AnchorNodeAnnounceCommand extends ZclRssiLocationCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/rssilocation/CompactLocationDataNotificationCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/rssilocation/CompactLocationDataNotificationCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.rssilocation;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 
 /**
@@ -20,8 +19,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class CompactLocationDataNotificationCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class CompactLocationDataNotificationCommand extends ZclRssiLocationCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/rssilocation/DeviceConfigurationResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/rssilocation/DeviceConfigurationResponse.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.rssilocation;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -23,8 +22,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class DeviceConfigurationResponse extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class DeviceConfigurationResponse extends ZclRssiLocationCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/rssilocation/GetDeviceConfigurationCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/rssilocation/GetDeviceConfigurationCommand.java
@@ -10,7 +10,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.rssilocation;
 import javax.annotation.Generated;
 
 import com.zsmartsystems.zigbee.IeeeAddress;
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -24,8 +23,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class GetDeviceConfigurationCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class GetDeviceConfigurationCommand extends ZclRssiLocationCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/rssilocation/GetLocationDataCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/rssilocation/GetLocationDataCommand.java
@@ -10,7 +10,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.rssilocation;
 import javax.annotation.Generated;
 
 import com.zsmartsystems.zigbee.IeeeAddress;
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -24,8 +23,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class GetLocationDataCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class GetLocationDataCommand extends ZclRssiLocationCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/rssilocation/LocationDataNotificationCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/rssilocation/LocationDataNotificationCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.rssilocation;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -23,8 +22,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class LocationDataNotificationCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class LocationDataNotificationCommand extends ZclRssiLocationCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/rssilocation/LocationDataResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/rssilocation/LocationDataResponse.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.rssilocation;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -23,8 +22,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class LocationDataResponse extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class LocationDataResponse extends ZclRssiLocationCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/rssilocation/ReportRssiMeasurementsCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/rssilocation/ReportRssiMeasurementsCommand.java
@@ -12,7 +12,6 @@ import java.util.List;
 import javax.annotation.Generated;
 
 import com.zsmartsystems.zigbee.IeeeAddress;
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.field.NeighborInformation;
@@ -27,8 +26,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class ReportRssiMeasurementsCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class ReportRssiMeasurementsCommand extends ZclRssiLocationCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/rssilocation/RequestOwnLocationCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/rssilocation/RequestOwnLocationCommand.java
@@ -10,7 +10,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.rssilocation;
 import javax.annotation.Generated;
 
 import com.zsmartsystems.zigbee.IeeeAddress;
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -24,8 +23,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class RequestOwnLocationCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class RequestOwnLocationCommand extends ZclRssiLocationCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/rssilocation/RssiPingCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/rssilocation/RssiPingCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.rssilocation;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -23,8 +22,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class RssiPingCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class RssiPingCommand extends ZclRssiLocationCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/rssilocation/RssiRequestCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/rssilocation/RssiRequestCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.rssilocation;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 
 /**
@@ -20,8 +19,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class RssiRequestCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class RssiRequestCommand extends ZclRssiLocationCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/rssilocation/RssiResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/rssilocation/RssiResponse.java
@@ -10,7 +10,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.rssilocation;
 import javax.annotation.Generated;
 
 import com.zsmartsystems.zigbee.IeeeAddress;
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -24,8 +23,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class RssiResponse extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class RssiResponse extends ZclRssiLocationCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/rssilocation/SendPingsCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/rssilocation/SendPingsCommand.java
@@ -10,7 +10,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.rssilocation;
 import javax.annotation.Generated;
 
 import com.zsmartsystems.zigbee.IeeeAddress;
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -24,8 +23,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class SendPingsCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class SendPingsCommand extends ZclRssiLocationCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/rssilocation/SetAbsoluteLocationCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/rssilocation/SetAbsoluteLocationCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.rssilocation;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -23,8 +22,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class SetAbsoluteLocationCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class SetAbsoluteLocationCommand extends ZclRssiLocationCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/rssilocation/SetDeviceConfigurationCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/rssilocation/SetDeviceConfigurationCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.rssilocation;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -23,8 +22,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class SetDeviceConfigurationCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class SetDeviceConfigurationCommand extends ZclRssiLocationCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/rssilocation/ZclRssiLocationCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/rssilocation/ZclRssiLocationCommand.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2016-2020 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.zcl.clusters.rssilocation;
+
+import javax.annotation.Generated;
+
+import com.zsmartsystems.zigbee.zcl.ZclCommand;
+/**
+ * Abstract base command class for all commands in the <b>RSSI Location</b> cluster (<i>Cluster ID 0x000B</i>).
+ * All commands sent through the {@link ZclRssiLocationCluster} must extend this class.
+ * <p>
+ * Code is auto-generated. Modifications may be overwritten!
+ */
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T10:29:23Z")
+public abstract class ZclRssiLocationCommand extends ZclCommand {
+}

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/AddSceneCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/AddSceneCommand.java
@@ -11,7 +11,6 @@ import java.util.List;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.field.ExtensionFieldSet;
@@ -28,8 +27,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class AddSceneCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class AddSceneCommand extends ZclScenesCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/AddSceneResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/AddSceneResponse.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.scenes;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -23,8 +22,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class AddSceneResponse extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class AddSceneResponse extends ZclScenesCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/CopySceneCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/CopySceneCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.scenes;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -26,8 +25,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-11-16T08:52:33Z")
-public class CopySceneCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class CopySceneCommand extends ZclScenesCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/CopySceneResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/CopySceneResponse.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.scenes;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -23,8 +22,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-11-15T22:10:14Z")
-public class CopySceneResponse extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class CopySceneResponse extends ZclScenesCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/EnhancedAddSceneCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/EnhancedAddSceneCommand.java
@@ -11,7 +11,6 @@ import java.util.List;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.field.ExtensionFieldSet;
@@ -29,8 +28,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-09-20T08:23:22Z")
-public class EnhancedAddSceneCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class EnhancedAddSceneCommand extends ZclScenesCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/EnhancedAddSceneResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/EnhancedAddSceneResponse.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.scenes;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -23,8 +22,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-11-15T22:10:14Z")
-public class EnhancedAddSceneResponse extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class EnhancedAddSceneResponse extends ZclScenesCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/EnhancedViewSceneCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/EnhancedViewSceneCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.scenes;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -26,8 +25,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-09-20T08:23:22Z")
-public class EnhancedViewSceneCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class EnhancedViewSceneCommand extends ZclScenesCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/EnhancedViewSceneResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/EnhancedViewSceneResponse.java
@@ -11,7 +11,6 @@ import java.util.List;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.field.ExtensionFieldSet;
@@ -26,8 +25,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-11-15T22:10:14Z")
-public class EnhancedViewSceneResponse extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class EnhancedViewSceneResponse extends ZclScenesCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/GetSceneMembershipCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/GetSceneMembershipCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.scenes;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -27,8 +26,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class GetSceneMembershipCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class GetSceneMembershipCommand extends ZclScenesCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/GetSceneMembershipResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/GetSceneMembershipResponse.java
@@ -11,7 +11,6 @@ import java.util.List;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -25,8 +24,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-09-20T08:23:22Z")
-public class GetSceneMembershipResponse extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class GetSceneMembershipResponse extends ZclScenesCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/RecallSceneCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/RecallSceneCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.scenes;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -25,8 +24,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class RecallSceneCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class RecallSceneCommand extends ZclScenesCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/RemoveAllScenesCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/RemoveAllScenesCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.scenes;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -25,8 +24,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class RemoveAllScenesCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class RemoveAllScenesCommand extends ZclScenesCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/RemoveAllScenesResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/RemoveAllScenesResponse.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.scenes;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -23,8 +22,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class RemoveAllScenesResponse extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class RemoveAllScenesResponse extends ZclScenesCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/RemoveSceneCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/RemoveSceneCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.scenes;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -25,8 +24,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class RemoveSceneCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class RemoveSceneCommand extends ZclScenesCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/RemoveSceneResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/RemoveSceneResponse.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.scenes;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -23,8 +22,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class RemoveSceneResponse extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class RemoveSceneResponse extends ZclScenesCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/StoreSceneCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/StoreSceneCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.scenes;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -25,8 +24,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class StoreSceneCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class StoreSceneCommand extends ZclScenesCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/StoreSceneResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/StoreSceneResponse.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.scenes;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -23,8 +22,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class StoreSceneResponse extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class StoreSceneResponse extends ZclScenesCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/ViewSceneCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/ViewSceneCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.scenes;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -25,8 +24,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class ViewSceneCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class ViewSceneCommand extends ZclScenesCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/ViewSceneResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/ViewSceneResponse.java
@@ -11,7 +11,6 @@ import java.util.List;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.field.ExtensionFieldSet;
@@ -26,8 +25,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class ViewSceneResponse extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class ViewSceneResponse extends ZclScenesCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/ZclScenesCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/ZclScenesCommand.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2016-2020 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.zcl.clusters.scenes;
+
+import javax.annotation.Generated;
+
+import com.zsmartsystems.zigbee.zcl.ZclCommand;
+/**
+ * Abstract base command class for all commands in the <b>Scenes</b> cluster (<i>Cluster ID 0x0005</i>).
+ * All commands sent through the {@link ZclScenesCluster} must extend this class.
+ * <p>
+ * Code is auto-generated. Modifications may be overwritten!
+ */
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T10:29:23Z")
+public abstract class ZclScenesCommand extends ZclCommand {
+}

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/smartenergytunneling/AckTransferDataClientToServer.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/smartenergytunneling/AckTransferDataClientToServer.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.smartenergytunneling;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -28,8 +27,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class AckTransferDataClientToServer extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class AckTransferDataClientToServer extends ZclSmartEnergyTunnelingCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/smartenergytunneling/AckTransferDataServerToClient.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/smartenergytunneling/AckTransferDataServerToClient.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.smartenergytunneling;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -28,8 +27,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class AckTransferDataServerToClient extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class AckTransferDataServerToClient extends ZclSmartEnergyTunnelingCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/smartenergytunneling/CloseTunnel.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/smartenergytunneling/CloseTunnel.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.smartenergytunneling;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -28,8 +27,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class CloseTunnel extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class CloseTunnel extends ZclSmartEnergyTunnelingCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/smartenergytunneling/GetSupportedTunnelProtocols.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/smartenergytunneling/GetSupportedTunnelProtocols.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.smartenergytunneling;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -26,8 +25,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class GetSupportedTunnelProtocols extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class GetSupportedTunnelProtocols extends ZclSmartEnergyTunnelingCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/smartenergytunneling/ReadyDataClientToServer.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/smartenergytunneling/ReadyDataClientToServer.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.smartenergytunneling;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -28,8 +27,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class ReadyDataClientToServer extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class ReadyDataClientToServer extends ZclSmartEnergyTunnelingCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/smartenergytunneling/ReadyDataServerToClient.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/smartenergytunneling/ReadyDataServerToClient.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.smartenergytunneling;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -28,8 +27,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class ReadyDataServerToClient extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class ReadyDataServerToClient extends ZclSmartEnergyTunnelingCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/smartenergytunneling/RequestTunnel.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/smartenergytunneling/RequestTunnel.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.smartenergytunneling;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -28,8 +27,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class RequestTunnel extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class RequestTunnel extends ZclSmartEnergyTunnelingCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/smartenergytunneling/RequestTunnelResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/smartenergytunneling/RequestTunnelResponse.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.smartenergytunneling;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -28,8 +27,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class RequestTunnelResponse extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class RequestTunnelResponse extends ZclSmartEnergyTunnelingCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/smartenergytunneling/SupportedTunnelProtocolsResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/smartenergytunneling/SupportedTunnelProtocolsResponse.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.smartenergytunneling;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.clusters.smartenergytunneling.Protocol;
@@ -28,8 +27,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class SupportedTunnelProtocolsResponse extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class SupportedTunnelProtocolsResponse extends ZclSmartEnergyTunnelingCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/smartenergytunneling/TransferDataClientToServer.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/smartenergytunneling/TransferDataClientToServer.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.smartenergytunneling;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -26,8 +25,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class TransferDataClientToServer extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class TransferDataClientToServer extends ZclSmartEnergyTunnelingCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/smartenergytunneling/TransferDataErrorClientToServer.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/smartenergytunneling/TransferDataErrorClientToServer.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.smartenergytunneling;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -38,8 +37,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class TransferDataErrorClientToServer extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class TransferDataErrorClientToServer extends ZclSmartEnergyTunnelingCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/smartenergytunneling/TransferDataErrorServerToClient.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/smartenergytunneling/TransferDataErrorServerToClient.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.smartenergytunneling;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -38,8 +37,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class TransferDataErrorServerToClient extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class TransferDataErrorServerToClient extends ZclSmartEnergyTunnelingCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/smartenergytunneling/TransferDataServerToClient.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/smartenergytunneling/TransferDataServerToClient.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.smartenergytunneling;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.field.ByteArray;
@@ -27,8 +26,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class TransferDataServerToClient extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class TransferDataServerToClient extends ZclSmartEnergyTunnelingCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/smartenergytunneling/TunnelClosureNotification.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/smartenergytunneling/TunnelClosureNotification.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.smartenergytunneling;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -30,8 +29,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class TunnelClosureNotification extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class TunnelClosureNotification extends ZclSmartEnergyTunnelingCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/smartenergytunneling/ZclSmartEnergyTunnelingCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/smartenergytunneling/ZclSmartEnergyTunnelingCommand.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2016-2020 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.zcl.clusters.smartenergytunneling;
+
+import javax.annotation.Generated;
+
+import com.zsmartsystems.zigbee.zcl.ZclCommand;
+/**
+ * Abstract base command class for all commands in the <b>Smart Energy Tunneling</b> cluster (<i>Cluster ID 0x0704</i>).
+ * All commands sent through the {@link ZclSmartEnergyTunnelingCluster} must extend this class.
+ * <p>
+ * Code is auto-generated. Modifications may be overwritten!
+ */
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T10:29:23Z")
+public abstract class ZclSmartEnergyTunnelingCommand extends ZclCommand {
+}

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/thermostat/ClearWeeklySchedule.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/thermostat/ClearWeeklySchedule.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.thermostat;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 
 /**
@@ -20,8 +19,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class ClearWeeklySchedule extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class ClearWeeklySchedule extends ZclThermostatCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/thermostat/GetRelayStatusLog.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/thermostat/GetRelayStatusLog.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.thermostat;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 
 /**
@@ -33,8 +32,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class GetRelayStatusLog extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class GetRelayStatusLog extends ZclThermostatCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/thermostat/GetRelayStatusLogResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/thermostat/GetRelayStatusLogResponse.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.thermostat;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -23,8 +22,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class GetRelayStatusLogResponse extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class GetRelayStatusLogResponse extends ZclThermostatCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/thermostat/GetWeeklySchedule.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/thermostat/GetWeeklySchedule.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.thermostat;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -23,8 +22,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class GetWeeklySchedule extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class GetWeeklySchedule extends ZclThermostatCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/thermostat/GetWeeklyScheduleResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/thermostat/GetWeeklyScheduleResponse.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.thermostat;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -23,8 +22,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class GetWeeklyScheduleResponse extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class GetWeeklyScheduleResponse extends ZclThermostatCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/thermostat/SetWeeklySchedule.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/thermostat/SetWeeklySchedule.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.thermostat;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -33,8 +32,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class SetWeeklySchedule extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class SetWeeklySchedule extends ZclThermostatCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/thermostat/SetpointRaiseLowerCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/thermostat/SetpointRaiseLowerCommand.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.thermostat;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -23,8 +22,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class SetpointRaiseLowerCommand extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class SetpointRaiseLowerCommand extends ZclThermostatCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/thermostat/ZclThermostatCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/thermostat/ZclThermostatCommand.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2016-2020 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.zcl.clusters.thermostat;
+
+import javax.annotation.Generated;
+
+import com.zsmartsystems.zigbee.zcl.ZclCommand;
+/**
+ * Abstract base command class for all commands in the <b>Thermostat</b> cluster (<i>Cluster ID 0x0201</i>).
+ * All commands sent through the {@link ZclThermostatCluster} must extend this class.
+ * <p>
+ * Code is auto-generated. Modifications may be overwritten!
+ */
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T10:29:23Z")
+public abstract class ZclThermostatCommand extends ZclCommand {
+}

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/windowcovering/WindowCoveringDownClose.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/windowcovering/WindowCoveringDownClose.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.windowcovering;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 
 /**
@@ -22,8 +21,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class WindowCoveringDownClose extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class WindowCoveringDownClose extends ZclWindowCoveringCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/windowcovering/WindowCoveringGoToLiftPercentage.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/windowcovering/WindowCoveringGoToLiftPercentage.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.windowcovering;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -25,8 +24,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class WindowCoveringGoToLiftPercentage extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class WindowCoveringGoToLiftPercentage extends ZclWindowCoveringCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/windowcovering/WindowCoveringGoToLiftValue.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/windowcovering/WindowCoveringGoToLiftValue.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.windowcovering;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -25,8 +24,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class WindowCoveringGoToLiftValue extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class WindowCoveringGoToLiftValue extends ZclWindowCoveringCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/windowcovering/WindowCoveringGoToTiltPercentage.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/windowcovering/WindowCoveringGoToTiltPercentage.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.windowcovering;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -25,8 +24,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class WindowCoveringGoToTiltPercentage extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class WindowCoveringGoToTiltPercentage extends ZclWindowCoveringCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/windowcovering/WindowCoveringGoToTiltValue.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/windowcovering/WindowCoveringGoToTiltValue.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.windowcovering;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
@@ -25,8 +24,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class WindowCoveringGoToTiltValue extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class WindowCoveringGoToTiltValue extends ZclWindowCoveringCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/windowcovering/WindowCoveringStop.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/windowcovering/WindowCoveringStop.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.windowcovering;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 
 /**
@@ -22,8 +21,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class WindowCoveringStop extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class WindowCoveringStop extends ZclWindowCoveringCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/windowcovering/WindowCoveringUpOpen.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/windowcovering/WindowCoveringUpOpen.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.zcl.clusters.windowcovering;
 
 import javax.annotation.Generated;
 
-import com.zsmartsystems.zigbee.zcl.ZclCommand;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 
 /**
@@ -22,8 +21,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-14T08:41:54Z")
-public class WindowCoveringUpOpen extends ZclCommand {
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T12:07:00Z")
+public class WindowCoveringUpOpen extends ZclWindowCoveringCommand {
     /**
      * The cluster ID to which this command belongs.
      */

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/windowcovering/ZclWindowCoveringCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/windowcovering/ZclWindowCoveringCommand.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2016-2020 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.zcl.clusters.windowcovering;
+
+import javax.annotation.Generated;
+
+import com.zsmartsystems.zigbee.zcl.ZclCommand;
+/**
+ * Abstract base command class for all commands in the <b>Window Covering</b> cluster (<i>Cluster ID 0x0102</i>).
+ * All commands sent through the {@link ZclWindowCoveringCluster} must extend this class.
+ * <p>
+ * Code is auto-generated. Modifications may be overwritten!
+ */
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T10:29:23Z")
+public abstract class ZclWindowCoveringCommand extends ZclCommand {
+}

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ZclZdoZigbeeDeviceObjectCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ZclZdoZigbeeDeviceObjectCommand.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2016-2020 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.zdo.command;
+
+import javax.annotation.Generated;
+
+import com.zsmartsystems.zigbee.zcl.ZclCommand;
+/**
+ * Abstract base command class for all commands in the <b>ZDO ZigBee Device Object</b> cluster (<i>Cluster ID 0x0000</i>).
+ * All commands sent through the {@link ZclZdoZigbeeDeviceObjectCluster} must extend this class.
+ * <p>
+ * Code is auto-generated. Modifications may be overwritten!
+ */
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-10T10:29:23Z")
+public abstract class ZclZdoZigbeeDeviceObjectCommand extends ZclCommand {
+}


### PR DESCRIPTION
As per the discussion in #948, this is the first part in refactoring the sending of commands through ZclCluster. This PR should not change any external interface, but will require users to recompile.

This provides a public ```sendCommand``` method alongside the existing ```sendResponse``` method. Both commands are now implemented in the cluster implementations to enforce that only commands for a specific cluster may be sent through that cluster. This changes the class hierarchy, but should remain source compatible to users.

The existing protected ```ZclCluster.send()``` method has been refactored to ```ZclCluster.sendCommand``` to be consistent with the above.

All commands now extend from an abstract base class specific to the cluster to enforce type checking of commands.

@wsowa please let me know if you have any comments - this implements what I understand from your suggestion in the previous thread. (note that deprecating the cluster commands and adding command constructors with the parameters will be a subsequent PR.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>