### PR TITLE
Add console on/off/level commands and wildcard endpoint

### DIFF
--- a/com.zsmartsystems.zigbee.console.main/src/main/java/com/zsmartsystems/zigbee/console/main/ZigBeeConsole.java
+++ b/com.zsmartsystems.zigbee.console.main/src/main/java/com/zsmartsystems/zigbee/console/main/ZigBeeConsole.java
@@ -61,6 +61,9 @@ import com.zsmartsystems.zigbee.console.ZigBeeConsoleReportingConfigCommand;
 import com.zsmartsystems.zigbee.console.ZigBeeConsoleReportingSubscribeCommand;
 import com.zsmartsystems.zigbee.console.ZigBeeConsoleReportingUnsubscribeCommand;
 import com.zsmartsystems.zigbee.console.ZigBeeConsoleSmartEnergyCommand;
+import com.zsmartsystems.zigbee.console.ZigBeeConsoleSwitchLevelCommand;
+import com.zsmartsystems.zigbee.console.ZigBeeConsoleSwitchOffCommand;
+import com.zsmartsystems.zigbee.console.ZigBeeConsoleSwitchOnCommand;
 import com.zsmartsystems.zigbee.console.ZigBeeConsoleTrustCentreCommand;
 import com.zsmartsystems.zigbee.console.ZigBeeConsoleUnbindCommand;
 import com.zsmartsystems.zigbee.console.ZigBeeConsoleWindowCoveringCommand;
