### PR TITLE
Fix auto selecting the quietest channel on Ember

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
@@ -988,7 +988,7 @@ public class ZigBeeDongleEzsp implements ZigBeeTransportTransmit, ZigBeeTranspor
 
     @Override
     public ZigBeeStatus setZigBeeChannel(ZigBeeChannel channel) {
-        if ((ZigBeeChannelMask.CHANNEL_MASK_2GHZ & channel.getMask()) == 0) {
+        if (channel != ZigBeeChannel.UNKNOWN && (ZigBeeChannelMask.CHANNEL_MASK_2GHZ & channel.getMask()) == 0) {
             logger.debug("Unable to set channel outside of 2.4GHz channels: {}", channel);
             return ZigBeeStatus.INVALID_ARGUMENTS;
         }

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/EmberNetworkInitialisation.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/EmberNetworkInitialisation.java
@@ -15,6 +15,7 @@ import org.slf4j.LoggerFactory;
 
 import com.zsmartsystems.zigbee.ExtendedPanId;
 import com.zsmartsystems.zigbee.IeeeAddress;
+import com.zsmartsystems.zigbee.ZigBeeChannel;
 import com.zsmartsystems.zigbee.ZigBeeChannelMask;
 import com.zsmartsystems.zigbee.dongle.ember.EmberNcp;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspEnergyScanResultHandler;
@@ -141,7 +142,7 @@ public class EmberNetworkInitialisation {
             logger.debug("Created random Extended PAN ID: {}", extendedPanIdBuilder.toString());
         }
 
-        if (networkParameters.getRadioChannel() == 0) {
+        if (networkParameters.getRadioChannel() == ZigBeeChannel.UNKNOWN.getChannel()) {
             networkParameters.setRadioChannel(quietestChannel);
         }
 


### PR DESCRIPTION
Using ZigbeeNetworkManager#setZigBeeChannel(ZigBeeChannel.UNKNOWN) before
the networkmanager startup will enable the scan for the quietest channel

Fixes #1003