### PR TITLE
Remove deprecated annotations where default constructor is permitted

### DIFF
--- a/com.zsmartsystems.zigbee.autocode/src/main/java/com/zsmartsystems/zigbee/autocode/ZigBeeZclCommandGenerator.java
+++ b/com.zsmartsystems.zigbee.autocode/src/main/java/com/zsmartsystems/zigbee/autocode/ZigBeeZclCommandGenerator.java
@@ -182,8 +182,10 @@ public class ZigBeeZclCommandGenerator extends ZigBeeBaseFieldGenerator {
             out.println("    /**");
             out.println("     * Default constructor.");
             out.println("     *");
-            out.println(
-                    "     * @deprecated from release 1.3.0. Use the parameterised constructor instead of the default contructor and setters.");
+            if (!command.fields.isEmpty()) {
+                out.println(
+                        "     * @deprecated from release 1.3.0. Use the parameterised constructor instead of the default contructor and setters.");
+            }
             out.println("     */");
             if (!command.fields.isEmpty()) {
                 out.println("    @Deprecated");

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/alarms/GetAlarmCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/alarms/GetAlarmCommand.java
@@ -24,7 +24,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-13T19:23:13Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-06-06T12:25:30Z")
 public class GetAlarmCommand extends ZclAlarmsCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -39,7 +39,6 @@ public class GetAlarmCommand extends ZclAlarmsCommand {
     /**
      * Default constructor.
      *
-     * @deprecated from release 1.3.0. Use the parameterised constructor instead of the default contructor and setters.
      */
     public GetAlarmCommand() {
         clusterId = CLUSTER_ID;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/alarms/ResetAlarmLogCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/alarms/ResetAlarmLogCommand.java
@@ -21,7 +21,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-13T19:23:13Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-06-06T12:25:30Z")
 public class ResetAlarmLogCommand extends ZclAlarmsCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -36,7 +36,6 @@ public class ResetAlarmLogCommand extends ZclAlarmsCommand {
     /**
      * Default constructor.
      *
-     * @deprecated from release 1.3.0. Use the parameterised constructor instead of the default contructor and setters.
      */
     public ResetAlarmLogCommand() {
         clusterId = CLUSTER_ID;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/alarms/ResetAllAlarmsCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/alarms/ResetAllAlarmsCommand.java
@@ -23,7 +23,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-13T19:23:13Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-06-06T12:25:30Z")
 public class ResetAllAlarmsCommand extends ZclAlarmsCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -38,7 +38,6 @@ public class ResetAllAlarmsCommand extends ZclAlarmsCommand {
     /**
      * Default constructor.
      *
-     * @deprecated from release 1.3.0. Use the parameterised constructor instead of the default contructor and setters.
      */
     public ResetAllAlarmsCommand() {
         clusterId = CLUSTER_ID;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/basic/ResetToFactoryDefaultsCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/basic/ResetToFactoryDefaultsCommand.java
@@ -23,7 +23,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-13T19:23:13Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-06-06T12:25:30Z")
 public class ResetToFactoryDefaultsCommand extends ZclBasicCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -38,7 +38,6 @@ public class ResetToFactoryDefaultsCommand extends ZclBasicCommand {
     /**
      * Default constructor.
      *
-     * @deprecated from release 1.3.0. Use the parameterised constructor instead of the default contructor and setters.
      */
     public ResetToFactoryDefaultsCommand() {
         clusterId = CLUSTER_ID;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/StopMoveStepCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/StopMoveStepCommand.java
@@ -27,7 +27,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-13T19:23:13Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-06-06T12:25:30Z")
 public class StopMoveStepCommand extends ZclColorControlCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -42,7 +42,6 @@ public class StopMoveStepCommand extends ZclColorControlCommand {
     /**
      * Default constructor.
      *
-     * @deprecated from release 1.3.0. Use the parameterised constructor instead of the default contructor and setters.
      */
     public StopMoveStepCommand() {
         clusterId = CLUSTER_ID;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/electricalmeasurement/GetProfileInfoCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/electricalmeasurement/GetProfileInfoCommand.java
@@ -21,7 +21,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-13T19:23:13Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-06-06T12:25:30Z")
 public class GetProfileInfoCommand extends ZclElectricalMeasurementCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -36,7 +36,6 @@ public class GetProfileInfoCommand extends ZclElectricalMeasurementCommand {
     /**
      * Default constructor.
      *
-     * @deprecated from release 1.3.0. Use the parameterised constructor instead of the default contructor and setters.
      */
     public GetProfileInfoCommand() {
         clusterId = CLUSTER_ID;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/groups/RemoveAllGroupsCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/groups/RemoveAllGroupsCommand.java
@@ -22,7 +22,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-13T19:23:13Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-06-06T12:25:30Z")
 public class RemoveAllGroupsCommand extends ZclGroupsCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -37,7 +37,6 @@ public class RemoveAllGroupsCommand extends ZclGroupsCommand {
     /**
      * Default constructor.
      *
-     * @deprecated from release 1.3.0. Use the parameterised constructor instead of the default contructor and setters.
      */
     public RemoveAllGroupsCommand() {
         clusterId = CLUSTER_ID;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/EmergencyCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/EmergencyCommand.java
@@ -19,7 +19,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-13T19:23:13Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-06-06T12:25:30Z")
 public class EmergencyCommand extends ZclIasAceCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -34,7 +34,6 @@ public class EmergencyCommand extends ZclIasAceCommand {
     /**
      * Default constructor.
      *
-     * @deprecated from release 1.3.0. Use the parameterised constructor instead of the default contructor and setters.
      */
     public EmergencyCommand() {
         clusterId = CLUSTER_ID;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/FireCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/FireCommand.java
@@ -19,7 +19,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-13T19:23:13Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-06-06T12:25:30Z")
 public class FireCommand extends ZclIasAceCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -34,7 +34,6 @@ public class FireCommand extends ZclIasAceCommand {
     /**
      * Default constructor.
      *
-     * @deprecated from release 1.3.0. Use the parameterised constructor instead of the default contructor and setters.
      */
     public FireCommand() {
         clusterId = CLUSTER_ID;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/GetBypassedZoneListCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/GetBypassedZoneListCommand.java
@@ -24,7 +24,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-13T19:23:13Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-06-06T12:25:30Z")
 public class GetBypassedZoneListCommand extends ZclIasAceCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -39,7 +39,6 @@ public class GetBypassedZoneListCommand extends ZclIasAceCommand {
     /**
      * Default constructor.
      *
-     * @deprecated from release 1.3.0. Use the parameterised constructor instead of the default contructor and setters.
      */
     public GetBypassedZoneListCommand() {
         clusterId = CLUSTER_ID;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/GetPanelStatusCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/GetPanelStatusCommand.java
@@ -25,7 +25,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-13T19:23:13Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-06-06T12:25:30Z")
 public class GetPanelStatusCommand extends ZclIasAceCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -40,7 +40,6 @@ public class GetPanelStatusCommand extends ZclIasAceCommand {
     /**
      * Default constructor.
      *
-     * @deprecated from release 1.3.0. Use the parameterised constructor instead of the default contructor and setters.
      */
     public GetPanelStatusCommand() {
         clusterId = CLUSTER_ID;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/GetZoneIdMapCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/GetZoneIdMapCommand.java
@@ -19,7 +19,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-13T19:23:13Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-06-06T12:25:30Z")
 public class GetZoneIdMapCommand extends ZclIasAceCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -34,7 +34,6 @@ public class GetZoneIdMapCommand extends ZclIasAceCommand {
     /**
      * Default constructor.
      *
-     * @deprecated from release 1.3.0. Use the parameterised constructor instead of the default contructor and setters.
      */
     public GetZoneIdMapCommand() {
         clusterId = CLUSTER_ID;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/PanicCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/PanicCommand.java
@@ -19,7 +19,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-13T19:23:13Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-06-06T12:25:30Z")
 public class PanicCommand extends ZclIasAceCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -34,7 +34,6 @@ public class PanicCommand extends ZclIasAceCommand {
     /**
      * Default constructor.
      *
-     * @deprecated from release 1.3.0. Use the parameterised constructor instead of the default contructor and setters.
      */
     public PanicCommand() {
         clusterId = CLUSTER_ID;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iaszone/InitiateNormalOperationModeCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iaszone/InitiateNormalOperationModeCommand.java
@@ -26,7 +26,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-13T19:23:13Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-06-06T12:25:30Z")
 public class InitiateNormalOperationModeCommand extends ZclIasZoneCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -41,7 +41,6 @@ public class InitiateNormalOperationModeCommand extends ZclIasZoneCommand {
     /**
      * Default constructor.
      *
-     * @deprecated from release 1.3.0. Use the parameterised constructor instead of the default contructor and setters.
      */
     public InitiateNormalOperationModeCommand() {
         clusterId = CLUSTER_ID;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/identify/IdentifyQueryCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/identify/IdentifyQueryCommand.java
@@ -19,7 +19,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-13T19:23:13Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-06-06T12:25:30Z")
 public class IdentifyQueryCommand extends ZclIdentifyCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -34,7 +34,6 @@ public class IdentifyQueryCommand extends ZclIdentifyCommand {
     /**
      * Default constructor.
      *
-     * @deprecated from release 1.3.0. Use the parameterised constructor instead of the default contructor and setters.
      */
     public IdentifyQueryCommand() {
         clusterId = CLUSTER_ID;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/levelcontrol/StopCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/levelcontrol/StopCommand.java
@@ -23,7 +23,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-13T19:23:13Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-06-06T12:25:30Z")
 public class StopCommand extends ZclLevelControlCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -38,7 +38,6 @@ public class StopCommand extends ZclLevelControlCommand {
     /**
      * Default constructor.
      *
-     * @deprecated from release 1.3.0. Use the parameterised constructor instead of the default contructor and setters.
      */
     public StopCommand() {
         clusterId = CLUSTER_ID;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/levelcontrol/StopWithOnOffCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/levelcontrol/StopWithOnOffCommand.java
@@ -19,7 +19,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-13T19:23:13Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-06-06T12:25:30Z")
 public class StopWithOnOffCommand extends ZclLevelControlCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -34,7 +34,6 @@ public class StopWithOnOffCommand extends ZclLevelControlCommand {
     /**
      * Default constructor.
      *
-     * @deprecated from release 1.3.0. Use the parameterised constructor instead of the default contructor and setters.
      */
     public StopWithOnOffCommand() {
         clusterId = CLUSTER_ID;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/RemoveMirror.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/RemoveMirror.java
@@ -21,7 +21,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-13T19:23:13Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-06-06T12:25:30Z")
 public class RemoveMirror extends ZclMeteringCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -36,7 +36,6 @@ public class RemoveMirror extends ZclMeteringCommand {
     /**
      * Default constructor.
      *
-     * @deprecated from release 1.3.0. Use the parameterised constructor instead of the default contructor and setters.
      */
     public RemoveMirror() {
         clusterId = CLUSTER_ID;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/RequestMirror.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/RequestMirror.java
@@ -21,7 +21,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-13T19:23:13Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-06-06T12:25:30Z")
 public class RequestMirror extends ZclMeteringCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -36,7 +36,6 @@ public class RequestMirror extends ZclMeteringCommand {
     /**
      * Default constructor.
      *
-     * @deprecated from release 1.3.0. Use the parameterised constructor instead of the default contructor and setters.
      */
     public RequestMirror() {
         clusterId = CLUSTER_ID;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/onoff/OffCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/onoff/OffCommand.java
@@ -23,7 +23,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-13T19:23:13Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-06-06T12:25:30Z")
 public class OffCommand extends ZclOnOffCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -38,7 +38,6 @@ public class OffCommand extends ZclOnOffCommand {
     /**
      * Default constructor.
      *
-     * @deprecated from release 1.3.0. Use the parameterised constructor instead of the default contructor and setters.
      */
     public OffCommand() {
         clusterId = CLUSTER_ID;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/onoff/OnCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/onoff/OnCommand.java
@@ -24,7 +24,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-13T19:23:13Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-06-06T12:25:30Z")
 public class OnCommand extends ZclOnOffCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -39,7 +39,6 @@ public class OnCommand extends ZclOnOffCommand {
     /**
      * Default constructor.
      *
-     * @deprecated from release 1.3.0. Use the parameterised constructor instead of the default contructor and setters.
      */
     public OnCommand() {
         clusterId = CLUSTER_ID;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/onoff/OnWithRecallGlobalSceneCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/onoff/OnWithRecallGlobalSceneCommand.java
@@ -22,7 +22,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-13T19:23:13Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-06-06T12:25:30Z")
 public class OnWithRecallGlobalSceneCommand extends ZclOnOffCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -37,7 +37,6 @@ public class OnWithRecallGlobalSceneCommand extends ZclOnOffCommand {
     /**
      * Default constructor.
      *
-     * @deprecated from release 1.3.0. Use the parameterised constructor instead of the default contructor and setters.
      */
     public OnWithRecallGlobalSceneCommand() {
         clusterId = CLUSTER_ID;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/onoff/ToggleCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/onoff/ToggleCommand.java
@@ -25,7 +25,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-13T19:23:13Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-06-06T12:25:30Z")
 public class ToggleCommand extends ZclOnOffCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -40,7 +40,6 @@ public class ToggleCommand extends ZclOnOffCommand {
     /**
      * Default constructor.
      *
-     * @deprecated from release 1.3.0. Use the parameterised constructor instead of the default contructor and setters.
      */
     public ToggleCommand() {
         clusterId = CLUSTER_ID;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/pollcontrol/CheckInCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/pollcontrol/CheckInCommand.java
@@ -29,7 +29,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-13T19:23:13Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-06-06T12:25:30Z")
 public class CheckInCommand extends ZclPollControlCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -44,7 +44,6 @@ public class CheckInCommand extends ZclPollControlCommand {
     /**
      * Default constructor.
      *
-     * @deprecated from release 1.3.0. Use the parameterised constructor instead of the default contructor and setters.
      */
     public CheckInCommand() {
         clusterId = CLUSTER_ID;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/pollcontrol/FastPollStopCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/pollcontrol/FastPollStopCommand.java
@@ -30,7 +30,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-13T19:23:13Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-06-06T12:25:30Z")
 public class FastPollStopCommand extends ZclPollControlCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -45,7 +45,6 @@ public class FastPollStopCommand extends ZclPollControlCommand {
     /**
      * Default constructor.
      *
-     * @deprecated from release 1.3.0. Use the parameterised constructor instead of the default contructor and setters.
      */
     public FastPollStopCommand() {
         clusterId = CLUSTER_ID;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/GetCurrencyConversionCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/GetCurrencyConversionCommand.java
@@ -24,7 +24,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-13T19:23:13Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-06-06T12:25:30Z")
 public class GetCurrencyConversionCommand extends ZclPriceCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -39,7 +39,6 @@ public class GetCurrencyConversionCommand extends ZclPriceCommand {
     /**
      * Default constructor.
      *
-     * @deprecated from release 1.3.0. Use the parameterised constructor instead of the default contructor and setters.
      */
     public GetCurrencyConversionCommand() {
         clusterId = CLUSTER_ID;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/GetTariffCancellationCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/GetTariffCancellationCommand.java
@@ -23,7 +23,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-13T19:23:13Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-06-06T12:25:30Z")
 public class GetTariffCancellationCommand extends ZclPriceCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -38,7 +38,6 @@ public class GetTariffCancellationCommand extends ZclPriceCommand {
     /**
      * Default constructor.
      *
-     * @deprecated from release 1.3.0. Use the parameterised constructor instead of the default contructor and setters.
      */
     public GetTariffCancellationCommand() {
         clusterId = CLUSTER_ID;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/rssilocation/CompactLocationDataNotificationCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/rssilocation/CompactLocationDataNotificationCommand.java
@@ -19,7 +19,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-13T19:23:13Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-06-06T12:25:30Z")
 public class CompactLocationDataNotificationCommand extends ZclRssiLocationCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -34,7 +34,6 @@ public class CompactLocationDataNotificationCommand extends ZclRssiLocationComma
     /**
      * Default constructor.
      *
-     * @deprecated from release 1.3.0. Use the parameterised constructor instead of the default contructor and setters.
      */
     public CompactLocationDataNotificationCommand() {
         clusterId = CLUSTER_ID;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/rssilocation/RssiRequestCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/rssilocation/RssiRequestCommand.java
@@ -19,7 +19,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-13T19:23:13Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-06-06T12:25:30Z")
 public class RssiRequestCommand extends ZclRssiLocationCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -34,7 +34,6 @@ public class RssiRequestCommand extends ZclRssiLocationCommand {
     /**
      * Default constructor.
      *
-     * @deprecated from release 1.3.0. Use the parameterised constructor instead of the default contructor and setters.
      */
     public RssiRequestCommand() {
         clusterId = CLUSTER_ID;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/thermostat/ClearWeeklySchedule.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/thermostat/ClearWeeklySchedule.java
@@ -19,7 +19,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-13T19:23:13Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-06-06T12:25:30Z")
 public class ClearWeeklySchedule extends ZclThermostatCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -34,7 +34,6 @@ public class ClearWeeklySchedule extends ZclThermostatCommand {
     /**
      * Default constructor.
      *
-     * @deprecated from release 1.3.0. Use the parameterised constructor instead of the default contructor and setters.
      */
     public ClearWeeklySchedule() {
         clusterId = CLUSTER_ID;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/thermostat/GetRelayStatusLog.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/thermostat/GetRelayStatusLog.java
@@ -32,7 +32,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-13T19:23:13Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-06-06T12:25:30Z")
 public class GetRelayStatusLog extends ZclThermostatCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -47,7 +47,6 @@ public class GetRelayStatusLog extends ZclThermostatCommand {
     /**
      * Default constructor.
      *
-     * @deprecated from release 1.3.0. Use the parameterised constructor instead of the default contructor and setters.
      */
     public GetRelayStatusLog() {
         clusterId = CLUSTER_ID;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/windowcovering/WindowCoveringDownClose.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/windowcovering/WindowCoveringDownClose.java
@@ -21,7 +21,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-13T19:23:13Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-06-06T12:25:30Z")
 public class WindowCoveringDownClose extends ZclWindowCoveringCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -36,7 +36,6 @@ public class WindowCoveringDownClose extends ZclWindowCoveringCommand {
     /**
      * Default constructor.
      *
-     * @deprecated from release 1.3.0. Use the parameterised constructor instead of the default contructor and setters.
      */
     public WindowCoveringDownClose() {
         clusterId = CLUSTER_ID;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/windowcovering/WindowCoveringStop.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/windowcovering/WindowCoveringStop.java
@@ -21,7 +21,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-13T19:23:13Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-06-06T12:25:30Z")
 public class WindowCoveringStop extends ZclWindowCoveringCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -36,7 +36,6 @@ public class WindowCoveringStop extends ZclWindowCoveringCommand {
     /**
      * Default constructor.
      *
-     * @deprecated from release 1.3.0. Use the parameterised constructor instead of the default contructor and setters.
      */
     public WindowCoveringStop() {
         clusterId = CLUSTER_ID;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/windowcovering/WindowCoveringUpOpen.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/windowcovering/WindowCoveringUpOpen.java
@@ -21,7 +21,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-13T19:23:13Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-06-06T12:25:30Z")
 public class WindowCoveringUpOpen extends ZclWindowCoveringCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -36,7 +36,6 @@ public class WindowCoveringUpOpen extends ZclWindowCoveringCommand {
     /**
      * Default constructor.
      *
-     * @deprecated from release 1.3.0. Use the parameterised constructor instead of the default contructor and setters.
      */
     public WindowCoveringUpOpen() {
         clusterId = CLUSTER_ID;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ActiveEndpointStoreRequest.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ActiveEndpointStoreRequest.java
@@ -23,7 +23,7 @@ import com.zsmartsystems.zigbee.zdo.ZdoRequest;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-13T19:23:13Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-06-06T12:25:30Z")
 public class ActiveEndpointStoreRequest extends ZdoRequest {
     /**
      * The ZDO cluster ID.
@@ -33,7 +33,6 @@ public class ActiveEndpointStoreRequest extends ZdoRequest {
     /**
      * Default constructor.
      *
-     * @deprecated from release 1.3.0. Use the parameterised constructor instead of the default contructor and setters.
      */
     public ActiveEndpointStoreRequest() {
         clusterId = CLUSTER_ID;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ActiveEndpointStoreResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ActiveEndpointStoreResponse.java
@@ -23,7 +23,7 @@ import com.zsmartsystems.zigbee.zdo.ZdoResponse;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-13T19:23:13Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-06-06T12:25:30Z")
 public class ActiveEndpointStoreResponse extends ZdoResponse {
     /**
      * The ZDO cluster ID.
@@ -33,7 +33,6 @@ public class ActiveEndpointStoreResponse extends ZdoResponse {
     /**
      * Default constructor.
      *
-     * @deprecated from release 1.3.0. Use the parameterised constructor instead of the default contructor and setters.
      */
     public ActiveEndpointStoreResponse() {
         clusterId = CLUSTER_ID;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/BackupBindTableRequest.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/BackupBindTableRequest.java
@@ -21,7 +21,7 @@ import com.zsmartsystems.zigbee.zdo.ZdoRequest;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-13T19:23:13Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-06-06T12:25:30Z")
 public class BackupBindTableRequest extends ZdoRequest {
     /**
      * The ZDO cluster ID.
@@ -31,7 +31,6 @@ public class BackupBindTableRequest extends ZdoRequest {
     /**
      * Default constructor.
      *
-     * @deprecated from release 1.3.0. Use the parameterised constructor instead of the default contructor and setters.
      */
     public BackupBindTableRequest() {
         clusterId = CLUSTER_ID;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/BindRegister.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/BindRegister.java
@@ -21,7 +21,7 @@ import com.zsmartsystems.zigbee.zdo.ZdoRequest;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-13T19:23:13Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-06-06T12:25:30Z")
 public class BindRegister extends ZdoRequest {
     /**
      * The ZDO cluster ID.
@@ -31,7 +31,6 @@ public class BindRegister extends ZdoRequest {
     /**
      * Default constructor.
      *
-     * @deprecated from release 1.3.0. Use the parameterised constructor instead of the default contructor and setters.
      */
     public BindRegister() {
         clusterId = CLUSTER_ID;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/CacheRequest.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/CacheRequest.java
@@ -21,7 +21,7 @@ import com.zsmartsystems.zigbee.zdo.ZdoRequest;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-13T19:23:13Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-06-06T12:25:30Z")
 public class CacheRequest extends ZdoRequest {
     /**
      * The ZDO cluster ID.
@@ -31,7 +31,6 @@ public class CacheRequest extends ZdoRequest {
     /**
      * Default constructor.
      *
-     * @deprecated from release 1.3.0. Use the parameterised constructor instead of the default contructor and setters.
      */
     public CacheRequest() {
         clusterId = CLUSTER_ID;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/DiscoveryCacheRequest.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/DiscoveryCacheRequest.java
@@ -21,7 +21,7 @@ import com.zsmartsystems.zigbee.zdo.ZdoRequest;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-13T19:23:13Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-06-06T12:25:30Z")
 public class DiscoveryCacheRequest extends ZdoRequest {
     /**
      * The ZDO cluster ID.
@@ -31,7 +31,6 @@ public class DiscoveryCacheRequest extends ZdoRequest {
     /**
      * Default constructor.
      *
-     * @deprecated from release 1.3.0. Use the parameterised constructor instead of the default contructor and setters.
      */
     public DiscoveryCacheRequest() {
         clusterId = CLUSTER_ID;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/DiscoveryCacheResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/DiscoveryCacheResponse.java
@@ -21,7 +21,7 @@ import com.zsmartsystems.zigbee.zdo.ZdoResponse;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-13T19:23:13Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-06-06T12:25:30Z")
 public class DiscoveryCacheResponse extends ZdoResponse {
     /**
      * The ZDO cluster ID.
@@ -31,7 +31,6 @@ public class DiscoveryCacheResponse extends ZdoResponse {
     /**
      * Default constructor.
      *
-     * @deprecated from release 1.3.0. Use the parameterised constructor instead of the default contructor and setters.
      */
     public DiscoveryCacheResponse() {
         clusterId = CLUSTER_ID;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/DiscoveryStoreRequestRequest.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/DiscoveryStoreRequestRequest.java
@@ -21,7 +21,7 @@ import com.zsmartsystems.zigbee.zdo.ZdoRequest;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-13T19:23:13Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-06-06T12:25:30Z")
 public class DiscoveryStoreRequestRequest extends ZdoRequest {
     /**
      * The ZDO cluster ID.
@@ -31,7 +31,6 @@ public class DiscoveryStoreRequestRequest extends ZdoRequest {
     /**
      * Default constructor.
      *
-     * @deprecated from release 1.3.0. Use the parameterised constructor instead of the default contructor and setters.
      */
     public DiscoveryStoreRequestRequest() {
         clusterId = CLUSTER_ID;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/DiscoveryStoreResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/DiscoveryStoreResponse.java
@@ -23,7 +23,7 @@ import com.zsmartsystems.zigbee.zdo.ZdoResponse;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-13T19:23:13Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-06-06T12:25:30Z")
 public class DiscoveryStoreResponse extends ZdoResponse {
     /**
      * The ZDO cluster ID.
@@ -33,7 +33,6 @@ public class DiscoveryStoreResponse extends ZdoResponse {
     /**
      * Default constructor.
      *
-     * @deprecated from release 1.3.0. Use the parameterised constructor instead of the default contructor and setters.
      */
     public DiscoveryStoreResponse() {
         clusterId = CLUSTER_ID;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ExtendedActiveEndpointRequest.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ExtendedActiveEndpointRequest.java
@@ -27,7 +27,7 @@ import com.zsmartsystems.zigbee.zdo.ZdoRequest;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-13T19:23:13Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-06-06T12:25:30Z")
 public class ExtendedActiveEndpointRequest extends ZdoRequest {
     /**
      * The ZDO cluster ID.
@@ -37,7 +37,6 @@ public class ExtendedActiveEndpointRequest extends ZdoRequest {
     /**
      * Default constructor.
      *
-     * @deprecated from release 1.3.0. Use the parameterised constructor instead of the default contructor and setters.
      */
     public ExtendedActiveEndpointRequest() {
         clusterId = CLUSTER_ID;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ExtendedActiveEndpointResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ExtendedActiveEndpointResponse.java
@@ -21,7 +21,7 @@ import com.zsmartsystems.zigbee.zdo.ZdoResponse;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-13T19:23:13Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-06-06T12:25:30Z")
 public class ExtendedActiveEndpointResponse extends ZdoResponse {
     /**
      * The ZDO cluster ID.
@@ -31,7 +31,6 @@ public class ExtendedActiveEndpointResponse extends ZdoResponse {
     /**
      * Default constructor.
      *
-     * @deprecated from release 1.3.0. Use the parameterised constructor instead of the default contructor and setters.
      */
     public ExtendedActiveEndpointResponse() {
         clusterId = CLUSTER_ID;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ExtendedSimpleDescriptorResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ExtendedSimpleDescriptorResponse.java
@@ -21,7 +21,7 @@ import com.zsmartsystems.zigbee.zdo.ZdoResponse;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-13T19:23:13Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-06-06T12:25:30Z")
 public class ExtendedSimpleDescriptorResponse extends ZdoResponse {
     /**
      * The ZDO cluster ID.
@@ -31,7 +31,6 @@ public class ExtendedSimpleDescriptorResponse extends ZdoResponse {
     /**
      * Default constructor.
      *
-     * @deprecated from release 1.3.0. Use the parameterised constructor instead of the default contructor and setters.
      */
     public ExtendedSimpleDescriptorResponse() {
         clusterId = CLUSTER_ID;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/FindNodeCacheRequest.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/FindNodeCacheRequest.java
@@ -26,7 +26,7 @@ import com.zsmartsystems.zigbee.zdo.ZdoRequest;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-13T19:23:13Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-06-06T12:25:30Z")
 public class FindNodeCacheRequest extends ZdoRequest {
     /**
      * The ZDO cluster ID.
@@ -36,7 +36,6 @@ public class FindNodeCacheRequest extends ZdoRequest {
     /**
      * Default constructor.
      *
-     * @deprecated from release 1.3.0. Use the parameterised constructor instead of the default contructor and setters.
      */
     public FindNodeCacheRequest() {
         clusterId = CLUSTER_ID;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/FindNodeCacheResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/FindNodeCacheResponse.java
@@ -24,7 +24,7 @@ import com.zsmartsystems.zigbee.zdo.ZdoResponse;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-13T19:23:13Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-06-06T12:25:30Z")
 public class FindNodeCacheResponse extends ZdoResponse {
     /**
      * The ZDO cluster ID.
@@ -34,7 +34,6 @@ public class FindNodeCacheResponse extends ZdoResponse {
     /**
      * Default constructor.
      *
-     * @deprecated from release 1.3.0. Use the parameterised constructor instead of the default contructor and setters.
      */
     public FindNodeCacheResponse() {
         clusterId = CLUSTER_ID;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ManagementCacheResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ManagementCacheResponse.java
@@ -31,7 +31,7 @@ import com.zsmartsystems.zigbee.zdo.ZdoResponse;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-13T19:23:13Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-06-06T12:25:30Z")
 public class ManagementCacheResponse extends ZdoResponse {
     /**
      * The ZDO cluster ID.
@@ -41,7 +41,6 @@ public class ManagementCacheResponse extends ZdoResponse {
     /**
      * Default constructor.
      *
-     * @deprecated from release 1.3.0. Use the parameterised constructor instead of the default contructor and setters.
      */
     public ManagementCacheResponse() {
         clusterId = CLUSTER_ID;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ManagementNetworkDiscoveryResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ManagementNetworkDiscoveryResponse.java
@@ -30,7 +30,7 @@ import com.zsmartsystems.zigbee.zdo.ZdoResponse;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-13T19:23:13Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-06-06T12:25:30Z")
 public class ManagementNetworkDiscoveryResponse extends ZdoResponse {
     /**
      * The ZDO cluster ID.
@@ -40,7 +40,6 @@ public class ManagementNetworkDiscoveryResponse extends ZdoResponse {
     /**
      * Default constructor.
      *
-     * @deprecated from release 1.3.0. Use the parameterised constructor instead of the default contructor and setters.
      */
     public ManagementNetworkDiscoveryResponse() {
         clusterId = CLUSTER_ID;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/NodeDescriptorStoreRequest.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/NodeDescriptorStoreRequest.java
@@ -22,7 +22,7 @@ import com.zsmartsystems.zigbee.zdo.ZdoRequest;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-13T19:23:13Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-06-06T12:25:30Z")
 public class NodeDescriptorStoreRequest extends ZdoRequest {
     /**
      * The ZDO cluster ID.
@@ -32,7 +32,6 @@ public class NodeDescriptorStoreRequest extends ZdoRequest {
     /**
      * Default constructor.
      *
-     * @deprecated from release 1.3.0. Use the parameterised constructor instead of the default contructor and setters.
      */
     public NodeDescriptorStoreRequest() {
         clusterId = CLUSTER_ID;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/NodeDescriptorStoreResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/NodeDescriptorStoreResponse.java
@@ -23,7 +23,7 @@ import com.zsmartsystems.zigbee.zdo.ZdoResponse;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-13T19:23:13Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-06-06T12:25:30Z")
 public class NodeDescriptorStoreResponse extends ZdoResponse {
     /**
      * The ZDO cluster ID.
@@ -33,7 +33,6 @@ public class NodeDescriptorStoreResponse extends ZdoResponse {
     /**
      * Default constructor.
      *
-     * @deprecated from release 1.3.0. Use the parameterised constructor instead of the default contructor and setters.
      */
     public NodeDescriptorStoreResponse() {
         clusterId = CLUSTER_ID;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/PowerDescriptorStoreRequest.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/PowerDescriptorStoreRequest.java
@@ -22,7 +22,7 @@ import com.zsmartsystems.zigbee.zdo.ZdoRequest;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-13T19:23:13Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-06-06T12:25:30Z")
 public class PowerDescriptorStoreRequest extends ZdoRequest {
     /**
      * The ZDO cluster ID.
@@ -32,7 +32,6 @@ public class PowerDescriptorStoreRequest extends ZdoRequest {
     /**
      * Default constructor.
      *
-     * @deprecated from release 1.3.0. Use the parameterised constructor instead of the default contructor and setters.
      */
     public PowerDescriptorStoreRequest() {
         clusterId = CLUSTER_ID;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/PowerDescriptorStoreResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/PowerDescriptorStoreResponse.java
@@ -23,7 +23,7 @@ import com.zsmartsystems.zigbee.zdo.ZdoResponse;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-13T19:23:13Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-06-06T12:25:30Z")
 public class PowerDescriptorStoreResponse extends ZdoResponse {
     /**
      * The ZDO cluster ID.
@@ -33,7 +33,6 @@ public class PowerDescriptorStoreResponse extends ZdoResponse {
     /**
      * Default constructor.
      *
-     * @deprecated from release 1.3.0. Use the parameterised constructor instead of the default contructor and setters.
      */
     public PowerDescriptorStoreResponse() {
         clusterId = CLUSTER_ID;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/RecoverBindTableRequest.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/RecoverBindTableRequest.java
@@ -21,7 +21,7 @@ import com.zsmartsystems.zigbee.zdo.ZdoRequest;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-13T19:23:13Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-06-06T12:25:30Z")
 public class RecoverBindTableRequest extends ZdoRequest {
     /**
      * The ZDO cluster ID.
@@ -31,7 +31,6 @@ public class RecoverBindTableRequest extends ZdoRequest {
     /**
      * Default constructor.
      *
-     * @deprecated from release 1.3.0. Use the parameterised constructor instead of the default contructor and setters.
      */
     public RecoverBindTableRequest() {
         clusterId = CLUSTER_ID;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/RecoverBindTableResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/RecoverBindTableResponse.java
@@ -30,7 +30,7 @@ import com.zsmartsystems.zigbee.zdo.ZdoResponse;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-13T19:23:13Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-06-06T12:25:30Z")
 public class RecoverBindTableResponse extends ZdoResponse {
     /**
      * The ZDO cluster ID.
@@ -40,7 +40,6 @@ public class RecoverBindTableResponse extends ZdoResponse {
     /**
      * Default constructor.
      *
-     * @deprecated from release 1.3.0. Use the parameterised constructor instead of the default contructor and setters.
      */
     public RecoverBindTableResponse() {
         clusterId = CLUSTER_ID;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/RecoverSourceBindResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/RecoverSourceBindResponse.java
@@ -30,7 +30,7 @@ import com.zsmartsystems.zigbee.zdo.ZdoResponse;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-13T19:23:13Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-06-06T12:25:30Z")
 public class RecoverSourceBindResponse extends ZdoResponse {
     /**
      * The ZDO cluster ID.
@@ -40,7 +40,6 @@ public class RecoverSourceBindResponse extends ZdoResponse {
     /**
      * Default constructor.
      *
-     * @deprecated from release 1.3.0. Use the parameterised constructor instead of the default contructor and setters.
      */
     public RecoverSourceBindResponse() {
         clusterId = CLUSTER_ID;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/RemoveBackupBindTableRequest.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/RemoveBackupBindTableRequest.java
@@ -22,7 +22,7 @@ import com.zsmartsystems.zigbee.zdo.ZdoRequest;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-13T19:23:13Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-06-06T12:25:30Z")
 public class RemoveBackupBindTableRequest extends ZdoRequest {
     /**
      * The ZDO cluster ID.
@@ -32,7 +32,6 @@ public class RemoveBackupBindTableRequest extends ZdoRequest {
     /**
      * Default constructor.
      *
-     * @deprecated from release 1.3.0. Use the parameterised constructor instead of the default contructor and setters.
      */
     public RemoveBackupBindTableRequest() {
         clusterId = CLUSTER_ID;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/RemoveNodeCache.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/RemoveNodeCache.java
@@ -23,7 +23,7 @@ import com.zsmartsystems.zigbee.zdo.ZdoRequest;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-13T19:23:13Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-06-06T12:25:30Z")
 public class RemoveNodeCache extends ZdoRequest {
     /**
      * The ZDO cluster ID.
@@ -33,7 +33,6 @@ public class RemoveNodeCache extends ZdoRequest {
     /**
      * Default constructor.
      *
-     * @deprecated from release 1.3.0. Use the parameterised constructor instead of the default contructor and setters.
      */
     public RemoveNodeCache() {
         clusterId = CLUSTER_ID;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/RemoveNodeCacheRequest.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/RemoveNodeCacheRequest.java
@@ -24,7 +24,7 @@ import com.zsmartsystems.zigbee.zdo.ZdoRequest;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-13T19:23:13Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-06-06T12:25:30Z")
 public class RemoveNodeCacheRequest extends ZdoRequest {
     /**
      * The ZDO cluster ID.
@@ -34,7 +34,6 @@ public class RemoveNodeCacheRequest extends ZdoRequest {
     /**
      * Default constructor.
      *
-     * @deprecated from release 1.3.0. Use the parameterised constructor instead of the default contructor and setters.
      */
     public RemoveNodeCacheRequest() {
         clusterId = CLUSTER_ID;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ReplaceDeviceRequest.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ReplaceDeviceRequest.java
@@ -28,7 +28,7 @@ import com.zsmartsystems.zigbee.zdo.ZdoRequest;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-13T19:23:13Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-06-06T12:25:30Z")
 public class ReplaceDeviceRequest extends ZdoRequest {
     /**
      * The ZDO cluster ID.
@@ -38,7 +38,6 @@ public class ReplaceDeviceRequest extends ZdoRequest {
     /**
      * Default constructor.
      *
-     * @deprecated from release 1.3.0. Use the parameterised constructor instead of the default contructor and setters.
      */
     public ReplaceDeviceRequest() {
         clusterId = CLUSTER_ID;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/SimpleDescriptorStore.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/SimpleDescriptorStore.java
@@ -27,7 +27,7 @@ import com.zsmartsystems.zigbee.zdo.ZdoRequest;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-13T19:23:13Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-06-06T12:25:30Z")
 public class SimpleDescriptorStore extends ZdoRequest {
     /**
      * The ZDO cluster ID.
@@ -37,7 +37,6 @@ public class SimpleDescriptorStore extends ZdoRequest {
     /**
      * Default constructor.
      *
-     * @deprecated from release 1.3.0. Use the parameterised constructor instead of the default contructor and setters.
      */
     public SimpleDescriptorStore() {
         clusterId = CLUSTER_ID;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/SimpleDescriptorStoreResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/SimpleDescriptorStoreResponse.java
@@ -23,7 +23,7 @@ import com.zsmartsystems.zigbee.zdo.ZdoResponse;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-13T19:23:13Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-06-06T12:25:30Z")
 public class SimpleDescriptorStoreResponse extends ZdoResponse {
     /**
      * The ZDO cluster ID.
@@ -33,7 +33,6 @@ public class SimpleDescriptorStoreResponse extends ZdoResponse {
     /**
      * Default constructor.
      *
-     * @deprecated from release 1.3.0. Use the parameterised constructor instead of the default contructor and setters.
      */
     public SimpleDescriptorStoreResponse() {
         clusterId = CLUSTER_ID;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/StoreBackupBindEntryRequest.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/StoreBackupBindEntryRequest.java
@@ -22,7 +22,7 @@ import com.zsmartsystems.zigbee.zdo.ZdoRequest;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-13T19:23:13Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-06-06T12:25:30Z")
 public class StoreBackupBindEntryRequest extends ZdoRequest {
     /**
      * The ZDO cluster ID.
@@ -32,7 +32,6 @@ public class StoreBackupBindEntryRequest extends ZdoRequest {
     /**
      * Default constructor.
      *
-     * @deprecated from release 1.3.0. Use the parameterised constructor instead of the default contructor and setters.
      */
     public StoreBackupBindEntryRequest() {
         clusterId = CLUSTER_ID;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/SystemServerDiscoveryRequest.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/SystemServerDiscoveryRequest.java
@@ -22,7 +22,7 @@ import com.zsmartsystems.zigbee.zdo.ZdoRequest;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-13T19:23:13Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-06-06T12:25:30Z")
 public class SystemServerDiscoveryRequest extends ZdoRequest {
     /**
      * The ZDO cluster ID.
@@ -32,7 +32,6 @@ public class SystemServerDiscoveryRequest extends ZdoRequest {
     /**
      * Default constructor.
      *
-     * @deprecated from release 1.3.0. Use the parameterised constructor instead of the default contructor and setters.
      */
     public SystemServerDiscoveryRequest() {
         clusterId = CLUSTER_ID;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/UserDescriptorConf.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/UserDescriptorConf.java
@@ -21,7 +21,7 @@ import com.zsmartsystems.zigbee.zdo.ZdoRequest;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-13T19:23:13Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-06-06T12:25:30Z")
 public class UserDescriptorConf extends ZdoRequest {
     /**
      * The ZDO cluster ID.
@@ -31,7 +31,6 @@ public class UserDescriptorConf extends ZdoRequest {
     /**
      * Default constructor.
      *
-     * @deprecated from release 1.3.0. Use the parameterised constructor instead of the default contructor and setters.
      */
     public UserDescriptorConf() {
         clusterId = CLUSTER_ID;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/UserDescriptorSetRequest.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/UserDescriptorSetRequest.java
@@ -27,7 +27,7 @@ import com.zsmartsystems.zigbee.zdo.ZdoRequest;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-13T19:23:13Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-06-06T12:25:30Z")
 public class UserDescriptorSetRequest extends ZdoRequest {
     /**
      * The ZDO cluster ID.
@@ -37,7 +37,6 @@ public class UserDescriptorSetRequest extends ZdoRequest {
     /**
      * Default constructor.
      *
-     * @deprecated from release 1.3.0. Use the parameterised constructor instead of the default contructor and setters.
      */
     public UserDescriptorSetRequest() {
         clusterId = CLUSTER_ID;


### PR DESCRIPTION
Removes `@deprecated` annotations where the default constructor is allowed - ie when commands have not parameters.

Closes #1069 

Signed-off-by: Chris Jackson <chris@cd-jackson.com>