### PR TITLE
Pass RSSI and LQI values from dongle to application layer

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
@@ -861,6 +861,9 @@ public class ZigBeeDongleEzsp implements ZigBeeTransportTransmit, ZigBeeTranspor
             apsFrame.setSourceAddress(incomingMessage.getSender());
             apsFrame.setSourceEndpoint(emberApsFrame.getSourceEndpoint());
 
+            apsFrame.setReceivedLqi(incomingMessage.getLastHopLqi());
+            apsFrame.setReceivedRssi(incomingMessage.getLastHopRssi());
+
             apsFrame.setPayload(incomingMessage.getMessageContents());
             zigbeeTransportReceive.receiveCommand(apsFrame);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeLinkQualityStatistics.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeLinkQualityStatistics.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2016-2020 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee;
+
+/**
+ * An interface that allows clients to retrieve link quality information available from a node
+ *
+ * @author Chris Jackson
+ *
+ */
+public interface ZigBeeLinkQualityStatistics {
+    /**
+     * Returns the LQI value from the last recieved packet
+     *
+     * @return the last received LQI value
+     */
+    public Integer getLastReceivedLqi();
+
+    /**
+     * Returns the RSSI value from the last recieved packet
+     *
+     * @return the last received RSSI value in dBm
+     */
+    public Integer getLastReceivedRssi();
+
+}

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
@@ -965,14 +965,25 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
 
         // Pass the command to the transaction manager for processing
         // If the transaction manager wants to drop this command, it returns null
