### PR TITLE
Check cluster IDs in ZclTransactionMatcher

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/ZclTransactionMatcher.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/ZclTransactionMatcher.java
@@ -7,6 +7,8 @@
  */
 package com.zsmartsystems.zigbee.zcl;
 
+import java.util.Objects;
+
 import com.zsmartsystems.zigbee.ZigBeeCommand;
 import com.zsmartsystems.zigbee.transaction.ZigBeeTransactionMatcher;
 
@@ -23,15 +25,22 @@ public class ZclTransactionMatcher implements ZigBeeTransactionMatcher {
 
     @Override
     public boolean isTransactionMatch(ZigBeeCommand request, ZigBeeCommand response) {
-        if (!request.getDestinationAddress().equals(response.getSourceAddress())) {
-            return false;
-        }
+        return (addressesMatch(request, response)
+                && response instanceof ZclCommand
+                && ((ZclCommand) request).getTransactionId() != null
+                && transactionIdsMatch((ZclCommand) request, (ZclCommand) response))
+                && clusterIdsMatch(request, response);
+    }
 
-        if (response instanceof ZclCommand && ((ZclCommand) request).getTransactionId() != null) {
-            final int transactionId = ((ZclCommand) request).getTransactionId();
-            return Integer.valueOf(transactionId).equals(((ZclCommand) response).getTransactionId());
-        } else {
-            return false;
-        }
+    private boolean addressesMatch(ZigBeeCommand request, ZigBeeCommand response) {
+        return request.getDestinationAddress().equals(response.getSourceAddress());
+    }
+    
+    private boolean transactionIdsMatch(ZclCommand request, ZclCommand response) {
+        return Objects.equals(request.getTransactionId(), response.getTransactionId());
+    }
+    
+    private boolean clusterIdsMatch(ZigBeeCommand request, ZigBeeCommand response) {
+        return Objects.equals(request.getClusterId(), response.getClusterId());
     }
 }


### PR DESCRIPTION
This addresses one (the easy) part of #988: The `ZclTransactionManager` now also checks that the cluster IDs of request and response match (in addition to checking that the addresses and the transaction IDs match).

Since the number of conditions checked by the `ZclTransactionManager` grows even more with this change, this change also attempts to formulate the conditions in the `isTransactionMatch` method so that they can be grasped more easily - but this could be personal preference (please shout if you like the older form more, Chris, I can change back if you dislike it :) ).

Signed-off-by: Henning Sudbrock <henning.sudbrock@telekom.de>