### PR TITLE
Updated install code handling for Ember ZNet 6.7+ (EZSP8+)

### DIFF
--- a/com.zsmartsystems.zigbee.console.ember/src/main/java/com/zsmartsystems/zigbee/console/ember/EmberConsoleSecurityStateCommand.java
+++ b/com.zsmartsystems.zigbee.console.ember/src/main/java/com/zsmartsystems/zigbee/console/ember/EmberConsoleSecurityStateCommand.java
@@ -23,6 +23,7 @@ import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EmberKeyType;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EmberLibraryId;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EmberLibraryStatus;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EmberNetworkStatus;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EmberTransientKeyData;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EzspConfigId;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EzspDecisionId;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EzspPolicyId;
@@ -102,6 +103,14 @@ public class EmberConsoleSecurityStateCommand extends EmberConsoleAbstractComman
             }
         }
 
+        List<EmberTransientKeyData> transientTable = new ArrayList<>();
+        for (int cnt = 0; cnt < keyTableSize; cnt++) {
+            EmberTransientKeyData key = ncp.getTransientLinkKeyIndex(cnt);
+            if (key != null) {
+                transientTable.add(key);
+            }
+        }
+
         out.println("Current Network State      : " + networkState);
         out.println("Trust Centre Address       : "
                 + (securityState == null ? "" : securityState.getTrustCenterLongAddress()));
@@ -140,7 +149,7 @@ public class EmberConsoleSecurityStateCommand extends EmberConsoleAbstractComman
         }
         out.println();
         out.println(
-                "Key Type                        IEEE Address      Key Data                          In Cnt    Out Cnt   Seq  Auth  Sleep");
+                "Key Type                        IEEE Address      Key Data                          In Cnt    Out Cnt   Seq  Auth  Sleep  Timer");
 
         if (linkKey != null) {
             out.println(printKey(linkKey));
@@ -150,6 +159,9 @@ public class EmberConsoleSecurityStateCommand extends EmberConsoleAbstractComman
         }
         for (EmberKeyStruct key : keyTable) {
             out.println(printKey(key));
+        }
+        for (EmberTransientKeyData key : transientTable) {
+            out.println(printTransientKey(key));
         }
     }
 
@@ -198,6 +210,25 @@ public class EmberConsoleSecurityStateCommand extends EmberConsoleAbstractComman
         } else {
             builder.append("No  ");
         }
+
+        return builder.toString();
+    }
+
+    private String printTransientKey(EmberTransientKeyData key) {
+        StringBuilder builder = new StringBuilder(110);
+
+        builder.append(String.format("%-30s  ", "EMBER_TRANSIENT_LINK_KEY"));
+
+        builder.append(key.getEui64());
+        builder.append("  ");
+
+        for (int value : key.getKeyData().getContents()) {
+            builder.append(String.format("%02X", value));
+        }
+
+        builder.append(String.format("  %08X  ", key.getIncomingFrameCounter()));
+        builder.append("                            ");
+        builder.append(String.format("% 5d", key.getCountdownTimerMs() / 100000));
 
         return builder.toString();
     }

--- a/com.zsmartsystems.zigbee.console.main/src/main/java/com/zsmartsystems/zigbee/console/main/ZigBeeConsole.java
+++ b/com.zsmartsystems.zigbee.console.main/src/main/java/com/zsmartsystems/zigbee/console/main/ZigBeeConsole.java
@@ -61,19 +61,14 @@ import com.zsmartsystems.zigbee.console.ZigBeeConsoleReportingConfigCommand;
 import com.zsmartsystems.zigbee.console.ZigBeeConsoleReportingSubscribeCommand;
 import com.zsmartsystems.zigbee.console.ZigBeeConsoleReportingUnsubscribeCommand;
 import com.zsmartsystems.zigbee.console.ZigBeeConsoleSmartEnergyCommand;
+import com.zsmartsystems.zigbee.console.ZigBeeConsoleTrustCentreCommand;
 import com.zsmartsystems.zigbee.console.ZigBeeConsoleUnbindCommand;
