### PR TITLE
add ability to configure ASH2 frame handler

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
@@ -129,6 +129,8 @@ public class ZigBeeDongleEzsp implements ZigBeeTransportTransmit, ZigBeeTranspor
      */
     private EzspProtocolHandler frameHandler;
 
+    private AshFrameHandler.AshFrameHandlerConfig ashFrameHandlerConfig;
+
     /**
      * The Ember bootload handler
      */
@@ -265,6 +267,17 @@ public class ZigBeeDongleEzsp implements ZigBeeTransportTransmit, ZigBeeTranspor
      */
     public ZigBeeDongleEzsp(final ZigBeePort serialPort) {
         this(serialPort, EmberSerialProtocol.ASH2);
+    }
+
+    /**
+     * Create a {@link ZigBeeDongleEzsp} with the default ASH2 frame handler.
+     * The provided config will be used to configure the ASH2 frame handler.
+     *
+     * @param serialPort the {@link ZigBeePort} to use for the connection
+     */
+    public ZigBeeDongleEzsp(final ZigBeePort serialPort, final AshFrameHandler.AshFrameHandlerConfig config) {
+        this(serialPort, EmberSerialProtocol.ASH2);
+        this.ashFrameHandlerConfig = config;
     }
 
     /**
@@ -1180,7 +1193,7 @@ public class ZigBeeDongleEzsp implements ZigBeeTransportTransmit, ZigBeeTranspor
 
         switch (protocol) {
             case ASH2:
-                frameHandler = new AshFrameHandler(this);
+                frameHandler = new AshFrameHandler(this, ashFrameHandlerConfig);
                 break;
             case SPI:
                 frameHandler = new SpiFrameHandler(this);

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/ash/AshFrameHandler.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/ash/AshFrameHandler.java
@@ -136,11 +136,6 @@ public class AshFrameHandler implements EzspProtocolHandler {
         }
     }
 
-    /**
-     * The logger.
-     */
-    private final Logger logger = LoggerFactory.getLogger(AshFrameHandler.class);
-
     private int receiveTimeout;
 
     private int retries = 0;


### PR DESCRIPTION
Under certain configurations, the default hard coded ASH2 frame handler configuration is not appropriate. This PR simply provides the ability to client code to configure the frame handler.

The changes are backward compatible.