### PR TITLE
add ability to write byte array on serial port

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.cc2531/src/main/java/com/zsmartsystems/zigbee/dongle/cc2531/network/impl/CommandInterfaceImpl.java
+++ b/com.zsmartsystems.zigbee.dongle.cc2531/src/main/java/com/zsmartsystems/zigbee/dongle/cc2531/network/impl/CommandInterfaceImpl.java
@@ -296,9 +296,7 @@ public class CommandInterfaceImpl implements ZToolPacketHandler, CommandInterfac
     @Override
     public void sendRaw(int[] packet) throws IOException {
         synchronized (port) {
-            for (int i = 0; i < packet.length; i++) {
-                port.write(packet[i]);
-            }
+            port.write(packet);
         }
     }
 

--- a/com.zsmartsystems.zigbee.dongle.cc2531/src/test/java/com/zsmartsystems/zigbee/dongle/cc2531/Cc2351TestPacket.java
+++ b/com.zsmartsystems.zigbee.dongle.cc2531/src/test/java/com/zsmartsystems/zigbee/dongle/cc2531/Cc2351TestPacket.java
@@ -81,6 +81,10 @@ public class Cc2351TestPacket {
         }
 
         @Override
+        public void write(int[] bytes) {
+        }
+
+        @Override
         public int read(int timeout) {
             return read();
         }

