### PR TITLE
Catch uncaught exceptions in attribute listeners and log them

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeExecutors.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeExecutors.java
@@ -24,8 +24,8 @@ import org.slf4j.LoggerFactory;
  *
  */
 public class ZigBeeExecutors {
-	
-	private static Logger logger = LoggerFactory.getLogger(ZigBeeExecutors.class);
+
+    private static Logger logger = LoggerFactory.getLogger(ZigBeeExecutors.class);
 
     /**
      * Creates a thread pool that creates new threads as needed, but will reuse previously constructed threads when they
@@ -114,11 +114,11 @@ public class ZigBeeExecutors {
                 thread.setPriority(Thread.NORM_PRIORITY);
             }
             thread.setUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler() {
-				@Override
-				public void uncaughtException(Thread t, Throwable e) {
-					logger.warn("Uncaught exception in thread {}", t.getName(), e);
-				}
-			});
+                @Override
+                public void uncaughtException(Thread t, Throwable e) {
+                    logger.warn("Uncaught exception in thread {}", t.getName(), e);
+                }
+            });
             return thread;
         }
     }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeExecutors.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeExecutors.java
@@ -13,6 +13,9 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * Extension of the {@link Executors} class to create threads with custom names. This allows better profiling of the
  * system as the source of all threads can be determined.
@@ -21,6 +24,8 @@ import java.util.concurrent.atomic.AtomicInteger;
  *
  */
 public class ZigBeeExecutors {
+	
+	private static Logger logger = LoggerFactory.getLogger(ZigBeeExecutors.class);
 
     /**
      * Creates a thread pool that creates new threads as needed, but will reuse previously constructed threads when they
@@ -108,6 +113,12 @@ public class ZigBeeExecutors {
             if (thread.getPriority() != Thread.NORM_PRIORITY) {
                 thread.setPriority(Thread.NORM_PRIORITY);
             }
+            thread.setUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler() {
+				@Override
+				public void uncaughtException(Thread t, Throwable e) {
+					logger.warn("Uncaught exception in thread {}", t.getName(), e);
+				}
+			});
             return thread;
         }
     }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/ZclCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/ZclCluster.java
@@ -1200,7 +1200,12 @@ public abstract class ZclCluster {
                     logger.trace("{}: ZclCluster.notifyAttributeListener {} of {} with value {}",
                             zigbeeEndpoint.getEndpointAddress(), listener, attribute, value);
 
-                    listener.attributeUpdated(attribute, value);
+                    try {
+                    	listener.attributeUpdated(attribute, value);
+                    } catch (Exception e) {
+                    	logger.warn("{}: Exception when notifying attribute listener {} of {} with value {}", 
+                    			zigbeeEndpoint.getEndpointAddress(), listener, attribute, value, e);
+                    }
                 }
             });
         }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/ZclCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/ZclCluster.java
@@ -1201,10 +1201,10 @@ public abstract class ZclCluster {
                             zigbeeEndpoint.getEndpointAddress(), listener, attribute, value);
 
                     try {
-                    	listener.attributeUpdated(attribute, value);
+                        listener.attributeUpdated(attribute, value);
                     } catch (Exception e) {
-                    	logger.warn("{}: Exception when notifying attribute listener {} of {} with value {}", 
-                    			zigbeeEndpoint.getEndpointAddress(), listener, attribute, value, e);
+                        logger.warn("{}: Exception when notifying attribute listener {} of {} with value {}",
+                                zigbeeEndpoint.getEndpointAddress(), listener, attribute, value, e);
                     }
                 }
             });


### PR DESCRIPTION
Also adds an UncaughtExceptionHandler that logs exceptions to the executors
provided by the framework.

Resolves #967