### PR TITLE
Fix updateNode(ZigBeeNode)

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNode.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNode.java
@@ -728,7 +728,7 @@ public class ZigBeeNode implements ZigBeeCommandListener {
 
         boolean updated = false;
 
-        if (nodeState != node.getNodeState()) {
+        if (node.getNodeState() != ZigBeeNodeState.UNKNOWN && nodeState != node.getNodeState()) {
             nodeState = node.getNodeState();
             updated = true;
         }

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeNodeTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeNodeTest.java
@@ -461,6 +461,8 @@ public class ZigBeeNodeTest {
         newNode = new ZigBeeNode(Mockito.mock(ZigBeeNetworkManager.class), new IeeeAddress("1234567890"));
         newNode.setNodeState(ZigBeeNodeState.ONLINE);
         assertTrue(node.updateNode(newNode));
+        newNode.setNodeState(ZigBeeNodeState.UNKNOWN);
+        assertFalse(node.updateNode(newNode));
     }
 
     @Test


### PR DESCRIPTION
Change `updateNode(ZigBeeNode node)` to not update the state of the node if the state of the node passed to it is `UNKNOWN`

Fixes #975 

Signed-off-by: Tejas Nandanikar <tejas3093@gmail.com>