### PR TITLE
Fix checksum error in FIND_DEVICE_CONFIRM on CC2531 and improve logging

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.cc2531/src/main/java/com/zsmartsystems/zigbee/dongle/cc2531/network/packet/simple/ZB_FIND_DEVICE_CONFIRM.java
+++ b/com.zsmartsystems.zigbee.dongle.cc2531/src/main/java/com/zsmartsystems/zigbee/dongle/cc2531/network/packet/simple/ZB_FIND_DEVICE_CONFIRM.java
@@ -30,6 +30,7 @@
 
 package com.zsmartsystems.zigbee.dongle.cc2531.network.packet.simple;
 
+import com.zsmartsystems.zigbee.dongle.cc2531.network.packet.ZToolCMD;
 import com.zsmartsystems.zigbee.dongle.cc2531.network.packet.ZToolPacket;
 import com.zsmartsystems.zigbee.dongle.cc2531.zigbee.util.DoubleByte;
 
@@ -62,6 +63,7 @@ public class ZB_FIND_DEVICE_CONFIRM extends ZToolPacket /*implements IRESPONSE_C
         for (int i = 0; i < 8; i++) {
             this.Result[i] = framedata[i + 3];
         }
+        super.buildPacket(new DoubleByte(ZToolCMD.ZB_FIND_DEVICE_CONFIRM), framedata);
     }
 
 }

--- a/com.zsmartsystems.zigbee.serial/src/main/java/com/zsmartsystems/zigbee/serial/ZigBeeSerialPort.java
+++ b/com.zsmartsystems.zigbee.serial/src/main/java/com/zsmartsystems/zigbee/serial/ZigBeeSerialPort.java
@@ -225,6 +225,7 @@ public class ZigBeeSerialPort implements ZigBeePort, SerialPortEventListener {
             try {
                 int[] input = serialPort.readIntArray();
                 if (input == null) {
+                    logger.warn("Nothing read from serial port.");
                     return;
                 }
 
@@ -234,14 +235,20 @@ public class ZigBeeSerialPort implements ZigBeePort, SerialPortEventListener {
                         if (end >= maxLength) {
                             end = 0;
                         }
+                        if (end == start) {
+                            logger.warn("Serial buffer overrun.");
+                            if (++start == maxLength) {
+                                start = 0;
+                            }
+                        }
                     }
-                }
-
-                synchronized (this) {
-                    this.notify();
                 }
             } catch (SerialPortException e) {
                 logger.error("Error while handling serial event.", e);
+            }
+
+            synchronized (this) {
+                this.notify();
             }
         }
     }


### PR DESCRIPTION
It's a minor fix that I made while debugging issue described in https://community.openhab.org/t/zigbee-devices-work-for-sometime-and-then-suddenly-stop-working/92231/52 that I thought would be good to keep.
It doesn't correct any significant behavior but adds a bit more logging and fix parsing of a packet that is ignored anyway but at least we will see no exception on the console. 