### PR TITLE
Update OTA Upgrade Server

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/aps/ApsDataEntity.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/aps/ApsDataEntity.java
@@ -45,7 +45,7 @@ import com.zsmartsystems.zigbee.transport.ZigBeeTransportTransmit;
 public class ApsDataEntity {
     private static final long DUPLICATE_TIME_WINDOW = 5000;
 
-    private static final int FRAGMENTATION_LENGTH = 65;
+    private static final int FRAGMENTATION_LENGTH = 78;
     private static final int FRAGMENTATION_WINDOW = 1;
 
     /**

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/app/otaupgrade/ZclOtaUpgradeServerTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/app/otaupgrade/ZclOtaUpgradeServerTest.java
@@ -42,6 +42,7 @@ import com.zsmartsystems.zigbee.app.otaserver.ZigBeeOtaStatusCallback;
 import com.zsmartsystems.zigbee.internal.NotificationService;
 import com.zsmartsystems.zigbee.zcl.ZclAttribute;
 import com.zsmartsystems.zigbee.zcl.clusters.ZclOtaUpgradeCluster;
+import com.zsmartsystems.zigbee.zcl.clusters.otaupgrade.ImageNotifyCommand;
 import com.zsmartsystems.zigbee.zcl.clusters.otaupgrade.QueryNextImageCommand;
 import com.zsmartsystems.zigbee.zdo.field.NodeDescriptor;
 
@@ -112,8 +113,7 @@ public class ZclOtaUpgradeServerTest implements ZigBeeOtaStatusCallback {
 
         // Set the firmware and send notification
         server.setFirmware(otaFile);
-        Mockito.verify(cluster, Mockito.times(1)).imageNotifyCommand(Mockito.any(), Mockito.any(), Mockito.any(),
-                Mockito.any(), Mockito.any());
+        Mockito.verify(cluster, Mockito.times(1)).sendCommand(ArgumentMatchers.any(ImageNotifyCommand.class));
 
         Awaitility.await().atMost(1000, TimeUnit.MILLISECONDS).until(() -> otaListenerUpdated());
 
@@ -165,11 +165,8 @@ public class ZclOtaUpgradeServerTest implements ZigBeeOtaStatusCallback {
         await().atMost(1, SECONDS)
                 .until(() -> assertTrue(otaStatusCapture.contains(ZigBeeOtaServerStatus.OTA_WAITING)));
 
-        QueryNextImageCommand query = new QueryNextImageCommand();
+        QueryNextImageCommand query = new QueryNextImageCommand(0, 123, 987, 0, 0);
         query.setApsSecurity(true);
-        query.setClusterId(ZclOtaUpgradeCluster.CLUSTER_ID);
-        query.setManufacturerCode(123);
-        query.setImageType(987);
 
         server.commandReceived(query);
         await().atMost(1, SECONDS)


### PR DESCRIPTION
Refactors the OTA Upgrade Server to use the new API and disables default response on image blocks where needed.

Currently this is untested but provided for visibility.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>