-        command = transactionManager.receive(command);
-        if (command == null) {
+        final ZigBeeCommand finalCommand = transactionManager.receive(command);
+        if (finalCommand == null) {
             return;
         }
 
         // Ignore the DefaultResponse
-        if (command instanceof DefaultResponse) {
+        if (finalCommand instanceof DefaultResponse) {
             return;
+        }
+
+        // Directly distribute commands to nodes
+        ZigBeeNode node = getNode(command.getSourceAddress().getAddress());
+        if (node != null) {
+            NotificationService.execute(new Runnable() {
+                @Override
+                public void run() {
+                    node.commandReceived(finalCommand, apsFrame.getReceivedRssi(), apsFrame.getReceivedLqi());
+                }
+            });
         }
 
         // Notify the listeners
@@ -1577,7 +1588,6 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
             return;
         }
         networkNodes.remove(node.getIeeeAddress());
-        removeCommandListener(node);
 
         synchronized (this) {
             if (networkState != ZigBeeNetworkState.ONLINE) {
@@ -1620,7 +1630,6 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
             return;
         }
         networkNodes.put(node.getIeeeAddress(), node);
-        addCommandListener(node);
 
         synchronized (this) {
             if (networkState != ZigBeeNetworkState.ONLINE) {

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/aps/ZigBeeApsFrame.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/aps/ZigBeeApsFrame.java
@@ -138,6 +138,9 @@ public class ZigBeeApsFrame {
      */
     private int apsCounter = -1;
 
+    private Integer rssi;
+    private Integer lqi;
+
     protected int fragmentSize;
     protected int fragmentBase = 0;
     protected int fragmentTotal = 0;
@@ -418,6 +421,62 @@ public class ZigBeeApsFrame {
         return payload;
     }
 
+    /**
+     * Calling this method indicates that transmission of a fragment has completed.
+     * It moves the fragment base and decrease outstanding fragments counter.
+     */
+    public void oneFragmentCompleted() {
+        fragmentBase++;
+        if (fragmentOutstanding > 0) {
+            fragmentOutstanding--;
+        }
+    }
+
+    /**
+     * Calling this method indicates that a fragment has been sent. It increases outstanding fragments counter.
+     */
+    public void oneFragmentSent() {
+        if (fragmentOutstanding <= fragmentTotal) {
+            this.fragmentOutstanding++;
+        }
+    }
+
+    /**
+     * Gets the RSSI from the packet. If this is unknown the method will return null
+     *
+     * @return the RSSI of the packet
+     */
+    public Integer getReceivedRssi() {
+        return rssi;
+    }
+
+    /**
+     * Sets the RSSI from the packet. If this is unknown the method will return null
+     *
+     * @param the RSSI of the packet
+     */
+    public void setReceivedRssi(int rssi) {
+        this.rssi = rssi;
+    }
+
+    /**
+     * Gets the LQI from the packet. If this is unknown the method will return null
+     *
+     * @return the LQI of the packet
+     */
+    public Integer getReceivedLqi() {
+        return lqi;
+    }
+
+    /**
+     * Sets the LQI from the packet. If this is unknown the method will return null
+     *
+     * @param the LQI of the packet
+     */
+    public void setReceivedLqi(int lqi) {
+        this.lqi = lqi;
+    }
+
     @Override
     public String toString() {
         StringBuilder builder = new StringBuilder(164);
@@ -439,6 +498,20 @@ public class ZigBeeApsFrame {
         } else {
             builder.append(String.format("%02X", apsCounter));
         }
+
+        builder.append(", rssi=");
+        if (rssi == null) {
+            builder.append("--");
+        } else {
+            builder.append(rssi);
+        }
+        builder.append(", lqi=");
+        if (lqi == null) {
+            builder.append("--");
+        } else {
+            builder.append(String.format("%02X", lqi));
+        }
+
         builder.append(", payload=");
         if (payload != null) {
             for (int c = 0; c < payload.length; c++) {
@@ -450,25 +523,5 @@ public class ZigBeeApsFrame {
         }
         builder.append(']');
         return builder.toString();
-    }
-
-    /**
-     * Calling this method indicates that transmission of a fragment has completed.
-     * It moves the fragment base and decrease outstanding fragments counter.
-     */
-    public void oneFragmentCompleted() {
-        fragmentBase++;
-        if (fragmentOutstanding > 0) {
-            fragmentOutstanding--;
-        }
-    }
-
-    /**
-     * Calling this method indicates that a fragment has been sent. It increases outstanding fragments counter.
-     */
-    public void oneFragmentSent() {
-        if (fragmentOutstanding <= fragmentTotal) {
-            this.fragmentOutstanding++;
-        }
     }
 }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/internal/ZigBeeNodeLinkQualityHandler.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/internal/ZigBeeNodeLinkQualityHandler.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2016-2020 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.internal;
+
+import com.zsmartsystems.zigbee.ZigBeeLinkQualityStatistics;
+
+/**
+ * Handler to record and manage link quality information for a node
+ *
+ * @author Chris Jackson
+ *
+ */
+public class ZigBeeNodeLinkQualityHandler implements ZigBeeLinkQualityStatistics {
+    Integer lastRssi;
+    Integer lastLqi;
+
+    /**
+     * Updates the Link Quality Indicator value with the value from the latest received packet
+     *
+     * @param lqi the last received LQI value
+     */
+    public void updateReceivedLqi(Integer lqi) {
+        if (lqi == null) {
+            return;
+        }
+        lastLqi = lqi;
+    }
+
+    /**
+     * Updates the Received Signal Strength Indicator value with the value from the latest received packet
+     *
+     * @param rssi the last received RSSI value in dBm
+     */
+    public void updateReceivedRssi(Integer rssi) {
+        if (rssi == null) {
+            return;
+        }
+        lastRssi = rssi;
+    }
+
+    @Override
+    public Integer getLastReceivedLqi() {
+        return lastLqi;
+    }
+
+    @Override
+    public Integer getLastReceivedRssi() {
+        return lastRssi;
+    }
+}

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeNetworkManagerTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeNetworkManagerTest.java
@@ -953,7 +953,8 @@ public class ZigBeeNetworkManagerTest
         TestUtilities.setField(ZigBeeNetworkManager.class, networkManager, "networkState", ZigBeeNetworkState.ONLINE);
         networkManager.receiveCommand(apsFrame);
         Mockito.verify(node, Mockito.timeout(TIMEOUT).times(1))
-                .commandReceived(ArgumentMatchers.any(ZigBeeCommand.class));
+                .commandReceived(ArgumentMatchers.any(ZigBeeCommand.class), ArgumentMatchers.any(),
+                        ArgumentMatchers.any());
         Awaitility.await().until(() -> commandListenerUpdated());
         if (commandListenerCapture.size() == 0) {
             return null;

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeNodeTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeNodeTest.java
@@ -518,7 +518,7 @@ public class ZigBeeNodeTest {
         Mockito.when(invalidSourceAddress.getEndpoint()).thenReturn(1);
         ZclCommand zigbeeCommand = Mockito.mock(ZclCommand.class);
         Mockito.when(zigbeeCommand.getSourceAddress()).thenReturn(invalidSourceAddress);
-        node.commandReceived(zigbeeCommand);
+        node.commandReceived(zigbeeCommand, null, null);
         Mockito.verify(endpoint1, Mockito.times(0)).commandReceived(ArgumentMatchers.any(ZclCommand.class));
         Mockito.verify(endpoint2, Mockito.times(0)).commandReceived(ArgumentMatchers.any(ZclCommand.class));
 
@@ -526,7 +526,7 @@ public class ZigBeeNodeTest {
         Mockito.when(zigbeeAddress.getAddress()).thenReturn(124);
         ZigBeeCommand zigbeeCommandInvalidAddressCmd = Mockito.mock(ZigBeeCommand.class);
         Mockito.when(zigbeeCommandInvalidAddressCmd.getSourceAddress()).thenReturn(zigbeeAddress);
-        node.commandReceived(zigbeeCommandInvalidAddressCmd);
+        node.commandReceived(zigbeeCommandInvalidAddressCmd, null, null);
         Mockito.verify(endpoint1, Mockito.times(0)).commandReceived(ArgumentMatchers.any(ZclCommand.class));
         Mockito.verify(endpoint2, Mockito.times(0)).commandReceived(ArgumentMatchers.any(ZclCommand.class));
 
@@ -540,12 +540,15 @@ public class ZigBeeNodeTest {
         Mockito.when(unicast.getTransactionId()).thenReturn(123);
         Mockito.when(unicast.getCommandId()).thenReturn(99);
 
-        node.commandReceived(unicast);
+        node.commandReceived(unicast, null, null);
         Mockito.verify(endpoint1, Mockito.times(1)).commandReceived(unicast);
         Mockito.verify(endpoint2, Mockito.times(0)).commandReceived(unicast);
 
+        assertNull(node.getLinkQualityStatistics().getLastReceivedLqi());
+        assertNull(node.getLinkQualityStatistics().getLastReceivedRssi());
+
         Mockito.when(sourceAddress.getEndpoint()).thenReturn(10);
-        node.commandReceived(unicast);
+        node.commandReceived(unicast, 1, 2);
         ArgumentCaptor<ZigBeeCommand> commandCapture = ArgumentCaptor.forClass(ZigBeeCommand.class);
         Mockito.verify(networkManager, Mockito.timeout(TIMEOUT).times(1)).sendTransaction(commandCapture.capture());
         ZigBeeCommand response = commandCapture.getValue();
@@ -557,11 +560,14 @@ public class ZigBeeNodeTest {
         assertEquals(ZclStatus.UNSUPPORTED_CLUSTER, defaultResponse.getStatusCode());
         assertEquals(Integer.valueOf(123), defaultResponse.getTransactionId());
 
+        assertEquals(Integer.valueOf(2), node.getLinkQualityStatistics().getLastReceivedLqi());
+        assertEquals(Integer.valueOf(1), node.getLinkQualityStatistics().getLastReceivedRssi());
+
         ZdoCommand zdoCommand = Mockito.mock(ZdoCommand.class);
         ZigBeeAddress zdoSource = Mockito.mock(ZigBeeAddress.class);
         Mockito.when(zdoSource.getAddress()).thenReturn(12345);
         Mockito.when(zdoCommand.getSourceAddress()).thenReturn(zdoSource);
-        node.commandReceived(zdoCommand);
+        node.commandReceived(zdoCommand, null, null);
     }
 
     @Test

--- a/com.zsmartsystems.zigbee/src/test/resource/logs/zdo.txt
+++ b/com.zsmartsystems.zigbee/src/test/resource/logs/zdo.txt
@@ -42,7 +42,7 @@ NodeDescriptorRequest [0000/0 -> 0000/0, cluster=0002, TID=1B, nwkAddrOfInterest
 ZigBeeApsFrame [sourceAddress=0000/0, destinationAddress=0000/0, profile=0000, cluster=0005, addressMode=DEVICE, radius=31, apsSecurity=false, apsCounter=1D, payload=00 1B 7A]
 ActiveEndpointsRequest [0000/0 -> 0000/0, cluster=0005, TID=1D, nwkAddrOfInterest=31259]
 
-ZigBeeApsFrame [sourceAddress=61585/0, destinationAddress=0000/0, profile=0000, cluster=8005, addressMode=null, radius=0, apsSecurity=false, apsCounter=3F, payload=00 00 91 F0 07 01 02 03 04 05 C8 E8]
+ZigBeeApsFrame [sourceAddress=0000/0, destinationAddress=0000/0, profile=0000, cluster=8005, addressMode=null, radius=0, apsSecurity=false, apsCounter=3F, payload=00 00 91 F0 07 01 02 03 04 05 C8 E8]
 ActiveEndpointsResponse [61585/0 -> 0000/0, cluster=8005, TID=--, status=SUCCESS, nwkAddrOfInterest=61585, activeEpList=[1, 2, 3, 4, 5, 200, 232]]
 
 ZigBeeApsFrame [sourceAddress=0000/0, destinationAddress=0000/0, profile=0000, cluster=0004, addressMode=DEVICE, radius=31, apsSecurity=false, apsCounter=1E, payload=00 1B 7A 03]


### PR DESCRIPTION
This PR adds LQI and RSSI information to the ```ZigBeeApsFrame``` to allow this information to be passed up from the dongle. This is processed within the ```ZigBeeNode``` when the packet is processed and this is managed through a class ```ZigBeeNodeLinkQualityHandler```.

Publicly, this information can be read from the node with the ```getLinkQualityStatistics``` method. This returns a ```ZigBeeLinkQualityStatistics``` which has public methods for accessing this data. Currently this only includes the ability to get the last RSSI and LQI values, but splitting the implementation into a separate class provides the potential for additional statistics in future.

This PR also changes the way that ```ZigBeeNode``` receives notifications - instead of registering for ```ZigBeeCommandListener``` calls, the ```commandReceived``` method is now directly called from the manager. This is a bit more efficient, but also allows this to be customised with the LQI/RSSI data as parameters.

Currently LQI and RSSI data is only passed through from the Ember dongles.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>