### PR TITLE
Set discoveryComplete flag when discovering attributes

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/ZclCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/ZclCluster.java
@@ -1354,6 +1354,7 @@ public abstract class ZclCluster {
 
         DiscoverAttributesResponse response = new DiscoverAttributesResponse();
         response.setAttributeInformation(attributeInformation);
+        response.setDiscoveryComplete(attributeInformation.size() == getLocalAttributes().size());
         sendResponse(command, response);
     }
 
@@ -1599,12 +1600,12 @@ public abstract class ZclCluster {
         supportedCommandsReceived.addAll(dao.getSupportedCommandsReceived());
 
         Map<Integer, ZclAttribute> attributes = isClient ? clientAttributes : serverAttributes;
-        
+
         for (ZclAttributeDao daoAttribute : dao.getAttributes().values()) {
             // Normalize the data to protect against the users serialisation system restoring incorrect data classes
             daoAttribute
                     .setLastValue(normalizer.normalizeZclData(daoAttribute.getDataType(), daoAttribute.getLastValue()));
-            
+
             ZclAttribute attribute = attributes.get(daoAttribute.getId());
             if (attribute == null || daoAttribute.getManufacturerCode() != null) {
                 attribute = new ZclAttribute();
@@ -1934,7 +1935,7 @@ public abstract class ZclCluster {
 
         return defaultResponse;
     }
-    
+
     public NotificationService getNotificationService() {
         return zigbeeEndpoint.getNotificationService();
     }

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zcl/ZclClusterTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zcl/ZclClusterTest.java
@@ -742,6 +742,7 @@ public class ZclClusterTest {
         assertEquals(1, discoverResponse.getAttributeInformation().get(0).getIdentifier());
         assertEquals(ZclDataType.UNSIGNED_8_BIT_INTEGER,
                 discoverResponse.getAttributeInformation().get(0).getDataType());
+        assertTrue(discoverResponse.getDiscoveryComplete());
 
         cluster.getLocalAttribute(1).setImplemented(false);
         cluster.handleCommand(discoverCommand);
@@ -768,6 +769,7 @@ public class ZclClusterTest {
         assertEquals(2, discoverResponse.getAttributeInformation().size());
         assertEquals(10, discoverResponse.getAttributeInformation().get(0).getIdentifier());
         assertEquals(ZclDataType.CHARACTER_STRING, discoverResponse.getAttributeInformation().get(0).getDataType());
+        assertFalse(discoverResponse.getDiscoveryComplete());
     }
 
     @Test


### PR DESCRIPTION
When requesting the list of supported attributes, the response was not properly handling the ```discoveryComplete``` flag which reports if there are more attributes than is being reported.

@tejas-n this will break your PR - please can you rebase #1017 against this once it's merged to master (I found this while reviewing your PR).

Signed-off-by: Chris Jackson <chris@cd-jackson.com>