### PR TITLE
Reduce Ember NCP max hops to 8

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
@@ -291,7 +291,7 @@ public class ZigBeeDongleEzsp implements ZigBeeTransportTransmit, ZigBeeTranspor
         stackConfiguration.put(EzspConfigId.EZSP_CONFIG_TRUST_CENTER_ADDRESS_CACHE_SIZE, 2);
         stackConfiguration.put(EzspConfigId.EZSP_CONFIG_STACK_PROFILE, 2);
         stackConfiguration.put(EzspConfigId.EZSP_CONFIG_INDIRECT_TRANSMISSION_TIMEOUT, 7680);
-        stackConfiguration.put(EzspConfigId.EZSP_CONFIG_MAX_HOPS, 30);
+        stackConfiguration.put(EzspConfigId.EZSP_CONFIG_MAX_HOPS, 8);
         stackConfiguration.put(EzspConfigId.EZSP_CONFIG_TX_POWER_MODE, 0);
         stackConfiguration.put(EzspConfigId.EZSP_CONFIG_SUPPORTED_NETWORKS, 1);
         stackConfiguration.put(EzspConfigId.EZSP_CONFIG_KEY_TABLE_SIZE, 4);

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
@@ -795,7 +795,7 @@ public class ZigBeeNetworkManager implements ZigBeeTransportReceive {
         // TODO: Set the source address correctly?
         apsFrame.setSourceAddress(localNwkAddress);
 
-        apsFrame.setRadius(31);
+        apsFrame.setRadius(8); // TODO: Make this configurable
 
         if (command.getDestinationAddress() instanceof ZigBeeEndpointAddress) {
             apsFrame.setAddressMode(ZigBeeNwkAddressMode.DEVICE);


### PR DESCRIPTION
This reduces the default number of hops in an effort to improve network performance.
In the Ember NCP using a large number of hops will increase route table size. Additionally, if there are too many hops the system is likely to hit other issues such as timeouts due to the delays through the network.

10 is the maximum recommended value in discussion with a Silabs FAE. Setting this to 8.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>