### PR TITLE
Remove the 'desiredVersion' parameter from the Ember NCP getVersion command

### DIFF
--- a/com.zsmartsystems.zigbee.console.ember/src/main/java/com/zsmartsystems/zigbee/console/ember/EmberConsoleNcpStateCommand.java
+++ b/com.zsmartsystems.zigbee.console.ember/src/main/java/com/zsmartsystems/zigbee/console/ember/EmberConsoleNcpStateCommand.java
@@ -94,7 +94,7 @@ public class EmberConsoleNcpStateCommand extends EmberConsoleAbstractCommand {
         String mfgName = ncp.getMfgName();
         String mfgBoard = ncp.getMfgBoardName();
         int customVersion = ncp.getMfgCustomVersion();
-        EzspVersionResponse version = ncp.getVersion(5);
+        EzspVersionResponse version = ncp.getVersion();
 
         out.println("Ember NCP state    : " + status);
         out.println("Local Node Type    : " + nwkParameterResponse.getNodeType());

--- a/com.zsmartsystems.zigbee.console.ember/src/main/java/com/zsmartsystems/zigbee/console/ember/EmberConsoleNcpVersionCommand.java
+++ b/com.zsmartsystems.zigbee.console.ember/src/main/java/com/zsmartsystems/zigbee/console/ember/EmberConsoleNcpVersionCommand.java
@@ -45,7 +45,7 @@ public class EmberConsoleNcpVersionCommand extends EmberConsoleAbstractCommand {
             throws IllegalArgumentException {
         EmberNcp ncp = getEmberNcp(networkManager);
 
-        EzspVersionResponse version = ncp.getVersion(0);
+        EzspVersionResponse version = ncp.getVersion();
         out.println("Ember NCP version " + getVersionString(version.getStackVersion()) + ", EZSP version "
                 + EzspFrame.getEzspVersion());
     }

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/EmberNcp.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/EmberNcp.java
@@ -175,10 +175,9 @@ public class EmberNcp {
      * The command allows the Host to specify the desired EZSP version and must be sent before any other command. The
      * response provides information about the firmware running on the NCP.
      *
-     * @param desiredVersion the requested version we support
      * @return the {@link EzspVersionResponse}
      */
-    public EzspVersionResponse getVersion(int desiredVersion) {
+    public EzspVersionResponse getVersion() {
         EzspVersionRequest request = new EzspVersionRequest();
         request.setDesiredProtocolVersion(EzspFrame.getEzspVersion());
         EzspTransaction transaction = protocolHandler

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
@@ -1245,7 +1245,7 @@ public class ZigBeeDongleEzsp implements ZigBeeTransportTransmit, ZigBeeTranspor
 
         // We MUST send the version command first.
         // Any failure to respond here indicates a failure of the ASH or EZSP layers to initialise
-        ezspVersion = ncp.getVersion(4);
+        ezspVersion = ncp.getVersion();
         if (ezspVersion == null) {
             logger.debug("EZSP Dongle: Version returned null. ASH/EZSP not initialised.");
             return false;
@@ -1259,7 +1259,7 @@ public class ZigBeeDongleEzsp implements ZigBeeTransportTransmit, ZigBeeTranspor
                 return false;
             }
 
-            ezspVersion = ncp.getVersion(EzspFrame.getEzspVersion());
+            ezspVersion = ncp.getVersion();
             logger.debug(ezspVersion.toString());
         }
 


### PR DESCRIPTION
Resolves #1059

As written in #1059, another option would be to actually use the `desiredVersion` parameter in the method (instead of using the static version value from `EzspFrame`), but as the implementation of `ZigBeeDongleEzsp` adapts the static version value in `EzspFrame` in case the chip supports another version only it sounded more sensible to me to remove the parameter.

If you disagree, Chris, I can adapt the PR.
