### PR TITLE
link quality reported instead of rssi

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
@@ -942,7 +942,7 @@ public class ZigBeeDongleEzsp implements ZigBeeTransportTransmit, ZigBeeTranspor
         if (response instanceof EzspMfglibRxHandler) {
             if (mfglibListener != null) {
                 EzspMfglibRxHandler mfglibHandler = (EzspMfglibRxHandler) response;
-                mfglibListener.emberMfgLibPacketReceived(mfglibHandler.getLinkQuality(), mfglibHandler.getLinkQuality(),
+                mfglibListener.emberMfgLibPacketReceived(mfglibHandler.getLinkQuality(), mfglibHandler.getRssi(),
                         mfglibHandler.getPacketContents());
             }
             return;


### PR DESCRIPTION
The link quality is passed as argument twice, while the second argument should be the RSSI.