### PR TITLE
Add the manufacturer code to the ZclAttributeDao

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/database/ZclAttributeDao.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/database/ZclAttributeDao.java
@@ -98,6 +98,12 @@ public class ZclAttributeDao {
     private int reportingTimeout;
 
     /**
+     * The manufacturer code of the attribute, in case the attribute is 
+     * manufacturer-specific. Otherwise, this field is null.
+     */
+    private Integer manufacturerCode;
+
+    /**
      * Records the last time a report was received
      */
     private Calendar lastReportTime;
@@ -273,6 +279,20 @@ public class ZclAttributeDao {
      */
     public void setReportingTimeout(int reportingTimeout) {
         this.reportingTimeout = reportingTimeout;
+    }
+
+    /**
+     * @return the manufacturer code (or null, if attribute is not manufacturer-specific)
+     */
+    public Integer getManufacturerCode() {
+        return manufacturerCode;
+    }
+
+    /**
+     * @param manufacturerCode the manufacturer code to set (or null, if attribute is not manufacturer-specific)
+     */
+    public void setManufacturerCode(Integer manufacturerCode) {
+        this.manufacturerCode = manufacturerCode;
     }
 
     /**

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/ZclAttribute.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/ZclAttribute.java
@@ -541,6 +541,7 @@ public class ZclAttribute {
         maximumReportingPeriod = dao.getMaximumReportingPeriod();
         reportingChange = dao.getReportingChange();
         reportingTimeout = dao.getReportingTimeout();
+        manufacturerCode = dao.getManufacturerCode();
     }
 
     /**
@@ -564,6 +565,7 @@ public class ZclAttribute {
         dao.setReportable(reportable);
         dao.setReportingChange(reportingChange);
         dao.setReportingTimeout(reportingTimeout);
+        dao.setManufacturerCode(manufacturerCode);
         dao.setLastValue(lastValue);
         dao.setLastReportTime(lastReportTime);
 

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zcl/ZclAttributeTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zcl/ZclAttributeTest.java
@@ -131,7 +131,7 @@ public class ZclAttributeTest {
     public void dao() {
         ZclCluster cluster = Mockito.mock(ZclCluster.class);
         ZclAttribute attribute = new ZclAttribute(cluster, 123, "Test Name", ZclDataType.UNSIGNED_8_BIT_INTEGER, true,
-                false, true, false);
+                false, true, false, 0x1234);
 
         attribute.updateValue(Integer.valueOf(12345));
 
@@ -144,6 +144,7 @@ public class ZclAttributeTest {
         assertTrue(dao.isWritable());
         assertFalse(dao.isReadable());
         assertFalse(dao.isReportable());
+        assertEquals(Integer.valueOf(0x1234), dao.getManufacturerCode());
         assertEquals(12345, dao.getLastValue());
 
         ZclAttribute daoAttribute = new ZclAttribute();
@@ -157,6 +158,7 @@ public class ZclAttributeTest {
         assertTrue(daoAttribute.isWritable());
         assertFalse(daoAttribute.isReadable());
         assertFalse(daoAttribute.isReportable());
+        assertEquals(Integer.valueOf(0x1234), daoAttribute.getManufacturerCode());
         assertEquals(12345, daoAttribute.getLastValue());
     }
 }


### PR DESCRIPTION
This field has previously been missing in the `ZclAttributeDao`, but should be stored
in the database as well.

What does go wrong without this fix? After re-filling the node list from the database, operations like, e.g., attribute reads for manufacturer-specific attributes will fail because the manufacturer-specific bit will not be set in the requests anymore.

Chris, this is one of the issues that we discussed in #989.

Signed-off-by: Henning Sudbrock <henning.sudbrock@telekom.de>