### PR TITLE
OTA: Send Image Blocks without APS ACKs requests when replying to Page Request

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.cc2531/src/main/java/com/zsmartsystems/zigbee/dongle/cc2531/ZigBeeDongleTiCc2531.java
+++ b/com.zsmartsystems.zigbee.dongle.cc2531/src/main/java/com/zsmartsystems/zigbee/dongle/cc2531/ZigBeeDongleTiCc2531.java
@@ -312,7 +312,7 @@ public class ZigBeeDongleTiCc2531
                 messageIdMap.put(apsFrame.getApsCounter(), msgTag);
                 ZToolPacket response = networkManager.sendCommand(new AF_DATA_REQUEST(apsFrame.getDestinationAddress(),
                         (short) apsFrame.getDestinationEndpoint(), sender, apsFrame.getCluster(),
-                        apsFrame.getApsCounter(), (byte) 0x30, (byte) apsFrame.getRadius(), apsFrame.getPayload()));
+                        apsFrame.getApsCounter(), (byte) (0x20 | (apsFrame.getAckRequest() ? 0x10 : 0)), (byte) apsFrame.getRadius(), apsFrame.getPayload()));
                 state = (response == null || ((AF_DATA_SRSP)response).Status != 0) ? ZigBeeTransportProgressState.TX_NAK : ZigBeeTransportProgressState.TX_ACK;
             } else {
                 ZToolPacket response = networkManager.sendCommand(new AF_DATA_REQUEST_EXT(apsFrame.getDestinationAddress(), sender,

--- a/com.zsmartsystems.zigbee.dongle.conbee/src/main/java/com/zsmartsystems/zigbee/dongle/conbee/ZigBeeDongleConBee.java
+++ b/com.zsmartsystems.zigbee.dongle.conbee/src/main/java/com/zsmartsystems/zigbee/dongle/conbee/ZigBeeDongleConBee.java
@@ -300,6 +300,7 @@ public class ZigBeeDongleConBee implements ZigBeeTransportTransmit {
 
         request.setRequestId(apsFrame.getApsCounter());
         request.setClusterId(apsFrame.getCluster());
+        request.setTxOptions(apsFrame.getAckRequest() ? 0x40 : 0);
         switch (apsFrame.getAddressMode()) {
             case DEVICE:
                 request.setDestinationAddress(
@@ -320,7 +321,6 @@ public class ZigBeeDongleConBee implements ZigBeeTransportTransmit {
         request.setProfileId(apsFrame.getProfile());
         request.setRadius(apsFrame.getRadius());
         request.setSourceEndpoint(apsFrame.getSourceEndpoint());
-        // request.setTxOptions(txOptions);
 
         request.setAdsuData(apsFrame.getPayload());
 

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
@@ -687,7 +687,9 @@ public class ZigBeeDongleEzsp implements ZigBeeTransportTransmit, ZigBeeTranspor
         emberApsFrame.setSourceEndpoint(apsFrame.getSourceEndpoint());
         emberApsFrame.setDestinationEndpoint(apsFrame.getDestinationEndpoint());
         emberApsFrame.setSequence(apsFrame.getApsCounter());
-        emberApsFrame.addOptions(EmberApsOption.EMBER_APS_OPTION_RETRY);
+        if (apsFrame.getAckRequest()) {
+            emberApsFrame.addOptions(EmberApsOption.EMBER_APS_OPTION_RETRY);
+        }
         emberApsFrame.addOptions(EmberApsOption.EMBER_APS_OPTION_ENABLE_ROUTE_DISCOVERY);
         emberApsFrame.addOptions(EmberApsOption.EMBER_APS_OPTION_ENABLE_ADDRESS_DISCOVERY);
 

--- a/com.zsmartsystems.zigbee.dongle.xbee/src/main/java/com/zsmartsystems/zigbee/dongle/xbee/ZigBeeDongleXBee.java
+++ b/com.zsmartsystems.zigbee.dongle.xbee/src/main/java/com/zsmartsystems/zigbee/dongle/xbee/ZigBeeDongleXBee.java
@@ -337,6 +337,10 @@ public class ZigBeeDongleXBee implements ZigBeeTransportTransmit, XBeeEventListe
             command.addOptions(TransmitOptions.ENABLE_APS_ENCRYPTION);
         }
 
+        if (!apsFrame.getAckRequest()) {
+            command.addOptions(TransmitOptions.DISABLE_RETRIES);
+        }
+
         command.setData(apsFrame.getPayload());
 
         logger.debug("XBee send: {}", command.toString());

--- a/com.zsmartsystems.zigbee.dongle.xbee/src/test/java/com/zsmartsystems/zigbee/dongle/xbee/ZigBeeDongleXBeeTest.java
+++ b/com.zsmartsystems.zigbee.dongle.xbee/src/test/java/com/zsmartsystems/zigbee/dongle/xbee/ZigBeeDongleXBeeTest.java
@@ -77,6 +77,7 @@ public class ZigBeeDongleXBeeTest {
         apsFrame.setAddressMode(ZigBeeNwkAddressMode.DEVICE);
         apsFrame.setRadius(31);
         apsFrame.setApsCounter(42);
+        apsFrame.setAckRequest(true);
         apsFrame.setPayload(new int[] { 0x00, 0x00, 0x2E, 0x5B, 0x01, 0x01 });
 
         System.out.println(command);

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeCommand.java
@@ -45,6 +45,11 @@ public class ZigBeeCommand {
     private boolean apsSecurity = false;
 
     /**
+     * True if APS Ack is requested. Default is true.
+     */
+    private boolean ackRequest = true;
+
+    /**
      * Gets destination address.
      *
      * @return the destination address.
@@ -114,6 +119,24 @@ public class ZigBeeCommand {
      */
     public boolean getApsSecurity() {
         return apsSecurity;
+    }
+
+    /**
+     * When set to true, the recipient is requested to send APS Acknowledgement frame. Default is true.
+     *
+     * @return the ackRequest flag - when set to true, the APS Ack is requested from the recipient
+     */
+    public boolean isAckRequest() {
+        return ackRequest;
+    }
+
+    /**
+     * When set to true, the recipient is requested to send APS Acknowledgement frame. Default is true.
+     *
+     * @param ackRequest true if the APS Ack is requested
+     */
+    public void setAckRequest(boolean ackRequest) {
+        this.ackRequest = ackRequest;
     }
 
     /**

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
@@ -792,6 +792,7 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
         apsFrame.setCluster(command.getClusterId());
         apsFrame.setApsCounter(apsCounter.getAndIncrement() & 0xff);
         apsFrame.setSecurityEnabled(command.getApsSecurity());
+        apsFrame.setAckRequest(command.isAckRequest());
 
         // TODO: Set the source address correctly?
         apsFrame.setSourceAddress(localNwkAddress);

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/otaserver/ZclOtaUpgradeServer.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/otaserver/ZclOtaUpgradeServer.java
@@ -544,6 +544,7 @@ public class ZclOtaUpgradeServer implements ZigBeeApplication, ZclCommandListene
 
         if (command == null) {
             response.setDisableDefaultResponse(true);
+            response.setAckRequest(false);
             cluster.sendCommand(response);
         } else {
             cluster.sendResponse(command, response);

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/aps/ZigBeeApsFrame.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/aps/ZigBeeApsFrame.java
@@ -79,6 +79,12 @@ public class ZigBeeApsFrame {
     private boolean securityEnable;
 
     /**
+     * The AckRequest parameter specifies whether the current transmission requires an acknowledgement frame to be sent
+     * be the recipient on receipt of the frame.
+     */
+    private boolean ackRequest;
+
+    /**
      * The destination endpoint field is 8-bits in length and specifies the endpoint of the final recipient of the
      * frame. This field shall be included in the frame only if the delivery mode sub-field of the frame control field
      * is set to 0b00 (normal unicast delivery), 0b01 (indirect delivery where the indirect address mode sub-field of
@@ -309,6 +315,24 @@ public class ZigBeeApsFrame {
         this.securityEnable = securityEnable;
     }
 
+    /**
+     * Gets Ack request state
+     *
+     * @return true if Ack is requested
+     */
+    public boolean getAckRequest() {
+        return ackRequest;
+    }
+
+    /**
+     * Sets Ack request state
+     *
+     * @param ackRequest true to request ACK from the recipient
+     */
+    public void setAckRequest(boolean ackRequest) {
+        this.ackRequest = ackRequest;
+    }
+
     // public boolean isDiscoverRoute() {
     // return discoverRoute;
     // }
@@ -407,6 +431,8 @@ public class ZigBeeApsFrame {
         builder.append(radius);
         builder.append(", apsSecurity=");
         builder.append(securityEnable);
+        builder.append(", ackRequest=");
+        builder.append(ackRequest);
         builder.append(", apsCounter=");
         if (apsCounter == -1) {
             builder.append("--");

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransaction.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransaction.java
@@ -455,7 +455,7 @@ public class ZigBeeTransaction {
                     break;
                 case TX_ACK:
                     // If we aren't waiting for a response, then we're done
-                    if (responseMatcher == null) {
+                    if (responseMatcher == null || command.isAckRequest() == false) {
                         completeTransaction(null);
                         break;
                     }

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/aps/ApsDataEntityTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/aps/ApsDataEntityTest.java
@@ -38,6 +38,7 @@ public class ApsDataEntityTest {
         ZigBeeApsFrame apsFrame = new ZigBeeApsFrame();
         ZigBeeApsFrame response;
         apsFrame.setApsCounter(1);
+        apsFrame.setAckRequest(true);
         apsFrame.setSourceAddress(1);
 
         response = aps.receive(apsFrame);
@@ -71,6 +72,7 @@ public class ApsDataEntityTest {
 
         ZigBeeApsFrame apsFrame = new ZigBeeApsFrame();
         apsFrame.setApsCounter(1);
+        apsFrame.setAckRequest(true);
         apsFrame.setPayload(createData(0, 30));
 
         aps.send(0, apsFrame);
@@ -93,6 +95,7 @@ public class ApsDataEntityTest {
 
         ZigBeeApsFrame apsFrame = new ZigBeeApsFrame();
         apsFrame.setApsCounter(1);
+        apsFrame.setAckRequest(true);
         apsFrame.setPayload(createData(0, 150));
 
         aps.send(0, apsFrame);
@@ -146,6 +149,7 @@ public class ApsDataEntityTest {
 
         ZigBeeApsFrame apsFrame = new ZigBeeApsFrame();
         apsFrame.setApsCounter(1);
+        apsFrame.setAckRequest(true);
         apsFrame.setPayload(createData(0, 150));
 
         aps.send(0, apsFrame);
@@ -236,6 +240,7 @@ public class ApsDataEntityTest {
 
         ZigBeeApsFrame apsFrame = new ZigBeeApsFrame();
         apsFrame.setApsCounter(1);
+        apsFrame.setAckRequest(true);
         apsFrame.setPayload(createData(0, FRAGMENTATION_LENGTH-1));
 
         aps.send(0, apsFrame);
@@ -253,6 +258,7 @@ public class ApsDataEntityTest {
 
         ZigBeeApsFrame apsFrame = new ZigBeeApsFrame();
         apsFrame.setApsCounter(1);
+        apsFrame.setAckRequest(true);
         apsFrame.setPayload(createData(0, FRAGMENTATION_LENGTH));
 
         aps.send(0, apsFrame);
@@ -270,6 +276,7 @@ public class ApsDataEntityTest {
 
         ZigBeeApsFrame apsFrame = new ZigBeeApsFrame();
         apsFrame.setApsCounter(1);
+        apsFrame.setAckRequest(true);
         apsFrame.setPayload(createData(0, FRAGMENTATION_LENGTH+1));
 
         aps.send(0, apsFrame);
@@ -290,6 +297,7 @@ public class ApsDataEntityTest {
 
         ZigBeeApsFrame apsFrame = new ZigBeeApsFrame();
         apsFrame.setApsCounter(1);
+        apsFrame.setAckRequest(true);
         apsFrame.setPayload(createData(0, FRAGMENTATION_LENGTH*2+1));
 
         aps.send(0, apsFrame);
@@ -302,6 +310,47 @@ public class ApsDataEntityTest {
 
         assertTrue(aps.receiveCommandState(0, ZigBeeTransportProgressState.TX_ACK));
         assertTrue(aps.receiveCommandState(0, ZigBeeTransportProgressState.RX_ACK));
+    }
+
+    @Test
+    public void shouldExpectTwoFramesTransmittedForPayloadFittingInTwoFragmentsWithNoApsAcks() {
+        ZigBeeTransportTransmit transport = Mockito.mock(ZigBeeTransportTransmit.class);
+        ApsDataEntity aps = new ApsDataEntity(transport);
+
+        aps.setFragmentationLength(FRAGMENTATION_LENGTH);
+
+        ZigBeeApsFrame apsFrame = new ZigBeeApsFrame();
+        apsFrame.setApsCounter(1);
+        apsFrame.setAckRequest(false);
+        apsFrame.setPayload(createData(0, FRAGMENTATION_LENGTH+1));
+
+        aps.send(0, apsFrame);
+
+        assertFalse(aps.receiveCommandState(0, ZigBeeTransportProgressState.TX_ACK));
+
+        assertTrue(aps.receiveCommandState(0, ZigBeeTransportProgressState.TX_ACK));
+    }
+
+    @Test
+    public void shouldExpectTwoFramesTransmittedForPayloadFittingInTwoFragmentsWithNoApsAcksButAcksReceived() {
+        ZigBeeTransportTransmit transport = Mockito.mock(ZigBeeTransportTransmit.class);
+        ApsDataEntity aps = new ApsDataEntity(transport);
+
+        aps.setFragmentationLength(FRAGMENTATION_LENGTH);
+
+        ZigBeeApsFrame apsFrame = new ZigBeeApsFrame();
+        apsFrame.setApsCounter(1);
+        apsFrame.setAckRequest(false);
+        apsFrame.setPayload(createData(0, FRAGMENTATION_LENGTH+1));
+
+        aps.send(0, apsFrame);
+
+        assertFalse(aps.receiveCommandState(0, ZigBeeTransportProgressState.TX_ACK));
+
+        // A misbehaving receiver or dongle not supporting disabling APS ACK disabling cause us to receive RX ACK
+        assertFalse(aps.receiveCommandState(0, ZigBeeTransportProgressState.RX_ACK));
+
+        assertTrue(aps.receiveCommandState(0, ZigBeeTransportProgressState.TX_ACK));
     }
 
     private int[] createData(int start, int length) {

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransactionTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransactionTest.java
@@ -139,6 +139,7 @@ public class ZigBeeTransactionTest {
         ZigBeeTransactionManager transactionManager = Mockito.mock(ZigBeeTransactionManager.class);
         ZigBeeCommand command = Mockito.mock(ZigBeeCommand.class);
         Mockito.when(command.getTransactionId()).thenReturn(12);
+        Mockito.when(command.isAckRequest()).thenReturn(true);
         ZigBeeTransactionMatcher matcher = Mockito.mock(ZigBeeTransactionMatcher.class);
 
         ZigBeeTransactionFuture transactionFuture = new ZigBeeTransactionFuture();
@@ -169,6 +170,7 @@ public class ZigBeeTransactionTest {
         ZigBeeTransactionManager transactionManager = Mockito.mock(ZigBeeTransactionManager.class);
         ZigBeeCommand command = Mockito.mock(ZigBeeCommand.class);
         Mockito.when(command.getTransactionId()).thenReturn(12);
+        Mockito.when(command.isAckRequest()).thenReturn(true);
         ZigBeeTransactionMatcher matcher = Mockito.mock(ZigBeeTransactionMatcher.class);
 
         ZigBeeCommand request = Mockito.mock(ZigBeeCommand.class);
@@ -205,6 +207,7 @@ public class ZigBeeTransactionTest {
         ZigBeeTransactionManager transactionManager = Mockito.mock(ZigBeeTransactionManager.class);
         ZigBeeCommand command = Mockito.mock(ZigBeeCommand.class);
         Mockito.when(command.getTransactionId()).thenReturn(12);
+        Mockito.when(command.isAckRequest()).thenReturn(true);
         ZigBeeTransactionMatcher matcher = Mockito.mock(ZigBeeTransactionMatcher.class);
 
         ZigBeeCommand request = Mockito.mock(ZigBeeCommand.class);
@@ -241,6 +244,7 @@ public class ZigBeeTransactionTest {
         ZclCommand command = Mockito.mock(ZclCommand.class);
         Mockito.when(command.isDisableDefaultResponse()).thenReturn(true);
         Mockito.when(command.getTransactionId()).thenReturn(12);
+        Mockito.when(command.isAckRequest()).thenReturn(true);
         Mockito.when(command.getDestinationAddress()).thenReturn(new ZigBeeEndpointAddress(1234, 5));
         ZigBeeTransactionMatcher matcher = Mockito.mock(ZigBeeTransactionMatcher.class);
 
@@ -278,6 +282,7 @@ public class ZigBeeTransactionTest {
         ZigBeeTransactionManager transactionManager = Mockito.mock(ZigBeeTransactionManager.class);
         ZigBeeCommand command = Mockito.mock(ZigBeeCommand.class);
         Mockito.when(command.getTransactionId()).thenReturn(12);
+        Mockito.when(command.isAckRequest()).thenReturn(true);
         ZigBeeTransactionMatcher matcher = Mockito.mock(ZigBeeTransactionMatcher.class);
 
         ZigBeeCommand request = Mockito.mock(ZigBeeCommand.class);
@@ -347,6 +352,37 @@ public class ZigBeeTransactionTest {
     @Test
     public void testSendOnlyRxAck() {
         testSendOnly(ZigBeeTransportProgressState.RX_ACK);
+    }
+
+    @Test
+    public void testThatTxAckCompletesTransactionWhenNoApsAckRequired() {
+        ZigBeeTransactionManager transactionManager = Mockito.mock(ZigBeeTransactionManager.class);
+        ZigBeeCommand command = Mockito.mock(ZigBeeCommand.class);
+        Mockito.when(command.getTransactionId()).thenReturn(12);
+        Mockito.when(command.isAckRequest()).thenReturn(false);
+        ZigBeeTransactionMatcher matcher = Mockito.mock(ZigBeeTransactionMatcher.class);
+
+        ZigBeeTransaction transaction = new ZigBeeTransaction(transactionManager, command, matcher);
+
+        transaction.transactionStatusReceived(ZigBeeTransportProgressState.TX_ACK, 12);
+
+        Mockito.verify(transactionManager, Mockito.times(1)).transactionComplete(transaction, TransactionState.COMPLETE);
+    }
+
+
+    @Test
+    public void testThatTxAckDoesntCompletesTransactionWhenApsAckRequired() {
+        ZigBeeTransactionManager transactionManager = Mockito.mock(ZigBeeTransactionManager.class);
+        ZigBeeCommand command = Mockito.mock(ZigBeeCommand.class);
+        Mockito.when(command.getTransactionId()).thenReturn(12);
+        Mockito.when(command.isAckRequest()).thenReturn(true);
+        ZigBeeTransactionMatcher matcher = Mockito.mock(ZigBeeTransactionMatcher.class);
+
+        ZigBeeTransaction transaction = new ZigBeeTransaction(transactionManager, command, matcher);
+
+        transaction.transactionStatusReceived(ZigBeeTransportProgressState.TX_ACK, 12);
+
+        Mockito.verify(transactionManager, Mockito.never()).transactionComplete(transaction, TransactionState.COMPLETE);
     }
 
     @Test


### PR DESCRIPTION
This PR adds support for disabling APS ACKs to the framework and use that option for replying to OTA Page Image Request.

Note that not all dongle types support disabling APS ACKs.

@cdjackson It should work ok but I will be able to test it with OTA next week. I'll let you know of the results when I have it.