### PR TITLE
Replacing the PrinterWriter with PrinterStream to make autocode UTF-8 safe

### DIFF
--- a/com.zsmartsystems.zigbee.autocode/src/main/java/com/zsmartsystems/zigbee/autocode/ZigBeeBaseClassGenerator.java
+++ b/com.zsmartsystems.zigbee.autocode/src/main/java/com/zsmartsystems/zigbee/autocode/ZigBeeBaseClassGenerator.java
@@ -13,7 +13,8 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.FileReader;
 import java.io.IOException;
-import java.io.PrintWriter;
+import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -187,12 +188,12 @@ public abstract class ZigBeeBaseClassGenerator {
         return val.substring(0, 1).toLowerCase() + val.substring(1);
     }
 
-    protected PrintWriter getClassOut(File packageFile, String className) throws FileNotFoundException {
+    protected PrintStream  getClassOut(File packageFile, String className) throws FileNotFoundException, UnsupportedEncodingException {
         packageFile.mkdirs();
         final File classFile = new File(packageFile + File.separator + className + ".java");
         System.out.println("Generating: " + classFile.getAbsolutePath());
         final FileOutputStream fileOutputStream = new FileOutputStream(classFile, false);
-        return new PrintWriter(fileOutputStream);
+        return new PrintStream (fileOutputStream,false,"UTF-8");
     }
 
     protected void importsClear() {
@@ -206,7 +207,7 @@ public abstract class ZigBeeBaseClassGenerator {
         importList.add(importClass);
     }
 
-    protected void outputImports(final PrintWriter out) {
+    protected void outputImports(final PrintStream out) {
         Collections.sort(importList);
         boolean found = false;
         for (final String importClass : importList) {
@@ -239,7 +240,7 @@ public abstract class ZigBeeBaseClassGenerator {
         }
     }
 
-    protected void outputWithLinebreak(PrintWriter out, String indent, List<ZigBeeXmlDescription> descriptions) {
+    protected void outputWithLinebreak(PrintStream out, String indent, List<ZigBeeXmlDescription> descriptions) {
         boolean firstDescription = true;
         for (ZigBeeXmlDescription description : descriptions) {
             if (description.description == null) {
@@ -290,7 +291,7 @@ public abstract class ZigBeeBaseClassGenerator {
         }
     }
 
-    protected void outputLicense(PrintWriter out) {
+    protected void outputLicense(PrintStream out) {
         String year = "XXXX";
 
         BufferedReader br;
@@ -338,12 +339,12 @@ public abstract class ZigBeeBaseClassGenerator {
         return sourceRootPath.getAbsolutePath() + File.separator + packageRoot.replace(".", File.separator);
     }
 
-    protected void outputClassGenerated(PrintWriter out) {
+    protected void outputClassGenerated(PrintStream out) {
         out.println("@Generated(value = \"" + ZigBeeCodeGenerator.class.getName() + "\", date = \"" + generatedDate
                 + "\")");
     }
 
-    protected void outputAttributeJavaDoc(PrintWriter out, String type, ZigBeeXmlAttribute attribute,
+    protected void outputAttributeJavaDoc(PrintStream out, String type, ZigBeeXmlAttribute attribute,
             DataTypeMap zclDataType) {
         out.println();
         out.println("    /**");

--- a/com.zsmartsystems.zigbee.autocode/src/main/java/com/zsmartsystems/zigbee/autocode/ZigBeeBaseFieldGenerator.java
+++ b/com.zsmartsystems.zigbee.autocode/src/main/java/com/zsmartsystems/zigbee/autocode/ZigBeeBaseFieldGenerator.java
@@ -7,7 +7,7 @@
  */
 package com.zsmartsystems.zigbee.autocode;
 
-import java.io.PrintWriter;
+import java.io.PrintStream;
 import java.util.List;
 
 import com.zsmartsystems.zigbee.autocode.xml.ZigBeeXmlField;
@@ -26,7 +26,7 @@ public class ZigBeeBaseFieldGenerator extends ZigBeeBaseClassGenerator {
     private final String OPERATOR_LESS_THAN = "LESS_THAN";
     private final String OPERATOR_LESS_THAN_OR_EQUAL = "LESS_THAN_OR_EQUAL";
 
-    protected void generateFields(PrintWriter out, String parentClass, String className, List<ZigBeeXmlField> fields,
+    protected void generateFields(PrintStream out, String parentClass, String className, List<ZigBeeXmlField> fields,
             List<String> reservedFields) {
         for (final ZigBeeXmlField field : fields) {
             if (reservedFields.contains(stringToLowerCamelCase(field.name))) {
@@ -221,7 +221,7 @@ public class ZigBeeBaseFieldGenerator extends ZigBeeBaseClassGenerator {
         }
     }
 
-    protected void generateToString(PrintWriter out, String className, List<ZigBeeXmlField> fields,
+    protected void generateToString(PrintStream out, String className, List<ZigBeeXmlField> fields,
             List<String> reservedFields) {
         int fieldLen = 0;
         for (final ZigBeeXmlField field : fields) {

--- a/com.zsmartsystems.zigbee.autocode/src/main/java/com/zsmartsystems/zigbee/autocode/ZigBeeZclClusterGenerator.java
+++ b/com.zsmartsystems.zigbee.autocode/src/main/java/com/zsmartsystems/zigbee/autocode/ZigBeeZclClusterGenerator.java
@@ -9,7 +9,7 @@ package com.zsmartsystems.zigbee.autocode;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.PrintWriter;
+import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
@@ -55,7 +55,7 @@ public class ZigBeeZclClusterGenerator extends ZigBeeBaseClassGenerator {
 
         final String clusterClassName = "Zcl" + stringToUpperCamelCase(cluster.name) + "Cluster";
         final String commandClassName = "Zcl" + stringToUpperCamelCase(cluster.name) + "Command";
-        final PrintWriter out = getClassOut(packageFile, clusterClassName);
+        final PrintStream out = getClassOut(packageFile, clusterClassName);
 
         outputLicense(out);
 
@@ -471,7 +471,7 @@ public class ZigBeeZclClusterGenerator extends ZigBeeBaseClassGenerator {
 
     }
 
-    private void createInitializeAttributes(PrintWriter out, String clusterName, List<ZigBeeXmlAttribute> attributes) {
+    private void createInitializeAttributes(PrintStream out, String clusterName, List<ZigBeeXmlAttribute> attributes) {
         out.println("        Map<Integer, ZclAttribute> attributeMap = new ConcurrentSkipListMap<>();");
 
         if (attributes.size() != 0) {

--- a/com.zsmartsystems.zigbee.autocode/src/main/java/com/zsmartsystems/zigbee/autocode/ZigBeeZclClusterTypeGenerator.java
+++ b/com.zsmartsystems.zigbee.autocode/src/main/java/com/zsmartsystems/zigbee/autocode/ZigBeeZclClusterTypeGenerator.java
@@ -9,7 +9,7 @@ package com.zsmartsystems.zigbee.autocode;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.PrintWriter;
+import java.io.PrintStream;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -44,7 +44,7 @@ public class ZigBeeZclClusterTypeGenerator extends ZigBeeBaseClassGenerator {
         final String packagePath = getPackagePath(sourceRootPath, packageRoot);
         final File packageFile = getPackageFile(packagePath);
 
-        final PrintWriter out = getClassOut(packageFile, className);
+        final PrintStream out = getClassOut(packageFile, className);
 
         outputLicense(out);
         importsClear();

--- a/com.zsmartsystems.zigbee.autocode/src/main/java/com/zsmartsystems/zigbee/autocode/ZigBeeZclCommandGenerator.java
+++ b/com.zsmartsystems.zigbee.autocode/src/main/java/com/zsmartsystems/zigbee/autocode/ZigBeeZclCommandGenerator.java
@@ -10,7 +10,8 @@ package com.zsmartsystems.zigbee.autocode;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.PrintWriter;
+import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -55,7 +56,7 @@ public class ZigBeeZclCommandGenerator extends ZigBeeBaseFieldGenerator {
             final String className = stringToUpperCamelCase(command.name);
             final String baseClassName = "Zcl" + stringToUpperCamelCase(cluster.name) + "Command";
 
-            final PrintWriter out = getClassOut(packageFile, className);
+            final PrintStream out = getClassOut(packageFile, className);
 
             // List of fields that are handled internally by super class
             List<String> reservedFields = new ArrayList<>();
@@ -328,14 +329,14 @@ public class ZigBeeZclCommandGenerator extends ZigBeeBaseFieldGenerator {
     }
 
     private void generateZclAbstractClusterCommand(ZigBeeXmlCluster cluster, String packageRootPrefix,
-            File sourceRootPath) throws FileNotFoundException {
+            File sourceRootPath) throws FileNotFoundException, UnsupportedEncodingException {
         final String packageRoot = getZclClusterCommandPackage(cluster);
         final String packagePath = getPackagePath(sourceRootPath, packageRoot);
         final File packageFile = getPackageFile(packagePath);
 
         final String clusterClassName = "Zcl" + stringToUpperCamelCase(cluster.name) + "Cluster";
         final String commandClassName = "Zcl" + stringToUpperCamelCase(cluster.name) + "Command";
-        final PrintWriter out = getClassOut(packageFile, commandClassName);
+        final PrintStream out = getClassOut(packageFile, commandClassName);
 
         importsClear();
         importsAdd(packageRootPrefix + packageZcl + ".ZclCommand");

--- a/com.zsmartsystems.zigbee.autocode/src/main/java/com/zsmartsystems/zigbee/autocode/ZigBeeZclConstantGenerator.java
+++ b/com.zsmartsystems.zigbee.autocode/src/main/java/com/zsmartsystems/zigbee/autocode/ZigBeeZclConstantGenerator.java
@@ -10,7 +10,8 @@ package com.zsmartsystems.zigbee.autocode;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.PrintWriter;
+import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
 import java.math.BigInteger;
 import java.util.List;
 import java.util.Map;
@@ -68,12 +69,12 @@ public class ZigBeeZclConstantGenerator extends ZigBeeBaseClassGenerator {
     }
 
     private void generateZclConstant(File sourceRootPath, String packageRoot, ZigBeeXmlConstant constant)
-            throws FileNotFoundException {
+            throws FileNotFoundException, UnsupportedEncodingException {
         final String packagePath = getPackagePath(sourceRootPath, packageRoot);
         final File packageFile = getPackageFile(packagePath);
 
         final String className = constant.className;
-        final PrintWriter out = getClassOut(packageFile, className);
+        final PrintStream out = getClassOut(packageFile, className);
 
         outputLicense(out);
 

--- a/com.zsmartsystems.zigbee.autocode/src/main/java/com/zsmartsystems/zigbee/autocode/ZigBeeZclReadmeGenerator.java
+++ b/com.zsmartsystems.zigbee.autocode/src/main/java/com/zsmartsystems/zigbee/autocode/ZigBeeZclReadmeGenerator.java
@@ -11,7 +11,7 @@ import java.io.BufferedReader;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.io.PrintWriter;
+import java.io.PrintStream;
 import java.util.List;
 
 import com.zsmartsystems.zigbee.autocode.xml.ZigBeeXmlCluster;
@@ -54,9 +54,9 @@ public class ZigBeeZclReadmeGenerator extends ZigBeeBaseClassGenerator {
             // Close the input stream
             fstream.close();
 
-            PrintWriter fos;
+            PrintStream fos;
 
-            fos = new PrintWriter(README_MD);
+            fos = new PrintStream(README_MD,"UTF-8");
             fos.print(mdContents);
             fos.close();
         } catch (IOException e) {

--- a/com.zsmartsystems.zigbee.autocode/src/main/java/com/zsmartsystems/zigbee/autocode/ZigBeeZclStructureGenerator.java
+++ b/com.zsmartsystems.zigbee.autocode/src/main/java/com/zsmartsystems/zigbee/autocode/ZigBeeZclStructureGenerator.java
@@ -9,7 +9,7 @@ package com.zsmartsystems.zigbee.autocode;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.PrintWriter;
+import java.io.PrintStream;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -53,7 +53,7 @@ public class ZigBeeZclStructureGenerator extends ZigBeeBaseFieldGenerator {
             final File packageFile = getPackageFile(packagePath);
 
             final String className = structure.className;
-            final PrintWriter out = getClassOut(packageFile, className);
+            final PrintStream out = getClassOut(packageFile, className);
 
             outputLicense(out);
 

--- a/com.zsmartsystems.zigbee.dongle.ember.autocode/src/main/java/com/zsmartsystems/zigbee/dongle/ember/autocode/ClassGenerator.java
+++ b/com.zsmartsystems.zigbee.dongle.ember.autocode/src/main/java/com/zsmartsystems/zigbee/dongle/ember/autocode/ClassGenerator.java
@@ -13,7 +13,8 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.FileReader;
 import java.io.IOException;
-import java.io.PrintWriter;
+import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -103,12 +104,12 @@ public abstract class ClassGenerator {
         return val.substring(0, 1).toUpperCase() + val.substring(1);
     }
 
-    protected PrintWriter getClassOut(File packageFile, String className) throws FileNotFoundException {
+    protected PrintStream getClassOut(File packageFile, String className) throws FileNotFoundException, UnsupportedEncodingException {
         packageFile.mkdirs();
         final File classFile = new File(packageFile + File.separator + className + ".java");
         System.out.println("Generating: " + classFile.getAbsolutePath());
         final FileOutputStream fileOutputStream = new FileOutputStream(classFile, false);
-        return new PrintWriter(fileOutputStream);
+        return new PrintStream(fileOutputStream,false,"UTF-8");
     }
 
     protected void clearImports() {
@@ -122,14 +123,14 @@ public abstract class ClassGenerator {
         importList.add(importClass);
     }
 
-    protected void outputImports(final PrintWriter out) {
+    protected void outputImports(final PrintStream out) {
         Collections.sort(importList);
         for (final String importClass : importList) {
             out.println("import " + importClass + ";");
         }
     }
 
-    protected void outputCopywrite(PrintWriter out) {
+    protected void outputCopywrite(PrintStream out) {
         String year = "XXXX";
 
         BufferedReader br;
@@ -182,7 +183,7 @@ public abstract class ClassGenerator {
         return null;
     }
 
-    protected void outputWithLinebreak(PrintWriter out, String indent, String line) {
+    protected void outputWithLinebreak(PrintStream out, String indent, String line) {
         String[] words = line.split(" ");
         if (words.length == 0) {
             return;

--- a/com.zsmartsystems.zigbee.dongle.ember.autocode/src/main/java/com/zsmartsystems/zigbee/dongle/ember/autocode/CommandGenerator.java
+++ b/com.zsmartsystems.zigbee.dongle.ember.autocode/src/main/java/com/zsmartsystems/zigbee/dongle/ember/autocode/CommandGenerator.java
@@ -7,10 +7,13 @@
  */
 package com.zsmartsystems.zigbee.dongle.ember.autocode;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileNotFoundException;
-import java.io.PrintWriter;
+import java.io.OutputStream;
+import java.io.PrintStream;
 import java.io.StringWriter;
+import java.io.UnsupportedEncodingException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -35,7 +38,7 @@ public class CommandGenerator extends ClassGenerator {
     protected final String ezspCommandPackage = "com.zsmartsystems.zigbee.dongle.ember.ezsp.command";
     protected final String ezspStructurePackage = "com.zsmartsystems.zigbee.dongle.ember.ezsp.structure";
 
-    public void go(Protocol protocol) throws FileNotFoundException {
+    public void go(Protocol protocol) throws FileNotFoundException, UnsupportedEncodingException {
         String className;
         for (Command command : protocol.commands) {
             if (command.name.endsWith("Handler")) {
@@ -63,12 +66,12 @@ public class CommandGenerator extends ClassGenerator {
     }
 
     private void createCommandClass(String className, Command command, List<Parameter> parameters)
-            throws FileNotFoundException {
+            throws FileNotFoundException, UnsupportedEncodingException {
 
         System.out.println("Processing command class " + command.name + "  [" + className + "()]");
 
-        StringWriter stringWriter = new StringWriter();
-        PrintWriter out = new PrintWriter(stringWriter);
+        OutputStream stringWriter = new ByteArrayOutputStream();
+        PrintStream out = new PrintStream(stringWriter,false,"UTF-8");
 
         clearImports();
         // addImport("org.slf4j.Logger");
@@ -271,7 +274,7 @@ public class CommandGenerator extends ClassGenerator {
         out.flush();
 
         File packageFile = new File(sourceRootPath + ezspCommandPackage.replace(".", "/"));
-        PrintWriter outFile = getClassOut(packageFile, className);
+        PrintStream outFile = getClassOut(packageFile, className);
 
         outputCopywrite(outFile);
         outFile.println("package " + ezspCommandPackage + ";");
@@ -289,12 +292,12 @@ public class CommandGenerator extends ClassGenerator {
         out.close();
     }
 
-    private void createStructureClass(Structure structure) throws FileNotFoundException {
+    private void createStructureClass(Structure structure) throws FileNotFoundException, UnsupportedEncodingException {
         String className = upperCaseFirstCharacter(structure.name);
         System.out.println("Processing structure class " + structure.name + "  [" + className + "()]");
 
-        StringWriter stringWriter = new StringWriter();
-        PrintWriter out = new PrintWriter(stringWriter);
+        OutputStream stringWriter = new ByteArrayOutputStream();
+        PrintStream out = new PrintStream(stringWriter,false,"UTF-8");
 
         clearImports();
         // addImport("org.slf4j.Logger");
@@ -536,7 +539,7 @@ public class CommandGenerator extends ClassGenerator {
         out.flush();
 
         File packageFile = new File(sourceRootPath + ezspStructurePackage.replace(".", "/"));
-        PrintWriter outFile = getClassOut(packageFile, className);
+        PrintStream outFile = getClassOut(packageFile, className);
 
         outputCopywrite(outFile);
         outFile.println("package " + ezspStructurePackage + ";");
@@ -554,12 +557,12 @@ public class CommandGenerator extends ClassGenerator {
         out.close();
     }
 
-    private void createEnumClass(Enumeration enumeration) throws FileNotFoundException {
+    private void createEnumClass(Enumeration enumeration) throws FileNotFoundException, UnsupportedEncodingException {
         String className = upperCaseFirstCharacter(enumeration.name);
         System.out.println("Processing enum class " + enumeration.name + "  [" + className + "()]");
 
-        StringWriter stringWriter = new StringWriter();
-        PrintWriter out = new PrintWriter(stringWriter);
+        OutputStream stringWriter = new ByteArrayOutputStream();
+        PrintStream out = new PrintStream(stringWriter,false,"UTF-8");
 
         clearImports();
 
@@ -656,7 +659,7 @@ public class CommandGenerator extends ClassGenerator {
         out.flush();
 
         File packageFile = new File(sourceRootPath + ezspStructurePackage.replace(".", "/"));
-        PrintWriter outFile = getClassOut(packageFile, className);
+        PrintStream outFile = getClassOut(packageFile, className);
 
         outputCopywrite(outFile);
         outFile.println("package " + ezspStructurePackage + ";");
@@ -890,9 +893,9 @@ public class CommandGenerator extends ClassGenerator {
         }
     }
 
-    private void createEmberFrame(Protocol protocol) throws FileNotFoundException {
-        StringWriter stringWriter = new StringWriter();
-        PrintWriter out = new PrintWriter(stringWriter);
+    private void createEmberFrame(Protocol protocol) throws FileNotFoundException, UnsupportedEncodingException {
+        OutputStream stringWriter = new ByteArrayOutputStream();
+        PrintStream out = new PrintStream(stringWriter);
 
         clearImports();
 
@@ -1128,7 +1131,7 @@ public class CommandGenerator extends ClassGenerator {
         out.flush();
 
         File packageFile = new File(sourceRootPath + ezspPackage.replace(".", "/"));
-        PrintWriter outFile = getClassOut(packageFile, "EzspFrame");
+        PrintStream outFile = getClassOut(packageFile, "EzspFrame");
 
         outFile.print(stringWriter.toString());
 

--- a/com.zsmartsystems.zigbee.dongle.ember.autocode/src/main/java/com/zsmartsystems/zigbee/dongle/ember/autocode/EmberAutocoder.java
+++ b/com.zsmartsystems.zigbee.dongle.ember.autocode/src/main/java/com/zsmartsystems/zigbee/dongle/ember/autocode/EmberAutocoder.java
@@ -9,6 +9,7 @@ package com.zsmartsystems.zigbee.dongle.ember.autocode;
 
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -57,7 +58,7 @@ public class EmberAutocoder {
 
         try {
             new CommandGenerator().go(protocol);
-        } catch (FileNotFoundException e) {
+        } catch (FileNotFoundException | UnsupportedEncodingException e) {
             e.printStackTrace();
         }
     }

--- a/com.zsmartsystems.zigbee.dongle.telegesis.autocode/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/autocode/ClassGenerator.java
+++ b/com.zsmartsystems.zigbee.dongle.telegesis.autocode/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/autocode/ClassGenerator.java
@@ -13,7 +13,8 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.FileReader;
 import java.io.IOException;
-import java.io.PrintWriter;
+import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -80,12 +81,12 @@ public abstract class ClassGenerator {
         return val.substring(0, 1).toLowerCase() + val.substring(1);
     }
 
-    protected PrintWriter getClassOut(File packageFile, String className) throws FileNotFoundException {
+    protected PrintStream getClassOut(File packageFile, String className) throws FileNotFoundException, UnsupportedEncodingException {
         packageFile.mkdirs();
         final File classFile = new File(packageFile + File.separator + className + ".java");
         System.out.println("Generating: " + classFile.getAbsolutePath());
         final FileOutputStream fileOutputStream = new FileOutputStream(classFile, false);
-        return new PrintWriter(fileOutputStream);
+        return new PrintStream(fileOutputStream,false,"UTF-8");
     }
 
     protected void clearImports() {
@@ -99,14 +100,14 @@ public abstract class ClassGenerator {
         importList.add(importClass);
     }
 
-    protected void outputImports(final PrintWriter out) {
+    protected void outputImports(final PrintStream outFile) {
         Collections.sort(importList);
         for (final String importClass : importList) {
-            out.println("import " + importClass + ";");
+            outFile.println("import " + importClass + ";");
         }
     }
 
-    protected void outputCopywrite(PrintWriter out) {
+    protected void outputCopywrite(PrintStream outFile) {
         String year = "XXXX";
 
         BufferedReader br;
@@ -126,12 +127,12 @@ public abstract class ClassGenerator {
             br = new BufferedReader(new FileReader("../src/etc/header.txt"));
             line = br.readLine();
 
-            out.println("/**");
+            outFile.println("/**");
             while (line != null) {
-                out.println(" * " + line.replaceFirst("\\$\\{year\\}", year));
+                outFile.println(" * " + line.replaceFirst("\\$\\{year\\}", year));
                 line = br.readLine();
             }
-            out.println(" */");
+            outFile.println(" */");
             br.close();
         } catch (FileNotFoundException e) {
             // TODO Auto-generated catch block
@@ -142,7 +143,7 @@ public abstract class ClassGenerator {
         }
     }
 
-    protected void outputWithLinebreak(PrintWriter out, String indent, String line) {
+    protected void outputWithLinebreak(PrintStream out, String indent, String line) {
         String[] words = line.split(" ");
         if (words.length == 0) {
             return;

--- a/com.zsmartsystems.zigbee.dongle.telegesis.autocode/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/autocode/CommandGenerator.java
+++ b/com.zsmartsystems.zigbee.dongle.telegesis.autocode/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/autocode/CommandGenerator.java
@@ -7,10 +7,12 @@
  */
 package com.zsmartsystems.zigbee.dongle.telegesis.autocode;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileNotFoundException;
-import java.io.PrintWriter;
-import java.io.StringWriter;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -37,7 +39,7 @@ public class CommandGenerator extends ClassGenerator {
 
     Map<String, String> events = new TreeMap<String, String>();
 
-    public void go(Protocol protocol) throws FileNotFoundException {
+    public void go(Protocol protocol) throws FileNotFoundException, UnsupportedEncodingException {
         String packageName;
         String className;
         for (Command command : protocol.commands) {
@@ -62,7 +64,7 @@ public class CommandGenerator extends ClassGenerator {
 
     private void createCommandClass(String packageName, String className, Command command,
             List<ParameterGroup> commandParameterGroup, List<ParameterGroup> responseParameterGroup)
-            throws FileNotFoundException {
+            throws FileNotFoundException, UnsupportedEncodingException {
 
         // Create a list of async events that we need to handle
         if (className.endsWith("Event")) {
@@ -71,8 +73,8 @@ public class CommandGenerator extends ClassGenerator {
 
         System.out.println("Processing command class " + command.name + "  [" + className + "()]");
 
-        StringWriter stringWriter = new StringWriter();
-        PrintWriter out = new PrintWriter(stringWriter);
+        OutputStream stringWriter = new ByteArrayOutputStream();
+        PrintStream out = new PrintStream(stringWriter,false,"UTF-8");
 
         clearImports();
         // addImport("org.slf4j.Logger");
@@ -505,7 +507,7 @@ public class CommandGenerator extends ClassGenerator {
         out.flush();
 
         File packageFile = new File(sourceRootPath + packageName.replace(".", "/"));
-        PrintWriter outFile = getClassOut(packageFile, className);
+        PrintStream outFile = getClassOut(packageFile, className);
 
         outputCopywrite(outFile);
         outFile.println("package " + packageName + ";");
@@ -523,7 +525,7 @@ public class CommandGenerator extends ClassGenerator {
         out.close();
     }
 
-    private void createParameterDefinition(PrintWriter out, String indent, Parameter parameter) {
+    private void createParameterDefinition(PrintStream out, String indent, Parameter parameter) {
         if (parameter.multiple) {
             addImport("java.util.List");
             addImport("java.util.ArrayList");
@@ -540,7 +542,7 @@ public class CommandGenerator extends ClassGenerator {
         }
     }
 
-    private void createParameterGetter(PrintWriter out, String indent, List<Parameter> parameters) {
+    private void createParameterGetter(PrintStream out, String indent, List<Parameter> parameters) {
         for (Parameter parameter : parameters) {
             if (parameter.auto_size != null) {
                 continue;
@@ -573,7 +575,7 @@ public class CommandGenerator extends ClassGenerator {
         }
     }
 
-    private void createParameterSetter(PrintWriter out, String indent, List<Parameter> parameters) {
+    private void createParameterSetter(PrintStream out, String indent, List<Parameter> parameters) {
         for (Parameter parameter : parameters) {
             if (parameter.auto_size != null) {
                 continue;
@@ -662,7 +664,7 @@ public class CommandGenerator extends ClassGenerator {
         }
     }
 
-    private void createDeserializer(PrintWriter out, String indent, ParameterGroup group) {
+    private void createDeserializer(PrintStream out, String indent, ParameterGroup group) {
         Map<String, String> autoSizers = new HashMap<String, String>();
         String conditional = null;
 
@@ -769,7 +771,7 @@ public class CommandGenerator extends ClassGenerator {
         }
     }
 
-    private void createToString(PrintWriter out, String indent, boolean first, String className, ParameterGroup group) {
+    private void createToString(PrintStream out, String indent, boolean first, String className, ParameterGroup group) {
         for (Parameter parameter : group.parameters) {
             if (parameter.auto_size != null) {
                 continue;
@@ -801,12 +803,12 @@ public class CommandGenerator extends ClassGenerator {
         }
     }
 
-    private void createEnumClass(Enumeration enumeration) throws FileNotFoundException {
+    private void createEnumClass(Enumeration enumeration) throws FileNotFoundException, UnsupportedEncodingException {
         String className = upperCaseFirstCharacter(enumeration.name);
         System.out.println("Processing enum class " + enumeration.name + "  [" + className + "()]");
 
-        StringWriter stringWriter = new StringWriter();
-        PrintWriter out = new PrintWriter(stringWriter);
+        OutputStream stringWriter = new ByteArrayOutputStream();
+        PrintStream out = new PrintStream(stringWriter,false,"UTF-8");
 
         clearImports();
 
@@ -931,7 +933,7 @@ public class CommandGenerator extends ClassGenerator {
         out.flush();
 
         File packageFile = new File(sourceRootPath + enumPackage.replace(".", "/"));
-        PrintWriter outFile = getClassOut(packageFile, className);
+        PrintStream outFile = getClassOut(packageFile, className);
 
         outputCopywrite(outFile);
         outFile.println("package " + enumPackage + ";");
@@ -961,7 +963,7 @@ public class CommandGenerator extends ClassGenerator {
         return hash;
     }
 
-    private void createFrameClass() throws FileNotFoundException {
+    private void createFrameClass() throws FileNotFoundException, UnsupportedEncodingException {
         // Do a quick check to make sure we don't have duplicate hash's
         List<Integer> hashcodes = new ArrayList<Integer>();
         for (String event : events.values()) {
@@ -972,8 +974,8 @@ public class CommandGenerator extends ClassGenerator {
             hashcodes.add(hash);
         }
 
-        StringWriter stringWriter = new StringWriter();
-        PrintWriter out = new PrintWriter(stringWriter);
+        OutputStream stringWriter = new ByteArrayOutputStream();
+        PrintStream out = new PrintStream(stringWriter,false,"UTF-8");
 
         clearImports();
         addImport(commandPackage + ".TelegesisEvent");
@@ -1061,7 +1063,7 @@ public class CommandGenerator extends ClassGenerator {
         out.flush();
 
         File packageFile = new File(sourceRootPath + internalPackage.replace(".", "/"));
-        PrintWriter outFile = getClassOut(packageFile, "TelegesisEventFactory");
+        PrintStream outFile = getClassOut(packageFile, "TelegesisEventFactory");
 
         outputCopywrite(outFile);
         outFile.println("package " + internalPackage + ";");

--- a/com.zsmartsystems.zigbee.dongle.telegesis.autocode/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/autocode/TelegesisAutocoder.java
+++ b/com.zsmartsystems.zigbee.dongle.telegesis.autocode/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/autocode/TelegesisAutocoder.java
@@ -9,6 +9,7 @@ package com.zsmartsystems.zigbee.dongle.telegesis.autocode;
 
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -33,7 +34,7 @@ import com.zsmartsystems.zigbee.dongle.telegesis.autocode.xml.Value;
  *
  */
 public class TelegesisAutocoder {
-    public static void main(final String[] args) {
+    public static void main(final String[] args)  {
 
         Protocol protocol;
         try {
@@ -57,7 +58,7 @@ public class TelegesisAutocoder {
         try {
             new CommandGenerator().go(protocol);
             // new PacketProcessing().go(protocol);
-        } catch (FileNotFoundException e) {
+        } catch (FileNotFoundException | UnsupportedEncodingException e) {
             e.printStackTrace();
         }
     }

--- a/com.zsmartsystems.zigbee.dongle.xbee.autocode/src/main/java/com/zsmartsystems/zigbee/dongle/xbee/autocode/ClassGenerator.java
+++ b/com.zsmartsystems.zigbee.dongle.xbee.autocode/src/main/java/com/zsmartsystems/zigbee/dongle/xbee/autocode/ClassGenerator.java
@@ -13,7 +13,8 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.FileReader;
 import java.io.IOException;
-import java.io.PrintWriter;
+import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -80,12 +81,12 @@ public abstract class ClassGenerator {
         return val.substring(0, 1).toLowerCase() + val.substring(1);
     }
 
-    protected PrintWriter getClassOut(File packageFile, String className) throws FileNotFoundException {
+    protected PrintStream getClassOut(File packageFile, String className) throws FileNotFoundException, UnsupportedEncodingException {
         packageFile.mkdirs();
         final File classFile = new File(packageFile + File.separator + className + ".java");
         System.out.println("Generating: " + classFile.getAbsolutePath());
         final FileOutputStream fileOutputStream = new FileOutputStream(classFile, false);
-        return new PrintWriter(fileOutputStream);
+        return new PrintStream(fileOutputStream,false,"UTF-8");
     }
 
     protected void clearImports() {
@@ -99,14 +100,14 @@ public abstract class ClassGenerator {
         importList.add(importClass);
     }
 
-    protected void outputImports(final PrintWriter out) {
+    protected void outputImports(final PrintStream out) {
         Collections.sort(importList);
         for (final String importClass : importList) {
             out.println("import " + importClass + ";");
         }
     }
 
-    protected void outputCopywrite(PrintWriter out) {
+    protected void outputCopywrite(PrintStream out) {
         String year = "XXXX";
 
         BufferedReader br;
@@ -142,7 +143,7 @@ public abstract class ClassGenerator {
         }
     }
 
-    protected void outputWithLinebreak(PrintWriter out, String indent, String line) {
+    protected void outputWithLinebreak(PrintStream out, String indent, String line) {
         String[] words = line.split("\\s+");
         if (words.length == 0) {
             return;

--- a/com.zsmartsystems.zigbee.dongle.xbee.autocode/src/main/java/com/zsmartsystems/zigbee/dongle/xbee/autocode/CommandGenerator.java
+++ b/com.zsmartsystems.zigbee.dongle.xbee.autocode/src/main/java/com/zsmartsystems/zigbee/dongle/xbee/autocode/CommandGenerator.java
@@ -7,10 +7,13 @@
  */
 package com.zsmartsystems.zigbee.dongle.xbee.autocode;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileNotFoundException;
-import java.io.PrintWriter;
+import java.io.OutputStream;
+import java.io.PrintStream;
 import java.io.StringWriter;
+import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -38,7 +41,7 @@ public class CommandGenerator extends ClassGenerator {
 
     Map<Integer, String> events = new TreeMap<Integer, String>();
 
-    public void go(Protocol protocol) throws FileNotFoundException {
+    public void go(Protocol protocol) throws FileNotFoundException, UnsupportedEncodingException {
         // Create "API" commands for AT commands
         for (Command atCommand : protocol.at_commands) {
             Parameter idParameter = new Parameter();
@@ -144,7 +147,7 @@ public class CommandGenerator extends ClassGenerator {
 
     private void createCommandClass(String packageName, String className, Command command,
             List<ParameterGroup> commandParameterGroup, List<ParameterGroup> responseParameterGroup)
-            throws FileNotFoundException {
+            throws FileNotFoundException, UnsupportedEncodingException {
         if (className == "XBeeZigBeeTransmitStatusCommand") {
             System.out.println();
         }
@@ -160,8 +163,8 @@ public class CommandGenerator extends ClassGenerator {
 
         System.out.println("Processing command class " + command.name + "  [" + className + "()]");
 
-        StringWriter stringWriter = new StringWriter();
-        PrintWriter out = new PrintWriter(stringWriter);
+        OutputStream stringWriter = new ByteArrayOutputStream();
+        PrintStream out = new PrintStream(stringWriter,false,"UTF-8");
 
         clearImports();
 
@@ -474,7 +477,7 @@ public class CommandGenerator extends ClassGenerator {
         out.flush();
 
         File packageFile = new File(sourceRootPath + packageName.replace(".", "/"));
-        PrintWriter outFile = getClassOut(packageFile, className);
+        PrintStream outFile = getClassOut(packageFile, className);
 
         outputCopywrite(outFile);
         outFile.println("package " + packageName + ";");
@@ -492,7 +495,7 @@ public class CommandGenerator extends ClassGenerator {
         out.close();
     }
 
-    private void createParameterDefinition(PrintWriter out, String indent, Parameter parameter) {
+    private void createParameterDefinition(PrintStream out, String indent, Parameter parameter) {
         if (parameter.multiple | parameter.bitfield) {
             addImport("java.util.List");
             addImport("java.util.ArrayList");
@@ -509,7 +512,7 @@ public class CommandGenerator extends ClassGenerator {
         }
     }
 
-    private void createParameterGetter(PrintWriter out, String indent, List<Parameter> parameters) {
+    private void createParameterGetter(PrintStream out, String indent, List<Parameter> parameters) {
         for (Parameter parameter : parameters) {
             if (parameter.auto_size != null) {
                 continue;
@@ -546,7 +549,7 @@ public class CommandGenerator extends ClassGenerator {
         }
     }
 
-    private void createParameterSetter(PrintWriter out, String indent, List<Parameter> parameters) {
+    private void createParameterSetter(PrintStream out, String indent, List<Parameter> parameters) {
         for (Parameter parameter : parameters) {
             if (parameter.auto_size != null) {
                 continue;
@@ -641,7 +644,7 @@ public class CommandGenerator extends ClassGenerator {
         }
     }
 
-    private void createDeserializer(PrintWriter out, String indent, ParameterGroup group) {
+    private void createDeserializer(PrintStream out, String indent, ParameterGroup group) {
         Map<String, String> autoSizers = new HashMap<String, String>();
         String conditional = null;
 
@@ -744,7 +747,7 @@ public class CommandGenerator extends ClassGenerator {
         }
     }
 
-    private void createToString(PrintWriter out, String indent, boolean first, String className, ParameterGroup group) {
+    private void createToString(PrintStream out, String indent, boolean first, String className, ParameterGroup group) {
         boolean extraIndent = false;
         for (Parameter parameter : group.parameters) {
             if (parameter.auto_size != null) {
@@ -810,12 +813,12 @@ public class CommandGenerator extends ClassGenerator {
         }
     }
 
-    private void createEnumClass(Enumeration enumeration) throws FileNotFoundException {
+    private void createEnumClass(Enumeration enumeration) throws FileNotFoundException, UnsupportedEncodingException {
         String className = upperCaseFirstCharacter(enumeration.name);
         System.out.println("Processing enum class " + enumeration.name + "  [" + className + "()]");
 
-        StringWriter stringWriter = new StringWriter();
-        PrintWriter out = new PrintWriter(stringWriter);
+        OutputStream stringWriter = new ByteArrayOutputStream();
+        PrintStream out = new PrintStream(stringWriter,false,"UTF-8");
 
         clearImports();
 
@@ -940,7 +943,7 @@ public class CommandGenerator extends ClassGenerator {
         out.flush();
 
         File packageFile = new File(sourceRootPath + enumPackage.replace(".", "/"));
-        PrintWriter outFile = getClassOut(packageFile, className);
+        PrintStream outFile = getClassOut(packageFile, className);
 
         outputCopywrite(outFile);
         outFile.println("package " + enumPackage + ";");
@@ -958,9 +961,9 @@ public class CommandGenerator extends ClassGenerator {
         out.close();
     }
 
-    private void createEventFactory(String className, Protocol protocol) throws FileNotFoundException {
-        StringWriter stringWriter = new StringWriter();
-        PrintWriter out = new PrintWriter(stringWriter);
+    private void createEventFactory(String className, Protocol protocol) throws FileNotFoundException, UnsupportedEncodingException {
+        OutputStream stringWriter = new ByteArrayOutputStream();
+        PrintStream out = new PrintStream(stringWriter,false,"UTF-8");
 
         clearImports();
         addImport(commandPackage + ".XBee" + className);
@@ -1085,7 +1088,7 @@ public class CommandGenerator extends ClassGenerator {
         out.flush();
 
         File packageFile = new File(sourceRootPath + internalPackage.replace(".", "/"));
-        PrintWriter outFile = getClassOut(packageFile, "XBee" + className + "Factory");
+        PrintStream outFile = getClassOut(packageFile, "XBee" + className + "Factory");
 
         outputCopywrite(outFile);
         outFile.println("package " + internalPackage + ";");

--- a/com.zsmartsystems.zigbee.dongle.xbee.autocode/src/main/java/com/zsmartsystems/zigbee/dongle/xbee/autocode/XBeeAutocoder.java
+++ b/com.zsmartsystems.zigbee.dongle.xbee.autocode/src/main/java/com/zsmartsystems/zigbee/dongle/xbee/autocode/XBeeAutocoder.java
@@ -9,6 +9,7 @@ package com.zsmartsystems.zigbee.dongle.xbee.autocode;
 
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -33,7 +34,7 @@ import com.zsmartsystems.zigbee.dongle.xbee.autocode.xml.Value;
  *
  */
 public class XBeeAutocoder {
-    public static void main(final String[] args) {
+    public static void main(final String[] args)  {
 
         Protocol protocol;
         try {
@@ -57,7 +58,7 @@ public class XBeeAutocoder {
         try {
             new CommandGenerator().go(protocol);
             // new PacketProcessing().go(protocol);
-        } catch (FileNotFoundException e) {
+        } catch (FileNotFoundException|UnsupportedEncodingException e) {
             e.printStackTrace();
         }
     }


### PR DESCRIPTION
As on some non UTF-8 Systems like windows the generated files are not compileable.

Please handle this as Proposal

Signed-off-by: bluelineXY <5988879+bluelineXY@users.noreply.github.com>