### PR TITLE
Document Ember Unicast Join issue

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
@@ -1391,7 +1391,8 @@ public class ZigBeeNetworkManager implements ZigBeeNetwork, ZigBeeTransportRecei
         sendTransaction(command);
 
         // If this is a broadcast, then we send it to our own address as well
-        // This seems to be required for some stacks (eg ZNP)
+        // This seems to be required for some stacks (eg TI ZNP).
+        // Note that in recent Ember ZNet stacks a unicast join will return an error INV_REQUESTTYPE!
         if (ZigBeeBroadcastDestination.isBroadcast(destination.getAddress())) {
             command = new ManagementPermitJoiningRequest(duration, true);
             command.setDestinationAddress(new ZigBeeEndpointAddress(0));


### PR DESCRIPTION
In recent (possibly starting at 6.5) versions of Ember ZNet, sending a unicast join request will result in an error ```INV_REQUESTTYPE```. The framework sends both a unicast and broadcast since the TI stack only works with a unicast!

This PR just adds a comment to the cost. Possibly we should have a smarter implementation, but for now sending both will work in all instances and the error can be ignored.

See -;
* https://www.silabs.com/community/wireless/zigbee-and-thread/forum.topic.html/inv_requesttype_responsetomanagementpermitjoinin-wVGE
* https://www.silabs.com/community/wireless/zigbee-and-thread/forum.topic.html/unicast_mgmt_permit-YtYd

Signed-off-by: Chris Jackson <chris@cd-jackson.com>