-import com.zsmartsystems.zigbee.security.ZigBeeKey;
-import com.zsmartsystems.zigbee.transport.TransportConfig;
-import com.zsmartsystems.zigbee.transport.TransportConfigOption;
-import com.zsmartsystems.zigbee.transport.TrustCentreJoinMode;
 import com.zsmartsystems.zigbee.transport.ZigBeeTransportFirmwareCallback;
 import com.zsmartsystems.zigbee.transport.ZigBeeTransportFirmwareStatus;
 import com.zsmartsystems.zigbee.transport.ZigBeeTransportFirmwareUpdate;
 import com.zsmartsystems.zigbee.transport.ZigBeeTransportTransmit;
 import com.zsmartsystems.zigbee.zcl.ZclStatus;
 import com.zsmartsystems.zigbee.zcl.clusters.ZclOnOffCluster;
-import com.zsmartsystems.zigbee.zcl.clusters.ZclOtaUpgradeCluster;
-import com.zsmartsystems.zigbee.zcl.clusters.general.ConfigureReportingResponse;
 import com.zsmartsystems.zigbee.zcl.clusters.general.ReportAttributesCommand;
 import com.zsmartsystems.zigbee.zcl.clusters.groups.GetGroupMembershipResponse;
 import com.zsmartsystems.zigbee.zcl.clusters.groups.ViewGroupResponse;
@@ -167,7 +162,6 @@ public final class ZigBeeConsole {
         commands.put("firmware", new FirmwareCommand());
 
         commands.put("supportedcluster", new SupportedClusterCommand());
-        commands.put("trustcentre", new TrustCentreCommand());
 
         commands.put("rediscover", new RediscoverCommand());
 
@@ -199,6 +193,7 @@ public final class ZigBeeConsole {
 
         newCommands.put("installkey", new ZigBeeConsoleInstallKeyCommand());
         newCommands.put("linkkey", new ZigBeeConsoleLinkKeyCommand());
+        newCommands.put("trustcentre", new ZigBeeConsoleTrustCentreCommand());
 
         newCommands.put("netstart", new ZigBeeConsoleNetworkStartCommand());
         newCommands.put("netbackup", new ZigBeeConsoleNetworkBackupCommand());
@@ -982,7 +977,7 @@ public final class ZigBeeConsole {
             return true;
         }
     }
-    
+
     /**
      * Writes an attribute to a device.
      */
@@ -1282,59 +1277,6 @@ public final class ZigBeeConsole {
                 out.println("Error executing command: " + result);
                 return true;
             }
-        }
-    }
-
-    /**
-     * Trust centre configuration.
-     */
-    private class TrustCentreCommand implements ConsoleCommand {
-        /**
-         * {@inheritDoc}
-         */
-        @Override
-        public String getDescription() {
-            return "Configures the trust centre.";
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        @Override
-        public String getSyntax() {
-            return "trustcentre [MODE|KEY] [MODE / KEY]";
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        @Override
-        public boolean process(final ZigBeeApi zigbeeApi, final String[] args, PrintStream out) throws Exception {
-            if (args.length < 3) {
-                return false;
-            }
-            TransportConfig config = new TransportConfig();
-            switch (args[1].toLowerCase()) {
-                case "mode":
-                    config.addOption(TransportConfigOption.TRUST_CENTRE_JOIN_MODE,
-                            TrustCentreJoinMode.valueOf(args[2].toUpperCase()));
-                    break;
-                case "key":
-                    String key = "";
-                    for (int cnt = 0; cnt < 16; cnt++) {
-                        key += args[cnt + 2];
-                    }
-                    config.addOption(TransportConfigOption.TRUST_CENTRE_LINK_KEY, new ZigBeeKey(key));
-                    break;
-
-                default:
-                    return false;
-            }
-
-            TransportConfigOption option = config.getOptions().iterator().next();
-            dongle.updateTransportConfig(config);
-            print("Trust Centre configuration for " + option + " returned " + config.getResult(option), out);
-            return true;
         }
     }
 

--- a/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleInstallKeyCommand.java
+++ b/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleInstallKeyCommand.java
@@ -67,8 +67,7 @@ public class ZigBeeConsoleInstallKeyCommand extends ZigBeeConsoleAbstractCommand
         installKey.setAddress(partner);
 
         ZigBeeStatus result = networkManager.setZigBeeInstallKey(installKey);
-        out.println("Install key " + hash.toString() + " for address " + partner + " was "
-                + (result == ZigBeeStatus.SUCCESS ? "" : "not") + " set.");
+        out.println("Install key " + hash.toString() + " for address " + partner + " completed with state " + result);
     }
 
 }

