### PR TITLE
Fix sending of general commands through ZclCluster

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/ZclCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/ZclCluster.java
@@ -288,6 +288,7 @@ public abstract class ZclCluster {
             command.setCommandDirection(ZclCommandDirection.SERVER_TO_CLIENT);
         }
 
+        command.setClusterId(clusterId);
         command.setApsSecurity(apsSecurityRequired);
 
         return zigbeeEndpoint.sendTransaction(command, new ZclTransactionMatcher());

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zcl/ZclClusterTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zcl/ZclClusterTest.java
@@ -96,6 +96,21 @@ public class ZclClusterTest {
     }
 
     @Test
+    public void sendCommand() {
+        createEndpoint();
+
+        ZclCluster cluster = new ZclOnOffCluster(endpoint);
+
+        ReadAttributesCommand command = new ReadAttributesCommand(
+                Collections.singletonList(ZclOnOffCluster.ATTR_ONOFF));
+        cluster.sendCommand(command);
+        assertEquals(1, commandCapture.getAllValues().size());
+        ZigBeeCommand txCommand = commandCapture.getValue();
+
+        assertEquals(Integer.valueOf(ZclOnOffCluster.CLUSTER_ID), txCommand.getClusterId());
+    }
+
+    @Test
     public void bind() {
         createEndpoint();
 


### PR DESCRIPTION
Fixes bug introduced in new sendCommand(ZclGeneralCommand)` in #1090 

Linked to #1091 

@triller-telekom FYI

Signed-off-by: Chris Jackson <chris@cd-jackson.com>