### PR TITLE
Add processing of networkId in EZSP frames

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.ember.autocode/src/main/java/com/zsmartsystems/zigbee/dongle/ember/autocode/CommandGenerator.java
+++ b/com.zsmartsystems.zigbee.dongle.ember.autocode/src/main/java/com/zsmartsystems/zigbee/dongle/ember/autocode/CommandGenerator.java
@@ -12,7 +12,6 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.OutputStream;
 import java.io.PrintStream;
-import java.io.StringWriter;
 import java.io.UnsupportedEncodingException;
 import java.util.HashMap;
 import java.util.List;
@@ -71,7 +70,7 @@ public class CommandGenerator extends ClassGenerator {
         System.out.println("Processing command class " + command.name + "  [" + className + "()]");
 
         OutputStream stringWriter = new ByteArrayOutputStream();
-        PrintStream out = new PrintStream(stringWriter,false,"UTF-8");
+        PrintStream out = new PrintStream(stringWriter, false, "UTF-8");
 
         clearImports();
         // addImport("org.slf4j.Logger");
@@ -240,19 +239,17 @@ public class CommandGenerator extends ClassGenerator {
             out.println("        return \"" + className + " []\";");
         } else {
             out.println("        final StringBuilder builder = new StringBuilder("
-                    + (className.length() + 3 + parameters.size() * 25) + ");");
-            boolean first = true;
+                    + (className.length() + 3 + (parameters.size() + 1) * 25) + ");");
+
+            out.println("        builder.append(\"" + className + " [networkId=\");");
+            out.println("        builder.append(networkId);");
+
             for (Parameter parameter : parameters) {
                 if (parameter.auto_size != null) {
                     continue;
                 }
 
-                if (first) {
-                    out.println("        builder.append(\"" + className + " [" + parameter.name + "=\");");
-                } else {
-                    out.println("        builder.append(\", " + parameter.name + "=\");");
-                }
-                first = false;
+                out.println("        builder.append(\", " + parameter.name + "=\");");
                 if (parameter.data_type.contains("[")) {
                     out.println("        for (int cnt = 0; cnt < " + parameter.name + ".length; cnt++) {");
                     out.println("            if (cnt > 0) {");
@@ -297,7 +294,7 @@ public class CommandGenerator extends ClassGenerator {
         System.out.println("Processing structure class " + structure.name + "  [" + className + "()]");
 
         OutputStream stringWriter = new ByteArrayOutputStream();
-        PrintStream out = new PrintStream(stringWriter,false,"UTF-8");
+        PrintStream out = new PrintStream(stringWriter, false, "UTF-8");
 
         clearImports();
         // addImport("org.slf4j.Logger");
@@ -562,7 +559,7 @@ public class CommandGenerator extends ClassGenerator {
         System.out.println("Processing enum class " + enumeration.name + "  [" + className + "()]");
 
         OutputStream stringWriter = new ByteArrayOutputStream();
-        PrintStream out = new PrintStream(stringWriter,false,"UTF-8");
+        PrintStream out = new PrintStream(stringWriter, false, "UTF-8");
 
         clearImports();
 
@@ -969,6 +966,16 @@ public class CommandGenerator extends ClassGenerator {
         out.println("    private static final int EZSP_MAX_VERSION = 8;");
         out.println();
         out.println("    /**");
+        out.println("     * The network ID bit shift");
+        out.println("     */");
+        out.println("    protected static final int EZSP_NETWORK_ID_SHIFT = 5;");
+        out.println();
+        out.println("    /**");
+        out.println("     * The network ID bit mask");
+        out.println("     */");
+        out.println("    protected static final int EZSP_NETWORK_ID_MASK = 0x60;");
+        out.println();
+        out.println("    /**");
         out.println("     * The current version of EZSP being used");
         out.println("     */");
         out.println("    protected static int ezspVersion = EZSP_MIN_VERSION;");
@@ -1000,6 +1007,7 @@ public class CommandGenerator extends ClassGenerator {
         out.println("    protected int sequenceNumber;");
         out.println("    protected int frameControl;");
         out.println("    protected int frameId = 0;");
+        out.println("    protected int networkId = 0;");
         out.println("    protected boolean isResponse = false;");
         out.println();
         out.println("    private static Map<Integer, Class<?>> ezspHandlerMap = new HashMap<Integer, Class<?>>();");
@@ -1020,6 +1028,24 @@ public class CommandGenerator extends ClassGenerator {
         out.println("    }");
         out.println();
 
+        out.println("    /**");
+        out.println("     * Sets the network ID (0 to 3)");
+        out.println("     *");
+        out.println("     * @param networkId the networkId");
+        out.println("     */");
+        out.println("    public void setNetworkId(int networkId) {");
+        out.println("        this.networkId = networkId;");
+        out.println("    }");
+        out.println();
+        out.println("    /**");
+        out.println("     * Gets the network ID (0 to 3)");
+        out.println("     *");
+        out.println("     * @return the networkId of this frame");
+        out.println("     */");
+        out.println("    public int getNetworkId() {");
+        out.println("        return networkId;");
+        out.println("    }");
+        out.println();
         out.println("    /**");
         out.println("     * Gets the 8 bit transaction sequence number");
         out.println("     *");

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/EzspFrame.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/EzspFrame.java
@@ -61,6 +61,16 @@ public abstract class EzspFrame {
     private static final int EZSP_MAX_VERSION = 8;
 
     /**
+     * The network ID bit shift
+     */
+    protected static final int EZSP_NETWORK_ID_SHIFT = 5;
+
+    /**
+     * The network ID bit mask
+     */
+    protected static final int EZSP_NETWORK_ID_MASK = 0x60;
+
+    /**
      * The current version of EZSP being used
      */
     protected static int ezspVersion = EZSP_MIN_VERSION;
@@ -224,6 +234,7 @@ public abstract class EzspFrame {
     protected int sequenceNumber;
     protected int frameControl;
     protected int frameId = 0;
+    protected int networkId = 0;
     protected boolean isResponse = false;
 
     private static Map<Integer, Class<?>> ezspHandlerMap = new HashMap<Integer, Class<?>>();
@@ -368,6 +379,24 @@ public abstract class EzspFrame {
         ezspHandlerMap.put(FRAME_ID_TRUST_CENTER_JOIN_HANDLER, EzspTrustCenterJoinHandler.class);
         ezspHandlerMap.put(FRAME_ID_VERSION, EzspVersionResponse.class);
         ezspHandlerMap.put(FRAME_ID_ZIGBEE_KEY_ESTABLISHMENT_HANDLER, EzspZigbeeKeyEstablishmentHandler.class);
+    }
+
+    /**
+     * Sets the network ID (0 to 3)
+     *
+     * @param networkId the networkId
+     */
+    public void setNetworkId(int networkId) {
+        this.networkId = networkId;
+    }
+
+    /**
+     * Gets the network ID (0 to 3)
+     *
+     * @return the networkId of this frame
+     */
+    public int getNetworkId() {
+        return networkId;
     }
 
     /**

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/EzspFrameRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/EzspFrameRequest.java
@@ -55,7 +55,7 @@ public abstract class EzspFrameRequest extends EzspFrame {
 
         if (ezspVersion >= 8) {
             // Output Frame Control - 2 Bytes
-            serializer.serializeUInt16(0x0100);
+            serializer.serializeUInt16(0x0100 + ((networkId << EZSP_NETWORK_ID_SHIFT) & EZSP_NETWORK_ID_MASK));
 
             // Output Frame ID - 2 Bytes
             serializer.serializeUInt16(frameId);

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/EzspFrameResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/EzspFrameResponse.java
@@ -68,6 +68,9 @@ public abstract class EzspFrameResponse extends EzspFrame {
                 frameId = deserializer.deserializeUInt8();
             }
         }
+
+        networkId = (frameControl & EZSP_NETWORK_ID_MASK) >> EZSP_NETWORK_ID_SHIFT;
+
         isResponse = (frameControl & EZSP_FC_RESPONSE) != 0;
         callbackPending = (frameControl & EZSP_FC_CB_PENDING) != 0;
     }

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspAddEndpointRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspAddEndpointRequest.java
@@ -221,8 +221,10 @@ public class EzspAddEndpointRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(225);
-        builder.append("EzspAddEndpointRequest [endpoint=");
+        final StringBuilder builder = new StringBuilder(250);
+        builder.append("EzspAddEndpointRequest [networkId=");
+        builder.append(networkId);
+        builder.append(", endpoint=");
         builder.append(endpoint);
         builder.append(", profileId=");
         builder.append(String.format("%04X", profileId));

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspAddEndpointResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspAddEndpointResponse.java
@@ -76,8 +76,10 @@ public class EzspAddEndpointResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(51);
-        builder.append("EzspAddEndpointResponse [status=");
+        final StringBuilder builder = new StringBuilder(76);
+        builder.append("EzspAddEndpointResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspAddOrUpdateKeyTableEntryRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspAddOrUpdateKeyTableEntryRequest.java
@@ -138,8 +138,10 @@ public class EzspAddOrUpdateKeyTableEntryRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(113);
-        builder.append("EzspAddOrUpdateKeyTableEntryRequest [address=");
+        final StringBuilder builder = new StringBuilder(138);
+        builder.append("EzspAddOrUpdateKeyTableEntryRequest [networkId=");
+        builder.append(networkId);
+        builder.append(", address=");
         builder.append(address);
         builder.append(", linkKey=");
         builder.append(linkKey);

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspAddOrUpdateKeyTableEntryResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspAddOrUpdateKeyTableEntryResponse.java
@@ -68,8 +68,10 @@ public class EzspAddOrUpdateKeyTableEntryResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(64);
-        builder.append("EzspAddOrUpdateKeyTableEntryResponse [status=");
+        final StringBuilder builder = new StringBuilder(89);
+        builder.append("EzspAddOrUpdateKeyTableEntryResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspAddTransientLinkKeyRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspAddTransientLinkKeyRequest.java
@@ -111,8 +111,10 @@ public class EzspAddTransientLinkKeyRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(83);
-        builder.append("EzspAddTransientLinkKeyRequest [partner=");
+        final StringBuilder builder = new StringBuilder(108);
+        builder.append("EzspAddTransientLinkKeyRequest [networkId=");
+        builder.append(networkId);
+        builder.append(", partner=");
         builder.append(partner);
         builder.append(", transientKey=");
         builder.append(transientKey);

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspAddTransientLinkKeyResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspAddTransientLinkKeyResponse.java
@@ -66,8 +66,10 @@ public class EzspAddTransientLinkKeyResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(59);
-        builder.append("EzspAddTransientLinkKeyResponse [status=");
+        final StringBuilder builder = new StringBuilder(84);
+        builder.append("EzspAddTransientLinkKeyResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspAesMmoHashRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspAesMmoHashRequest.java
@@ -164,8 +164,10 @@ public class EzspAesMmoHashRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(124);
-        builder.append("EzspAesMmoHashRequest [context=");
+        final StringBuilder builder = new StringBuilder(149);
+        builder.append("EzspAesMmoHashRequest [networkId=");
+        builder.append(networkId);
+        builder.append(", context=");
         builder.append(context);
         builder.append(", finalize=");
         builder.append(finalize);

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspAesMmoHashResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspAesMmoHashResponse.java
@@ -96,8 +96,10 @@ public class EzspAesMmoHashResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(75);
-        builder.append("EzspAesMmoHashResponse [status=");
+        final StringBuilder builder = new StringBuilder(100);
+        builder.append("EzspAesMmoHashResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(", returnContext=");
         builder.append(returnContext);

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspBecomeTrustCenterRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspBecomeTrustCenterRequest.java
@@ -80,8 +80,10 @@ public class EzspBecomeTrustCenterRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(56);
-        builder.append("EzspBecomeTrustCenterRequest [newNetworkKey=");
+        final StringBuilder builder = new StringBuilder(81);
+        builder.append("EzspBecomeTrustCenterRequest [networkId=");
+        builder.append(networkId);
+        builder.append(", newNetworkKey=");
         builder.append(newNetworkKey);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspBecomeTrustCenterResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspBecomeTrustCenterResponse.java
@@ -67,8 +67,10 @@ public class EzspBecomeTrustCenterResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(57);
-        builder.append("EzspBecomeTrustCenterResponse [status=");
+        final StringBuilder builder = new StringBuilder(82);
+        builder.append("EzspBecomeTrustCenterResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspBindingIsActiveRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspBindingIsActiveRequest.java
@@ -79,8 +79,10 @@ public class EzspBindingIsActiveRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(54);
-        builder.append("EzspBindingIsActiveRequest [index=");
+        final StringBuilder builder = new StringBuilder(79);
+        builder.append("EzspBindingIsActiveRequest [networkId=");
+        builder.append(networkId);
+        builder.append(", index=");
         builder.append(index);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspBindingIsActiveResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspBindingIsActiveResponse.java
@@ -66,8 +66,10 @@ public class EzspBindingIsActiveResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(55);
-        builder.append("EzspBindingIsActiveResponse [active=");
+        final StringBuilder builder = new StringBuilder(80);
+        builder.append("EzspBindingIsActiveResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", active=");
         builder.append(active);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspCalculateSmacs283k1Handler.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspCalculateSmacs283k1Handler.java
@@ -124,8 +124,10 @@ public class EzspCalculateSmacs283k1Handler extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(108);
-        builder.append("EzspCalculateSmacs283k1Handler [status=");
+        final StringBuilder builder = new StringBuilder(133);
+        builder.append("EzspCalculateSmacs283k1Handler [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(", initiatorSmac=");
         builder.append(initiatorSmac);

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspCalculateSmacs283k1Request.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspCalculateSmacs283k1Request.java
@@ -138,8 +138,10 @@ public class EzspCalculateSmacs283k1Request extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(108);
-        builder.append("EzspCalculateSmacs283k1Request [amInitiator=");
+        final StringBuilder builder = new StringBuilder(133);
+        builder.append("EzspCalculateSmacs283k1Request [networkId=");
+        builder.append(networkId);
+        builder.append(", amInitiator=");
         builder.append(amInitiator);
         builder.append(", partnerCertificate=");
         builder.append(partnerCertificate);

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspCalculateSmacs283k1Response.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspCalculateSmacs283k1Response.java
@@ -68,8 +68,10 @@ public class EzspCalculateSmacs283k1Response extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(59);
-        builder.append("EzspCalculateSmacs283k1Response [status=");
+        final StringBuilder builder = new StringBuilder(84);
+        builder.append("EzspCalculateSmacs283k1Response [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspCalculateSmacsHandler.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspCalculateSmacsHandler.java
@@ -124,8 +124,10 @@ public class EzspCalculateSmacsHandler extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(103);
-        builder.append("EzspCalculateSmacsHandler [status=");
+        final StringBuilder builder = new StringBuilder(128);
+        builder.append("EzspCalculateSmacsHandler [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(", initiatorSmac=");
         builder.append(initiatorSmac);

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspCalculateSmacsRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspCalculateSmacsRequest.java
@@ -137,8 +137,10 @@ public class EzspCalculateSmacsRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(103);
-        builder.append("EzspCalculateSmacsRequest [amInitiator=");
+        final StringBuilder builder = new StringBuilder(128);
+        builder.append("EzspCalculateSmacsRequest [networkId=");
+        builder.append(networkId);
+        builder.append(", amInitiator=");
         builder.append(amInitiator);
         builder.append(", partnerCertificate=");
         builder.append(partnerCertificate);

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspCalculateSmacsResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspCalculateSmacsResponse.java
@@ -67,8 +67,10 @@ public class EzspCalculateSmacsResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(54);
-        builder.append("EzspCalculateSmacsResponse [status=");
+        final StringBuilder builder = new StringBuilder(79);
+        builder.append("EzspCalculateSmacsResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspChangeSourceRouteHandler.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspChangeSourceRouteHandler.java
@@ -119,8 +119,10 @@ public class EzspChangeSourceRouteHandler extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(106);
-        builder.append("EzspChangeSourceRouteHandler [newChildId=");
+        final StringBuilder builder = new StringBuilder(131);
+        builder.append("EzspChangeSourceRouteHandler [networkId=");
+        builder.append(networkId);
+        builder.append(", newChildId=");
         builder.append(String.format("%04X", newChildId));
         builder.append(", newParentId=");
         builder.append(String.format("%04X", newParentId));

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspChildJoinHandler.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspChildJoinHandler.java
@@ -177,8 +177,10 @@ public class EzspChildJoinHandler extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(148);
-        builder.append("EzspChildJoinHandler [index=");
+        final StringBuilder builder = new StringBuilder(173);
+        builder.append("EzspChildJoinHandler [networkId=");
+        builder.append(networkId);
+        builder.append(", index=");
         builder.append(index);
         builder.append(", joining=");
         builder.append(joining);

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspClearBindingTableResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspClearBindingTableResponse.java
@@ -64,8 +64,10 @@ public class EzspClearBindingTableResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(57);
-        builder.append("EzspClearBindingTableResponse [status=");
+        final StringBuilder builder = new StringBuilder(82);
+        builder.append("EzspClearBindingTableResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspClearKeyTableResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspClearKeyTableResponse.java
@@ -64,8 +64,10 @@ public class EzspClearKeyTableResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(53);
-        builder.append("EzspClearKeyTableResponse [status=");
+        final StringBuilder builder = new StringBuilder(78);
+        builder.append("EzspClearKeyTableResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspClearTemporaryDataMaybeStoreLinkKey283k1Request.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspClearTemporaryDataMaybeStoreLinkKey283k1Request.java
@@ -81,8 +81,10 @@ public class EzspClearTemporaryDataMaybeStoreLinkKey283k1Request extends EzspFra
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(79);
-        builder.append("EzspClearTemporaryDataMaybeStoreLinkKey283k1Request [storeLinkKey=");
+        final StringBuilder builder = new StringBuilder(104);
+        builder.append("EzspClearTemporaryDataMaybeStoreLinkKey283k1Request [networkId=");
+        builder.append(networkId);
+        builder.append(", storeLinkKey=");
         builder.append(storeLinkKey);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspClearTemporaryDataMaybeStoreLinkKey283k1Response.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspClearTemporaryDataMaybeStoreLinkKey283k1Response.java
@@ -66,8 +66,10 @@ public class EzspClearTemporaryDataMaybeStoreLinkKey283k1Response extends EzspFr
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(80);
-        builder.append("EzspClearTemporaryDataMaybeStoreLinkKey283k1Response [status=");
+        final StringBuilder builder = new StringBuilder(105);
+        builder.append("EzspClearTemporaryDataMaybeStoreLinkKey283k1Response [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspClearTemporaryDataMaybeStoreLinkKeyRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspClearTemporaryDataMaybeStoreLinkKeyRequest.java
@@ -81,8 +81,10 @@ public class EzspClearTemporaryDataMaybeStoreLinkKeyRequest extends EzspFrameReq
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(74);
-        builder.append("EzspClearTemporaryDataMaybeStoreLinkKeyRequest [storeLinkKey=");
+        final StringBuilder builder = new StringBuilder(99);
+        builder.append("EzspClearTemporaryDataMaybeStoreLinkKeyRequest [networkId=");
+        builder.append(networkId);
+        builder.append(", storeLinkKey=");
         builder.append(storeLinkKey);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspClearTemporaryDataMaybeStoreLinkKeyResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspClearTemporaryDataMaybeStoreLinkKeyResponse.java
@@ -66,8 +66,10 @@ public class EzspClearTemporaryDataMaybeStoreLinkKeyResponse extends EzspFrameRe
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(75);
-        builder.append("EzspClearTemporaryDataMaybeStoreLinkKeyResponse [status=");
+        final StringBuilder builder = new StringBuilder(100);
+        builder.append("EzspClearTemporaryDataMaybeStoreLinkKeyResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspCounterRolloverHandler.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspCounterRolloverHandler.java
@@ -63,8 +63,10 @@ public class EzspCounterRolloverHandler extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(54);
-        builder.append("EzspCounterRolloverHandler [type=");
+        final StringBuilder builder = new StringBuilder(79);
+        builder.append("EzspCounterRolloverHandler [networkId=");
+        builder.append(networkId);
+        builder.append(", type=");
         builder.append(type);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspDGpSendRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspDGpSendRequest.java
@@ -246,8 +246,10 @@ public class EzspDGpSendRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(221);
-        builder.append("EzspDGpSendRequest [action=");
+        final StringBuilder builder = new StringBuilder(246);
+        builder.append("EzspDGpSendRequest [networkId=");
+        builder.append(networkId);
+        builder.append(", action=");
         builder.append(action);
         builder.append(", useCca=");
         builder.append(useCca);

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspDGpSendResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspDGpSendResponse.java
@@ -64,8 +64,10 @@ public class EzspDGpSendResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(47);
-        builder.append("EzspDGpSendResponse [status=");
+        final StringBuilder builder = new StringBuilder(72);
+        builder.append("EzspDGpSendResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspDGpSentHandler.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspDGpSentHandler.java
@@ -92,8 +92,10 @@ public class EzspDGpSentHandler extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(71);
-        builder.append("EzspDGpSentHandler [status=");
+        final StringBuilder builder = new StringBuilder(96);
+        builder.append("EzspDGpSentHandler [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(", gpepHandle=");
         builder.append(gpepHandle);

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspDeleteBindingRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspDeleteBindingRequest.java
@@ -76,8 +76,10 @@ public class EzspDeleteBindingRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(52);
-        builder.append("EzspDeleteBindingRequest [index=");
+        final StringBuilder builder = new StringBuilder(77);
+        builder.append("EzspDeleteBindingRequest [networkId=");
+        builder.append(networkId);
+        builder.append(", index=");
         builder.append(index);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspDeleteBindingResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspDeleteBindingResponse.java
@@ -64,8 +64,10 @@ public class EzspDeleteBindingResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(53);
-        builder.append("EzspDeleteBindingResponse [status=");
+        final StringBuilder builder = new StringBuilder(78);
+        builder.append("EzspDeleteBindingResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspEnergyScanRequestRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspEnergyScanRequestRequest.java
@@ -165,8 +165,10 @@ public class EzspEnergyScanRequestRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(131);
-        builder.append("EzspEnergyScanRequestRequest [target=");
+        final StringBuilder builder = new StringBuilder(156);
+        builder.append("EzspEnergyScanRequestRequest [networkId=");
+        builder.append(networkId);
+        builder.append(", target=");
         builder.append(String.format("%04X", target));
         builder.append(", scanChannels=");
         builder.append(String.format("%08X", scanChannels));

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspEnergyScanRequestResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspEnergyScanRequestResponse.java
@@ -66,8 +66,10 @@ public class EzspEnergyScanRequestResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(57);
-        builder.append("EzspEnergyScanRequestResponse [status=");
+        final StringBuilder builder = new StringBuilder(82);
+        builder.append("EzspEnergyScanRequestResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspEnergyScanResultHandler.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspEnergyScanResultHandler.java
@@ -92,8 +92,10 @@ public class EzspEnergyScanResultHandler extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(80);
-        builder.append("EzspEnergyScanResultHandler [channel=");
+        final StringBuilder builder = new StringBuilder(105);
+        builder.append("EzspEnergyScanResultHandler [networkId=");
+        builder.append(networkId);
+        builder.append(", channel=");
         builder.append(channel);
         builder.append(", maxRssiValue=");
         builder.append(maxRssiValue);

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspEraseKeyTableEntryRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspEraseKeyTableEntryRequest.java
@@ -77,8 +77,10 @@ public class EzspEraseKeyTableEntryRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(57);
-        builder.append("EzspEraseKeyTableEntryRequest [index=");
+        final StringBuilder builder = new StringBuilder(82);
+        builder.append("EzspEraseKeyTableEntryRequest [networkId=");
+        builder.append(networkId);
+        builder.append(", index=");
         builder.append(index);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspEraseKeyTableEntryResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspEraseKeyTableEntryResponse.java
@@ -65,8 +65,10 @@ public class EzspEraseKeyTableEntryResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(58);
-        builder.append("EzspEraseKeyTableEntryResponse [status=");
+        final StringBuilder builder = new StringBuilder(83);
+        builder.append("EzspEraseKeyTableEntryResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspFindAndRejoinNetworkRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspFindAndRejoinNetworkRequest.java
@@ -128,8 +128,10 @@ public class EzspFindAndRejoinNetworkRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(84);
-        builder.append("EzspFindAndRejoinNetworkRequest [haveCurrentNetworkKey=");
+        final StringBuilder builder = new StringBuilder(109);
+        builder.append("EzspFindAndRejoinNetworkRequest [networkId=");
+        builder.append(networkId);
+        builder.append(", haveCurrentNetworkKey=");
         builder.append(haveCurrentNetworkKey);
         builder.append(", channelMask=");
         builder.append(String.format("%08X", channelMask));

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspFindAndRejoinNetworkResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspFindAndRejoinNetworkResponse.java
@@ -73,8 +73,10 @@ public class EzspFindAndRejoinNetworkResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(60);
-        builder.append("EzspFindAndRejoinNetworkResponse [status=");
+        final StringBuilder builder = new StringBuilder(85);
+        builder.append("EzspFindAndRejoinNetworkResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspFindKeyTableEntryRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspFindKeyTableEntryRequest.java
@@ -112,8 +112,10 @@ public class EzspFindKeyTableEntryRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(81);
-        builder.append("EzspFindKeyTableEntryRequest [address=");
+        final StringBuilder builder = new StringBuilder(106);
+        builder.append("EzspFindKeyTableEntryRequest [networkId=");
+        builder.append(networkId);
+        builder.append(", address=");
         builder.append(address);
         builder.append(", linkKey=");
         builder.append(linkKey);

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspFindKeyTableEntryResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspFindKeyTableEntryResponse.java
@@ -67,8 +67,10 @@ public class EzspFindKeyTableEntryResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(57);
-        builder.append("EzspFindKeyTableEntryResponse [index=");
+        final StringBuilder builder = new StringBuilder(82);
+        builder.append("EzspFindKeyTableEntryResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", index=");
         builder.append(index);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspFormNetworkRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspFormNetworkRequest.java
@@ -77,8 +77,10 @@ public class EzspFormNetworkRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(50);
-        builder.append("EzspFormNetworkRequest [parameters=");
+        final StringBuilder builder = new StringBuilder(75);
+        builder.append("EzspFormNetworkRequest [networkId=");
+        builder.append(networkId);
+        builder.append(", parameters=");
         builder.append(parameters);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspFormNetworkResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspFormNetworkResponse.java
@@ -64,8 +64,10 @@ public class EzspFormNetworkResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(51);
-        builder.append("EzspFormNetworkResponse [status=");
+        final StringBuilder builder = new StringBuilder(76);
+        builder.append("EzspFormNetworkResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGenerateCbkeKeys283k1Handler.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGenerateCbkeKeys283k1Handler.java
@@ -96,8 +96,10 @@ public class EzspGenerateCbkeKeys283k1Handler extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(85);
-        builder.append("EzspGenerateCbkeKeys283k1Handler [status=");
+        final StringBuilder builder = new StringBuilder(110);
+        builder.append("EzspGenerateCbkeKeys283k1Handler [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(", ephemeralPublicKey=");
         builder.append(ephemeralPublicKey);

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGenerateCbkeKeys283k1Response.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGenerateCbkeKeys283k1Response.java
@@ -66,8 +66,10 @@ public class EzspGenerateCbkeKeys283k1Response extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(61);
-        builder.append("EzspGenerateCbkeKeys283k1Response [status=");
+        final StringBuilder builder = new StringBuilder(86);
+        builder.append("EzspGenerateCbkeKeys283k1Response [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGenerateCbkeKeysHandler.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGenerateCbkeKeysHandler.java
@@ -95,8 +95,10 @@ public class EzspGenerateCbkeKeysHandler extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(80);
-        builder.append("EzspGenerateCbkeKeysHandler [status=");
+        final StringBuilder builder = new StringBuilder(105);
+        builder.append("EzspGenerateCbkeKeysHandler [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(", ephemeralPublicKey=");
         builder.append(ephemeralPublicKey);

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGenerateCbkeKeysResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGenerateCbkeKeysResponse.java
@@ -65,8 +65,10 @@ public class EzspGenerateCbkeKeysResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(56);
-        builder.append("EzspGenerateCbkeKeysResponse [status=");
+        final StringBuilder builder = new StringBuilder(81);
+        builder.append("EzspGenerateCbkeKeysResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetAddressTableRemoteEui64Request.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetAddressTableRemoteEui64Request.java
@@ -76,8 +76,10 @@ public class EzspGetAddressTableRemoteEui64Request extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(65);
-        builder.append("EzspGetAddressTableRemoteEui64Request [addressTableIndex=");
+        final StringBuilder builder = new StringBuilder(90);
+        builder.append("EzspGetAddressTableRemoteEui64Request [networkId=");
+        builder.append(networkId);
+        builder.append(", addressTableIndex=");
         builder.append(addressTableIndex);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetAddressTableRemoteEui64Response.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetAddressTableRemoteEui64Response.java
@@ -64,8 +64,10 @@ public class EzspGetAddressTableRemoteEui64Response extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(66);
-        builder.append("EzspGetAddressTableRemoteEui64Response [eui64=");
+        final StringBuilder builder = new StringBuilder(91);
+        builder.append("EzspGetAddressTableRemoteEui64Response [networkId=");
+        builder.append(networkId);
+        builder.append(", eui64=");
         builder.append(eui64);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetBindingRemoteNodeIdRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetBindingRemoteNodeIdRequest.java
@@ -81,8 +81,10 @@ public class EzspGetBindingRemoteNodeIdRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(61);
-        builder.append("EzspGetBindingRemoteNodeIdRequest [index=");
+        final StringBuilder builder = new StringBuilder(86);
+        builder.append("EzspGetBindingRemoteNodeIdRequest [networkId=");
+        builder.append(networkId);
+        builder.append(", index=");
         builder.append(index);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetBindingRemoteNodeIdResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetBindingRemoteNodeIdResponse.java
@@ -68,8 +68,10 @@ public class EzspGetBindingRemoteNodeIdResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(62);
-        builder.append("EzspGetBindingRemoteNodeIdResponse [nodeId=");
+        final StringBuilder builder = new StringBuilder(87);
+        builder.append("EzspGetBindingRemoteNodeIdResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", nodeId=");
         builder.append(String.format("%04X", nodeId));
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetBindingRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetBindingRequest.java
@@ -76,8 +76,10 @@ public class EzspGetBindingRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(49);
-        builder.append("EzspGetBindingRequest [index=");
+        final StringBuilder builder = new StringBuilder(74);
+        builder.append("EzspGetBindingRequest [networkId=");
+        builder.append(networkId);
+        builder.append(", index=");
         builder.append(index);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetBindingResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetBindingResponse.java
@@ -93,8 +93,10 @@ public class EzspGetBindingResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(75);
-        builder.append("EzspGetBindingResponse [status=");
+        final StringBuilder builder = new StringBuilder(100);
+        builder.append("EzspGetBindingResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(", value=");
         builder.append(value);

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetCertificate283k1Response.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetCertificate283k1Response.java
@@ -93,8 +93,10 @@ public class EzspGetCertificate283k1Response extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(84);
-        builder.append("EzspGetCertificate283k1Response [status=");
+        final StringBuilder builder = new StringBuilder(109);
+        builder.append("EzspGetCertificate283k1Response [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(", localCert=");
         builder.append(localCert);

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetCertificateResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetCertificateResponse.java
@@ -93,8 +93,10 @@ public class EzspGetCertificateResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(79);
-        builder.append("EzspGetCertificateResponse [status=");
+        final StringBuilder builder = new StringBuilder(104);
+        builder.append("EzspGetCertificateResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(", localCert=");
         builder.append(localCert);

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetChildDataRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetChildDataRequest.java
@@ -79,8 +79,10 @@ public class EzspGetChildDataRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(51);
-        builder.append("EzspGetChildDataRequest [index=");
+        final StringBuilder builder = new StringBuilder(76);
+        builder.append("EzspGetChildDataRequest [networkId=");
+        builder.append(networkId);
+        builder.append(", index=");
         builder.append(index);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetChildDataResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetChildDataResponse.java
@@ -150,8 +150,10 @@ public class EzspGetChildDataResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(127);
-        builder.append("EzspGetChildDataResponse [status=");
+        final StringBuilder builder = new StringBuilder(152);
+        builder.append("EzspGetChildDataResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(", childId=");
         builder.append(String.format("%04X", childId));

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetConfigurationValueRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetConfigurationValueRequest.java
@@ -77,8 +77,10 @@ public class EzspGetConfigurationValueRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(60);
-        builder.append("EzspGetConfigurationValueRequest [configId=");
+        final StringBuilder builder = new StringBuilder(85);
+        builder.append("EzspGetConfigurationValueRequest [networkId=");
+        builder.append(networkId);
+        builder.append(", configId=");
         builder.append(configId);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetConfigurationValueResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetConfigurationValueResponse.java
@@ -95,8 +95,10 @@ public class EzspGetConfigurationValueResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(86);
-        builder.append("EzspGetConfigurationValueResponse [status=");
+        final StringBuilder builder = new StringBuilder(111);
+        builder.append("EzspGetConfigurationValueResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(", value=");
         builder.append(value);

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetCurrentSecurityStateResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetCurrentSecurityStateResponse.java
@@ -93,8 +93,10 @@ public class EzspGetCurrentSecurityStateResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(88);
-        builder.append("EzspGetCurrentSecurityStateResponse [status=");
+        final StringBuilder builder = new StringBuilder(113);
+        builder.append("EzspGetCurrentSecurityStateResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(", state=");
         builder.append(state);

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetEui64Response.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetEui64Response.java
@@ -64,8 +64,10 @@ public class EzspGetEui64Response extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(48);
-        builder.append("EzspGetEui64Response [eui64=");
+        final StringBuilder builder = new StringBuilder(73);
+        builder.append("EzspGetEui64Response [networkId=");
+        builder.append(networkId);
+        builder.append(", eui64=");
         builder.append(eui64);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetExtendedTimeoutRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetExtendedTimeoutRequest.java
@@ -78,8 +78,10 @@ public class EzspGetExtendedTimeoutRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(57);
-        builder.append("EzspGetExtendedTimeoutRequest [remoteEui64=");
+        final StringBuilder builder = new StringBuilder(82);
+        builder.append("EzspGetExtendedTimeoutRequest [networkId=");
+        builder.append(networkId);
+        builder.append(", remoteEui64=");
         builder.append(remoteEui64);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetExtendedTimeoutResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetExtendedTimeoutResponse.java
@@ -67,8 +67,10 @@ public class EzspGetExtendedTimeoutResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(58);
-        builder.append("EzspGetExtendedTimeoutResponse [extendedTimeout=");
+        final StringBuilder builder = new StringBuilder(83);
+        builder.append("EzspGetExtendedTimeoutResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", extendedTimeout=");
         builder.append(extendedTimeout);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetKeyRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetKeyRequest.java
@@ -72,8 +72,10 @@ public class EzspGetKeyRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(45);
-        builder.append("EzspGetKeyRequest [keyType=");
+        final StringBuilder builder = new StringBuilder(70);
+        builder.append("EzspGetKeyRequest [networkId=");
+        builder.append(networkId);
+        builder.append(", keyType=");
         builder.append(keyType);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetKeyResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetKeyResponse.java
@@ -93,8 +93,10 @@ public class EzspGetKeyResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(71);
-        builder.append("EzspGetKeyResponse [status=");
+        final StringBuilder builder = new StringBuilder(96);
+        builder.append("EzspGetKeyResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(", keyStruct=");
         builder.append(keyStruct);

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetKeyTableEntryRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetKeyTableEntryRequest.java
@@ -76,8 +76,10 @@ public class EzspGetKeyTableEntryRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(55);
-        builder.append("EzspGetKeyTableEntryRequest [index=");
+        final StringBuilder builder = new StringBuilder(80);
+        builder.append("EzspGetKeyTableEntryRequest [networkId=");
+        builder.append(networkId);
+        builder.append(", index=");
         builder.append(index);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetKeyTableEntryResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetKeyTableEntryResponse.java
@@ -96,8 +96,10 @@ public class EzspGetKeyTableEntryResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(81);
-        builder.append("EzspGetKeyTableEntryResponse [status=");
+        final StringBuilder builder = new StringBuilder(106);
+        builder.append("EzspGetKeyTableEntryResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(", keyStruct=");
         builder.append(keyStruct);

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetLibraryStatusRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetLibraryStatusRequest.java
@@ -78,8 +78,10 @@ public class EzspGetLibraryStatusRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(55);
-        builder.append("EzspGetLibraryStatusRequest [libraryId=");
+        final StringBuilder builder = new StringBuilder(80);
+        builder.append("EzspGetLibraryStatusRequest [networkId=");
+        builder.append(networkId);
+        builder.append(", libraryId=");
         builder.append(libraryId);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetLibraryStatusResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetLibraryStatusResponse.java
@@ -65,8 +65,10 @@ public class EzspGetLibraryStatusResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(56);
-        builder.append("EzspGetLibraryStatusResponse [status=");
+        final StringBuilder builder = new StringBuilder(81);
+        builder.append("EzspGetLibraryStatusResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetMfgTokenRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetMfgTokenRequest.java
@@ -78,8 +78,10 @@ public class EzspGetMfgTokenRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(50);
-        builder.append("EzspGetMfgTokenRequest [tokenId=");
+        final StringBuilder builder = new StringBuilder(75);
+        builder.append("EzspGetMfgTokenRequest [networkId=");
+        builder.append(networkId);
+        builder.append(", tokenId=");
         builder.append(tokenId);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetMfgTokenResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetMfgTokenResponse.java
@@ -65,8 +65,10 @@ public class EzspGetMfgTokenResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(76);
-        builder.append("EzspGetMfgTokenResponse [tokenData=");
+        final StringBuilder builder = new StringBuilder(101);
+        builder.append("EzspGetMfgTokenResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", tokenData=");
         for (int cnt = 0; cnt < tokenData.length; cnt++) {
             if (cnt > 0) {
                 builder.append(' ');

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetNeighborRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetNeighborRequest.java
@@ -80,8 +80,10 @@ public class EzspGetNeighborRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(50);
-        builder.append("EzspGetNeighborRequest [index=");
+        final StringBuilder builder = new StringBuilder(75);
+        builder.append("EzspGetNeighborRequest [networkId=");
+        builder.append(networkId);
+        builder.append(", index=");
         builder.append(index);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetNeighborResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetNeighborResponse.java
@@ -97,8 +97,10 @@ public class EzspGetNeighborResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(76);
-        builder.append("EzspGetNeighborResponse [status=");
+        final StringBuilder builder = new StringBuilder(101);
+        builder.append("EzspGetNeighborResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(", value=");
         builder.append(value);

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetNetworkParametersResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetNetworkParametersResponse.java
@@ -122,8 +122,10 @@ public class EzspGetNetworkParametersResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(110);
-        builder.append("EzspGetNetworkParametersResponse [status=");
+        final StringBuilder builder = new StringBuilder(135);
+        builder.append("EzspGetNetworkParametersResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(", nodeType=");
         builder.append(nodeType);

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetNodeIdResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetNodeIdResponse.java
@@ -63,8 +63,10 @@ public class EzspGetNodeIdResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(49);
-        builder.append("EzspGetNodeIdResponse [nodeId=");
+        final StringBuilder builder = new StringBuilder(74);
+        builder.append("EzspGetNodeIdResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", nodeId=");
         builder.append(String.format("%04X", nodeId));
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetParentChildParametersResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetParentChildParametersResponse.java
@@ -126,8 +126,10 @@ public class EzspGetParentChildParametersResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(114);
-        builder.append("EzspGetParentChildParametersResponse [childCount=");
+        final StringBuilder builder = new StringBuilder(139);
+        builder.append("EzspGetParentChildParametersResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", childCount=");
         builder.append(childCount);
         builder.append(", parentEui64=");
         builder.append(parentEui64);

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetPolicyRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetPolicyRequest.java
@@ -77,8 +77,10 @@ public class EzspGetPolicyRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(48);
-        builder.append("EzspGetPolicyRequest [policyId=");
+        final StringBuilder builder = new StringBuilder(73);
+        builder.append("EzspGetPolicyRequest [networkId=");
+        builder.append(networkId);
+        builder.append(", policyId=");
         builder.append(policyId);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetPolicyResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetPolicyResponse.java
@@ -96,8 +96,10 @@ public class EzspGetPolicyResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(74);
-        builder.append("EzspGetPolicyResponse [status=");
+        final StringBuilder builder = new StringBuilder(99);
+        builder.append("EzspGetPolicyResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(", decisionId=");
         builder.append(decisionId);

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetRouteTableEntryRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetRouteTableEntryRequest.java
@@ -77,8 +77,10 @@ public class EzspGetRouteTableEntryRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(57);
-        builder.append("EzspGetRouteTableEntryRequest [index=");
+        final StringBuilder builder = new StringBuilder(82);
+        builder.append("EzspGetRouteTableEntryRequest [networkId=");
+        builder.append(networkId);
+        builder.append(", index=");
         builder.append(index);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetRouteTableEntryResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetRouteTableEntryResponse.java
@@ -97,8 +97,10 @@ public class EzspGetRouteTableEntryResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(83);
-        builder.append("EzspGetRouteTableEntryResponse [status=");
+        final StringBuilder builder = new StringBuilder(108);
+        builder.append("EzspGetRouteTableEntryResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(", value=");
         builder.append(value);

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetStandaloneBootloaderVersionPlatMicroPhyResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetStandaloneBootloaderVersionPlatMicroPhyResponse.java
@@ -152,8 +152,10 @@ public class EzspGetStandaloneBootloaderVersionPlatMicroPhyResponse extends Ezsp
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(157);
-        builder.append("EzspGetStandaloneBootloaderVersionPlatMicroPhyResponse [bootloaderVersion=");
+        final StringBuilder builder = new StringBuilder(182);
+        builder.append("EzspGetStandaloneBootloaderVersionPlatMicroPhyResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", bootloaderVersion=");
         builder.append(String.format("%04X", bootloaderVersion));
         builder.append(", nodePlat=");
         builder.append(nodePlat);

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetTransientKeyTableEntryRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetTransientKeyTableEntryRequest.java
@@ -76,8 +76,10 @@ public class EzspGetTransientKeyTableEntryRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(64);
-        builder.append("EzspGetTransientKeyTableEntryRequest [index=");
+        final StringBuilder builder = new StringBuilder(89);
+        builder.append("EzspGetTransientKeyTableEntryRequest [networkId=");
+        builder.append(networkId);
+        builder.append(", index=");
         builder.append(index);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetTransientKeyTableEntryResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetTransientKeyTableEntryResponse.java
@@ -93,8 +93,10 @@ public class EzspGetTransientKeyTableEntryResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(90);
-        builder.append("EzspGetTransientKeyTableEntryResponse [status=");
+        final StringBuilder builder = new StringBuilder(115);
+        builder.append("EzspGetTransientKeyTableEntryResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(", transientKeyData=");
         builder.append(transientKeyData);

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetTransientLinkKeyRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetTransientLinkKeyRequest.java
@@ -79,8 +79,10 @@ public class EzspGetTransientLinkKeyRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(58);
-        builder.append("EzspGetTransientLinkKeyRequest [eui=");
+        final StringBuilder builder = new StringBuilder(83);
+        builder.append("EzspGetTransientLinkKeyRequest [networkId=");
+        builder.append(networkId);
+        builder.append(", eui=");
         builder.append(eui);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetTransientLinkKeyResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetTransientLinkKeyResponse.java
@@ -95,8 +95,10 @@ public class EzspGetTransientLinkKeyResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(84);
-        builder.append("EzspGetTransientLinkKeyResponse [status=");
+        final StringBuilder builder = new StringBuilder(109);
+        builder.append("EzspGetTransientLinkKeyResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(", transientKeyData=");
         builder.append(transientKeyData);

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetValueRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetValueRequest.java
@@ -77,8 +77,10 @@ public class EzspGetValueRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(47);
-        builder.append("EzspGetValueRequest [valueId=");
+        final StringBuilder builder = new StringBuilder(72);
+        builder.append("EzspGetValueRequest [networkId=");
+        builder.append(networkId);
+        builder.append(", valueId=");
         builder.append(valueId);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetValueResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetValueResponse.java
@@ -96,8 +96,10 @@ public class EzspGetValueResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(98);
-        builder.append("EzspGetValueResponse [status=");
+        final StringBuilder builder = new StringBuilder(123);
+        builder.append("EzspGetValueResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(", value=");
         for (int cnt = 0; cnt < value.length; cnt++) {

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetXncpInfoResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetXncpInfoResponse.java
@@ -122,8 +122,10 @@ public class EzspGetXncpInfoResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(101);
-        builder.append("EzspGetXncpInfoResponse [status=");
+        final StringBuilder builder = new StringBuilder(126);
+        builder.append("EzspGetXncpInfoResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(", manufacturerId=");
         builder.append(manufacturerId);

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGpProxyTableGetEntryRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGpProxyTableGetEntryRequest.java
@@ -76,8 +76,10 @@ public class EzspGpProxyTableGetEntryRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(59);
-        builder.append("EzspGpProxyTableGetEntryRequest [proxyIndex=");
+        final StringBuilder builder = new StringBuilder(84);
+        builder.append("EzspGpProxyTableGetEntryRequest [networkId=");
+        builder.append(networkId);
+        builder.append(", proxyIndex=");
         builder.append(proxyIndex);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGpProxyTableGetEntryResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGpProxyTableGetEntryResponse.java
@@ -93,8 +93,10 @@ public class EzspGpProxyTableGetEntryResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(85);
-        builder.append("EzspGpProxyTableGetEntryResponse [status=");
+        final StringBuilder builder = new StringBuilder(110);
+        builder.append("EzspGpProxyTableGetEntryResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(", entry=");
         builder.append(entry);

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGpProxyTableLookupRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGpProxyTableLookupRequest.java
@@ -77,8 +77,10 @@ public class EzspGpProxyTableLookupRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(57);
-        builder.append("EzspGpProxyTableLookupRequest [addr=");
+        final StringBuilder builder = new StringBuilder(82);
+        builder.append("EzspGpProxyTableLookupRequest [networkId=");
+        builder.append(networkId);
+        builder.append(", addr=");
         builder.append(addr);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGpProxyTableLookupResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGpProxyTableLookupResponse.java
@@ -63,8 +63,10 @@ public class EzspGpProxyTableLookupResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(58);
-        builder.append("EzspGpProxyTableLookupResponse [index=");
+        final StringBuilder builder = new StringBuilder(83);
+        builder.append("EzspGpProxyTableLookupResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", index=");
         builder.append(index);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGpProxyTableProcessGpPairingRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGpProxyTableProcessGpPairingRequest.java
@@ -275,8 +275,10 @@ public class EzspGpProxyTableProcessGpPairingRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(242);
-        builder.append("EzspGpProxyTableProcessGpPairingRequest [options=");
+        final StringBuilder builder = new StringBuilder(267);
+        builder.append("EzspGpProxyTableProcessGpPairingRequest [networkId=");
+        builder.append(networkId);
+        builder.append(", options=");
         builder.append(options);
         builder.append(", addr=");
         builder.append(addr);

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGpProxyTableProcessGpPairingResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGpProxyTableProcessGpPairingResponse.java
@@ -63,8 +63,10 @@ public class EzspGpProxyTableProcessGpPairingResponse extends EzspFrameResponse 
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(68);
-        builder.append("EzspGpProxyTableProcessGpPairingResponse [gpPairingAdded=");
+        final StringBuilder builder = new StringBuilder(93);
+        builder.append("EzspGpProxyTableProcessGpPairingResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", gpPairingAdded=");
         builder.append(gpPairingAdded);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGpSinkTableFindOrAllocateEntryRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGpSinkTableFindOrAllocateEntryRequest.java
@@ -77,8 +77,10 @@ public class EzspGpSinkTableFindOrAllocateEntryRequest extends EzspFrameRequest 
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(69);
-        builder.append("EzspGpSinkTableFindOrAllocateEntryRequest [addr=");
+        final StringBuilder builder = new StringBuilder(94);
+        builder.append("EzspGpSinkTableFindOrAllocateEntryRequest [networkId=");
+        builder.append(networkId);
+        builder.append(", addr=");
         builder.append(addr);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGpSinkTableFindOrAllocateEntryResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGpSinkTableFindOrAllocateEntryResponse.java
@@ -63,8 +63,10 @@ public class EzspGpSinkTableFindOrAllocateEntryResponse extends EzspFrameRespons
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(70);
-        builder.append("EzspGpSinkTableFindOrAllocateEntryResponse [index=");
+        final StringBuilder builder = new StringBuilder(95);
+        builder.append("EzspGpSinkTableFindOrAllocateEntryResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", index=");
         builder.append(index);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGpSinkTableGetEntryRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGpSinkTableGetEntryRequest.java
@@ -76,8 +76,10 @@ public class EzspGpSinkTableGetEntryRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(58);
-        builder.append("EzspGpSinkTableGetEntryRequest [sinkIndex=");
+        final StringBuilder builder = new StringBuilder(83);
+        builder.append("EzspGpSinkTableGetEntryRequest [networkId=");
+        builder.append(networkId);
+        builder.append(", sinkIndex=");
         builder.append(sinkIndex);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGpSinkTableGetEntryResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGpSinkTableGetEntryResponse.java
@@ -93,8 +93,10 @@ public class EzspGpSinkTableGetEntryResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(84);
-        builder.append("EzspGpSinkTableGetEntryResponse [status=");
+        final StringBuilder builder = new StringBuilder(109);
+        builder.append("EzspGpSinkTableGetEntryResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(", entry=");
         builder.append(entry);

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGpSinkTableLookupRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGpSinkTableLookupRequest.java
@@ -77,8 +77,10 @@ public class EzspGpSinkTableLookupRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(56);
-        builder.append("EzspGpSinkTableLookupRequest [addr=");
+        final StringBuilder builder = new StringBuilder(81);
+        builder.append("EzspGpSinkTableLookupRequest [networkId=");
+        builder.append(networkId);
+        builder.append(", addr=");
         builder.append(addr);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGpSinkTableLookupResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGpSinkTableLookupResponse.java
@@ -63,8 +63,10 @@ public class EzspGpSinkTableLookupResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(57);
-        builder.append("EzspGpSinkTableLookupResponse [index=");
+        final StringBuilder builder = new StringBuilder(82);
+        builder.append("EzspGpSinkTableLookupResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", index=");
         builder.append(index);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGpSinkTableRemoveEntryRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGpSinkTableRemoveEntryRequest.java
@@ -76,8 +76,10 @@ public class EzspGpSinkTableRemoveEntryRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(61);
-        builder.append("EzspGpSinkTableRemoveEntryRequest [sinkIndex=");
+        final StringBuilder builder = new StringBuilder(86);
+        builder.append("EzspGpSinkTableRemoveEntryRequest [networkId=");
+        builder.append(networkId);
+        builder.append(", sinkIndex=");
         builder.append(sinkIndex);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGpSinkTableSetEntryRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGpSinkTableSetEntryRequest.java
@@ -105,8 +105,10 @@ public class EzspGpSinkTableSetEntryRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(83);
-        builder.append("EzspGpSinkTableSetEntryRequest [sinkIndex=");
+        final StringBuilder builder = new StringBuilder(108);
+        builder.append("EzspGpSinkTableSetEntryRequest [networkId=");
+        builder.append(networkId);
+        builder.append(", sinkIndex=");
         builder.append(sinkIndex);
         builder.append(", entry=");
         builder.append(entry);

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGpSinkTableSetEntryResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGpSinkTableSetEntryResponse.java
@@ -64,8 +64,10 @@ public class EzspGpSinkTableSetEntryResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(59);
-        builder.append("EzspGpSinkTableSetEntryResponse [status=");
+        final StringBuilder builder = new StringBuilder(84);
+        builder.append("EzspGpSinkTableSetEntryResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGpepIncomingMessageHandler.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGpepIncomingMessageHandler.java
@@ -404,8 +404,10 @@ public class EzspGpepIncomingMessageHandler extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(383);
-        builder.append("EzspGpepIncomingMessageHandler [status=");
+        final StringBuilder builder = new StringBuilder(408);
+        builder.append("EzspGpepIncomingMessageHandler [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(", gpdLink=");
         builder.append(gpdLink);

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspIdConflictHandler.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspIdConflictHandler.java
@@ -67,8 +67,10 @@ public class EzspIdConflictHandler extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(49);
-        builder.append("EzspIdConflictHandler [id=");
+        final StringBuilder builder = new StringBuilder(74);
+        builder.append("EzspIdConflictHandler [networkId=");
+        builder.append(networkId);
+        builder.append(", id=");
         builder.append(String.format("%04X", id));
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspIncomingManyToOneRouteRequestHandler.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspIncomingManyToOneRouteRequestHandler.java
@@ -124,8 +124,10 @@ public class EzspIncomingManyToOneRouteRequestHandler extends EzspFrameResponse 
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(118);
-        builder.append("EzspIncomingManyToOneRouteRequestHandler [source=");
+        final StringBuilder builder = new StringBuilder(143);
+        builder.append("EzspIncomingManyToOneRouteRequestHandler [networkId=");
+        builder.append(networkId);
+        builder.append(", source=");
         builder.append(String.format("%04X", source));
         builder.append(", longId=");
         builder.append(longId);

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspIncomingMessageHandler.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspIncomingMessageHandler.java
@@ -274,8 +274,10 @@ public class EzspIncomingMessageHandler extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(254);
-        builder.append("EzspIncomingMessageHandler [type=");
+        final StringBuilder builder = new StringBuilder(279);
+        builder.append("EzspIncomingMessageHandler [networkId=");
+        builder.append(networkId);
+        builder.append(", type=");
         builder.append(type);
         builder.append(", apsFrame=");
         builder.append(apsFrame);

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspIncomingRouteErrorHandler.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspIncomingRouteErrorHandler.java
@@ -93,8 +93,10 @@ public class EzspIncomingRouteErrorHandler extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(82);
-        builder.append("EzspIncomingRouteErrorHandler [status=");
+        final StringBuilder builder = new StringBuilder(107);
+        builder.append("EzspIncomingRouteErrorHandler [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(", target=");
         builder.append(String.format("%04X", target));

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspIncomingRouteRecordHandler.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspIncomingRouteRecordHandler.java
@@ -177,8 +177,10 @@ public class EzspIncomingRouteRecordHandler extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(183);
-        builder.append("EzspIncomingRouteRecordHandler [source=");
+        final StringBuilder builder = new StringBuilder(208);
+        builder.append("EzspIncomingRouteRecordHandler [networkId=");
+        builder.append(networkId);
+        builder.append(", source=");
         builder.append(String.format("%04X", source));
         builder.append(", sourceEui=");
         builder.append(sourceEui);

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspIncomingSenderEui64Handler.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspIncomingSenderEui64Handler.java
@@ -66,8 +66,10 @@ public class EzspIncomingSenderEui64Handler extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(58);
-        builder.append("EzspIncomingSenderEui64Handler [senderEui64=");
+        final StringBuilder builder = new StringBuilder(83);
+        builder.append("EzspIncomingSenderEui64Handler [networkId=");
+        builder.append(networkId);
+        builder.append(", senderEui64=");
         builder.append(senderEui64);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspInvalidCommandResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspInvalidCommandResponse.java
@@ -64,8 +64,10 @@ public class EzspInvalidCommandResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(54);
-        builder.append("EzspInvalidCommandResponse [reason=");
+        final StringBuilder builder = new StringBuilder(79);
+        builder.append("EzspInvalidCommandResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", reason=");
         builder.append(reason);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspJoinNetworkRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspJoinNetworkRequest.java
@@ -111,8 +111,10 @@ public class EzspJoinNetworkRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(75);
-        builder.append("EzspJoinNetworkRequest [nodeType=");
+        final StringBuilder builder = new StringBuilder(100);
+        builder.append("EzspJoinNetworkRequest [networkId=");
+        builder.append(networkId);
+        builder.append(", nodeType=");
         builder.append(nodeType);
         builder.append(", parameters=");
         builder.append(parameters);

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspJoinNetworkResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspJoinNetworkResponse.java
@@ -66,8 +66,10 @@ public class EzspJoinNetworkResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(51);
-        builder.append("EzspJoinNetworkResponse [status=");
+        final StringBuilder builder = new StringBuilder(76);
+        builder.append("EzspJoinNetworkResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspLaunchStandaloneBootloaderRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspLaunchStandaloneBootloaderRequest.java
@@ -92,8 +92,10 @@ public class EzspLaunchStandaloneBootloaderRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(65);
-        builder.append("EzspLaunchStandaloneBootloaderRequest [mode=");
+        final StringBuilder builder = new StringBuilder(90);
+        builder.append("EzspLaunchStandaloneBootloaderRequest [networkId=");
+        builder.append(networkId);
+        builder.append(", mode=");
         builder.append(mode);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspLaunchStandaloneBootloaderResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspLaunchStandaloneBootloaderResponse.java
@@ -65,8 +65,10 @@ public class EzspLaunchStandaloneBootloaderResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(66);
-        builder.append("EzspLaunchStandaloneBootloaderResponse [status=");
+        final StringBuilder builder = new StringBuilder(91);
+        builder.append("EzspLaunchStandaloneBootloaderResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspLeaveNetworkResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspLeaveNetworkResponse.java
@@ -66,8 +66,10 @@ public class EzspLeaveNetworkResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(52);
-        builder.append("EzspLeaveNetworkResponse [status=");
+        final StringBuilder builder = new StringBuilder(77);
+        builder.append("EzspLeaveNetworkResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspLookupEui64ByNodeIdRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspLookupEui64ByNodeIdRequest.java
@@ -77,8 +77,10 @@ public class EzspLookupEui64ByNodeIdRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(58);
-        builder.append("EzspLookupEui64ByNodeIdRequest [nodeId=");
+        final StringBuilder builder = new StringBuilder(83);
+        builder.append("EzspLookupEui64ByNodeIdRequest [networkId=");
+        builder.append(networkId);
+        builder.append(", nodeId=");
         builder.append(String.format("%04X", nodeId));
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspLookupEui64ByNodeIdResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspLookupEui64ByNodeIdResponse.java
@@ -94,8 +94,10 @@ public class EzspLookupEui64ByNodeIdResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(84);
-        builder.append("EzspLookupEui64ByNodeIdResponse [status=");
+        final StringBuilder builder = new StringBuilder(109);
+        builder.append("EzspLookupEui64ByNodeIdResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(", eui64=");
         builder.append(eui64);

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspLookupNodeIdByEui64Request.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspLookupNodeIdByEui64Request.java
@@ -78,8 +78,10 @@ public class EzspLookupNodeIdByEui64Request extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(58);
-        builder.append("EzspLookupNodeIdByEui64Request [eui64=");
+        final StringBuilder builder = new StringBuilder(83);
+        builder.append("EzspLookupNodeIdByEui64Request [networkId=");
+        builder.append(networkId);
+        builder.append(", eui64=");
         builder.append(eui64);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspLookupNodeIdByEui64Response.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspLookupNodeIdByEui64Response.java
@@ -64,8 +64,10 @@ public class EzspLookupNodeIdByEui64Response extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(59);
-        builder.append("EzspLookupNodeIdByEui64Response [nodeId=");
+        final StringBuilder builder = new StringBuilder(84);
+        builder.append("EzspLookupNodeIdByEui64Response [networkId=");
+        builder.append(networkId);
+        builder.append(", nodeId=");
         builder.append(String.format("%04X", nodeId));
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspMacFilterMatchMessageHandler.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspMacFilterMatchMessageHandler.java
@@ -178,8 +178,10 @@ public class EzspMacFilterMatchMessageHandler extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(185);
-        builder.append("EzspMacFilterMatchMessageHandler [filterIndexMatch=");
+        final StringBuilder builder = new StringBuilder(210);
+        builder.append("EzspMacFilterMatchMessageHandler [networkId=");
+        builder.append(networkId);
+        builder.append(", filterIndexMatch=");
         builder.append(filterIndexMatch);
         builder.append(", legacyPassthroughType=");
         builder.append(legacyPassthroughType);

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspMessageSentHandler.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspMessageSentHandler.java
@@ -222,8 +222,10 @@ public class EzspMessageSentHandler extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(200);
-        builder.append("EzspMessageSentHandler [type=");
+        final StringBuilder builder = new StringBuilder(225);
+        builder.append("EzspMessageSentHandler [networkId=");
+        builder.append(networkId);
+        builder.append(", type=");
         builder.append(type);
         builder.append(", indexOrDestination=");
         builder.append(indexOrDestination);

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspMfglibEndResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspMfglibEndResponse.java
@@ -65,8 +65,10 @@ public class EzspMfglibEndResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(49);
-        builder.append("EzspMfglibEndResponse [status=");
+        final StringBuilder builder = new StringBuilder(74);
+        builder.append("EzspMfglibEndResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspMfglibGetChannelResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspMfglibGetChannelResponse.java
@@ -63,8 +63,10 @@ public class EzspMfglibGetChannelResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(56);
-        builder.append("EzspMfglibGetChannelResponse [channel=");
+        final StringBuilder builder = new StringBuilder(81);
+        builder.append("EzspMfglibGetChannelResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", channel=");
         builder.append(channel);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspMfglibGetPowerResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspMfglibGetPowerResponse.java
@@ -63,8 +63,10 @@ public class EzspMfglibGetPowerResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(54);
-        builder.append("EzspMfglibGetPowerResponse [power=");
+        final StringBuilder builder = new StringBuilder(79);
+        builder.append("EzspMfglibGetPowerResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", power=");
         builder.append(power);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspMfglibRxHandler.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspMfglibRxHandler.java
@@ -120,8 +120,10 @@ public class EzspMfglibRxHandler extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(122);
-        builder.append("EzspMfglibRxHandler [linkQuality=");
+        final StringBuilder builder = new StringBuilder(147);
+        builder.append("EzspMfglibRxHandler [networkId=");
+        builder.append(networkId);
+        builder.append(", linkQuality=");
         builder.append(linkQuality);
         builder.append(", rssi=");
         builder.append(rssi);

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspMfglibSendPacketRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspMfglibSendPacketRequest.java
@@ -80,8 +80,10 @@ public class EzspMfglibSendPacketRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(80);
-        builder.append("EzspMfglibSendPacketRequest [packetContents=");
+        final StringBuilder builder = new StringBuilder(105);
+        builder.append("EzspMfglibSendPacketRequest [networkId=");
+        builder.append(networkId);
+        builder.append(", packetContents=");
         for (int cnt = 0; cnt < packetContents.length; cnt++) {
             if (cnt > 0) {
                 builder.append(' ');

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspMfglibSendPacketResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspMfglibSendPacketResponse.java
@@ -67,8 +67,10 @@ public class EzspMfglibSendPacketResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(56);
-        builder.append("EzspMfglibSendPacketResponse [status=");
+        final StringBuilder builder = new StringBuilder(81);
+        builder.append("EzspMfglibSendPacketResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspMfglibSetChannelRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspMfglibSetChannelRequest.java
@@ -77,8 +77,10 @@ public class EzspMfglibSetChannelRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(55);
-        builder.append("EzspMfglibSetChannelRequest [channel=");
+        final StringBuilder builder = new StringBuilder(80);
+        builder.append("EzspMfglibSetChannelRequest [networkId=");
+        builder.append(networkId);
+        builder.append(", channel=");
         builder.append(channel);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspMfglibSetChannelResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspMfglibSetChannelResponse.java
@@ -65,8 +65,10 @@ public class EzspMfglibSetChannelResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(56);
-        builder.append("EzspMfglibSetChannelResponse [status=");
+        final StringBuilder builder = new StringBuilder(81);
+        builder.append("EzspMfglibSetChannelResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspMfglibSetPowerRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspMfglibSetPowerRequest.java
@@ -108,8 +108,10 @@ public class EzspMfglibSetPowerRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(78);
-        builder.append("EzspMfglibSetPowerRequest [txPowerMode=");
+        final StringBuilder builder = new StringBuilder(103);
+        builder.append("EzspMfglibSetPowerRequest [networkId=");
+        builder.append(networkId);
+        builder.append(", txPowerMode=");
         builder.append(txPowerMode);
         builder.append(", power=");
         builder.append(power);

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspMfglibSetPowerResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspMfglibSetPowerResponse.java
@@ -67,8 +67,10 @@ public class EzspMfglibSetPowerResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(54);
-        builder.append("EzspMfglibSetPowerResponse [status=");
+        final StringBuilder builder = new StringBuilder(79);
+        builder.append("EzspMfglibSetPowerResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspMfglibStartRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspMfglibStartRequest.java
@@ -79,8 +79,10 @@ public class EzspMfglibStartRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(50);
-        builder.append("EzspMfglibStartRequest [rxCallback=");
+        final StringBuilder builder = new StringBuilder(75);
+        builder.append("EzspMfglibStartRequest [networkId=");
+        builder.append(networkId);
+        builder.append(", rxCallback=");
         builder.append(rxCallback);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspMfglibStartResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspMfglibStartResponse.java
@@ -67,8 +67,10 @@ public class EzspMfglibStartResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(51);
-        builder.append("EzspMfglibStartResponse [status=");
+        final StringBuilder builder = new StringBuilder(76);
+        builder.append("EzspMfglibStartResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspMfglibStartStreamResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspMfglibStartStreamResponse.java
@@ -65,8 +65,10 @@ public class EzspMfglibStartStreamResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(57);
-        builder.append("EzspMfglibStartStreamResponse [status=");
+        final StringBuilder builder = new StringBuilder(82);
+        builder.append("EzspMfglibStartStreamResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspMfglibStartToneResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspMfglibStartToneResponse.java
@@ -67,8 +67,10 @@ public class EzspMfglibStartToneResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(55);
-        builder.append("EzspMfglibStartToneResponse [status=");
+        final StringBuilder builder = new StringBuilder(80);
+        builder.append("EzspMfglibStartToneResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspMfglibStopStreamResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspMfglibStopStreamResponse.java
@@ -64,8 +64,10 @@ public class EzspMfglibStopStreamResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(56);
-        builder.append("EzspMfglibStopStreamResponse [status=");
+        final StringBuilder builder = new StringBuilder(81);
+        builder.append("EzspMfglibStopStreamResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspMfglibStopToneResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspMfglibStopToneResponse.java
@@ -64,8 +64,10 @@ public class EzspMfglibStopToneResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(54);
-        builder.append("EzspMfglibStopToneResponse [status=");
+        final StringBuilder builder = new StringBuilder(79);
+        builder.append("EzspMfglibStopToneResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspNeighborCountResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspNeighborCountResponse.java
@@ -63,8 +63,10 @@ public class EzspNeighborCountResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(53);
-        builder.append("EzspNeighborCountResponse [value=");
+        final StringBuilder builder = new StringBuilder(78);
+        builder.append("EzspNeighborCountResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", value=");
         builder.append(value);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspNetworkFoundHandler.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspNetworkFoundHandler.java
@@ -121,8 +121,10 @@ public class EzspNetworkFoundHandler extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(101);
-        builder.append("EzspNetworkFoundHandler [networkFound=");
+        final StringBuilder builder = new StringBuilder(126);
+        builder.append("EzspNetworkFoundHandler [networkId=");
+        builder.append(networkId);
+        builder.append(", networkFound=");
         builder.append(networkFound);
         builder.append(", lastHopLqi=");
         builder.append(lastHopLqi);

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspNetworkInitResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspNetworkInitResponse.java
@@ -69,8 +69,10 @@ public class EzspNetworkInitResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(51);
-        builder.append("EzspNetworkInitResponse [status=");
+        final StringBuilder builder = new StringBuilder(76);
+        builder.append("EzspNetworkInitResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspNetworkStateResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspNetworkStateResponse.java
@@ -64,8 +64,10 @@ public class EzspNetworkStateResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(52);
-        builder.append("EzspNetworkStateResponse [status=");
+        final StringBuilder builder = new StringBuilder(77);
+        builder.append("EzspNetworkStateResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspPermitJoiningRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspPermitJoiningRequest.java
@@ -80,8 +80,10 @@ public class EzspPermitJoiningRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(52);
-        builder.append("EzspPermitJoiningRequest [duration=");
+        final StringBuilder builder = new StringBuilder(77);
+        builder.append("EzspPermitJoiningRequest [networkId=");
+        builder.append(networkId);
+        builder.append(", duration=");
         builder.append(duration);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspPermitJoiningResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspPermitJoiningResponse.java
@@ -65,8 +65,10 @@ public class EzspPermitJoiningResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(53);
-        builder.append("EzspPermitJoiningResponse [status=");
+        final StringBuilder builder = new StringBuilder(78);
+        builder.append("EzspPermitJoiningResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspPollHandler.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspPollHandler.java
@@ -64,8 +64,10 @@ public class EzspPollHandler extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(43);
-        builder.append("EzspPollHandler [senderEui64=");
+        final StringBuilder builder = new StringBuilder(68);
+        builder.append("EzspPollHandler [networkId=");
+        builder.append(networkId);
+        builder.append(", senderEui64=");
         builder.append(senderEui64);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspReadAndClearCountersResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspReadAndClearCountersResponse.java
@@ -64,8 +64,10 @@ public class EzspReadAndClearCountersResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(60);
-        builder.append("EzspReadAndClearCountersResponse [values=");
+        final StringBuilder builder = new StringBuilder(85);
+        builder.append("EzspReadAndClearCountersResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", values=");
         for (int cnt = 0; cnt < values.length; cnt++) {
             if (cnt > 0) {
                 builder.append(' ');

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspReadCountersResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspReadCountersResponse.java
@@ -63,8 +63,10 @@ public class EzspReadCountersResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(52);
-        builder.append("EzspReadCountersResponse [values=");
+        final StringBuilder builder = new StringBuilder(77);
+        builder.append("EzspReadCountersResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", values=");
         for (int cnt = 0; cnt < values.length; cnt++) {
             if (cnt > 0) {
                 builder.append(' ');

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspRemoteDeleteBindingHandler.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspRemoteDeleteBindingHandler.java
@@ -94,8 +94,10 @@ public class EzspRemoteDeleteBindingHandler extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(83);
-        builder.append("EzspRemoteDeleteBindingHandler [index=");
+        final StringBuilder builder = new StringBuilder(108);
+        builder.append("EzspRemoteDeleteBindingHandler [networkId=");
+        builder.append(networkId);
+        builder.append(", index=");
         builder.append(index);
         builder.append(", policyDecision=");
         builder.append(policyDecision);

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspRemoteSetBindingHandler.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspRemoteSetBindingHandler.java
@@ -123,8 +123,10 @@ public class EzspRemoteSetBindingHandler extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(105);
-        builder.append("EzspRemoteSetBindingHandler [entry=");
+        final StringBuilder builder = new StringBuilder(130);
+        builder.append("EzspRemoteSetBindingHandler [networkId=");
+        builder.append(networkId);
+        builder.append(", entry=");
         builder.append(entry);
         builder.append(", index=");
         builder.append(index);

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspRemoveDeviceRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspRemoveDeviceRequest.java
@@ -134,8 +134,10 @@ public class EzspRemoveDeviceRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(101);
-        builder.append("EzspRemoveDeviceRequest [destShort=");
+        final StringBuilder builder = new StringBuilder(126);
+        builder.append("EzspRemoveDeviceRequest [networkId=");
+        builder.append(networkId);
+        builder.append(", destShort=");
         builder.append(String.format("%04X", destShort));
         builder.append(", destLong=");
         builder.append(destLong);

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspRemoveDeviceResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspRemoveDeviceResponse.java
@@ -65,8 +65,10 @@ public class EzspRemoveDeviceResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(52);
-        builder.append("EzspRemoveDeviceResponse [status=");
+        final StringBuilder builder = new StringBuilder(77);
+        builder.append("EzspRemoveDeviceResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspRequestLinkKeyRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspRequestLinkKeyRequest.java
@@ -88,8 +88,10 @@ public class EzspRequestLinkKeyRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(53);
-        builder.append("EzspRequestLinkKeyRequest [partner=");
+        final StringBuilder builder = new StringBuilder(78);
+        builder.append("EzspRequestLinkKeyRequest [networkId=");
+        builder.append(networkId);
+        builder.append(", partner=");
         builder.append(partner);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspRequestLinkKeyResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspRequestLinkKeyResponse.java
@@ -78,8 +78,10 @@ public class EzspRequestLinkKeyResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(54);
-        builder.append("EzspRequestLinkKeyResponse [status=");
+        final StringBuilder builder = new StringBuilder(79);
+        builder.append("EzspRequestLinkKeyResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspResetToFactoryDefaultsResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspResetToFactoryDefaultsResponse.java
@@ -64,8 +64,10 @@ public class EzspResetToFactoryDefaultsResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(62);
-        builder.append("EzspResetToFactoryDefaultsResponse [status=");
+        final StringBuilder builder = new StringBuilder(87);
+        builder.append("EzspResetToFactoryDefaultsResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspScanCompleteHandler.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspScanCompleteHandler.java
@@ -97,8 +97,10 @@ public class EzspScanCompleteHandler extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(76);
-        builder.append("EzspScanCompleteHandler [channel=");
+        final StringBuilder builder = new StringBuilder(101);
+        builder.append("EzspScanCompleteHandler [networkId=");
+        builder.append(networkId);
+        builder.append(", channel=");
         builder.append(channel);
         builder.append(", status=");
         builder.append(status);

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSendBroadcastRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSendBroadcastRequest.java
@@ -199,8 +199,10 @@ public class EzspSendBroadcastRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(177);
-        builder.append("EzspSendBroadcastRequest [destination=");
+        final StringBuilder builder = new StringBuilder(202);
+        builder.append("EzspSendBroadcastRequest [networkId=");
+        builder.append(networkId);
+        builder.append(", destination=");
         builder.append(String.format("%04X", destination));
         builder.append(", apsFrame=");
         builder.append(apsFrame);

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSendBroadcastResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSendBroadcastResponse.java
@@ -92,8 +92,10 @@ public class EzspSendBroadcastResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(78);
-        builder.append("EzspSendBroadcastResponse [status=");
+        final StringBuilder builder = new StringBuilder(103);
+        builder.append("EzspSendBroadcastResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(", sequence=");
         builder.append(String.format("%02X", sequence));

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSendManyToOneRouteRequestRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSendManyToOneRouteRequestRequest.java
@@ -144,8 +144,10 @@ public class EzspSendManyToOneRouteRequestRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(89);
-        builder.append("EzspSendManyToOneRouteRequestRequest [concentratorType=");
+        final StringBuilder builder = new StringBuilder(114);
+        builder.append("EzspSendManyToOneRouteRequestRequest [networkId=");
+        builder.append(networkId);
+        builder.append(", concentratorType=");
         builder.append(concentratorType);
         builder.append(", radius=");
         builder.append(radius);

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSendManyToOneRouteRequestResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSendManyToOneRouteRequestResponse.java
@@ -88,8 +88,10 @@ public class EzspSendManyToOneRouteRequestResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(65);
-        builder.append("EzspSendManyToOneRouteRequestResponse [status=");
+        final StringBuilder builder = new StringBuilder(90);
+        builder.append("EzspSendManyToOneRouteRequestResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSendMulticastRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSendMulticastRequest.java
@@ -200,8 +200,10 @@ public class EzspSendMulticastRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(177);
-        builder.append("EzspSendMulticastRequest [apsFrame=");
+        final StringBuilder builder = new StringBuilder(202);
+        builder.append("EzspSendMulticastRequest [networkId=");
+        builder.append(networkId);
+        builder.append(", apsFrame=");
         builder.append(apsFrame);
         builder.append(", hops=");
         builder.append(hops);

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSendMulticastResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSendMulticastResponse.java
@@ -111,8 +111,10 @@ public class EzspSendMulticastResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(78);
-        builder.append("EzspSendMulticastResponse [status=");
+        final StringBuilder builder = new StringBuilder(103);
+        builder.append("EzspSendMulticastResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(", sequence=");
         builder.append(String.format("%02X", sequence));

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSendReplyRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSendReplyRequest.java
@@ -166,8 +166,10 @@ public class EzspSendReplyRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(148);
-        builder.append("EzspSendReplyRequest [sender=");
+        final StringBuilder builder = new StringBuilder(173);
+        builder.append("EzspSendReplyRequest [networkId=");
+        builder.append(networkId);
+        builder.append(", sender=");
         builder.append(String.format("%04X", sender));
         builder.append(", apsFrame=");
         builder.append(apsFrame);

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSendReplyResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSendReplyResponse.java
@@ -89,8 +89,10 @@ public class EzspSendReplyResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(49);
-        builder.append("EzspSendReplyResponse [policyDecision=");
+        final StringBuilder builder = new StringBuilder(74);
+        builder.append("EzspSendReplyResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", policyDecision=");
         builder.append(policyDecision);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSendTrustCenterLinkKeyRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSendTrustCenterLinkKeyRequest.java
@@ -107,8 +107,10 @@ public class EzspSendTrustCenterLinkKeyRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(86);
-        builder.append("EzspSendTrustCenterLinkKeyRequest [destinationNodeId=");
+        final StringBuilder builder = new StringBuilder(111);
+        builder.append("EzspSendTrustCenterLinkKeyRequest [networkId=");
+        builder.append(networkId);
+        builder.append(", destinationNodeId=");
         builder.append(String.format("%04X", destinationNodeId));
         builder.append(", destinationEui64=");
         builder.append(destinationEui64);

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSendTrustCenterLinkKeyResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSendTrustCenterLinkKeyResponse.java
@@ -66,8 +66,10 @@ public class EzspSendTrustCenterLinkKeyResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(62);
-        builder.append("EzspSendTrustCenterLinkKeyResponse [status=");
+        final StringBuilder builder = new StringBuilder(87);
+        builder.append("EzspSendTrustCenterLinkKeyResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSendUnicastRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSendUnicastRequest.java
@@ -219,8 +219,10 @@ public class EzspSendUnicastRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(175);
-        builder.append("EzspSendUnicastRequest [type=");
+        final StringBuilder builder = new StringBuilder(200);
+        builder.append("EzspSendUnicastRequest [networkId=");
+        builder.append(networkId);
+        builder.append(", type=");
         builder.append(type);
         builder.append(", indexOrDestination=");
         builder.append(String.format("%04X", indexOrDestination));

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSendUnicastResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSendUnicastResponse.java
@@ -111,8 +111,10 @@ public class EzspSendUnicastResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(76);
-        builder.append("EzspSendUnicastResponse [status=");
+        final StringBuilder builder = new StringBuilder(101);
+        builder.append("EzspSendUnicastResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(", sequence=");
         builder.append(String.format("%02X", sequence));

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetBindingRemoteNodeIdRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetBindingRemoteNodeIdRequest.java
@@ -105,8 +105,10 @@ public class EzspSetBindingRemoteNodeIdRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(86);
-        builder.append("EzspSetBindingRemoteNodeIdRequest [index=");
+        final StringBuilder builder = new StringBuilder(111);
+        builder.append("EzspSetBindingRemoteNodeIdRequest [networkId=");
+        builder.append(networkId);
+        builder.append(", index=");
         builder.append(index);
         builder.append(", nodeId=");
         builder.append(String.format("%04X", nodeId));

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetBindingRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetBindingRequest.java
@@ -105,8 +105,10 @@ public class EzspSetBindingRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(74);
-        builder.append("EzspSetBindingRequest [index=");
+        final StringBuilder builder = new StringBuilder(99);
+        builder.append("EzspSetBindingRequest [networkId=");
+        builder.append(networkId);
+        builder.append(", index=");
         builder.append(index);
         builder.append(", value=");
         builder.append(value);

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetBindingResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetBindingResponse.java
@@ -64,8 +64,10 @@ public class EzspSetBindingResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(50);
-        builder.append("EzspSetBindingResponse [status=");
+        final StringBuilder builder = new StringBuilder(75);
+        builder.append("EzspSetBindingResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetConcentratorRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetConcentratorRequest.java
@@ -266,8 +266,10 @@ public class EzspSetConcentratorRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(204);
-        builder.append("EzspSetConcentratorRequest [enable=");
+        final StringBuilder builder = new StringBuilder(229);
+        builder.append("EzspSetConcentratorRequest [networkId=");
+        builder.append(networkId);
+        builder.append(", enable=");
         builder.append(enable);
         builder.append(", concentratorType=");
         builder.append(concentratorType);

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetConcentratorResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetConcentratorResponse.java
@@ -64,8 +64,10 @@ public class EzspSetConcentratorResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(55);
-        builder.append("EzspSetConcentratorResponse [status=");
+        final StringBuilder builder = new StringBuilder(80);
+        builder.append("EzspSetConcentratorResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetConfigurationValueRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetConfigurationValueRequest.java
@@ -108,8 +108,10 @@ public class EzspSetConfigurationValueRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(85);
-        builder.append("EzspSetConfigurationValueRequest [configId=");
+        final StringBuilder builder = new StringBuilder(110);
+        builder.append("EzspSetConfigurationValueRequest [networkId=");
+        builder.append(networkId);
+        builder.append(", configId=");
         builder.append(configId);
         builder.append(", value=");
         builder.append(value);

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetConfigurationValueResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetConfigurationValueResponse.java
@@ -76,8 +76,10 @@ public class EzspSetConfigurationValueResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(61);
-        builder.append("EzspSetConfigurationValueResponse [status=");
+        final StringBuilder builder = new StringBuilder(86);
+        builder.append("EzspSetConfigurationValueResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetExtendedTimeoutRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetExtendedTimeoutRequest.java
@@ -115,8 +115,10 @@ public class EzspSetExtendedTimeoutRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(82);
-        builder.append("EzspSetExtendedTimeoutRequest [remoteEui64=");
+        final StringBuilder builder = new StringBuilder(107);
+        builder.append("EzspSetExtendedTimeoutRequest [networkId=");
+        builder.append(networkId);
+        builder.append(", remoteEui64=");
         builder.append(remoteEui64);
         builder.append(", extendedTimeout=");
         builder.append(extendedTimeout);

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetInitialSecurityStateRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetInitialSecurityStateRequest.java
@@ -80,8 +80,10 @@ public class EzspSetInitialSecurityStateRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(62);
-        builder.append("EzspSetInitialSecurityStateRequest [state=");
+        final StringBuilder builder = new StringBuilder(87);
+        builder.append("EzspSetInitialSecurityStateRequest [networkId=");
+        builder.append(networkId);
+        builder.append(", state=");
         builder.append(state);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetInitialSecurityStateResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetInitialSecurityStateResponse.java
@@ -67,8 +67,10 @@ public class EzspSetInitialSecurityStateResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(63);
-        builder.append("EzspSetInitialSecurityStateResponse [status=");
+        final StringBuilder builder = new StringBuilder(88);
+        builder.append("EzspSetInitialSecurityStateResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetKeyTableEntryRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetKeyTableEntryRequest.java
@@ -162,8 +162,10 @@ public class EzspSetKeyTableEntryRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(130);
-        builder.append("EzspSetKeyTableEntryRequest [index=");
+        final StringBuilder builder = new StringBuilder(155);
+        builder.append("EzspSetKeyTableEntryRequest [networkId=");
+        builder.append(networkId);
+        builder.append(", index=");
         builder.append(index);
         builder.append(", address=");
         builder.append(address);

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetKeyTableEntryResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetKeyTableEntryResponse.java
@@ -67,8 +67,10 @@ public class EzspSetKeyTableEntryResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(56);
-        builder.append("EzspSetKeyTableEntryResponse [status=");
+        final StringBuilder builder = new StringBuilder(81);
+        builder.append("EzspSetKeyTableEntryResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetManufacturerCodeRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetManufacturerCodeRequest.java
@@ -77,8 +77,10 @@ public class EzspSetManufacturerCodeRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(58);
-        builder.append("EzspSetManufacturerCodeRequest [code=");
+        final StringBuilder builder = new StringBuilder(83);
+        builder.append("EzspSetManufacturerCodeRequest [networkId=");
+        builder.append(networkId);
+        builder.append(", code=");
         builder.append(code);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetPolicyRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetPolicyRequest.java
@@ -106,8 +106,10 @@ public class EzspSetPolicyRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(73);
-        builder.append("EzspSetPolicyRequest [policyId=");
+        final StringBuilder builder = new StringBuilder(98);
+        builder.append("EzspSetPolicyRequest [networkId=");
+        builder.append(networkId);
+        builder.append(", policyId=");
         builder.append(policyId);
         builder.append(", decisionId=");
         builder.append(decisionId);

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetPolicyResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetPolicyResponse.java
@@ -67,8 +67,10 @@ public class EzspSetPolicyResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(49);
-        builder.append("EzspSetPolicyResponse [status=");
+        final StringBuilder builder = new StringBuilder(74);
+        builder.append("EzspSetPolicyResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetPowerDescriptorRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetPowerDescriptorRequest.java
@@ -77,8 +77,10 @@ public class EzspSetPowerDescriptorRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(57);
-        builder.append("EzspSetPowerDescriptorRequest [descriptor=");
+        final StringBuilder builder = new StringBuilder(82);
+        builder.append("EzspSetPowerDescriptorRequest [networkId=");
+        builder.append(networkId);
+        builder.append(", descriptor=");
         builder.append(descriptor);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetPreinstalledCbkeData283k1Response.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetPreinstalledCbkeData283k1Response.java
@@ -66,8 +66,10 @@ public class EzspSetPreinstalledCbkeData283k1Response extends EzspFrameResponse 
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(68);
-        builder.append("EzspSetPreinstalledCbkeData283k1Response [status=");
+        final StringBuilder builder = new StringBuilder(93);
+        builder.append("EzspSetPreinstalledCbkeData283k1Response [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetPreinstalledCbkeDataRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetPreinstalledCbkeDataRequest.java
@@ -136,8 +136,10 @@ public class EzspSetPreinstalledCbkeDataRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(112);
-        builder.append("EzspSetPreinstalledCbkeDataRequest [caCert=");
+        final StringBuilder builder = new StringBuilder(137);
+        builder.append("EzspSetPreinstalledCbkeDataRequest [networkId=");
+        builder.append(networkId);
+        builder.append(", caCert=");
         builder.append(caCert);
         builder.append(", myCert=");
         builder.append(myCert);

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetPreinstalledCbkeDataResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetPreinstalledCbkeDataResponse.java
@@ -65,8 +65,10 @@ public class EzspSetPreinstalledCbkeDataResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(63);
-        builder.append("EzspSetPreinstalledCbkeDataResponse [status=");
+        final StringBuilder builder = new StringBuilder(88);
+        builder.append("EzspSetPreinstalledCbkeDataResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetRadioChannelRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetRadioChannelRequest.java
@@ -81,8 +81,10 @@ public class EzspSetRadioChannelRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(54);
-        builder.append("EzspSetRadioChannelRequest [channel=");
+        final StringBuilder builder = new StringBuilder(79);
+        builder.append("EzspSetRadioChannelRequest [networkId=");
+        builder.append(networkId);
+        builder.append(", channel=");
         builder.append(channel);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetRadioChannelResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetRadioChannelResponse.java
@@ -69,8 +69,10 @@ public class EzspSetRadioChannelResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(55);
-        builder.append("EzspSetRadioChannelResponse [status=");
+        final StringBuilder builder = new StringBuilder(80);
+        builder.append("EzspSetRadioChannelResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetRadioPowerRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetRadioPowerRequest.java
@@ -83,8 +83,10 @@ public class EzspSetRadioPowerRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(52);
-        builder.append("EzspSetRadioPowerRequest [power=");
+        final StringBuilder builder = new StringBuilder(77);
+        builder.append("EzspSetRadioPowerRequest [networkId=");
+        builder.append(networkId);
+        builder.append(", power=");
         builder.append(power);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetRadioPowerResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetRadioPowerResponse.java
@@ -71,8 +71,10 @@ public class EzspSetRadioPowerResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(53);
-        builder.append("EzspSetRadioPowerResponse [status=");
+        final StringBuilder builder = new StringBuilder(78);
+        builder.append("EzspSetRadioPowerResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetSourceRouteRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetSourceRouteRequest.java
@@ -105,8 +105,10 @@ public class EzspSetSourceRouteRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(103);
-        builder.append("EzspSetSourceRouteRequest [destination=");
+        final StringBuilder builder = new StringBuilder(128);
+        builder.append("EzspSetSourceRouteRequest [networkId=");
+        builder.append(networkId);
+        builder.append(", destination=");
         builder.append(String.format("%04X", destination));
         builder.append(", relayList=");
         for (int cnt = 0; cnt < relayList.length; cnt++) {

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetSourceRouteResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetSourceRouteResponse.java
@@ -67,8 +67,10 @@ public class EzspSetSourceRouteResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(54);
-        builder.append("EzspSetSourceRouteResponse [status=");
+        final StringBuilder builder = new StringBuilder(79);
+        builder.append("EzspSetSourceRouteResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetValueRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetValueRequest.java
@@ -106,8 +106,10 @@ public class EzspSetValueRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(97);
-        builder.append("EzspSetValueRequest [valueId=");
+        final StringBuilder builder = new StringBuilder(122);
+        builder.append("EzspSetValueRequest [networkId=");
+        builder.append(networkId);
+        builder.append(", valueId=");
         builder.append(valueId);
         builder.append(", value=");
         for (int cnt = 0; cnt < value.length; cnt++) {

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetValueResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetValueResponse.java
@@ -70,8 +70,10 @@ public class EzspSetValueResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(48);
-        builder.append("EzspSetValueResponse [status=");
+        final StringBuilder builder = new StringBuilder(73);
+        builder.append("EzspSetValueResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspStackStatusHandler.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspStackStatusHandler.java
@@ -70,8 +70,10 @@ public class EzspStackStatusHandler extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(50);
-        builder.append("EzspStackStatusHandler [status=");
+        final StringBuilder builder = new StringBuilder(75);
+        builder.append("EzspStackStatusHandler [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspStackTokenChangedHandler.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspStackTokenChangedHandler.java
@@ -63,8 +63,10 @@ public class EzspStackTokenChangedHandler extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(56);
-        builder.append("EzspStackTokenChangedHandler [tokenAddress=");
+        final StringBuilder builder = new StringBuilder(81);
+        builder.append("EzspStackTokenChangedHandler [networkId=");
+        builder.append(networkId);
+        builder.append(", tokenAddress=");
         builder.append(tokenAddress);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspStartScanRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspStartScanRequest.java
@@ -157,8 +157,10 @@ public class EzspStartScanRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(98);
-        builder.append("EzspStartScanRequest [scanType=");
+        final StringBuilder builder = new StringBuilder(123);
+        builder.append("EzspStartScanRequest [networkId=");
+        builder.append(networkId);
+        builder.append(", scanType=");
         builder.append(scanType);
         builder.append(", channelMask=");
         builder.append(String.format("%08X", channelMask));

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspStartScanResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspStartScanResponse.java
@@ -79,8 +79,10 @@ public class EzspStartScanResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(49);
-        builder.append("EzspStartScanResponse [status=");
+        final StringBuilder builder = new StringBuilder(74);
+        builder.append("EzspStartScanResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspStopScanResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspStopScanResponse.java
@@ -64,8 +64,10 @@ public class EzspStopScanResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(48);
-        builder.append("EzspStopScanResponse [status=");
+        final StringBuilder builder = new StringBuilder(73);
+        builder.append("EzspStopScanResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", status=");
         builder.append(status);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSwitchNetworkKeyHandler.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSwitchNetworkKeyHandler.java
@@ -65,8 +65,10 @@ public class EzspSwitchNetworkKeyHandler extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(55);
-        builder.append("EzspSwitchNetworkKeyHandler [sequenceNumber=");
+        final StringBuilder builder = new StringBuilder(80);
+        builder.append("EzspSwitchNetworkKeyHandler [networkId=");
+        builder.append(networkId);
+        builder.append(", sequenceNumber=");
         builder.append(sequenceNumber);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspTrustCenterJoinHandler.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspTrustCenterJoinHandler.java
@@ -180,8 +180,10 @@ public class EzspTrustCenterJoinHandler extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(154);
-        builder.append("EzspTrustCenterJoinHandler [newNodeId=");
+        final StringBuilder builder = new StringBuilder(179);
+        builder.append("EzspTrustCenterJoinHandler [networkId=");
+        builder.append(networkId);
+        builder.append(", newNodeId=");
         builder.append(String.format("%04X", newNodeId));
         builder.append(", newNodeEui64=");
         builder.append(newNodeEui64);

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspVersionRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspVersionRequest.java
@@ -81,8 +81,10 @@ public class EzspVersionRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(46);
-        builder.append("EzspVersionRequest [desiredProtocolVersion=");
+        final StringBuilder builder = new StringBuilder(71);
+        builder.append("EzspVersionRequest [networkId=");
+        builder.append(networkId);
+        builder.append(", desiredProtocolVersion=");
         builder.append(desiredProtocolVersion);
         builder.append(']');
         return builder.toString();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspVersionResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspVersionResponse.java
@@ -121,8 +121,10 @@ public class EzspVersionResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(97);
-        builder.append("EzspVersionResponse [protocolVersion=");
+        final StringBuilder builder = new StringBuilder(122);
+        builder.append("EzspVersionResponse [networkId=");
+        builder.append(networkId);
+        builder.append(", protocolVersion=");
         builder.append(protocolVersion);
         builder.append(", stackType=");
         builder.append(stackType);

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspZigbeeKeyEstablishmentHandler.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspZigbeeKeyEstablishmentHandler.java
@@ -97,8 +97,10 @@ public class EzspZigbeeKeyEstablishmentHandler extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(86);
-        builder.append("EzspZigbeeKeyEstablishmentHandler [partner=");
+        final StringBuilder builder = new StringBuilder(111);
+        builder.append("EzspZigbeeKeyEstablishmentHandler [networkId=");
+        builder.append(networkId);
+        builder.append(", partner=");
         builder.append(partner);
         builder.append(", status=");
         builder.append(status);

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/EzspFrameRequestTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/EzspFrameRequestTest.java
@@ -24,7 +24,7 @@ import com.zsmartsystems.zigbee.dongle.ember.internal.serializer.EzspSerializer;
 public class EzspFrameRequestTest {
 
     @Test
-    public void testResponseV4() {
+    public void testRequestV4() {
         EzspFrame.setEzspVersion(4);
 
         EzspFrameRequest request = Mockito.mock(EzspFrameRequest.class, Mockito.CALLS_REAL_METHODS);
@@ -36,7 +36,7 @@ public class EzspFrameRequestTest {
     }
 
     @Test
-    public void testResponseV5() {
+    public void testRequestV5() {
         EzspFrame.setEzspVersion(5);
 
         EzspFrameRequest request = Mockito.mock(EzspFrameRequest.class, Mockito.CALLS_REAL_METHODS);
@@ -48,7 +48,7 @@ public class EzspFrameRequestTest {
     }
 
     @Test
-    public void testResponseV8() {
+    public void testRequestV8() {
         EzspFrame.setEzspVersion(8);
 
         EzspFrameRequest request = Mockito.mock(EzspFrameRequest.class, Mockito.CALLS_REAL_METHODS);
@@ -58,4 +58,24 @@ public class EzspFrameRequestTest {
         assertTrue(Arrays.equals(new int[] { 0x00, 0x00, 0x01, 0x00, 0x00 }, serializer.getPayload()));
         EzspFrame.setEzspVersion(4);
     }
+
+    @Test
+    public void testRequestV8NetworkId() {
+        EzspFrame.setEzspVersion(8);
+
+        EzspFrameRequest request = Mockito.mock(EzspFrameRequest.class, Mockito.CALLS_REAL_METHODS);
+
+        request.setNetworkId(1);
+        EzspSerializer serializer = new EzspSerializer();
+        request.serializeHeader(serializer);
+        assertTrue(Arrays.equals(new int[] { 0x00, 0x20, 0x01, 0x00, 0x00 }, serializer.getPayload()));
+
+        request.setNetworkId(3);
+        serializer = new EzspSerializer();
+        request.serializeHeader(serializer);
+        assertTrue(Arrays.equals(new int[] { 0x00, 0x60, 0x01, 0x00, 0x00 }, serializer.getPayload()));
+
+        EzspFrame.setEzspVersion(4);
+    }
+
 }

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/EzspFrameResponseTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/EzspFrameResponseTest.java
@@ -46,7 +46,6 @@ public class EzspFrameResponseTest {
 
     @Test
     public void testResponseV8() {
-        EzspFrame.setEzspVersion(4);
         EzspFrame.setEzspVersion(8);
         EzspVersionResponse response = new EzspVersionResponse(
                 new int[] { 0x01, 0x80, 0x01, 0x00, 0x00, 0x08, 0x02, 0x00, 0x67 });
@@ -54,6 +53,15 @@ public class EzspFrameResponseTest {
 
         assertEquals(8, response.getProtocolVersion());
         assertEquals(0x6700, response.getStackVersion());
+        assertEquals(0, response.getNetworkId());
+
+        response = new EzspVersionResponse(
+                new int[] { 0x01, 0xC0, 0x01, 0x00, 0x00, 0x08, 0x02, 0x00, 0x67 });
+        System.out.println(response);
+
+        assertEquals(8, response.getProtocolVersion());
+        assertEquals(0x6700, response.getStackVersion());
+        assertEquals(2, response.getNetworkId());
     }
 
     @Test


### PR DESCRIPTION
This processes the ```networkId``` bits in the EZSP control byte.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>