--- a/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleTrustCentreCommand.java
+++ b/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleTrustCentreCommand.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2016-2020 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.console;
+
+import java.io.PrintStream;
+
+import com.zsmartsystems.zigbee.ZigBeeNetworkManager;
+import com.zsmartsystems.zigbee.ZigBeeStatus;
+import com.zsmartsystems.zigbee.transport.TransportConfig;
+import com.zsmartsystems.zigbee.transport.TransportConfigOption;
+import com.zsmartsystems.zigbee.transport.TrustCentreJoinMode;
+
+/**
+ * Handles management of the trust centre
+ *
+ * @author Chris Jackson
+ *
+ */
+public class ZigBeeConsoleTrustCentreCommand extends ZigBeeConsoleAbstractCommand {
+    @Override
+    public String getCommand() {
+        return "trustcentre";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Configures the trust centre";
+    }
+
+    @Override
+    public String getSyntax() {
+        return "JOINMODE [DENY|INSECURE|SECURE|INSTALLCODE]";
+    }
+
+    @Override
+    public String getHelp() {
+        return "";
+    }
+
+    @Override
+    public void process(ZigBeeNetworkManager networkManager, String[] args, PrintStream out)
+            throws IllegalArgumentException {
+        if (args.length < 2 || args.length > 3) {
+            throw new IllegalArgumentException("Incorrect number of arguments.");
+        }
+
+        switch (args[1].toUpperCase()) {
+            case "JOINMODE":
+                setJoinMode(networkManager, args, out);
+                break;
+        }
+    }
+
+    private ZigBeeStatus setJoinMode(ZigBeeNetworkManager networkManager, String[] args, PrintStream out) {
+        TrustCentreJoinMode joinMode;
+        try {
+            joinMode = TrustCentreJoinMode.valueOf("TC_JOIN_" + args[2].toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Join mode is incorrect value.");
+        }
+
+        TransportConfig config = new TransportConfig(TransportConfigOption.TRUST_CENTRE_JOIN_MODE, joinMode);
+        networkManager.getZigBeeTransport().updateTransportConfig(config);
+
+        out.println("Join mode set to " + joinMode);
+
+        return config.getResult(TransportConfigOption.TRUST_CENTRE_JOIN_MODE);
+    }
+}

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/EmberNcp.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/EmberNcp.java
@@ -65,6 +65,10 @@ import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspGetPolicyRequest;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspGetPolicyResponse;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspGetStandaloneBootloaderVersionPlatMicroPhyRequest;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspGetStandaloneBootloaderVersionPlatMicroPhyResponse;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspGetTransientKeyTableEntryRequest;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspGetTransientKeyTableEntryResponse;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspGetTransientLinkKeyRequest;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspGetTransientLinkKeyResponse;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspGetValueRequest;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspGetValueResponse;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspLeaveNetworkRequest;
@@ -107,6 +111,7 @@ import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EmberLibraryStatus;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EmberNetworkParameters;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EmberNetworkStatus;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EmberStatus;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EmberTransientKeyData;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EzspConfigId;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EzspDecisionId;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EzspMfgTokenId;
@@ -583,6 +588,49 @@ public class EmberNcp {
         }
 
         return response.getStatus();
+    }
+
+    /**
+     * Gets a transient link key from the NCP
+     *
+     * @param index the key index to retrieve
+     * @return the {@link EmberTransientKeyData} of the response
+     */
+    public EmberTransientKeyData getTransientLinkKeyIndex(int index) {
+        EzspGetTransientKeyTableEntryRequest request = new EzspGetTransientKeyTableEntryRequest();
+        request.setIndex(index);
+        EzspTransaction transaction = protocolHandler
+                .sendEzspTransaction(
+                        new EzspSingleResponseTransaction(request, EzspGetTransientKeyTableEntryResponse.class));
+        EzspGetTransientKeyTableEntryResponse response = (EzspGetTransientKeyTableEntryResponse) transaction
+                .getResponse();
+        logger.debug(response.toString());
+        lastStatus = response.getStatus();
+        if (lastStatus != EmberStatus.EMBER_SUCCESS) {
+            return null;
+        }
+        return response.getTransientKeyData();
+    }
+
+    /**
+     * Gets a transient link key from the NCP
+     *
+     * @param ieeeAddress the {@link IeeeAddress} transient key to retrieve
+     * @return the {@link EmberTransientKeyData} of the response
+     */
+    public EmberTransientKeyData getTransientLinkKey(IeeeAddress ieeeAddress) {
+        EzspGetTransientLinkKeyRequest request = new EzspGetTransientLinkKeyRequest();
+        request.setEui(ieeeAddress);
+        EzspTransaction transaction = protocolHandler
+                .sendEzspTransaction(new EzspSingleResponseTransaction(request, EzspGetTransientLinkKeyResponse.class));
+        EzspGetTransientLinkKeyResponse response = (EzspGetTransientLinkKeyResponse) transaction
+                .getResponse();
+        logger.debug(response.toString());
+        lastStatus = response.getStatus();
+        if (lastStatus != EmberStatus.EMBER_SUCCESS) {
+            return null;
+        }
+        return response.getTransientKeyData();
     }
 
     /**

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
@@ -1183,6 +1183,11 @@ public class ZigBeeDongleEzsp implements ZigBeeTransportTransmit, ZigBeeTranspor
             case TC_JOIN_DENY:
                 emberJoinMode = EzspDecisionId.EZSP_DISALLOW_ALL_JOINS_AND_REJOINS;
                 break;
+            case TC_JOIN_INSTALLCODE:
+                emberJoinMode = EzspDecisionId.EZSP_ALLOW_PRECONFIGURED_KEY_JOINS;
+                bitmask = EzspDecisionBitmask.EZSP_DECISION_ALLOW_JOINS.getKey()
+                        + EzspDecisionBitmask.EZSP_DECISION_JOINS_USE_INSTALL_CODE_KEY.getKey();
+                break;
             default:
                 return ZigBeeStatus.INVALID_ARGUMENTS;
         }

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzspTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzspTest.java
@@ -126,7 +126,7 @@ public class ZigBeeDongleEzspTest {
     }
 
     @Test
-    public void setTcJoinMode() throws Exception {
+    public void setTcJoinModeV4() throws Exception {
         System.out.println("--- " + Thread.currentThread().getStackTrace()[1].getMethodName());
         ArgumentCaptor<EzspPolicyId> policyId = ArgumentCaptor.forClass(EzspPolicyId.class);
         ArgumentCaptor<EzspDecisionId> decisionId = ArgumentCaptor.forClass(EzspDecisionId.class);
@@ -164,6 +164,60 @@ public class ZigBeeDongleEzspTest {
         assertEquals(ZigBeeStatus.SUCCESS, configuration.getResult(TransportConfigOption.TRUST_CENTRE_JOIN_MODE));
         assertEquals(policyId.getValue(), EzspPolicyId.EZSP_TRUST_CENTER_POLICY);
         assertEquals(decisionId.getValue(), EzspDecisionId.EZSP_ALLOW_PRECONFIGURED_KEY_JOINS);
+
+        configuration = new TransportConfig();
+        configuration.addOption(TransportConfigOption.TRUST_CENTRE_JOIN_MODE, Integer.valueOf(0));
+        dongle.updateTransportConfig(configuration);
+        assertEquals(ZigBeeStatus.INVALID_ARGUMENTS,
+                configuration.getResult(TransportConfigOption.TRUST_CENTRE_JOIN_MODE));
+    }
+
+    @Test
+    public void setTcJoinModeV8() throws Exception {
+        System.out.println("--- " + Thread.currentThread().getStackTrace()[1].getMethodName());
+        ArgumentCaptor<EzspPolicyId> policyId = ArgumentCaptor.forClass(EzspPolicyId.class);
+        ArgumentCaptor<Integer> decisionId = ArgumentCaptor.forClass(Integer.class);
+
+        final EmberNcp ncp = Mockito.mock(EmberNcp.class);
+        Mockito.when(ncp.setPolicy(policyId.capture(), decisionId.capture())).thenReturn(EzspStatus.EZSP_SUCCESS);
+        ZigBeeDongleEzsp dongle = new ZigBeeDongleEzsp(null) {
+            @Override
+            public EmberNcp getEmberNcp() {
+                return ncp;
+            }
+        };
+
+        EzspVersionResponse ezspVersion = Mockito.mock(EzspVersionResponse.class);
+        Mockito.when(ezspVersion.getProtocolVersion()).thenReturn(8);
+        TestUtilities.setField(ZigBeeDongleEzsp.class, dongle, "ezspVersion", ezspVersion);
+
+        TransportConfig configuration = new TransportConfig();
+        configuration.addOption(TransportConfigOption.TRUST_CENTRE_JOIN_MODE, TrustCentreJoinMode.TC_JOIN_DENY);
+        dongle.updateTransportConfig(configuration);
+        assertEquals(ZigBeeStatus.SUCCESS, configuration.getResult(TransportConfigOption.TRUST_CENTRE_JOIN_MODE));
+        assertEquals(policyId.getValue(), EzspPolicyId.EZSP_TRUST_CENTER_POLICY);
+        assertEquals(Integer.valueOf(0), decisionId.getValue());
+
+        configuration = new TransportConfig();
+        configuration.addOption(TransportConfigOption.TRUST_CENTRE_JOIN_MODE, TrustCentreJoinMode.TC_JOIN_INSECURE);
+        dongle.updateTransportConfig(configuration);
+        assertEquals(ZigBeeStatus.SUCCESS, configuration.getResult(TransportConfigOption.TRUST_CENTRE_JOIN_MODE));
+        assertEquals(policyId.getValue(), EzspPolicyId.EZSP_TRUST_CENTER_POLICY);
+        assertEquals(Integer.valueOf(3), decisionId.getValue());
+
+        configuration = new TransportConfig();
+        configuration.addOption(TransportConfigOption.TRUST_CENTRE_JOIN_MODE, TrustCentreJoinMode.TC_JOIN_SECURE);
+        dongle.updateTransportConfig(configuration);
+        assertEquals(ZigBeeStatus.SUCCESS, configuration.getResult(TransportConfigOption.TRUST_CENTRE_JOIN_MODE));
+        assertEquals(policyId.getValue(), EzspPolicyId.EZSP_TRUST_CENTER_POLICY);
+        assertEquals(Integer.valueOf(9), decisionId.getValue());
+
+        configuration = new TransportConfig();
+        configuration.addOption(TransportConfigOption.TRUST_CENTRE_JOIN_MODE, TrustCentreJoinMode.TC_JOIN_INSTALLCODE);
+        dongle.updateTransportConfig(configuration);
+        assertEquals(ZigBeeStatus.SUCCESS, configuration.getResult(TransportConfigOption.TRUST_CENTRE_JOIN_MODE));
+        assertEquals(policyId.getValue(), EzspPolicyId.EZSP_TRUST_CENTER_POLICY);
+        assertEquals(Integer.valueOf(17), decisionId.getValue());
 
         configuration = new TransportConfig();
         configuration.addOption(TransportConfigOption.TRUST_CENTRE_JOIN_MODE, Integer.valueOf(0));

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transport/TrustCentreJoinMode.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transport/TrustCentreJoinMode.java
@@ -26,5 +26,9 @@ public enum TrustCentreJoinMode {
     /**
      * The TC should allow joins only with a preconfigured link key / device specific install code.
      */
-    TC_JOIN_SECURE
+    TC_JOIN_SECURE,
+    /**
+     * The TC should only allow devices to join when there is a device specific install code derived link key
+     */
+    TC_JOIN_INSTALLCODE
 }


### PR DESCRIPTION
Adds a new option ```TC_JOIN_INSTALLCODE``` to the ```TrustCentreJoinMode```. This option will only allow joins when a device specific link key is available.

Additionally, this will now dump the transient link key table in the Ember ```ncpsecuritystate``` console command.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>