### PR TITLE
Fix unit test for receive default command

### DIFF
--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeNetworkManagerTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeNetworkManagerTest.java
@@ -476,6 +476,7 @@ public class ZigBeeNetworkManagerTest
 
         ZigBeeEndpoint endpoint = Mockito.mock(ZigBeeEndpoint.class);
         ZclCluster cluster = new ZclOnOffCluster(endpoint);
+        Mockito.when(endpoint.getOutputCluster(cluster.getClusterId())).thenReturn(cluster);
 
         ZigBeeNode node = Mockito.mock(ZigBeeNode.class);
         Mockito.when(node.getIeeeAddress()).thenReturn(new IeeeAddress("1111111111111111"));
@@ -490,7 +491,7 @@ public class ZigBeeNetworkManagerTest
         apsFrame.setApsCounter(1);
 
         apsFrame.setCluster(6);
-        apsFrame.setDestinationEndpoint(2);
+        apsFrame.setDestinationEndpoint(1);
         apsFrame.setProfile(0x104);
         apsFrame.setSourceEndpoint(5);
 


### PR DESCRIPTION
The unit test `ZigBeeNetworkManagerTest.testReceiveDefaultCommand` should originally test that the `ZigBeeNetworkManager` does not notify about default responses. However, after ignoring endpoints other than 1 (cf. https://github.com/zsmartsystems/com.zsmartsystems.zigbee/pull/829) the test does not test this anymore. Why is that? The test uses a default response to endpoint 2, and this message is now dropped not because it is a default response, but because it is not for endpoint 1.

This PR adapts the unit test to use a default response for endpoint 1, so that it actually tests the correct behaviour for default responses again. It slightly extends the mocking, because otherwise the test runs into a NPE (this was not necessary when the test was first implemented, but due to other changes in the `ZigBeeNetworkManager` this  is now necessary...) 