### PR TITLE
Make ZclIasZoneClient use cache to determine if already enrolled to a zone

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/iasclient/ZclIasZoneClient.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/iasclient/ZclIasZoneClient.java
@@ -195,7 +195,8 @@ public class ZclIasZoneClient implements ZigBeeApplication, ZclCommandListener {
     }
 
     private void initialise() {
-        Integer currentState = (Integer) iasZoneCluster.getAttribute(ZclIasZoneCluster.ATTR_ZONESTATE).readValue(0);
+        Integer currentState = (Integer) iasZoneCluster.getAttribute(ZclIasZoneCluster.ATTR_ZONESTATE)
+                .readValue(Long.MAX_VALUE);
         if (currentState != null) {
             ZoneStateEnum currentStateEnum = ZoneStateEnum.getByValue(currentState);
             logger.debug("{}: IAS CIE state is currently {}[{}]", iasZoneCluster.getZigBeeAddress(), currentStateEnum,


### PR DESCRIPTION
Fixes #1022

Signed-off-by: Stefan Triller <stefan.triller@telekom.de>