### PR TITLE
Ensure discovery tasks are run in order

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeDiscoveryExtension.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeDiscoveryExtension.java
@@ -74,10 +74,13 @@ public class ZigBeeDiscoveryExtension
     private boolean extensionStarted = false;
 
     /**
-     * List of tasks to be completed during a mesh update
+     * List of tasks to be completed during a mesh update.
+     * We want to get the neighbors and routes so we have visibility of the mesh. We also default to requesting the
+     * network address to ensure that it hasn't changed.
      */
     private List<NodeDiscoveryTask> meshUpdateTasks = Arrays
-            .asList(new NodeDiscoveryTask[] { NodeDiscoveryTask.NEIGHBORS, NodeDiscoveryTask.ROUTES });
+            .asList(new NodeDiscoveryTask[] { NodeDiscoveryTask.NWK_ADDRESS, NodeDiscoveryTask.NEIGHBORS,
+                    NodeDiscoveryTask.ROUTES });
 
     @Override
     public ZigBeeStatus extensionInitialize(ZigBeeNetworkManager networkManager) {

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeNodeServiceDiscoverer.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeNodeServiceDiscoverer.java
@@ -12,8 +12,8 @@ import java.util.Calendar;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.List;
+import java.util.PriorityQueue;
 import java.util.Queue;
 import java.util.Random;
 import java.util.Set;
@@ -152,8 +152,9 @@ public class ZigBeeNodeServiceDiscoverer {
     private List<NodeDiscoveryTask> meshUpdateTasks = Collections.emptyList();
 
     /**
-     *
-     *
+     * The definition of discovery tasks.
+     * <p>
+     * Note that tasks will be run in the order of the enum definition.
      */
     public enum NodeDiscoveryTask {
         NWK_ADDRESS,
@@ -168,7 +169,7 @@ public class ZigBeeNodeServiceDiscoverer {
     /**
      * The list of tasks we need to complete
      */
-    private final Queue<NodeDiscoveryTask> discoveryTasks = new LinkedList<NodeDiscoveryTask>();
+    private final Queue<NodeDiscoveryTask> discoveryTasks = new PriorityQueue<NodeDiscoveryTask>();
 
     private boolean closed = false;
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeNodeServiceDiscoverer.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeNodeServiceDiscoverer.java
@@ -154,17 +154,20 @@ public class ZigBeeNodeServiceDiscoverer {
     /**
      * The definition of discovery tasks.
      * <p>
-     * Note that tasks will be run in the order of the enum definition.
+     * Please note that the ordering of the tasks in the enum is significant; a task that needs to be run before another
+     * task must be placed before that other task in the enum. Examples are that the network address must be discovered
+     * before all other tasks can be run, and that the node descriptor must be discovered before the endpoint simple
+     * descriptor.
      */
     public enum NodeDiscoveryTask {
         /**
          * Retrieve NWK Address. Note that this must be first as other tasks require the network address
          */
         NWK_ADDRESS,
-        ASSOCIATED_NODES,
         NODE_DESCRIPTOR,
         POWER_DESCRIPTOR,
         ACTIVE_ENDPOINTS,
+        ASSOCIATED_NODES,
         NEIGHBORS,
         ROUTES
     }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeNodeServiceDiscoverer.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeNodeServiceDiscoverer.java
@@ -157,6 +157,9 @@ public class ZigBeeNodeServiceDiscoverer {
      * Note that tasks will be run in the order of the enum definition.
      */
     public enum NodeDiscoveryTask {
+        /**
+         * Retrieve NWK Address. Note that this must be first as other tasks require the network address
+         */
         NWK_ADDRESS,
         ASSOCIATED_NODES,
         NODE_DESCRIPTOR,
@@ -203,6 +206,12 @@ public class ZigBeeNodeServiceDiscoverer {
         // complete. When no tasks are left in the queue, the worker thread will exit.
         synchronized (discoveryTasks) {
             logger.debug("{}: Node SVC Discovery: starting new tasks {}", node.getIeeeAddress(), newTasks);
+
+            // Ensure that we always know the network address
+            if (node.getNetworkAddress() == null) {
+                logger.debug("{}: Node SVC Discovery: network address was not known", node.getIeeeAddress());
+                newTasks.add(NodeDiscoveryTask.NWK_ADDRESS);
+            }
 
             // Remove router/coordinator-only tasks if the device is possibly an end node.
             final boolean isPossibleEndDevice = isPossibleEndDevice();

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransactionManager.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransactionManager.java
@@ -34,7 +34,6 @@ import com.zsmartsystems.zigbee.ZigBeeExecutors;
 import com.zsmartsystems.zigbee.ZigBeeNetworkManager;
 import com.zsmartsystems.zigbee.ZigBeeNetworkNodeListener;
 import com.zsmartsystems.zigbee.ZigBeeNode;
-import com.zsmartsystems.zigbee.internal.NotificationService;
 import com.zsmartsystems.zigbee.transaction.ZigBeeTransaction.TransactionState;
 import com.zsmartsystems.zigbee.transport.ZigBeeTransportProgressState;
 import com.zsmartsystems.zigbee.zdo.field.NodeDescriptor.MacCapabilitiesType;

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeNodeServiceDiscovererTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeNodeServiceDiscovererTest.java
@@ -15,8 +15,11 @@ import static org.junit.Assert.assertTrue;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Queue;
+import java.util.Set;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledFuture;
 
@@ -49,12 +52,10 @@ import com.zsmartsystems.zigbee.zdo.command.NetworkAddressResponse;
 import com.zsmartsystems.zigbee.zdo.command.NodeDescriptorResponse;
 import com.zsmartsystems.zigbee.zdo.command.PowerDescriptorResponse;
 import com.zsmartsystems.zigbee.zdo.command.SimpleDescriptorResponse;
-import com.zsmartsystems.zigbee.zdo.field.NeighborTable;
 import com.zsmartsystems.zigbee.zdo.field.NodeDescriptor;
 import com.zsmartsystems.zigbee.zdo.field.NodeDescriptor.LogicalType;
 import com.zsmartsystems.zigbee.zdo.field.PowerDescriptor;
 import com.zsmartsystems.zigbee.zdo.field.PowerDescriptor.CurrentPowerModeType;
-import com.zsmartsystems.zigbee.zdo.field.RoutingTable;
 import com.zsmartsystems.zigbee.zdo.field.SimpleDescriptor;
 
 /**
@@ -146,7 +147,8 @@ public class ZigBeeNodeServiceDiscovererTest {
         nwkResponse.setDestinationAddress(new ZigBeeEndpointAddress(0));
         responses.put(ZdoCommandType.NETWORK_ADDRESS_REQUEST.getClusterId(), nwkResponse);
 
-        IeeeAddressResponse ieeeResponse = new IeeeAddressResponse(ZdoStatus.SUCCESS, new IeeeAddress("1234567890ABCDEF"), null, null, null);
+        IeeeAddressResponse ieeeResponse = new IeeeAddressResponse(ZdoStatus.SUCCESS,
+                new IeeeAddress("1234567890ABCDEF"), null, null, null);
         ieeeResponse.setSourceAddress(new ZigBeeEndpointAddress(123));
         ieeeResponse.setDestinationAddress(new ZigBeeEndpointAddress(0));
         responses.put(ZdoCommandType.IEEE_ADDRESS_REQUEST.getClusterId(), ieeeResponse);
@@ -179,7 +181,8 @@ public class ZigBeeNodeServiceDiscovererTest {
         List<Integer> outputClusterList = new ArrayList<Integer>();
         simpleDescriptor.setInputClusterList(inputClusterList);
         simpleDescriptor.setOutputClusterList(outputClusterList);
-        SimpleDescriptorResponse simpleResponse = new SimpleDescriptorResponse(ZdoStatus.SUCCESS, 0, null, simpleDescriptor);
+        SimpleDescriptorResponse simpleResponse = new SimpleDescriptorResponse(ZdoStatus.SUCCESS, 0, null,
+                simpleDescriptor);
         simpleResponse.setSourceAddress(new ZigBeeEndpointAddress(123));
         simpleResponse.setDestinationAddress(new ZigBeeEndpointAddress(0, 1));
         responses.put(ZdoCommandType.SIMPLE_DESCRIPTOR_REQUEST.getClusterId(), simpleResponse);
@@ -189,7 +192,8 @@ public class ZigBeeNodeServiceDiscovererTest {
         lqiRequest.setDestinationAddress(new ZigBeeEndpointAddress(0));
         responses.put(ZdoCommandType.MANAGEMENT_LQI_REQUEST.getClusterId(), lqiRequest);
 
-        ManagementRoutingResponse routingResponse = new ManagementRoutingResponse(ZdoStatus.SUCCESS, 0, 0, new ArrayList<>());
+        ManagementRoutingResponse routingResponse = new ManagementRoutingResponse(ZdoStatus.SUCCESS, 0, 0,
+                new ArrayList<>());
         routingResponse.setSourceAddress(new ZigBeeEndpointAddress(123));
         routingResponse.setDestinationAddress(new ZigBeeEndpointAddress(0));
         responses.put(ZdoCommandType.MANAGEMENT_ROUTING_REQUEST.getClusterId(), routingResponse);
@@ -307,5 +311,32 @@ public class ZigBeeNodeServiceDiscovererTest {
         assertTrue(discoverer.getTasks().contains(NodeDiscoveryTask.NEIGHBORS));
 
         discoverer.stopDiscovery();
+    }
+
+    @Test
+    public void ordering() throws Exception {
+        ZigBeeNode node = Mockito.mock(ZigBeeNode.class);
+        Mockito.when(node.getLogicalType()).thenReturn(LogicalType.UNKNOWN);
+        Mockito.when(node.getIeeeAddress()).thenReturn(new IeeeAddress("1234567890ABCDEF"));
+
+        ZigBeeNodeServiceDiscoverer discoverer = new ZigBeeNodeServiceDiscoverer(networkManager, node);
+
+        Set<NodeDiscoveryTask> tasks = new HashSet<NodeDiscoveryTask>();
+
+        tasks.add(NodeDiscoveryTask.NEIGHBORS);
+        tasks.add(NodeDiscoveryTask.ROUTES);
+        tasks.add(NodeDiscoveryTask.NWK_ADDRESS);
+        tasks.add(NodeDiscoveryTask.NODE_DESCRIPTOR);
+
+        TestUtilities.invokeMethod(ZigBeeNodeServiceDiscoverer.class, discoverer, "startDiscovery", Set.class, tasks);
+        Queue<NodeDiscoveryTask> tasksOut = (Queue<NodeDiscoveryTask>) TestUtilities.getField(
+                ZigBeeNodeServiceDiscoverer.class, discoverer,
+                "discoveryTasks");
+
+        int lastValue = -1;
+        for (NodeDiscoveryTask task : tasksOut) {
+            assertTrue(task.ordinal() > lastValue);
+            lastValue = task.ordinal();
+        }
     }
 }


### PR DESCRIPTION
This is an alternative suggestion to resolve #1057 and replaces #1058.

@hsudbrock I think this is simpler than your or @triller-telekom suggestion and I think it solves the issue. This simply changes the  `discoveryTasks `  implementation of `Queue` from `LinkedList` to `PriorityQueue` - thus ensuring the discovery order is based on the `enum` ordinal.

I think this will resolve the issue Stefan raised. I also think this is safer - we guarantee the order of discovery as there are potentially other dependencies - eg we can't request the endpoint simple descriptor until we have the node descriptor.

What do you think?

Signed-off-by: Chris Jackson <chris@cd-jackson.com>