### PR TITLE
Add console support for window covering commands

### DIFF
--- a/com.zsmartsystems.zigbee.console.main/src/main/java/com/zsmartsystems/zigbee/console/main/ZigBeeConsole.java
+++ b/com.zsmartsystems.zigbee.console.main/src/main/java/com/zsmartsystems/zigbee/console/main/ZigBeeConsole.java
@@ -63,6 +63,7 @@ import com.zsmartsystems.zigbee.console.ZigBeeConsoleReportingUnsubscribeCommand
 import com.zsmartsystems.zigbee.console.ZigBeeConsoleSmartEnergyCommand;
 import com.zsmartsystems.zigbee.console.ZigBeeConsoleTrustCentreCommand;
 import com.zsmartsystems.zigbee.console.ZigBeeConsoleUnbindCommand;
+import com.zsmartsystems.zigbee.console.ZigBeeConsoleWindowCoveringCommand;
 import com.zsmartsystems.zigbee.transport.ZigBeeTransportFirmwareCallback;
 import com.zsmartsystems.zigbee.transport.ZigBeeTransportFirmwareStatus;
 import com.zsmartsystems.zigbee.transport.ZigBeeTransportFirmwareUpdate;
@@ -204,6 +205,8 @@ public final class ZigBeeConsole {
 
         newCommands.put("smartenergy", new ZigBeeConsoleSmartEnergyCommand());
         newCommands.put("cbke", new ZigBeeConsoleCbkeCommand());
+
+        newCommands.put("covering", new ZigBeeConsoleWindowCoveringCommand());
 
         zigBeeApi = new ZigBeeApi(networkManager);
 

--- a/com.zsmartsystems.zigbee.console.main/src/main/java/com/zsmartsystems/zigbee/console/main/ZigBeeConsoleMain.java
+++ b/com.zsmartsystems.zigbee.console.main/src/main/java/com/zsmartsystems/zigbee/console/main/ZigBeeConsoleMain.java
@@ -72,6 +72,7 @@ import com.zsmartsystems.zigbee.zcl.clusters.ZclLevelControlCluster;
 import com.zsmartsystems.zigbee.zcl.clusters.ZclOnOffCluster;
 import com.zsmartsystems.zigbee.zcl.clusters.ZclPressureMeasurementCluster;
 import com.zsmartsystems.zigbee.zcl.clusters.ZclThermostatCluster;
+import com.zsmartsystems.zigbee.zcl.clusters.ZclWindowCoveringCluster;
 
 /**
  * The ZigBee test console. Simple console used for testing the framework.
@@ -102,13 +103,14 @@ public class ZigBeeConsoleMain {
         supportedClientClusters.addAll(Stream
                 .of(ZclBasicCluster.CLUSTER_ID, ZclOnOffCluster.CLUSTER_ID, ZclLevelControlCluster.CLUSTER_ID,
                         ZclColorControlCluster.CLUSTER_ID, ZclPressureMeasurementCluster.CLUSTER_ID,
-                        ZclThermostatCluster.CLUSTER_ID)
+                        ZclThermostatCluster.CLUSTER_ID, ZclWindowCoveringCluster.CLUSTER_ID)
                 .collect(Collectors.toSet()));
 
         final Set<Integer> supportedServerClusters = new TreeSet<>();
         supportedServerClusters.addAll(Stream
                 .of(ZclBasicCluster.CLUSTER_ID, ZclOnOffCluster.CLUSTER_ID, ZclLevelControlCluster.CLUSTER_ID,
-                        ZclColorControlCluster.CLUSTER_ID, ZclPressureMeasurementCluster.CLUSTER_ID)
+                        ZclColorControlCluster.CLUSTER_ID, ZclPressureMeasurementCluster.CLUSTER_ID,
+                        ZclWindowCoveringCluster.CLUSTER_ID)
                 .collect(Collectors.toSet()));
 
         final TransportConfig transportOptions = new TransportConfig();

--- a/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleAbstractCommand.java
+++ b/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleAbstractCommand.java
@@ -191,6 +191,19 @@ public abstract class ZigBeeConsoleAbstractCommand implements ZigBeeConsoleComma
     }
 
     /**
+     * Parses a percentage as a string to an integer. The string should be in the range 0-100, and the returned integer
+     * is in the range 0-254 as per the ZigBee standard.
+     *
+     * @param percentage a {@link String} of the percentage value
+     * @return the integer in the range 0-254 as per the ZigBee standard
+     * @throws IllegalArgumentException
+     */
+    protected Integer parsePercentage(final String percentage) throws IllegalArgumentException {
+        int value = parseInteger(percentage);
+        return (int) (value * 254.0f / 100.0f + 0.5f);
+    }
+
+    /**
      * Default processing for command result.
      *
      * @param result the command result

--- a/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleWindowCoveringCommand.java
+++ b/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleWindowCoveringCommand.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2016-2020 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.console;
+
+import java.io.PrintStream;
+
+import com.zsmartsystems.zigbee.ZigBeeEndpoint;
+import com.zsmartsystems.zigbee.ZigBeeNetworkManager;
+import com.zsmartsystems.zigbee.zcl.clusters.ZclWindowCoveringCluster;
+import com.zsmartsystems.zigbee.zcl.clusters.windowcovering.WindowCoveringDownClose;
+import com.zsmartsystems.zigbee.zcl.clusters.windowcovering.WindowCoveringGoToLiftPercentage;
+import com.zsmartsystems.zigbee.zcl.clusters.windowcovering.WindowCoveringGoToTiltPercentage;
+import com.zsmartsystems.zigbee.zcl.clusters.windowcovering.WindowCoveringStop;
+import com.zsmartsystems.zigbee.zcl.clusters.windowcovering.WindowCoveringUpOpen;
+
+/**
+ *
+ * @author Chris Jackson
+ *
+ */
+public class ZigBeeConsoleWindowCoveringCommand extends ZigBeeConsoleAbstractCommand {
+    @Override
+    public String getCommand() {
+        return "covering";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Performs commands on the windowing covering cluster.";
+    }
+
+    @Override
+    public String getSyntax() {
+        return "ENDPOINT [UP | DOWN | OPEN | CLOSE | STOP | LIFT | TILT] [value]";
+    }
+
+    @Override
+    public String getHelp() {
+        return "";
+    }
+
+    @Override
+    public void process(ZigBeeNetworkManager networkManager, String[] args, PrintStream out)
+            throws IllegalArgumentException {
+        if (args.length < 3 || args.length > 4) {
+            throw new IllegalArgumentException("Invalid number of commands");
+        }
+
+        ZigBeeEndpoint endpoint = getEndpoint(networkManager, args[1]);
+        ZclWindowCoveringCluster cluster = (ZclWindowCoveringCluster) endpoint
+                .getInputCluster(ZclWindowCoveringCluster.CLUSTER_ID);
+
+        if (cluster == null) {
+            throw new IllegalStateException("Window covering cluster not found");
+        }
+
+        switch (args[2].toUpperCase()) {
+            case "UP":
+            case "OPEN":
+                cluster.sendCommand(new WindowCoveringUpOpen());
+                break;
+            case "DOWN":
+            case "CLOSED":
+                cluster.sendCommand(new WindowCoveringDownClose());
+                break;
+            case "STOP":
+                cluster.sendCommand(new WindowCoveringStop());
+                break;
+            case "LIFT":
+                cluster.sendCommand(new WindowCoveringGoToLiftPercentage(parsePercentage(args[3])));
+                break;
+            case "TILT":
+                cluster.sendCommand(new WindowCoveringGoToTiltPercentage(parsePercentage(args[3])));
+                break;
+            default:
+                throw new IllegalArgumentException("Invalid command argument " + args[2]);
+        }
+    }
+}


### PR DESCRIPTION
This adds a simple `covering` command to implement the `ZclWindowCoveringCluster` commands.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>