--- a/com.zsmartsystems.zigbee.dongle.conbee/src/main/java/com/zsmartsystems/zigbee/dongle/conbee/internal/ConBeeFrameHandler.java
+++ b/com.zsmartsystems.zigbee.dongle.conbee/src/main/java/com/zsmartsystems/zigbee/dongle/conbee/internal/ConBeeFrameHandler.java
@@ -19,6 +19,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -274,31 +275,39 @@ public class ConBeeFrameHandler {
         StringBuilder result = new StringBuilder();
         // Send the data
         logger.debug("CONBEE TX: {}", frame);
-        serialPort.write(SLIP_END);
 
-        for (int val : frame.getOutputBuffer()) {
+        final int[] dataBuffer = frame.getOutputBuffer();
+        List<Integer> data = new ArrayList<>(dataBuffer.length * 2);
+
+        data.add(SLIP_END);
+
+        for (int val : dataBuffer) {
             result.append(String.format(" %02X", val));
             // logger.debug("CONBEE TX: {}", String.format("%02X", val));
             switch (val) {
                 case SLIP_END:
                     // logger.debug("CONBEE TX: [ESC]");
-                    serialPort.write(SLIP_ESC);
-                    serialPort.write(SLIP_ESC_END);
+                    data.add(SLIP_ESC);
+                    data.add(SLIP_ESC_END);
                     break;
                 case SLIP_ESC:
                     // logger.debug("CONBEE TX: [ESC]");
-                    serialPort.write(SLIP_ESC);
-                    serialPort.write(SLIP_ESC_ESC);
+                    data.add(SLIP_ESC);
+                    data.add(SLIP_ESC_ESC);
                     break;
                 default:
-                    serialPort.write(val);
+                    data.add(val);
                     break;
             }
         }
 
         logger.debug("CONBEE TX:{}", result.toString());
 
-        serialPort.write(SLIP_END);
+        data.add(SLIP_END);
+
+        int[] outputBuffer = new int[data.size()];
+        for(int i = 0; i < data.size(); ++i) outputBuffer[i] = data.get(i);
+        serialPort.write(outputBuffer);
 
         startRetryTimer();
     }

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/ash/AshFrameHandler.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/ash/AshFrameHandler.java
@@ -479,9 +479,7 @@ public class AshFrameHandler implements EzspProtocolHandler {
         logger.debug("--> TX ASH frame: {}", ashFrame);
 
         // Send the data
-        for (int outByte : ashFrame.getOutputBuffer()) {
-            port.write(outByte);
-        }
+        port.write(ashFrame.getOutputBuffer());
 
         // Only start the timer for data and reset frames
         if (ashFrame instanceof AshFrameData || ashFrame instanceof AshFrameRst) {

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/spi/SpiFrameHandler.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/spi/SpiFrameHandler.java
@@ -564,9 +564,11 @@ public class SpiFrameHandler implements EzspProtocolHandler {
             // Send the data
             for (int outByte : outputData) {
                 logger.trace("SPI TX: {}", String.format("%02X", outByte));
-                port.write(outByte);
             }
-            port.write(SPI_FLAG_BYTE);
+            int[] frameData = new int[outputData.length + 1];
+            System.arraycopy(outputData, 0, frameData, 0, outputData.length);
+            frameData[frameData.length - 1] = SPI_FLAG_BYTE;
+            port.write(frameData);
 
             startRetryTimer();
         }

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/EmberFirmwareUpdateHandlerTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/EmberFirmwareUpdateHandlerTest.java
@@ -168,6 +168,13 @@ public class EmberFirmwareUpdateHandlerTest {
         }
 
         @Override
+        public void write(int[] bytes) {
+            for(int val : bytes) {
+                output[cnt++] = (byte) val;
+            }
+        }
+
+        @Override
         public int read(int timeout) {
             return read();
         }

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/ash/AshFrameHandlerTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/ash/AshFrameHandlerTest.java
@@ -21,6 +21,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -165,6 +166,13 @@ public class AshFrameHandlerTest {
         @Override
         public void write(int value) {
             outputData.add(value);
+        }
+
+        @Override
+        public void write(int[] bytes) {
+            for(int val : bytes) {
+                outputData.add(val);
+            }
         }
 
         @Override

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/spi/SpiFrameHandlerTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/spi/SpiFrameHandlerTest.java
@@ -321,6 +321,13 @@ public class SpiFrameHandlerTest {
         }
 
         @Override
+        public void write(int[] bytes) {
+            for(int val : bytes) {
+                portOutData.add(val);
+            }
+        }
+
+        @Override
         public int read(int timeout) {
             return read();
         }

--- a/com.zsmartsystems.zigbee.dongle.telegesis/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/internal/TelegesisFrameHandler.java
+++ b/com.zsmartsystems.zigbee.dongle.telegesis/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/internal/TelegesisFrameHandler.java
@@ -355,10 +355,11 @@ public class TelegesisFrameHandler {
 
             // Send the data
             StringBuilder builder = new StringBuilder();
-            for (int sendByte : nextFrame.serialize()) {
+            int[] frameData = nextFrame.serialize();
+            for (int sendByte : frameData) {
                 builder.append(String.format("%c", sendByte));
-                serialPort.write(sendByte);
             }
+            serialPort.write(frameData);
             logger.debug("TX Telegesis Data:{}", builder.toString());
 
             // Start the timeout

--- a/com.zsmartsystems.zigbee.dongle.telegesis/src/test/java/com/zsmartsystems/zigbee/dongle/telegesis/internal/TelegesisFirmwareUpdateHandlerTest.java
+++ b/com.zsmartsystems.zigbee.dongle.telegesis/src/test/java/com/zsmartsystems/zigbee/dongle/telegesis/internal/TelegesisFirmwareUpdateHandlerTest.java
@@ -169,6 +169,13 @@ public class TelegesisFirmwareUpdateHandlerTest {
         }
 
         @Override
+        public void write(int[] bytes) {
+            for(int val : bytes) {
+                output[cnt++] = (byte) val;
+            }
+        }
+
+        @Override
         public int read(int timeout) {
             return read();
         }

--- a/com.zsmartsystems.zigbee.dongle.telegesis/src/test/java/com/zsmartsystems/zigbee/dongle/telegesis/internal/TelegesisFrameHandlerTest.java
+++ b/com.zsmartsystems.zigbee.dongle.telegesis/src/test/java/com/zsmartsystems/zigbee/dongle/telegesis/internal/TelegesisFrameHandlerTest.java
@@ -298,6 +298,10 @@ public class TelegesisFrameHandlerTest {
         }
 
         @Override
+        public void write(int[] bytes) {
+        }
+
+        @Override
         public int read(int timeout) {
             return read();
         }

--- a/com.zsmartsystems.zigbee.dongle.xbee/src/main/java/com/zsmartsystems/zigbee/dongle/xbee/internal/XBeeFrameHandler.java
+++ b/com.zsmartsystems.zigbee.dongle.xbee/src/main/java/com/zsmartsystems/zigbee/dongle/xbee/internal/XBeeFrameHandler.java
@@ -356,20 +356,27 @@ public class XBeeFrameHandler {
             // Remember the command we're processing
             sentCommand = nextFrame;
 
-            serialPort.write(XBEE_FLAG);
+            final int[] dataBuffer = nextFrame.serialize();
+            List<Integer> data = new ArrayList<>(dataBuffer.length * 2);
+
+            data.add(XBEE_FLAG);
 
             // Send the data
             StringBuilder builder = new StringBuilder();
-            for (int sendByte : nextFrame.serialize()) {
+            for (int sendByte : dataBuffer) {
                 builder.append(String.format(" %02X", sendByte));
                 if (escapeCodes.contains(sendByte)) {
-                    serialPort.write(XBEE_ESCAPE);
-                    serialPort.write(sendByte ^ XBEE_XOR);
+                    data.add(XBEE_ESCAPE);
+                    data.add(sendByte ^ XBEE_XOR);
                 } else {
-                    serialPort.write(sendByte);
+                    data.add(sendByte);
                 }
             }
             logger.debug("TX XBEE Data:{}", builder.toString());
+
+            int[] outputBuffer = new int[data.size()];
+            for(int i = 0; i < data.size(); ++i) outputBuffer[i] = data.get(i);
+            serialPort.write(outputBuffer);
 
             // Start the timeout
             startTimer();

--- a/com.zsmartsystems.zigbee.dongle.xbee/src/test/java/com/zsmartsystems/zigbee/dongle/xbee/internal/XBeeFrameHandlerTest.java
+++ b/com.zsmartsystems.zigbee.dongle.xbee/src/test/java/com/zsmartsystems/zigbee/dongle/xbee/internal/XBeeFrameHandlerTest.java
@@ -121,6 +121,10 @@ public class XBeeFrameHandlerTest {
         }
 
         @Override
+        public void write(int[] bytes) {
+        }
+
+        @Override
         public int read(int timeout) {
             return read();
         }

--- a/com.zsmartsystems.zigbee.serial/src/main/java/com/zsmartsystems/zigbee/serial/ZigBeeSerialPort.java
+++ b/com.zsmartsystems.zigbee.serial/src/main/java/com/zsmartsystems/zigbee/serial/ZigBeeSerialPort.java
@@ -185,6 +185,18 @@ public class ZigBeeSerialPort implements ZigBeePort, SerialPortEventListener {
     }
 
     @Override
+    public void write(int[] bytes) {
+        if (serialPort == null) {
+            return;
+        }
+        try {
+            serialPort.writeIntArray(bytes);
+        } catch (SerialPortException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
     public int read() {
         return read(9999999);
     }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transport/ZigBeePort.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transport/ZigBeePort.java
@@ -63,9 +63,7 @@ public interface ZigBeePort {
      *
      * @param bytes the bytes to write.
      */
-    default void write(int[] bytes) {
-        throw new UnsupportedOperationException();
-    }
+    void write(int[] bytes);
 
     /**
      * Read a value from the port. This should block until a byte is available.

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transport/ZigBeePort.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transport/ZigBeePort.java
@@ -59,6 +59,13 @@ public interface ZigBeePort {
     void write(int value);
 
     /**
+     * Write data to serial port. This should be non-blocking.
+     *
+     * @param bytes the bytes to write.
+     */
+    void write(int[] bytes);
+
+    /**
      * Read a value from the port. This should block until a byte is available.
      *
      * @return the data byte (integer) read from the port

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transport/ZigBeePort.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transport/ZigBeePort.java
@@ -63,7 +63,9 @@ public interface ZigBeePort {
      *
      * @param bytes the bytes to write.
      */
-    void write(int[] bytes);
+    default void write(int[] bytes) {
+        throw new UnsupportedOperationException();
+    }
 
     /**
      * Read a value from the port. This should block until a byte is available.


### PR DESCRIPTION
The current ZigBeePort interface only provides the ability to write data one byte after the other.

For regular serial communication, that may not be a problem but for some other protocols, it causes a waste of bandwidth due to additional overhead for transferring every byte separately.

This pull request simply adds another method to the interface for writing a byte array instead. Of course, this is backward compatible change.