### PR TITLE
Don't use APS sequence ID int EZSP layer

### DIFF
--- a/com.zsmartsystems.zigbee.console.main/src/main/java/com/zsmartsystems/zigbee/console/main/ZigBeeConsoleMain.java
+++ b/com.zsmartsystems.zigbee.console.main/src/main/java/com/zsmartsystems/zigbee/console/main/ZigBeeConsoleMain.java
@@ -22,7 +22,6 @@ import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
-import org.apache.log4j.xml.DOMConfigurator;
 
 import com.zsmartsystems.zigbee.ExtendedPanId;
 import com.zsmartsystems.zigbee.ZigBeeChannel;
@@ -91,7 +90,7 @@ public class ZigBeeConsoleMain {
      * @param args the command arguments
      */
     public static void main(final String[] args) {
-        DOMConfigurator.configure("./log4j.xml");
+        // DOMConfigurator.configure("./log4j.xml");
 
         final String serialPortName;
         final String dongleName;

--- a/com.zsmartsystems.zigbee.dongle.ember.autocode/src/main/java/com/zsmartsystems/zigbee/dongle/ember/autocode/CommandGenerator.java
+++ b/com.zsmartsystems.zigbee.dongle.ember.autocode/src/main/java/com/zsmartsystems/zigbee/dongle/ember/autocode/CommandGenerator.java
@@ -1018,15 +1018,6 @@ public class CommandGenerator extends ClassGenerator {
         out.println();
 
         out.println("    /**");
-        out.println("     * Sets the 8 bit transaction sequence number");
-        out.println("     *");
-        out.println("     * @param sequenceNumber");
-        out.println("     */");
-        out.println("    public void setSequenceNumber(int sequenceNumber) {");
-        out.println("        this.sequenceNumber = sequenceNumber;");
-        out.println("    }");
-        out.println();
-        out.println("    /**");
         out.println("     * Gets the 8 bit transaction sequence number");
         out.println("     *");
         out.println("     * @return sequence number");

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
@@ -702,7 +702,6 @@ public class ZigBeeDongleEzsp implements ZigBeeTransportTransmit, ZigBeeTranspor
             EzspSendUnicastRequest emberUnicast = new EzspSendUnicastRequest();
             emberUnicast.setIndexOrDestination(apsFrame.getDestinationAddress());
             emberUnicast.setMessageTag(msgTag);
-            emberUnicast.setSequenceNumber(apsFrame.getApsCounter());
             emberUnicast.setType(EmberOutgoingMessageType.EMBER_OUTGOING_DIRECT);
             emberUnicast.setApsFrame(emberApsFrame);
             emberUnicast.setMessageContents(apsFrame.getPayload());
@@ -726,7 +725,6 @@ public class ZigBeeDongleEzsp implements ZigBeeTransportTransmit, ZigBeeTranspor
             EzspSendBroadcastRequest emberBroadcast = new EzspSendBroadcastRequest();
             emberBroadcast.setDestination(apsFrame.getDestinationAddress());
             emberBroadcast.setMessageTag(msgTag);
-            emberBroadcast.setSequenceNumber(apsFrame.getApsCounter());
             emberBroadcast.setApsFrame(emberApsFrame);
             emberBroadcast.setRadius(apsFrame.getRadius());
             emberBroadcast.setMessageContents(apsFrame.getPayload());

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/EzspFrame.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/EzspFrame.java
@@ -371,15 +371,6 @@ public abstract class EzspFrame {
     }
 
     /**
-     * Sets the 8 bit transaction sequence number
-     *
-     * @param sequenceNumber
-     */
-    public void setSequenceNumber(int sequenceNumber) {
-        this.sequenceNumber = sequenceNumber;
-    }
-
-    /**
      * Gets the 8 bit transaction sequence number
      *
      * @return sequence number

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspAddEndpointRequestTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspAddEndpointRequestTest.java
@@ -13,9 +13,9 @@ import java.util.Arrays;
 
 import org.junit.Test;
 
+import com.zsmartsystems.zigbee.TestUtilities;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.EzspFrame;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.EzspFrameTest;
-import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspAddEndpointRequest;
 
 /**
  *
@@ -24,7 +24,7 @@ import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspAddEndpointRequest
  */
 public class EzspAddEndpointRequestTest extends EzspFrameTest {
     @Test
-    public void testAddEndpointRequest() {
+    public void testAddEndpointRequest() throws Exception {
         EzspFrame.setEzspVersion(4);
         int[] clusters = new int[] { 0, 1, 6 };
         EzspAddEndpointRequest request = new EzspAddEndpointRequest();
@@ -34,7 +34,7 @@ public class EzspAddEndpointRequestTest extends EzspFrameTest {
         request.setInputClusterList(clusters);
         request.setOutputClusterList(clusters);
         request.setProfileId(0x104);
-        request.setSequenceNumber(2);
+        TestUtilities.setField(EzspFrame.class, request, "sequenceNumber", 2);
         System.out.println(request);
 
         assertTrue(Arrays.equals(getPacketData("02 00 02 01 04 01 00 00 00 03 03 00 00 01 00 06 00 00 00 01 00 06 00"),
@@ -42,7 +42,7 @@ public class EzspAddEndpointRequestTest extends EzspFrameTest {
     }
 
     @Test
-    public void testAddEndpointRequestNoClusters() {
+    public void testAddEndpointRequestNoClusters() throws Exception {
         EzspFrame.setEzspVersion(4);
         int[] clusters = new int[] {};
         EzspAddEndpointRequest request = new EzspAddEndpointRequest();
@@ -51,7 +51,7 @@ public class EzspAddEndpointRequestTest extends EzspFrameTest {
         request.setInputClusterList(clusters);
         request.setOutputClusterList(clusters);
         request.setProfileId(0x104);
-        request.setSequenceNumber(170);
+        TestUtilities.setField(EzspFrame.class, request, "sequenceNumber", 170);
         System.out.println(request);
 
         assertTrue(Arrays.equals(getPacketData("AA 00 02 01 04 01 00 00 00 00 00"), request.serialize()));

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspAesMmoHashRequestTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspAesMmoHashRequestTest.java
@@ -13,9 +13,9 @@ import java.util.Arrays;
 
 import org.junit.Test;
 
+import com.zsmartsystems.zigbee.TestUtilities;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.EzspFrame;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.EzspFrameTest;
-import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspAesMmoHashRequest;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EmberAesMmoHashContext;
 
 /**
@@ -26,7 +26,7 @@ import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EmberAesMmoHashConte
 public class EzspAesMmoHashRequestTest extends EzspFrameTest {
 
     @Test
-    public void test() {
+    public void test() throws Exception {
         EzspFrame.setEzspVersion(4);
         EmberAesMmoHashContext context = new EmberAesMmoHashContext();
         context.setResult(new int[16]);
@@ -34,7 +34,7 @@ public class EzspAesMmoHashRequestTest extends EzspFrameTest {
         request.setContext(context);
         request.setData(new int[] { 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77 });
         request.setFinalize(true);
-        request.setSequenceNumber(170);
+        TestUtilities.setField(EzspFrame.class, request, "sequenceNumber", 170);
         System.out.println(request);
 
         assertTrue(Arrays.equals(getPacketData(

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetKeyRequestTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetKeyRequestTest.java
@@ -13,9 +13,9 @@ import java.util.Arrays;
 
 import org.junit.Test;
 
+import com.zsmartsystems.zigbee.TestUtilities;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.EzspFrame;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.EzspFrameTest;
-import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspGetKeyRequest;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EmberKeyType;
 
 /**
@@ -25,11 +25,11 @@ import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EmberKeyType;
  */
 public class EzspGetKeyRequestTest extends EzspFrameTest {
     @Test
-    public void testAddEndpointRequest() {
+    public void testAddEndpointRequest() throws Exception {
         EzspFrame.setEzspVersion(4);
         EzspGetKeyRequest request = new EzspGetKeyRequest();
         request.setKeyType(EmberKeyType.EMBER_APPLICATION_LINK_KEY);
-        request.setSequenceNumber(2);
+        TestUtilities.setField(EzspFrame.class, request, "sequenceNumber", 2);
         System.out.println(request);
 
         assertTrue(Arrays.equals(getPacketData("02 00 6A 05"), request.serialize()));

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetKeyTableEntryRequestTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetKeyTableEntryRequestTest.java
@@ -13,9 +13,9 @@ import java.util.Arrays;
 
 import org.junit.Test;
 
+import com.zsmartsystems.zigbee.TestUtilities;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.EzspFrame;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.EzspFrameTest;
-import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspGetKeyTableEntryRequest;
 
 /**
  *
@@ -24,11 +24,11 @@ import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspGetKeyTableEntryRe
  */
 public class EzspGetKeyTableEntryRequestTest extends EzspFrameTest {
     @Test
-    public void testAddEndpointRequest() {
+    public void testAddEndpointRequest() throws Exception {
         EzspFrame.setEzspVersion(4);
         EzspGetKeyTableEntryRequest request = new EzspGetKeyTableEntryRequest();
         request.setIndex(0);
-        request.setSequenceNumber(2);
+        TestUtilities.setField(EzspFrame.class, request, "sequenceNumber", 2);
         System.out.println(request);
 
         assertTrue(Arrays.equals(getPacketData("02 00 71 00"), request.serialize()));

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspLookupEui64ByNodeIdRequestTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspLookupEui64ByNodeIdRequestTest.java
@@ -13,9 +13,9 @@ import java.util.Arrays;
 
 import org.junit.Test;
 
+import com.zsmartsystems.zigbee.TestUtilities;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.EzspFrame;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.EzspFrameTest;
-import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspLookupEui64ByNodeIdRequest;
 
 /**
  *
@@ -24,11 +24,11 @@ import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspLookupEui64ByNodeI
  */
 public class EzspLookupEui64ByNodeIdRequestTest extends EzspFrameTest {
     @Test
-    public void testLookupAddress() {
+    public void testLookupAddress() throws Exception {
         EzspFrame.setEzspVersion(4);
         EzspLookupEui64ByNodeIdRequest request = new EzspLookupEui64ByNodeIdRequest();
         request.setNodeId(0);
-        request.setSequenceNumber(5);
+        TestUtilities.setField(EzspFrame.class, request, "sequenceNumber", 5);
         System.out.println(request);
 
         assertTrue(Arrays.equals(getPacketData("05 00 61 00 00"), request.serialize()));

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSendBroadcastTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSendBroadcastTest.java
@@ -13,9 +13,10 @@ import java.util.Arrays;
 
 import org.junit.Test;
 
+import com.zsmartsystems.zigbee.TestUtilities;
 import com.zsmartsystems.zigbee.ZigBeeEndpointAddress;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.EzspFrame;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.EzspFrameTest;
-import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspSendBroadcastRequest;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EmberApsFrame;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EmberApsOption;
 import com.zsmartsystems.zigbee.serialization.DefaultSerializer;
@@ -28,7 +29,7 @@ import com.zsmartsystems.zigbee.zdo.command.ManagementPermitJoiningRequest;
 public class EzspSendBroadcastTest extends EzspFrameTest {
 
     @Test
-    public void testSendPermitJoining() {
+    public void testSendPermitJoining() throws Exception {
         ManagementPermitJoiningRequest permitJoining = new ManagementPermitJoiningRequest();
 
         permitJoining.setDestinationAddress(new ZigBeeEndpointAddress(0xFFFC));
@@ -54,7 +55,7 @@ public class EzspSendBroadcastTest extends EzspFrameTest {
         apsFrame.setGroupId(0);
 
         emberBroadcast.setMessageTag(5);
-        emberBroadcast.setSequenceNumber(5);
+        TestUtilities.setField(EzspFrame.class, emberBroadcast, "sequenceNumber", 5);
         emberBroadcast.setApsFrame(apsFrame);
         emberBroadcast.setDestination(permitJoining.getDestinationAddress().getAddress());
         emberBroadcast.setMessageContents(payload);

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSendUnicastTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSendUnicastTest.java
@@ -14,11 +14,10 @@ import java.util.Arrays;
 
 import org.junit.Test;
 
+import com.zsmartsystems.zigbee.TestUtilities;
 import com.zsmartsystems.zigbee.ZigBeeEndpointAddress;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.EzspFrame;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.EzspFrameTest;
-import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspSendUnicastRequest;
-import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspSendUnicastResponse;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EmberApsFrame;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EmberApsOption;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EmberOutgoingMessageType;
@@ -44,7 +43,7 @@ public class EzspSendUnicastTest extends EzspFrameTest {
     }
 
     @Test
-    public void testSendPermitJoining() {
+    public void testSendPermitJoining() throws Exception {
         EzspFrame.setEzspVersion(4);
         ManagementPermitJoiningRequest permitJoining = new ManagementPermitJoiningRequest();
 
@@ -71,7 +70,7 @@ public class EzspSendUnicastTest extends EzspFrameTest {
         apsFrame.setGroupId(0xffff);
 
         emberUnicast.setMessageTag(0x99);
-        emberUnicast.setSequenceNumber(0xaa);
+        TestUtilities.setField(EzspFrame.class, emberUnicast, "sequenceNumber", 0xAA);
         emberUnicast.setType(EmberOutgoingMessageType.EMBER_OUTGOING_DIRECT);
         emberUnicast.setApsFrame(apsFrame);
         emberUnicast.setIndexOrDestination(permitJoining.getDestinationAddress().getAddress());

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetConcentratorRequestTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetConcentratorRequestTest.java
@@ -13,9 +13,9 @@ import java.util.Arrays;
 
 import org.junit.Test;
 
+import com.zsmartsystems.zigbee.TestUtilities;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.EzspFrame;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.EzspFrameTest;
-import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspSetConcentratorRequest;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EmberConcentratorType;
 
 /**
@@ -25,10 +25,10 @@ import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EmberConcentratorTyp
  */
 public class EzspSetConcentratorRequestTest extends EzspFrameTest {
     @Test
-    public void testEnabled() {
+    public void testEnabled() throws Exception {
         EzspFrame.setEzspVersion(4);
         EzspSetConcentratorRequest request = new EzspSetConcentratorRequest();
-        request.setSequenceNumber(52);
+        TestUtilities.setField(EzspFrame.class, request, "sequenceNumber", 52);
         request.setConcentratorType(EmberConcentratorType.EMBER_HIGH_RAM_CONCENTRATOR);
         request.setMinTime(60);
         request.setMaxTime(3600);
@@ -42,10 +42,10 @@ public class EzspSetConcentratorRequestTest extends EzspFrameTest {
     }
 
     @Test
-    public void testDisabled() {
+    public void testDisabled() throws Exception {
         EzspFrame.setEzspVersion(4);
         EzspSetConcentratorRequest request = new EzspSetConcentratorRequest();
-        request.setSequenceNumber(52);
+        TestUtilities.setField(EzspFrame.class, request, "sequenceNumber", 52);
         request.setConcentratorType(EmberConcentratorType.EMBER_LOW_RAM_CONCENTRATOR);
         request.setMinTime(60);
         request.setMaxTime(3600);

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetConfigurationValueRequestTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetConfigurationValueRequestTest.java
@@ -13,9 +13,9 @@ import java.util.Arrays;
 
 import org.junit.Test;
 
+import com.zsmartsystems.zigbee.TestUtilities;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.EzspFrame;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.EzspFrameTest;
-import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspSetConfigurationValueRequest;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EmberZdoConfigurationFlags;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EzspConfigId;
 
@@ -26,10 +26,10 @@ import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EzspConfigId;
  */
 public class EzspSetConfigurationValueRequestTest extends EzspFrameTest {
     @Test
-    public void testVersion() {
+    public void testVersion() throws Exception {
         EzspFrame.setEzspVersion(4);
         EzspSetConfigurationValueRequest request = new EzspSetConfigurationValueRequest();
-        request.setSequenceNumber(2);
+        TestUtilities.setField(EzspFrame.class, request, "sequenceNumber", 2);
         request.setConfigId(EzspConfigId.EZSP_CONFIG_APPLICATION_ZDO_FLAGS);
         request.setValue(EmberZdoConfigurationFlags.EMBER_APP_RECEIVES_SUPPORTED_ZDO_REQUESTS.getKey());
         System.out.println(request);

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetInitialSecurityStateRequestTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetInitialSecurityStateRequestTest.java
@@ -14,9 +14,9 @@ import java.util.Arrays;
 import org.junit.Test;
 
 import com.zsmartsystems.zigbee.IeeeAddress;
+import com.zsmartsystems.zigbee.TestUtilities;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.EzspFrame;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.EzspFrameTest;
-import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspSetInitialSecurityStateRequest;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EmberInitialSecurityBitmask;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EmberInitialSecurityState;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EmberKeyData;
@@ -28,7 +28,7 @@ import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EmberKeyData;
  */
 public class EzspSetInitialSecurityStateRequestTest extends EzspFrameTest {
     @Test
-    public void testSecurityStateRequest() {
+    public void testSecurityStateRequest() throws Exception {
         EzspFrame.setEzspVersion(4);
 
         EmberKeyData keyData;
@@ -44,7 +44,7 @@ public class EzspSetInitialSecurityStateRequestTest extends EzspFrameTest {
         state.setNetworkKeySequenceNumber(0);
         state.addBitmask(EmberInitialSecurityBitmask.EMBER_STANDARD_SECURITY_MODE);
         request.setState(state);
-        request.setSequenceNumber(7);
+        TestUtilities.setField(EzspFrame.class, request, "sequenceNumber", 7);
         System.out.println(request);
 
         assertTrue(Arrays.equals(getPacketData(

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetValueRequestTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetValueRequestTest.java
@@ -13,9 +13,9 @@ import java.util.Arrays;
 
 import org.junit.Test;
 
+import com.zsmartsystems.zigbee.TestUtilities;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.EzspFrame;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.EzspFrameTest;
-import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspSetValueRequest;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EzspValueId;
 
 /**
@@ -25,10 +25,10 @@ import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EzspValueId;
  */
 public class EzspSetValueRequestTest extends EzspFrameTest {
     @Test
-    public void testSetValue() {
+    public void testSetValue() throws Exception {
         EzspFrame.setEzspVersion(4);
         EzspSetValueRequest request = new EzspSetValueRequest();
-        request.setSequenceNumber(2);
+        TestUtilities.setField(EzspFrame.class, request, "sequenceNumber", 2);
         request.setValueId(EzspValueId.EZSP_VALUE_APS_FRAME_COUNTER);
         request.setValue(new int[] { 1, 2, 3, 4 });
         System.out.println(request);

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspStartScanRequestTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspStartScanRequestTest.java
@@ -13,10 +13,10 @@ import java.util.Arrays;
 
 import org.junit.Test;
 
+import com.zsmartsystems.zigbee.TestUtilities;
 import com.zsmartsystems.zigbee.ZigBeeChannelMask;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.EzspFrame;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.EzspFrameTest;
-import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspStartScanRequest;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EzspNetworkScanType;
 
 /**
@@ -26,10 +26,10 @@ import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EzspNetworkScanType;
  */
 public class EzspStartScanRequestTest extends EzspFrameTest {
     @Test
-    public void testVersion() {
+    public void testVersion() throws Exception {
         EzspFrame.setEzspVersion(4);
         EzspStartScanRequest request = new EzspStartScanRequest();
-        request.setSequenceNumber(3);
+        TestUtilities.setField(EzspFrame.class, request, "sequenceNumber", 3);
         request.setScanType(EzspNetworkScanType.EZSP_ENERGY_SCAN);
         request.setChannelMask(ZigBeeChannelMask.CHANNEL_MASK_2GHZ);
         request.setDuration(1);

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspVersionRequestTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspVersionRequestTest.java
@@ -13,9 +13,9 @@ import java.util.Arrays;
 
 import org.junit.Test;
 
+import com.zsmartsystems.zigbee.TestUtilities;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.EzspFrame;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.EzspFrameTest;
-import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspVersionRequest;
 
 /**
  *
@@ -24,33 +24,33 @@ import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspVersionRequest;
  */
 public class EzspVersionRequestTest extends EzspFrameTest {
     @Test
-    public void testVersion4() {
+    public void testVersion4() throws Exception {
         EzspFrame.setEzspVersion(4);
         EzspVersionRequest version = new EzspVersionRequest();
         version.setDesiredProtocolVersion(4);
-        version.setSequenceNumber(0);
+        TestUtilities.setField(EzspFrame.class, version, "sequenceNumber", 0);
         System.out.println(version);
 
         assertTrue(Arrays.equals(getPacketData("00 00 00 04"), version.serialize()));
     }
 
     @Test
-    public void testVersion5() {
+    public void testVersion5() throws Exception {
         EzspFrame.setEzspVersion(5);
         EzspVersionRequest version = new EzspVersionRequest();
         version.setDesiredProtocolVersion(5);
-        version.setSequenceNumber(0);
+        TestUtilities.setField(EzspFrame.class, version, "sequenceNumber", 0);
         System.out.println(version);
 
         assertTrue(Arrays.equals(getPacketData("00 00 FF 00 00 05"), version.serialize()));
     }
 
     @Test
-    public void testVersion6() {
+    public void testVersion6() throws Exception {
         EzspFrame.setEzspVersion(6);
         EzspVersionRequest version = new EzspVersionRequest();
         version.setDesiredProtocolVersion(6);
-        version.setSequenceNumber(0);
+        TestUtilities.setField(EzspFrame.class, version, "sequenceNumber", 0);
         System.out.println(version);
 
         assertTrue(Arrays.equals(getPacketData("00 00 FF 00 00 06"), version.serialize()));

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/ash/AshFrameDataTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/ash/AshFrameDataTest.java
@@ -14,6 +14,8 @@ import java.util.Arrays;
 
 import org.junit.Test;
 
+import com.zsmartsystems.zigbee.TestUtilities;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.EzspFrame;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspVersionRequest;
 import com.zsmartsystems.zigbee.dongle.ember.internal.ash.AshFrame.FrameType;
 
@@ -25,17 +27,17 @@ import com.zsmartsystems.zigbee.dongle.ember.internal.ash.AshFrame.FrameType;
 public class AshFrameDataTest {
 
     @Test
-    public void testAshFrameData() {
+    public void testAshFrameData() throws Exception {
         AshFrameData frame;
         EzspVersionRequest request = new EzspVersionRequest();
-        request.setSequenceNumber(1);
+        TestUtilities.setField(EzspFrame.class, request, "sequenceNumber", 1);
         request.setDesiredProtocolVersion(4);
         frame = new AshFrameData(request);
         System.out.println(frame);
         assertTrue(Arrays.equals(new int[] { 0, 67, 33, 168, 80, 155, 152, 126 }, frame.getOutputBuffer()));
 
         request = new EzspVersionRequest();
-        request.setSequenceNumber(2);
+        TestUtilities.setField(EzspFrame.class, request, "sequenceNumber", 2);
         request.setDesiredProtocolVersion(4);
         frame = new AshFrameData(request);
         frame.setAckNum(3);
@@ -44,7 +46,7 @@ public class AshFrameDataTest {
         assertTrue(Arrays.equals(new int[] { 67, 64, 33, 168, 80, 255, 254, 126 }, frame.getOutputBuffer()));
 
         request = new EzspVersionRequest();
-        request.setSequenceNumber(3);
+        TestUtilities.setField(EzspFrame.class, request, "sequenceNumber", 3);
         request.setDesiredProtocolVersion(4);
         frame = new AshFrameData(request);
         frame.setAckNum(6);

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/ash/AshFrameHandlerTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/ash/AshFrameHandlerTest.java
@@ -28,6 +28,7 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 import com.zsmartsystems.zigbee.TestUtilities;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.EzspFrame;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.EzspFrameRequest;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspVersionRequest;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspVersionResponse;
@@ -237,7 +238,7 @@ public class AshFrameHandlerTest {
         TestUtilities.setField(AshFrameHandler.class, frameHandler, "stateConnected", true);
 
         EzspVersionRequest request = new EzspVersionRequest();
-        request.setSequenceNumber(3);
+        TestUtilities.setField(EzspFrame.class, request, "sequenceNumber", 3);
         request.setDesiredProtocolVersion(4);
 
         EzspTransaction transaction = frameHandler

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/spi/SpiFrameHandlerTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/spi/SpiFrameHandlerTest.java
@@ -26,6 +26,7 @@ import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
+import com.zsmartsystems.zigbee.TestUtilities;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.EzspFrame;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.EzspFrameRequest;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspGetConfigurationValueResponse;
@@ -277,14 +278,14 @@ public class SpiFrameHandlerTest {
     }
 
     @Test
-    public void testSendEzspFrame() {
+    public void testSendEzspFrame() throws Exception {
         portOutData = new ArrayList<>();
         SpiFrameHandler handler = new SpiFrameHandler(Mockito.mock(EzspFrameHandler.class));
         handler.start(new TestPort(Mockito.mock(InputStream.class), Mockito.mock(OutputStream.class)));
 
         EzspVersionRequest command = new EzspVersionRequest();
         command.setDesiredProtocolVersion(4);
-        command.setSequenceNumber(1);
+        TestUtilities.setField(EzspFrame.class, command, "sequenceNumber", 1);
         sendEzspFrame(handler, command);
         assertEquals(7, portOutData.size());
         assertEquals(Integer.valueOf(0xFE), portOutData.get(0));

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/transaction/EzspScanTransactionTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/transaction/EzspScanTransactionTest.java
@@ -17,6 +17,7 @@ import java.util.Set;
 
 import org.junit.Test;
 
+import com.zsmartsystems.zigbee.TestUtilities;
 import com.zsmartsystems.zigbee.ZigBeeChannelMask;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.EzspFrame;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.EzspFrameResponse;
@@ -36,12 +37,12 @@ import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EzspNetworkScanType;
  */
 public class EzspScanTransactionTest extends EzspFrameTest {
     @Test
-    public void testScanTransaction() {
+    public void testScanTransaction() throws Exception {
         EzspFrame.setEzspVersion(4);
         EzspStartScanRequest energyScan = new EzspStartScanRequest();
         energyScan.setChannelMask(ZigBeeChannelMask.CHANNEL_MASK_2GHZ);
         energyScan.setDuration(1);
-        energyScan.setSequenceNumber(3);
+        TestUtilities.setField(EzspFrame.class, energyScan, "sequenceNumber", 3);
         energyScan.setScanType(EzspNetworkScanType.EZSP_ENERGY_SCAN);
 
         Set<Class<?>> relatedResponses = new HashSet<Class<?>>(Arrays.asList(EzspStartScanResponse.class,

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/transaction/EzspSingleResponseTransactionTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/transaction/EzspSingleResponseTransactionTest.java
@@ -15,11 +15,11 @@ import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
+import com.zsmartsystems.zigbee.TestUtilities;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.EzspFrame;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.EzspFrameTest;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspVersionRequest;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspVersionResponse;
-import com.zsmartsystems.zigbee.dongle.ember.internal.transaction.EzspSingleResponseTransaction;
-import com.zsmartsystems.zigbee.dongle.ember.internal.transaction.EzspTransaction;
 
 /**
  *
@@ -28,9 +28,9 @@ import com.zsmartsystems.zigbee.dongle.ember.internal.transaction.EzspTransactio
  */
 public class EzspSingleResponseTransactionTest extends EzspFrameTest {
     @Test
-    public void testResponseMatches() {
+    public void testResponseMatches() throws Exception {
         EzspVersionRequest version = new EzspVersionRequest();
-        version.setSequenceNumber(3);
+        TestUtilities.setField(EzspFrame.class, version, "sequenceNumber", 3);
         version.setDesiredProtocolVersion(4);
 
         EzspTransaction versionTransaction = new EzspSingleResponseTransaction(version, EzspVersionResponse.class);
@@ -46,9 +46,9 @@ public class EzspSingleResponseTransactionTest extends EzspFrameTest {
     }
 
     @Test
-    public void testResponseMatchFails() {
+    public void testResponseMatchFails() throws Exception {
         EzspVersionRequest version = new EzspVersionRequest();
-        version.setSequenceNumber(4);
+        TestUtilities.setField(EzspFrame.class, version, "sequenceNumber", 4);
         version.setDesiredProtocolVersion(4);
 
         EzspTransaction versionTransaction = new EzspSingleResponseTransaction(version, EzspVersionResponse.class);


### PR DESCRIPTION
This removes the call to ```setSequenceNumber``` at the EZSP layer and allows EZSP to use the sequence number defined in ```EzspRequestFrame``` when sending commands.
Closes #790 
Signed-off-by: Chris Jackson <chris@cd-jackson.com>