### PR TITLE
Only restore attribute state from the node database for non-manufacturer-specific attributes

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/ZclAttribute.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/ZclAttribute.java
@@ -543,6 +543,17 @@ public class ZclAttribute {
         reportingTimeout = dao.getReportingTimeout();
         manufacturerCode = dao.getManufacturerCode();
     }
+    
+    /**
+     * Sets the dynamic state of the attribute from a {@link ZclAttributeDao} which has been restored from a persisted state.
+     *
+     * @param dao the {@link ZclAttributeDao} from which to restore the dynamic state
+     */
+    public void setDynamicStateFromDao(ZclAttributeDao dao) {
+        implemented = dao.isImplemented();
+        lastValue = dao.getLastValue();
+        lastReportTime = dao.getLastReportTime();
+    }
 
     /**
      * Returns a Data Acquisition Object for this attribute. This is a clean class recording the state of the primary

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/ZclCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/ZclCluster.java
@@ -1598,20 +1598,21 @@ public abstract class ZclCluster {
         supportedCommandsGenerated.addAll(dao.getSupportedCommandsGenerated());
         supportedCommandsReceived.addAll(dao.getSupportedCommandsReceived());
 
-        Map<Integer, ZclAttribute> daoZclAttributes = new HashMap<>();
+        Map<Integer, ZclAttribute> attributes = isClient ? clientAttributes : serverAttributes;
+        
         for (ZclAttributeDao daoAttribute : dao.getAttributes().values()) {
             // Normalize the data to protect against the users serialisation system restoring incorrect data classes
             daoAttribute
                     .setLastValue(normalizer.normalizeZclData(daoAttribute.getDataType(), daoAttribute.getLastValue()));
-            ZclAttribute attribute = new ZclAttribute();
-            attribute.setDao(this, daoAttribute);
-            daoZclAttributes.put(daoAttribute.getId(), attribute);
-        }
-
-        if (isClient) {
-            clientAttributes = daoZclAttributes;
-        } else {
-            serverAttributes = daoZclAttributes;
+            
+            ZclAttribute attribute = attributes.get(daoAttribute.getId());
+            if (attribute == null || daoAttribute.getManufacturerCode() != null) {
+                attribute = new ZclAttribute();
+                attribute.setDao(this, daoAttribute);
+                attributes.put(daoAttribute.getId(), attribute);
+            } else {
+                attribute.setDynamicStateFromDao(daoAttribute);
+            }
         }
     }
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/ZclCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/ZclCluster.java
@@ -141,14 +141,14 @@ public abstract class ZclCluster {
 
     /**
      * Map of client attributes supported by the cluster. This contains all attributes, even if they are not supported
-     * by the remote device. To check what attributes are supported by the remove device, us the
+     * by the remote device. To check what attributes are supported by the remove device, use the
      * {@link #discoverAttributes()} method followed by the {@link #getSupportedAttributes()} method.
      */
     protected Map<Integer, ZclAttribute> clientAttributes = initializeClientAttributes();
 
     /**
      * Map of server attributes supported by the cluster. This contains all attributes, even if they are not supported
-     * by the remote device. To check what attributes are supported by the remove device, us the
+     * by the remote device. To check what attributes are supported by the remove device, use the
      * {@link #discoverAttributes()} method followed by the {@link #getSupportedAttributes()} method.
      */
     protected Map<Integer, ZclAttribute> serverAttributes = initializeServerAttributes();


### PR DESCRIPTION
This resolves #989 and #236.

With this change, when restoring a cluster from a `ZclClusterDao` obtained from the node database, for non-manufacturer-specific attributes only the dynamic attribute state will be restored (i.e., last value, last reporting time, and whether the attribute was marked as implemented).

The benefit is that changes in the attribute definition in the `Zcl***Cluster` classes generated by the autocoder will be applied to attributes, even when the information stored in the node database is from before those changes were made. (E.g., when adding new attributes as described in #236, or when fixing datatypes as described in #989.)