@@ -150,10 +153,7 @@ public final class ZigBeeConsole {
         commands.put("quit", new QuitCommand());
         commands.put("help", new HelpCommand());
         commands.put("descriptor", new SetDescriptorCommand());
-        commands.put("on", new OnCommand());
-        commands.put("off", new OffCommand());
         commands.put("color", new ColorCommand());
-        commands.put("level", new LevelCommand());
         commands.put("listen", new ListenCommand());
         commands.put("unlisten", new UnlistenCommand());
 
@@ -206,6 +206,9 @@ public final class ZigBeeConsole {
         newCommands.put("smartenergy", new ZigBeeConsoleSmartEnergyCommand());
         newCommands.put("cbke", new ZigBeeConsoleCbkeCommand());
 
+        newCommands.put("on", new ZigBeeConsoleSwitchOnCommand());
+        newCommands.put("off", new ZigBeeConsoleSwitchOffCommand());
+        newCommands.put("level", new ZigBeeConsoleSwitchLevelCommand());
         newCommands.put("covering", new ZigBeeConsoleWindowCoveringCommand());
 
         zigBeeApi = new ZigBeeApi(networkManager);
@@ -583,84 +586,8 @@ public final class ZigBeeConsole {
     }
 
     /**
-     * Switches a device on.
-     */
-    private class OnCommand implements ConsoleCommand {
-        /**
-         * {@inheritDoc}
-         */
-        @Override
-        public String getDescription() {
-            return "Switches device on.";
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        @Override
-        public String getSyntax() {
-            return "on DEVICEID/DEVICELABEL/GROUPID";
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        @Override
-        public boolean process(final ZigBeeApi zigbeeApi, final String[] args, PrintStream out) throws Exception {
-            if (args.length != 2) {
-                return false;
-            }
-
-            final ZigBeeAddress destination = getDestination(zigbeeApi, args[1], out);
-
-            if (destination == null) {
-                return false;
-            }
-
-            final CommandResult response = zigbeeApi.on(destination).get();
-            return defaultResponseProcessing(response, out);
-        }
-    }
-
-    /**
      * Switches a device off.
      */
-    private class OffCommand implements ConsoleCommand {
-        /**
-         * {@inheritDoc}
-         */
-        @Override
-        public String getDescription() {
-            return "Switches device off.";
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        @Override
-        public String getSyntax() {
-            return "off DEVICEID/DEVICELABEL/GROUPID";
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        @Override
-        public boolean process(final ZigBeeApi zigbeeApi, final String[] args, PrintStream out) throws Exception {
-            if (args.length != 2) {
-                return false;
-            }
-
-            final ZigBeeAddress destination = getDestination(zigbeeApi, args[1], out);
-
-            if (destination == null) {
-                return false;
-            }
-
-            final CommandResult response = zigbeeApi.off(destination).get();
-            return defaultResponseProcessing(response, out);
-        }
-    }
 
     /**
      * Changes a light color on device.
@@ -849,61 +776,6 @@ public final class ZigBeeConsole {
             return false;
             // final CommandResult response = zigbeeApi.describe(device, label).get();
             // return defaultResponseProcessing(response, out);
-        }
-    }
-
-    /**
-     * Changes a device level for example lamp brightness.
-     */
-    private class LevelCommand implements ConsoleCommand {
-        /**
-         * {@inheritDoc}
-         */
-        @Override
-        public String getDescription() {
-            return "Changes device level for example lamp brightness, where LEVEL is between 0 and 1.";
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        @Override
-        public String getSyntax() {
-            return "level DEVICEID LEVEL [RATE]";
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        @Override
-        public boolean process(final ZigBeeApi zigbeeApi, final String[] args, PrintStream out) throws Exception {
-            if (args.length < 3) {
-                return false;
-            }
-
-            final ZigBeeAddress destination = getDestination(zigbeeApi, args[1], out);
-            if (destination == null) {
-                return false;
-            }
-
-            float level;
-            try {
-                level = Float.parseFloat(args[2]);
-            } catch (final NumberFormatException e) {
-                return false;
-            }
-
-            float time = (float) 1.0;
-            if (args.length == 4) {
-                try {
-                    time = Float.parseFloat(args[3]);
-                } catch (final NumberFormatException e) {
-                    return false;
-                }
-            }
-
-            final CommandResult response = zigbeeApi.level(destination, level, time).get();
-            return defaultResponseProcessing(response, out);
         }
     }
 

--- a/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleAbstractCommand.java
+++ b/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleAbstractCommand.java
@@ -29,6 +29,8 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  */
 public abstract class ZigBeeConsoleAbstractCommand implements ZigBeeConsoleCommand {
 
+    protected static final String WILDCARD = "*";
+
     /**
      * Gets a {@link ZigBeeNode}
      *

--- a/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleNodeListCommand.java
+++ b/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleNodeListCommand.java
@@ -63,6 +63,8 @@ public class ZigBeeConsoleNodeListCommand extends ZigBeeConsoleAbstractCommand {
         String tableHeader = String.format("%-7s  %-4s  %-16s  %-12s  %-9s  %-3s  %-25s  %-25s  %-15s  %-15s",
                 "Network", "Addr", "IEEE Address", "Logical Type", "State", "EP", "Profile", "Device Type",
                 "Manufacturer", "Model");
+
+        out.println("Total known nodes in network: " + nodes.size());
         out.println(tableHeader);
 
         for (Integer nodeId : nodeIds) {

--- a/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleSwitchLevelCommand.java
+++ b/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleSwitchLevelCommand.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2016-2020 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.console;
+
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.zsmartsystems.zigbee.ZigBeeEndpoint;
+import com.zsmartsystems.zigbee.ZigBeeNetworkManager;
+import com.zsmartsystems.zigbee.ZigBeeNode;
+import com.zsmartsystems.zigbee.zcl.clusters.ZclLevelControlCluster;
+import com.zsmartsystems.zigbee.zcl.clusters.ZclOnOffCluster;
+import com.zsmartsystems.zigbee.zcl.clusters.levelcontrol.MoveToLevelCommand;
+
+/**
+ * Uses the LevelControl cluster to set the level
+ *
+ * @author Chris Jackson
+ *
+ */
+public class ZigBeeConsoleSwitchLevelCommand extends ZigBeeConsoleAbstractCommand {
+    @Override
+    public String getCommand() {
+        return "level";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Sets the device level";
+    }
+
+    @Override
+    public String getSyntax() {
+        return "ENDPOINT LEVEL [RATE]";
+    }
+
+    @Override
+    public String getHelp() {
+        return "";
+    }
+
+    @Override
+    public void process(ZigBeeNetworkManager networkManager, String[] args, PrintStream out)
+            throws IllegalArgumentException {
+        if (args.length < 3) {
+            throw new IllegalArgumentException("Invalid number of arguments");
+        }
+
+        List<ZclLevelControlCluster> clusters = new ArrayList<>();
+        if (WILDCARD.equals(args[1])) {
+            for (ZigBeeNode node : networkManager.getNodes()) {
+                for (ZigBeeEndpoint endpoint : node.getEndpoints()) {
+                    ZclLevelControlCluster cluster = (ZclLevelControlCluster) endpoint
+                            .getInputCluster(ZclLevelControlCluster.CLUSTER_ID);
+                    if (cluster != null) {
+                        clusters.add(cluster);
+                    }
+                }
+            }
+        } else {
+            ZigBeeEndpoint endpoint = getEndpoint(networkManager, args[1]);
+            ZclLevelControlCluster cluster = (ZclLevelControlCluster) endpoint
+                    .getInputCluster(ZclOnOffCluster.CLUSTER_ID);
+            if (cluster != null) {
+                clusters.add(cluster);
+            }
+        }
+
+        int level = parsePercentage(args[2]);
+
+        int rate = 10;
+        if (args.length == 3) {
+            rate = parseInteger(args[3]);
+        }
+
+        for (ZclLevelControlCluster cluster : clusters) {
+            MoveToLevelCommand command = new MoveToLevelCommand(level, rate);
+            cluster.sendCommand(command);
+        }
+    }
+}

--- a/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleSwitchOffCommand.java
+++ b/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleSwitchOffCommand.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) 2016-2020 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.console;
+
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.zsmartsystems.zigbee.ZigBeeEndpoint;
+import com.zsmartsystems.zigbee.ZigBeeNetworkManager;
+import com.zsmartsystems.zigbee.ZigBeeNode;
+import com.zsmartsystems.zigbee.zcl.clusters.ZclOnOffCluster;
+import com.zsmartsystems.zigbee.zcl.clusters.onoff.OffCommand;
+
+/**
+ * Uses the OnOff cluster to switch a device off
+ *
+ * @author Chris Jackson
+ *
+ */
+public class ZigBeeConsoleSwitchOffCommand extends ZigBeeConsoleAbstractCommand {
+    @Override
+    public String getCommand() {
+        return "off";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Switches a device OFF";
+    }
+
+    @Override
+    public String getSyntax() {
+        return "ENDPOINT";
+    }
+
+    @Override
+    public String getHelp() {
+        return "";
+    }
+
+    @Override
+    public void process(ZigBeeNetworkManager networkManager, String[] args, PrintStream out)
+            throws IllegalArgumentException {
+        if (args.length < 2) {
+            throw new IllegalArgumentException("Invalid number of arguments");
+        }
+
+        List<ZclOnOffCluster> clusters = new ArrayList<>();
+        if (WILDCARD.equals(args[1])) {
+            for (ZigBeeNode node : networkManager.getNodes()) {
+                for (ZigBeeEndpoint endpoint : node.getEndpoints()) {
+                    ZclOnOffCluster cluster = (ZclOnOffCluster) endpoint.getInputCluster(ZclOnOffCluster.CLUSTER_ID);
+                    if (cluster != null) {
+                        clusters.add(cluster);
+                    }
+                }
+            }
+        } else {
+            ZigBeeEndpoint endpoint = getEndpoint(networkManager, args[1]);
+            ZclOnOffCluster cluster = (ZclOnOffCluster) endpoint.getInputCluster(ZclOnOffCluster.CLUSTER_ID);
+            if (cluster != null) {
+                clusters.add(cluster);
+            }
+        }
+
+        for (ZclOnOffCluster cluster : clusters) {
+            OffCommand command = new OffCommand();
+            cluster.sendCommand(command);
+        }
+    }
+}

--- a/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleSwitchOnCommand.java
+++ b/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleSwitchOnCommand.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) 2016-2020 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.console;
+
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.zsmartsystems.zigbee.ZigBeeEndpoint;
+import com.zsmartsystems.zigbee.ZigBeeNetworkManager;
+import com.zsmartsystems.zigbee.ZigBeeNode;
+import com.zsmartsystems.zigbee.zcl.clusters.ZclOnOffCluster;
+import com.zsmartsystems.zigbee.zcl.clusters.onoff.OnCommand;
+
+/**
+ * Uses the OnOff cluster to switch a device on
+ *
+ * @author Chris Jackson
+ *
+ */
+public class ZigBeeConsoleSwitchOnCommand extends ZigBeeConsoleAbstractCommand {
+    @Override
+    public String getCommand() {
+        return "on";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Switches a device ON";
+    }
+
+    @Override
+    public String getSyntax() {
+        return "ENDPOINT";
+    }
+
+    @Override
+    public String getHelp() {
+        return "";
+    }
+
+    @Override
+    public void process(ZigBeeNetworkManager networkManager, String[] args, PrintStream out)
+            throws IllegalArgumentException {
+        if (args.length < 2) {
+            throw new IllegalArgumentException("Invalid number of arguments");
+        }
+
+        List<ZclOnOffCluster> clusters = new ArrayList<>();
+        if (WILDCARD.equals(args[1])) {
+            for (ZigBeeNode node : networkManager.getNodes()) {
+                for (ZigBeeEndpoint endpoint : node.getEndpoints()) {
+                    ZclOnOffCluster cluster = (ZclOnOffCluster) endpoint.getInputCluster(ZclOnOffCluster.CLUSTER_ID);
+                    if (cluster != null) {
+                        clusters.add(cluster);
+                    }
+                }
+            }
+        } else {
+            ZigBeeEndpoint endpoint = getEndpoint(networkManager, args[1]);
+            ZclOnOffCluster cluster = (ZclOnOffCluster) endpoint.getInputCluster(ZclOnOffCluster.CLUSTER_ID);
+            if (cluster != null) {
+                clusters.add(cluster);
+            }
+        }
+
+        for (ZclOnOffCluster cluster : clusters) {
+            OnCommand command = new OnCommand();
+            cluster.sendCommand(command);
+        }
+    }
+}

--- a/com.zsmartsystems.zigbee.dongle.cc2531/src/main/java/com/zsmartsystems/zigbee/dongle/cc2531/network/packet/system/SYS_RPC_ERROR.java
+++ b/com.zsmartsystems.zigbee.dongle.cc2531/src/main/java/com/zsmartsystems/zigbee/dongle/cc2531/network/packet/system/SYS_RPC_ERROR.java
@@ -7,12 +7,12 @@
  */
 /*
    Copyright 2008-2013 ITACA-TSB, http://www.tsb.upv.es/
-   Instituto Tecnologico de Aplicaciones de Comunicacion 
-   Avanzadas - Grupo Tecnologias para la Salud y el 
+   Instituto Tecnologico de Aplicaciones de Comunicacion
+   Avanzadas - Grupo Tecnologias para la Salud y el
    Bienestar (TSB)
 
 
-   See the NOTICE file distributed with this work for additional 
+   See the NOTICE file distributed with this work for additional
    information regarding copyright ownership
 
    Licensed under the Apache License, Version 2.0 (the "License");
@@ -39,7 +39,7 @@ import com.zsmartsystems.zigbee.dongle.cc2531.zigbee.util.DoubleByte;
  * @author <a href="mailto:alfiva@aaa.upv.es">Alvaro Fides Valero</a>
  * @version $LastChangedRevision: 799 $ ($LastChangedDate: 2013-08-06 19:00:05 +0300 (Tue, 06 Aug 2013) $)
  */
-public class SYS_RPC_ERROR extends ZToolPacket /*implements IRESPONSE, ISYSTEM*/ {
+public class SYS_RPC_ERROR extends ZToolPacket /* implements IRESPONSE, ISYSTEM */ {
     /// <name>TI.ZPI2.SYS_RPC_ERROR.ErrCmd0</name>
     /// <summary>Command byte 0 of the message causing an error.</summary>
     public int ErrCmd0;
@@ -61,14 +61,14 @@ public class SYS_RPC_ERROR extends ZToolPacket /*implements IRESPONSE, ISYSTEM*/
         this.Status = num1;
         this.ErrCmd0 = num2;
         this.ErrCmd1 = num3;
-        int[] framedata = {num1, num2, num3};
+        int[] framedata = { num1, num2, num3 };
         super.buildPacket(new DoubleByte(ZToolCMD.SYS_RPC_ERROR), framedata);
     }
 
     public SYS_RPC_ERROR(int[] framedata) {
         this.Status = framedata[0];
         this.ErrCmd0 = framedata[1];
-        this.ErrCmd1 = framedata[3];
+        this.ErrCmd1 = framedata[2];
         super.buildPacket(new DoubleByte(ZToolCMD.SYS_RPC_ERROR), framedata);
     }
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
@@ -1413,7 +1413,9 @@ public class ZigBeeNetworkManager implements ZigBeeTransportReceive {
     }
 
     /**
-     * Sends a ZDO Leave Request to a device requesting that an end device leave the network.
+     * Sends a ZDO Leave Request to a device requesting that an device leave the network. If the node responds
+     * successfully, the node is removed from the network, and the {@link ZigBeeNetworkNodeListener#nodeRemoved}
+     * notification is called.
      *
      * @param destinationAddress the network address to send the request to - this is the device parent or the the
      *            device we want to leave.
@@ -1668,7 +1670,8 @@ public class ZigBeeNetworkManager implements ZigBeeTransportReceive {
         if (node == null) {
             return null;
         }
-        logger.debug("{}: Node {} update", node.getIeeeAddress(), String.format("%04X", node.getNetworkAddress()));
+        logger.debug("{}: Node update. NWK Address={}", node.getIeeeAddress(),
+                String.format("%04X", node.getNetworkAddress()));
 
         final ZigBeeNode currentNode;
         currentNode = networkNodes.get(node.getIeeeAddress());


### PR DESCRIPTION
This adds new console commands for `level`, `on`, and `off`. It also adds the ability to use the wildcard (`*`) as the endpoint ID for some commands (including these 3). This allows for example the command -:

```
on *
```

to turn on all devices supporting the `OnOffCluster`. This actually loops through all endpoints, so if a device has multiple endpoints with the required cluster, commands will be sent to all endpoints.  The commands are all queued immediately - ie sent to the transaction manager at the same time.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>