### PR TITLE
When creating an updated ZigBeeNode in ZigBeeNodeServiceDiscoverer, copy across the node state of the node that is being discovered

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeNodeServiceDiscoverer.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeNodeServiceDiscoverer.java
@@ -235,6 +235,7 @@ public class ZigBeeNodeServiceDiscoverer {
                 // Create a new node to store the data from this update.
                 // We set the network address so that we can detect the change later if needed.
                 updatedNode = new ZigBeeNode(networkManager, node.getIeeeAddress(), node.getNetworkAddress());
+                updatedNode.setNodeState(node.getNodeState());
                 lastDiscoveryStarted = Calendar.getInstance();
             }
 

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeNodeServiceDiscovererTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeNodeServiceDiscovererTest.java
@@ -234,6 +234,7 @@ public class ZigBeeNodeServiceDiscovererTest {
     @Test
     public void testLocal() throws Exception {
         ZigBeeNode node = Mockito.mock(ZigBeeNode.class);
+        Mockito.when(node.getNodeState()).thenReturn(ZigBeeNode.ZigBeeNodeState.ONLINE);
         ZigBeeNodeServiceDiscoverer discoverer = new ZigBeeNodeServiceDiscoverer(networkManager, node);
 
         TestUtilities.setField(ZigBeeNodeServiceDiscoverer.class, discoverer, "retryPeriod", 1);
@@ -264,6 +265,7 @@ public class ZigBeeNodeServiceDiscovererTest {
         Mockito.verify(futureTask, Mockito.times(1)).cancel(true);
 
         Mockito.verify(networkManager, Mockito.timeout(TIMEOUT).times(1)).updateNode(nodeCapture.capture());
+        assertEquals(ZigBeeNode.ZigBeeNodeState.ONLINE, nodeCapture.getValue().getNodeState());
 
         assertNotNull(discoverer.getLastDiscoveryStarted());
         assertNotNull(discoverer.getLastDiscoveryCompleted());


### PR DESCRIPTION
Fixes #975 