### PR TITLE
Remove the transaction from the queue if it is cancelled

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeNetworkDiscoverer.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeNetworkDiscoverer.java
@@ -83,7 +83,6 @@ public class ZigBeeNetworkDiscoverer implements ZigBeeCommandListener, ZigBeeAnn
      */
     protected ZigBeeNetworkDiscoverer(final ZigBeeNetworkManager networkManager) {
         this.networkManager = networkManager;
-
     }
 
     /**

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransaction.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransaction.java
@@ -506,8 +506,9 @@ public class ZigBeeTransaction {
                     break;
             }
         }
-        logger.debug("Transaction state updated: TID {} -> {} == {}", String.format("%02X", transactionId), progress,
-                state);
+        logger.debug("Transaction state changed: nwk={}, TID={}, event={}, state={}",
+                String.format("%04X", command.getDestinationAddress().getAddress()),
+                String.format("%02X", transactionId), progress, state);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransaction.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransaction.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.transaction;
 
 import java.util.concurrent.ScheduledFuture;
 
-import com.zsmartsystems.zigbee.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -17,6 +16,7 @@ import com.zsmartsystems.zigbee.CommandResult;
 import com.zsmartsystems.zigbee.IeeeAddress;
 import com.zsmartsystems.zigbee.ZigBeeAddress;
 import com.zsmartsystems.zigbee.ZigBeeCommand;
+import com.zsmartsystems.zigbee.ZigBeeStatus;
 import com.zsmartsystems.zigbee.transport.ZigBeeTransportProgressState;
 import com.zsmartsystems.zigbee.zcl.ZclCommand;
 
@@ -78,7 +78,12 @@ public class ZigBeeTransaction {
         /**
          * Transaction failed - no response received
          */
-        FAILED
+        FAILED,
+
+        /**
+         * Transaction cancelled
+         */
+        CANCELLED
     }
 
     /**
@@ -327,23 +332,28 @@ public class ZigBeeTransaction {
 
     /**
      * Cancels the transaction. The transaction will immediately be cancelled and the state will be set to
-     * {@link TransactionState#FAILED}.
+     * {@link TransactionState#CANCELLED}.
+     * <p>
      * No further retry will be conducted and the transaction manager will not be notified (the assumption being that
      * the cancellation is made through the transaction manager).
      */
     protected void cancel() {
-        state = TransactionState.FAILED;
-
-        if (timeoutTask != null) {
-            timeoutTask.cancel(false);
+        if (state == TransactionState.CANCELLED) {
+            return;
         }
-        logger.debug("Transaction terminated: {}", this);
+
+        state = TransactionState.CANCELLED;
+        stopTimer();
+
+        logger.debug("Transaction cancelled: {}", this);
         if (transactionFuture != null) {
             synchronized (transactionFuture) {
                 transactionFuture.cancel(false);
-                transactionFuture.notify();
+                transactionFuture = null;
             }
         }
+
+        transactionManager.transactionComplete(this, state);
     }
 
     /**
@@ -378,10 +388,15 @@ public class ZigBeeTransaction {
         }
     }
 
-    private void startTimer(int timeout) {
+    private void stopTimer() {
         if (timeoutTask != null) {
             timeoutTask.cancel(false);
+            timeoutTask = null;
         }
+    }
+
+    private void startTimer(int timeout) {
+        stopTimer();
 
         // Schedule a task to timeout the transaction
         timeoutTask = transactionManager.scheduleTask(new Runnable() {
@@ -394,7 +409,7 @@ public class ZigBeeTransaction {
                     // so it's treated as complete.
                     completeTransaction(completionCommand);
                 } else {
-                    cancelTransaction();
+                    failTransaction();
                 }
             }
         }, timeout);
@@ -406,9 +421,8 @@ public class ZigBeeTransaction {
         }
 
         state = TransactionState.COMPLETE;
-        if (timeoutTask != null) {
-            timeoutTask.cancel(false);
-        }
+        stopTimer();
+
         if (transactionFuture != null) {
             synchronized (transactionFuture) {
                 transactionFuture.set(new CommandResult(ZigBeeStatus.SUCCESS, receivedCommand));
@@ -419,15 +433,13 @@ public class ZigBeeTransaction {
         transactionManager.transactionComplete(this, TransactionState.COMPLETE);
     }
 
-    private void cancelTransaction() {
+    private void failTransaction() {
         if (isTransactionComplete()) {
             return;
         }
 
         state = TransactionState.FAILED;
-        if (timeoutTask != null) {
-            timeoutTask.cancel(false);
-        }
+        stopTimer();
 
         transactionManager.transactionComplete(this, TransactionState.FAILED);
     }
@@ -452,7 +464,7 @@ public class ZigBeeTransaction {
             switch (progress) {
                 case TX_NAK:
                     // The transport layer failed to send the command
-                    cancelTransaction();
+                    failTransaction();
                     break;
                 case TX_ACK:
                     // If we aren't waiting for a response, then we're done
@@ -474,7 +486,7 @@ public class ZigBeeTransaction {
                         // we did receive a response that completed the transaction at application level
                         completeTransaction(completionCommand);
                     } else {
-                        cancelTransaction();
+                        failTransaction();
                     }
                     break;
                 case RX_ACK:

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransactionFuture.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransactionFuture.java
@@ -11,6 +11,9 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.zsmartsystems.zigbee.CommandResult;
 import com.zsmartsystems.zigbee.ZigBeeStatus;
 
@@ -21,6 +24,11 @@ import com.zsmartsystems.zigbee.ZigBeeStatus;
  * @author Chris Jackson
  */
 public class ZigBeeTransactionFuture implements Future<CommandResult> {
+    /**
+     * The logger.
+     */
+    private final Logger logger = LoggerFactory.getLogger(ZigBeeTransactionFuture.class);
+
     /**
      * The {@link CommandResult}
      */
@@ -38,7 +46,7 @@ public class ZigBeeTransactionFuture implements Future<CommandResult> {
     private static long TIMEOUT_MINUTES = 5;
 
     /**
-     * Constructur
+     * Constructor
      *
      * @param transaction the {@link ZigBeTransaction} linked to this future
      */
@@ -81,10 +89,13 @@ public class ZigBeeTransactionFuture implements Future<CommandResult> {
     }
 
     @Override
-    public CommandResult get() throws InterruptedException, ExecutionException {
+    public CommandResult get() throws ExecutionException {
+        long start = System.currentTimeMillis();
         try {
             return get(TIMEOUT_MINUTES, TimeUnit.MINUTES);
         } catch (InterruptedException e) {
+            logger.debug("TransactionFuture interrupted after {}ms: {}", System.currentTimeMillis() - start,
+                    transaction);
             set(new CommandResult(ZigBeeStatus.FAILURE, null));
             cancel(true);
             return result;
@@ -104,5 +115,11 @@ public class ZigBeeTransactionFuture implements Future<CommandResult> {
             }
             return result;
         }
+    }
+
+    @Override
+    public String toString() {
+        return "ZigBeeTransactionFuture [cancelled=" + cancelled + ", transaction=" + transaction + ", result=" + result
+                + "]";
     }
 }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransactionManager.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransactionManager.java
@@ -332,9 +332,6 @@ public class ZigBeeTransactionManager implements ZigBeeNetworkNodeListener {
      * @param command the {@link ZigBeeCommand} to send
      */
     public void sendTransaction(ZigBeeCommand command) {
-        if (isShutdown) {
-            return;
-        }
         sendTransaction(command, null);
     }
 
@@ -363,6 +360,7 @@ public class ZigBeeTransactionManager implements ZigBeeNetworkNodeListener {
      */
     private ZigBeeTransactionFuture queueTransaction(ZigBeeTransactionQueue queue, ZigBeeTransaction transaction) {
         if (isShutdown) {
+            logger.debug("Transaction Manager is shutdown. Transaction not sent: {}", transaction);
             return null;
         }
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransactionManager.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransactionManager.java
@@ -348,7 +348,7 @@ public class ZigBeeTransactionManager implements ZigBeeNetworkNodeListener {
         synchronized (this) {
             ZigBeeTransactionQueue queue = getTransactionQueue(transaction);
             if (queue == null) {
-                logger.debug("Error getting queue for {}", transaction);
+                logger.debug("Error getting queue when sending {}", transaction);
                 return null;
             }
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransactionQueue.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransactionQueue.java
@@ -292,6 +292,7 @@ public class ZigBeeTransactionQueue {
      * @param state the {@link TransactionState} of the transaction on completion
      */
     protected void transactionComplete(ZigBeeTransaction transaction, TransactionState state) {
+        System.out.println("ZigBeeTransactionQueue.transactionComplete()");
         if (isShutdown) {
             transaction.cancel();
             return;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransactionQueue.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransactionQueue.java
@@ -233,16 +233,6 @@ public class ZigBeeTransactionQueue {
     }
 
     /**
-     * Removes a transaction from the queue
-     *
-     * @param transaction {@link ZigBeeTransaction}
-     * @return true if an element was removed as a result of this call
-     */
-    protected boolean removeFromQueue(ZigBeeTransaction transaction) {
-        return queue.remove(transaction);
-    }
-
-    /**
      * Get a transaction from the queue. This method will return the next transaction required to be sent, based on
      * priority and any other internal selection mechanism. If no transaction is available to be sent, or if the queue
      * manager does not want to send a transaction at this time (e.g. due to inter-transaction delays), it will return
@@ -308,26 +298,26 @@ public class ZigBeeTransactionQueue {
      * @param state the {@link TransactionState} of the transaction on completion
      */
     protected void transactionComplete(ZigBeeTransaction transaction, TransactionState state) {
-        System.out.println("ZigBeeTransactionQueue.transactionComplete()");
         if (isShutdown) {
             transaction.cancel();
             return;
         }
 
         if (!outstandingTransactions.remove(transaction)) {
-            logger.debug("{}: transactionComplete but not outstanding {} {}", queueName, state,
+            logger.debug("{}: transactionComplete but not outstanding, state={}, outstanding={}", queueName, state,
                     outstandingTransactions.size());
             transaction.cancel();
             return;
         }
-        logger.debug("{}: transactionComplete {} {}", queueName, state, outstandingTransactions.size());
+        logger.debug("{}: transactionComplete, state={}, outstanding={}", queueName, state,
+                outstandingTransactions.size());
 
         if (state == TransactionState.FAILED) {
             if (transaction.getSendCnt() < profile.getMaxRetries()) {
                 // Transaction failed - requeue
                 addToQueue(transaction);
             } else {
-                logger.debug("{}: transactionComplete exceeded retries {}", queueName, transaction.getSendCnt());
+                logger.debug("{}: transactionComplete exceeded max retries {}", queueName, transaction.getSendCnt());
                 transaction.cancel();
             }
         }

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeNodeTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeNodeTest.java
@@ -32,6 +32,8 @@ import org.mockito.stubbing.Answer;
 import com.zsmartsystems.zigbee.ZigBeeNode.ZigBeeNodeState;
 import com.zsmartsystems.zigbee.internal.NotificationService;
 import com.zsmartsystems.zigbee.serialization.DefaultDeserializer;
+import com.zsmartsystems.zigbee.transaction.ZigBeeTransaction;
+import com.zsmartsystems.zigbee.transaction.ZigBeeTransactionCallback;
 import com.zsmartsystems.zigbee.transaction.ZigBeeTransactionFuture;
 import com.zsmartsystems.zigbee.transaction.ZigBeeTransactionMatcher;
 import com.zsmartsystems.zigbee.zcl.ZclCommand;
@@ -588,7 +590,8 @@ public class ZigBeeNodeTest {
             public Future<CommandResult> answer(InvocationOnMock invocation) {
                 ZigBeeCommand command = (ZigBeeCommand) invocation.getArguments()[0];
 
-                ZigBeeTransactionFuture commandFuture = new ZigBeeTransactionFuture();
+                ZigBeeTransactionFuture commandFuture = new ZigBeeTransactionFuture(
+                        Mockito.mock(ZigBeeTransactionCallback.class), Mockito.mock(ZigBeeTransaction.class));
                 CommandResult result = new CommandResult(responses.get(command.getClusterId()));
                 commandFuture.set(result);
                 return commandFuture;

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeNodeTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeNodeTest.java
@@ -33,7 +33,6 @@ import com.zsmartsystems.zigbee.ZigBeeNode.ZigBeeNodeState;
 import com.zsmartsystems.zigbee.internal.NotificationService;
 import com.zsmartsystems.zigbee.serialization.DefaultDeserializer;
 import com.zsmartsystems.zigbee.transaction.ZigBeeTransaction;
-import com.zsmartsystems.zigbee.transaction.ZigBeeTransactionCallback;
 import com.zsmartsystems.zigbee.transaction.ZigBeeTransactionFuture;
 import com.zsmartsystems.zigbee.transaction.ZigBeeTransactionMatcher;
 import com.zsmartsystems.zigbee.zcl.ZclCommand;
@@ -591,7 +590,7 @@ public class ZigBeeNodeTest {
                 ZigBeeCommand command = (ZigBeeCommand) invocation.getArguments()[0];
 
                 ZigBeeTransactionFuture commandFuture = new ZigBeeTransactionFuture(
-                        Mockito.mock(ZigBeeTransactionCallback.class), Mockito.mock(ZigBeeTransaction.class));
+                        Mockito.mock(ZigBeeTransaction.class));
                 CommandResult result = new CommandResult(responses.get(command.getClusterId()));
                 commandFuture.set(result);
                 return commandFuture;

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeNetworkDiscovererTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeNetworkDiscovererTest.java
@@ -32,6 +32,7 @@ import com.zsmartsystems.zigbee.ZigBeeEndpointAddress;
 import com.zsmartsystems.zigbee.ZigBeeNetworkManager;
 import com.zsmartsystems.zigbee.ZigBeeNode;
 import com.zsmartsystems.zigbee.ZigBeeNodeStatus;
+import com.zsmartsystems.zigbee.transaction.ZigBeeTransaction;
 import com.zsmartsystems.zigbee.transaction.ZigBeeTransactionFuture;
 import com.zsmartsystems.zigbee.transaction.ZigBeeTransactionMatcher;
 import com.zsmartsystems.zigbee.zcl.ZclCommand;
@@ -63,7 +64,8 @@ public class ZigBeeNetworkDiscovererTest {
             public Future<CommandResult> answer(InvocationOnMock invocation) {
                 ZigBeeCommand command = (ZigBeeCommand) invocation.getArguments()[0];
 
-                ZigBeeTransactionFuture commandFuture = new ZigBeeTransactionFuture();
+                ZigBeeTransactionFuture commandFuture = new ZigBeeTransactionFuture(
+                        Mockito.mock(ZigBeeTransaction.class));
                 CommandResult result = new CommandResult(responses.get(command.getClusterId()));
                 commandFuture.set(result);
                 return commandFuture;
@@ -75,7 +77,8 @@ public class ZigBeeNetworkDiscovererTest {
             public Future<CommandResult> answer(InvocationOnMock invocation) {
                 ZigBeeCommand command = (ZigBeeCommand) invocation.getArguments()[0];
 
-                ZigBeeTransactionFuture commandFuture = new ZigBeeTransactionFuture();
+                ZigBeeTransactionFuture commandFuture = new ZigBeeTransactionFuture(
+                        Mockito.mock(ZigBeeTransaction.class));
                 CommandResult result = new CommandResult(responses.get(command.getClusterId()));
                 commandFuture.set(result);
                 return commandFuture;
@@ -98,7 +101,8 @@ public class ZigBeeNetworkDiscovererTest {
         // Add all the required responses to a list
         List<Integer> remotes = new ArrayList<>();
         remotes.add(1);
-        IeeeAddressResponse ieeeResponse = new IeeeAddressResponse(ZdoStatus.SUCCESS, new IeeeAddress("1234567890ABCDEF"), 0, 0, remotes);
+        IeeeAddressResponse ieeeResponse = new IeeeAddressResponse(ZdoStatus.SUCCESS,
+                new IeeeAddress("1234567890ABCDEF"), 0, 0, remotes);
         ieeeResponse.setSourceAddress(new ZigBeeEndpointAddress(0));
         ieeeResponse.setDestinationAddress(new ZigBeeEndpointAddress(0));
         responses.put(ZdoCommandType.IEEE_ADDRESS_REQUEST.getClusterId(), ieeeResponse);
@@ -193,7 +197,8 @@ public class ZigBeeNetworkDiscovererTest {
     public void rediscoverNodeByEui() throws Exception {
         ZigBeeNetworkDiscoverer discoverer = new ZigBeeNetworkDiscoverer(networkManager);
 
-        IeeeAddressResponse ieeeResponse = new IeeeAddressResponse(ZdoStatus.SUCCESS, new IeeeAddress("1111111111111111"), 1111, null, null);
+        IeeeAddressResponse ieeeResponse = new IeeeAddressResponse(ZdoStatus.SUCCESS,
+                new IeeeAddress("1111111111111111"), 1111, null, null);
         ieeeResponse.setSourceAddress(new ZigBeeEndpointAddress(1111));
         ieeeResponse.setDestinationAddress(new ZigBeeEndpointAddress(0));
         responses.put(ZdoCommandType.IEEE_ADDRESS_REQUEST.getClusterId(), ieeeResponse);
@@ -217,7 +222,8 @@ public class ZigBeeNetworkDiscovererTest {
     public void rediscoverNodeByNwk() throws Exception {
         ZigBeeNetworkDiscoverer discoverer = new ZigBeeNetworkDiscoverer(networkManager);
 
-        NetworkAddressResponse nwkResponse = new NetworkAddressResponse(ZdoStatus.SUCCESS, new IeeeAddress("1111111111111111"), 1111, null, null);
+        NetworkAddressResponse nwkResponse = new NetworkAddressResponse(ZdoStatus.SUCCESS,
+                new IeeeAddress("1111111111111111"), 1111, null, null);
         nwkResponse.setSourceAddress(new ZigBeeEndpointAddress(1111));
         nwkResponse.setDestinationAddress(new ZigBeeEndpointAddress(0));
         responses.put(ZdoCommandType.NETWORK_ADDRESS_REQUEST.getClusterId(), nwkResponse);

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeNodeServiceDiscovererTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeNodeServiceDiscovererTest.java
@@ -40,6 +40,7 @@ import com.zsmartsystems.zigbee.ZigBeeEndpointAddress;
 import com.zsmartsystems.zigbee.ZigBeeNetworkManager;
 import com.zsmartsystems.zigbee.ZigBeeNode;
 import com.zsmartsystems.zigbee.app.discovery.ZigBeeNodeServiceDiscoverer.NodeDiscoveryTask;
+import com.zsmartsystems.zigbee.transaction.ZigBeeTransaction;
 import com.zsmartsystems.zigbee.transaction.ZigBeeTransactionFuture;
 import com.zsmartsystems.zigbee.transaction.ZigBeeTransactionMatcher;
 import com.zsmartsystems.zigbee.zdo.ZdoCommandType;
@@ -80,7 +81,8 @@ public class ZigBeeNodeServiceDiscovererTest {
             public Future<CommandResult> answer(InvocationOnMock invocation) {
                 ZigBeeCommand command = (ZigBeeCommand) invocation.getArguments()[0];
 
-                ZigBeeTransactionFuture commandFuture = new ZigBeeTransactionFuture();
+                ZigBeeTransactionFuture commandFuture = new ZigBeeTransactionFuture(
+                        Mockito.mock(ZigBeeTransaction.class));
                 CommandResult result = new CommandResult(responses.get(command.getClusterId()));
                 commandFuture.set(result);
                 return commandFuture;

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransactionFutureTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransactionFutureTest.java
@@ -35,8 +35,7 @@ public class ZigBeeTransactionFutureTest {
 
     @Test
     public void testIsDone() throws InterruptedException, ExecutionException, TimeoutException {
-        ZigBeeTransactionFuture future = new ZigBeeTransactionFuture(Mockito.mock(ZigBeeTransactionCallback.class),
-                Mockito.mock(ZigBeeTransaction.class));
+        ZigBeeTransactionFuture future = new ZigBeeTransactionFuture(Mockito.mock(ZigBeeTransaction.class));
         assertFalse(future.isDone());
 
         CommandResult result = new CommandResult(ZigBeeStatus.FAILURE, null);
@@ -49,7 +48,7 @@ public class ZigBeeTransactionFutureTest {
 
     @Test
     public void testDefaultTimeout() throws Exception {
-        ZigBeeTransactionFuture future = new ZigBeeTransactionFuture(Mockito.mock(ZigBeeTransactionCallback.class),
+        ZigBeeTransactionFuture future = new ZigBeeTransactionFuture(
                 Mockito.mock(ZigBeeTransaction.class));
         assertFalse(future.isDone());
 
@@ -61,8 +60,7 @@ public class ZigBeeTransactionFutureTest {
 
     @Test
     public void testTimeout() throws InterruptedException, ExecutionException, TimeoutException {
-        ZigBeeTransactionFuture future = new ZigBeeTransactionFuture(Mockito.mock(ZigBeeTransactionCallback.class),
-                Mockito.mock(ZigBeeTransaction.class));
+        ZigBeeTransactionFuture future = new ZigBeeTransactionFuture(Mockito.mock(ZigBeeTransaction.class));
         assertFalse(future.isDone());
 
         assertNotNull(future.get(0, TimeUnit.MICROSECONDS));
@@ -76,21 +74,20 @@ public class ZigBeeTransactionFutureTest {
 
     @Test
     public void testCancel() {
-        ZigBeeTransactionCallback callback = Mockito.mock(ZigBeeTransactionCallback.class);
         ZigBeeTransaction transaction = Mockito.mock(ZigBeeTransaction.class);
-        ZigBeeTransactionFuture future = new ZigBeeTransactionFuture(callback, transaction);
+        ZigBeeTransactionFuture future = new ZigBeeTransactionFuture(transaction);
         assertFalse(future.isCancelled());
         assertTrue(future.cancel(true));
-        Mockito.verify(callback, Mockito.timeout(TIMEOUT).times(1)).cancelTransaction(transaction);
+        Mockito.verify(transaction, Mockito.timeout(TIMEOUT).times(1)).cancel();
         assertFalse(future.cancel(true));
-        Mockito.verify(callback, Mockito.timeout(TIMEOUT).times(1)).cancelTransaction(transaction);
+        Mockito.verify(transaction, Mockito.timeout(TIMEOUT).times(1)).cancel();
         assertTrue(future.isCancelled());
     }
 
     @Test
     public void testMultipleThreadIsDone() throws InterruptedException, ExecutionException, TimeoutException {
         // Tests that multiple threads waiting on the same future will be notified when it completes
-        ZigBeeTransactionFuture future = new ZigBeeTransactionFuture(Mockito.mock(ZigBeeTransactionCallback.class),
+        ZigBeeTransactionFuture future = new ZigBeeTransactionFuture(
                 Mockito.mock(ZigBeeTransaction.class));
         assertFalse(future.isDone());
 
@@ -103,7 +100,7 @@ public class ZigBeeTransactionFutureTest {
                 startLatch.countDown();
                 try {
                     future.get();
-                } catch (InterruptedException | ExecutionException e) {
+                } catch (ExecutionException e) {
                     e.printStackTrace();
                 }
                 finishLatch.countDown();
@@ -115,7 +112,7 @@ public class ZigBeeTransactionFutureTest {
                 startLatch.countDown();
                 try {
                     future.get();
-                } catch (InterruptedException | ExecutionException e) {
+                } catch (ExecutionException e) {
                     e.printStackTrace();
                 }
                 finishLatch.countDown();

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransactionFutureTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransactionFutureTest.java
@@ -18,11 +18,12 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import com.zsmartsystems.zigbee.ZigBeeStatus;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import com.zsmartsystems.zigbee.CommandResult;
 import com.zsmartsystems.zigbee.TestUtilities;
+import com.zsmartsystems.zigbee.ZigBeeStatus;
 
 /**
  *
@@ -34,7 +35,8 @@ public class ZigBeeTransactionFutureTest {
 
     @Test
     public void testIsDone() throws InterruptedException, ExecutionException, TimeoutException {
-        ZigBeeTransactionFuture future = new ZigBeeTransactionFuture();
+        ZigBeeTransactionFuture future = new ZigBeeTransactionFuture(Mockito.mock(ZigBeeTransactionCallback.class),
+                Mockito.mock(ZigBeeTransaction.class));
         assertFalse(future.isDone());
 
         CommandResult result = new CommandResult(ZigBeeStatus.FAILURE, null);
@@ -47,7 +49,8 @@ public class ZigBeeTransactionFutureTest {
 
     @Test
     public void testDefaultTimeout() throws Exception {
-        ZigBeeTransactionFuture future = new ZigBeeTransactionFuture();
+        ZigBeeTransactionFuture future = new ZigBeeTransactionFuture(Mockito.mock(ZigBeeTransactionCallback.class),
+                Mockito.mock(ZigBeeTransaction.class));
         assertFalse(future.isDone());
 
         TestUtilities.setField(ZigBeeTransactionFuture.class, future, "TIMEOUT_MINUTES", (long) 0);
@@ -58,7 +61,8 @@ public class ZigBeeTransactionFutureTest {
 
     @Test
     public void testTimeout() throws InterruptedException, ExecutionException, TimeoutException {
-        ZigBeeTransactionFuture future = new ZigBeeTransactionFuture();
+        ZigBeeTransactionFuture future = new ZigBeeTransactionFuture(Mockito.mock(ZigBeeTransactionCallback.class),
+                Mockito.mock(ZigBeeTransaction.class));
         assertFalse(future.isDone());
 
         assertNotNull(future.get(0, TimeUnit.MICROSECONDS));
@@ -72,17 +76,22 @@ public class ZigBeeTransactionFutureTest {
 
     @Test
     public void testCancel() {
-        ZigBeeTransactionFuture future = new ZigBeeTransactionFuture();
+        ZigBeeTransactionCallback callback = Mockito.mock(ZigBeeTransactionCallback.class);
+        ZigBeeTransaction transaction = Mockito.mock(ZigBeeTransaction.class);
+        ZigBeeTransactionFuture future = new ZigBeeTransactionFuture(callback, transaction);
         assertFalse(future.isCancelled());
         assertTrue(future.cancel(true));
+        Mockito.verify(callback, Mockito.timeout(TIMEOUT).times(1)).cancelTransaction(transaction);
         assertFalse(future.cancel(true));
+        Mockito.verify(callback, Mockito.timeout(TIMEOUT).times(1)).cancelTransaction(transaction);
         assertTrue(future.isCancelled());
     }
 
     @Test
     public void testMultipleThreadIsDone() throws InterruptedException, ExecutionException, TimeoutException {
         // Tests that multiple threads waiting on the same future will be notified when it completes
-        ZigBeeTransactionFuture future = new ZigBeeTransactionFuture();
+        ZigBeeTransactionFuture future = new ZigBeeTransactionFuture(Mockito.mock(ZigBeeTransactionCallback.class),
+                Mockito.mock(ZigBeeTransaction.class));
         assertFalse(future.isDone());
 
         CountDownLatch startLatch = new CountDownLatch(2);

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransactionManagerTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransactionManagerTest.java
@@ -7,7 +7,6 @@
  */
 package com.zsmartsystems.zigbee.transaction;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -25,6 +24,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.Test;
 import org.mockito.ArgumentMatchers;
@@ -190,8 +190,11 @@ public class ZigBeeTransactionManagerTest {
 
         transactionManager.shutdown();
 
-        await().atMost(TIMEOUT, SECONDS)
+        // Mockito.verify(transactionManager, Mockito.timeout(TIMEOUT).times(1))
+        // .getQueue(new IeeeAddress("1111111111111111"));
+        await().atMost(TIMEOUT, TimeUnit.MILLISECONDS)
                 .until(() -> assertNull(transactionManager.getQueue(new IeeeAddress("1111111111111111"))));
+        System.out.println(cmdResult);
         assertTrue(cmdResult.isCancelled());
     }
 

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransactionQueueTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransactionQueueTest.java
@@ -144,18 +144,4 @@ public class ZigBeeTransactionQueueTest {
 
         assertEquals(newAddress, rewrittenTransaction.getDestinationAddress().getAddress());
     }
-
-    @Test
-    public void testCancel() {
-        ZigBeeTransactionQueue queue = new ZigBeeTransactionQueue("QueueName", null);
-        ZigBeeTransaction transaction = Mockito.mock(ZigBeeTransaction.class);
-        assertEquals(0, queue.size());
-        queue.cancelTransaction(transaction);
-        Mockito.verify(transaction, Mockito.timeout(TIMEOUT).times(1)).cancel();
-        queue.addToQueue(transaction);
-        assertEquals(1, queue.size());
-        queue.cancelTransaction(transaction);
-        Mockito.verify(transaction, Mockito.timeout(TIMEOUT).times(2)).cancel();
-        assertEquals(0, queue.size());
-    }
 }

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransactionQueueTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransactionQueueTest.java
@@ -31,6 +31,7 @@ import com.zsmartsystems.zigbee.transaction.ZigBeeTransaction.TransactionState;
  *
  */
 public class ZigBeeTransactionQueueTest {
+    private final long TIMEOUT = 5000;
 
     @Test
     public void testQueueFifo() {
@@ -142,5 +143,19 @@ public class ZigBeeTransactionQueueTest {
         ZigBeeTransaction rewrittenTransaction = queue.getTransaction();
 
         assertEquals(newAddress, rewrittenTransaction.getDestinationAddress().getAddress());
+    }
+
+    @Test
+    public void testCancel() {
+        ZigBeeTransactionQueue queue = new ZigBeeTransactionQueue("QueueName", null);
+        ZigBeeTransaction transaction = Mockito.mock(ZigBeeTransaction.class);
+        assertEquals(0, queue.size());
+        queue.cancelTransaction(transaction);
+        Mockito.verify(transaction, Mockito.timeout(TIMEOUT).times(1)).cancel();
+        queue.addToQueue(transaction);
+        assertEquals(1, queue.size());
+        queue.cancelTransaction(transaction);
+        Mockito.verify(transaction, Mockito.timeout(TIMEOUT).times(2)).cancel();
+        assertEquals(0, queue.size());
     }
 }

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransactionTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransactionTest.java
@@ -41,7 +41,8 @@ public class ZigBeeTransactionTest {
         ZigBeeCommand command = Mockito.mock(ZigBeeCommand.class);
         ZigBeeTransactionMatcher matcher = Mockito.mock(ZigBeeTransactionMatcher.class);
 
-        ZigBeeTransactionFuture transactionFuture = new ZigBeeTransactionFuture();
+        ZigBeeTransactionFuture transactionFuture = new ZigBeeTransactionFuture(
+                Mockito.mock(ZigBeeTransactionCallback.class), Mockito.mock(ZigBeeTransaction.class));
 
         ZigBeeTransaction transaction = new ZigBeeTransaction(transactionManager, command, matcher);
         transaction.setFuture(transactionFuture);
@@ -101,7 +102,8 @@ public class ZigBeeTransactionTest {
         Mockito.when(command.getTransactionId()).thenReturn(12);
         ZigBeeTransactionMatcher matcher = Mockito.mock(ZigBeeTransactionMatcher.class);
 
-        ZigBeeTransactionFuture transactionFuture = new ZigBeeTransactionFuture();
+        ZigBeeTransactionFuture transactionFuture = new ZigBeeTransactionFuture(
+                Mockito.mock(ZigBeeTransactionCallback.class), Mockito.mock(ZigBeeTransaction.class));
 
         ZigBeeTransaction transaction = new ZigBeeTransaction(transactionManager, command, matcher);
         transaction.setFuture(transactionFuture);
@@ -142,7 +144,8 @@ public class ZigBeeTransactionTest {
         Mockito.when(command.isAckRequest()).thenReturn(true);
         ZigBeeTransactionMatcher matcher = Mockito.mock(ZigBeeTransactionMatcher.class);
 
-        ZigBeeTransactionFuture transactionFuture = new ZigBeeTransactionFuture();
+        ZigBeeTransactionFuture transactionFuture = new ZigBeeTransactionFuture(
+                Mockito.mock(ZigBeeTransactionCallback.class), Mockito.mock(ZigBeeTransaction.class));
 
         ZigBeeTransaction transaction = new ZigBeeTransaction(transactionManager, command, matcher);
         transaction.setFuture(transactionFuture);
@@ -176,7 +179,8 @@ public class ZigBeeTransactionTest {
         ZigBeeCommand request = Mockito.mock(ZigBeeCommand.class);
         Mockito.when(matcher.isTransactionMatch(command, request)).thenReturn(true);
 
-        ZigBeeTransactionFuture transactionFuture = new ZigBeeTransactionFuture();
+        ZigBeeTransactionFuture transactionFuture = new ZigBeeTransactionFuture(
+                Mockito.mock(ZigBeeTransactionCallback.class), Mockito.mock(ZigBeeTransaction.class));
 
         ZigBeeTransaction transaction = new ZigBeeTransaction(transactionManager, command, matcher);
         transaction.setFuture(transactionFuture);
@@ -213,7 +217,8 @@ public class ZigBeeTransactionTest {
         ZigBeeCommand request = Mockito.mock(ZigBeeCommand.class);
         Mockito.when(matcher.isTransactionMatch(command, request)).thenReturn(true);
 
-        ZigBeeTransactionFuture transactionFuture = new ZigBeeTransactionFuture();
+        ZigBeeTransactionFuture transactionFuture = new ZigBeeTransactionFuture(
+                Mockito.mock(ZigBeeTransactionCallback.class), Mockito.mock(ZigBeeTransaction.class));
 
         ZigBeeTransaction transaction = new ZigBeeTransaction(transactionManager, command, matcher);
         transaction.setFuture(transactionFuture);
@@ -251,7 +256,8 @@ public class ZigBeeTransactionTest {
         ZigBeeCommand request = Mockito.mock(ZigBeeCommand.class);
         Mockito.when(matcher.isTransactionMatch(command, request)).thenReturn(true);
 
-        ZigBeeTransactionFuture transactionFuture = new ZigBeeTransactionFuture();
+        ZigBeeTransactionFuture transactionFuture = new ZigBeeTransactionFuture(
+                Mockito.mock(ZigBeeTransactionCallback.class), Mockito.mock(ZigBeeTransaction.class));
 
         ZigBeeTransaction transaction = new ZigBeeTransaction(transactionManager, command, matcher);
         transaction.setFuture(transactionFuture);
@@ -288,7 +294,8 @@ public class ZigBeeTransactionTest {
         ZigBeeCommand request = Mockito.mock(ZigBeeCommand.class);
         Mockito.when(matcher.isTransactionMatch(command, request)).thenReturn(true);
 
-        ZigBeeTransactionFuture transactionFuture = new ZigBeeTransactionFuture();
+        ZigBeeTransactionFuture transactionFuture = new ZigBeeTransactionFuture(
+                Mockito.mock(ZigBeeTransactionCallback.class), Mockito.mock(ZigBeeTransaction.class));
 
         ZigBeeTransaction transaction = new ZigBeeTransaction(transactionManager, command, matcher);
         transaction.setFuture(transactionFuture);
@@ -318,7 +325,8 @@ public class ZigBeeTransactionTest {
         ZigBeeCommand command = Mockito.mock(ZigBeeCommand.class);
         Mockito.when(command.getTransactionId()).thenReturn(12);
 
-        ZigBeeTransactionFuture transactionFuture = new ZigBeeTransactionFuture();
+        ZigBeeTransactionFuture transactionFuture = new ZigBeeTransactionFuture(
+                Mockito.mock(ZigBeeTransactionCallback.class), Mockito.mock(ZigBeeTransaction.class));
 
         ZigBeeTransaction transaction = new ZigBeeTransaction(transactionManager, command, null);
         transaction.setTimerPeriod1(Integer.MAX_VALUE);
@@ -366,9 +374,9 @@ public class ZigBeeTransactionTest {
 
         transaction.transactionStatusReceived(ZigBeeTransportProgressState.TX_ACK, 12);
 
-        Mockito.verify(transactionManager, Mockito.times(1)).transactionComplete(transaction, TransactionState.COMPLETE);
+        Mockito.verify(transactionManager, Mockito.times(1)).transactionComplete(transaction,
+                TransactionState.COMPLETE);
     }
-
 
     @Test
     public void testThatTxAckDoesntCompletesTransactionWhenApsAckRequired() {
@@ -393,7 +401,8 @@ public class ZigBeeTransactionTest {
         ZigBeeCommand command = Mockito.mock(ZigBeeCommand.class);
         Mockito.when(command.getTransactionId()).thenReturn(12);
 
-        ZigBeeTransactionFuture transactionFuture = new ZigBeeTransactionFuture();
+        ZigBeeTransactionFuture transactionFuture = new ZigBeeTransactionFuture(
+                Mockito.mock(ZigBeeTransactionCallback.class), Mockito.mock(ZigBeeTransaction.class));
 
         ZigBeeCommand matchRequest = Mockito.mock(ZigBeeCommand.class);
         ZigBeeCommand nomatchRequest = Mockito.mock(ZigBeeCommand.class);

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransactionTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransactionTest.java
@@ -41,8 +41,7 @@ public class ZigBeeTransactionTest {
         ZigBeeCommand command = Mockito.mock(ZigBeeCommand.class);
         ZigBeeTransactionMatcher matcher = Mockito.mock(ZigBeeTransactionMatcher.class);
 
-        ZigBeeTransactionFuture transactionFuture = new ZigBeeTransactionFuture(
-                Mockito.mock(ZigBeeTransactionCallback.class), Mockito.mock(ZigBeeTransaction.class));
+        ZigBeeTransactionFuture transactionFuture = new ZigBeeTransactionFuture(Mockito.mock(ZigBeeTransaction.class));
 
         ZigBeeTransaction transaction = new ZigBeeTransaction(transactionManager, command, matcher);
         transaction.setFuture(transactionFuture);
@@ -98,12 +97,10 @@ public class ZigBeeTransactionTest {
     @Test
     public void testTxNak() {
         ZigBeeTransactionManager transactionManager = Mockito.mock(ZigBeeTransactionManager.class);
-        ZigBeeCommand command = Mockito.mock(ZigBeeCommand.class);
-        Mockito.when(command.getTransactionId()).thenReturn(12);
+        ZigBeeCommand command = createCommand(false);
         ZigBeeTransactionMatcher matcher = Mockito.mock(ZigBeeTransactionMatcher.class);
 
-        ZigBeeTransactionFuture transactionFuture = new ZigBeeTransactionFuture(
-                Mockito.mock(ZigBeeTransactionCallback.class), Mockito.mock(ZigBeeTransaction.class));
+        ZigBeeTransactionFuture transactionFuture = new ZigBeeTransactionFuture(Mockito.mock(ZigBeeTransaction.class));
 
         ZigBeeTransaction transaction = new ZigBeeTransaction(transactionManager, command, matcher);
         transaction.setFuture(transactionFuture);
@@ -139,13 +136,10 @@ public class ZigBeeTransactionTest {
     @Test
     public void testRxNak() {
         ZigBeeTransactionManager transactionManager = Mockito.mock(ZigBeeTransactionManager.class);
-        ZigBeeCommand command = Mockito.mock(ZigBeeCommand.class);
-        Mockito.when(command.getTransactionId()).thenReturn(12);
-        Mockito.when(command.isAckRequest()).thenReturn(true);
+        ZigBeeCommand command = createCommand(true);
         ZigBeeTransactionMatcher matcher = Mockito.mock(ZigBeeTransactionMatcher.class);
 
-        ZigBeeTransactionFuture transactionFuture = new ZigBeeTransactionFuture(
-                Mockito.mock(ZigBeeTransactionCallback.class), Mockito.mock(ZigBeeTransaction.class));
+        ZigBeeTransactionFuture transactionFuture = new ZigBeeTransactionFuture(Mockito.mock(ZigBeeTransaction.class));
 
         ZigBeeTransaction transaction = new ZigBeeTransaction(transactionManager, command, matcher);
         transaction.setFuture(transactionFuture);
@@ -171,16 +165,13 @@ public class ZigBeeTransactionTest {
     @Test
     public void testMatchedAfterRxAck() {
         ZigBeeTransactionManager transactionManager = Mockito.mock(ZigBeeTransactionManager.class);
-        ZigBeeCommand command = Mockito.mock(ZigBeeCommand.class);
-        Mockito.when(command.getTransactionId()).thenReturn(12);
-        Mockito.when(command.isAckRequest()).thenReturn(true);
+        ZigBeeCommand command = createCommand(true);
         ZigBeeTransactionMatcher matcher = Mockito.mock(ZigBeeTransactionMatcher.class);
 
-        ZigBeeCommand request = Mockito.mock(ZigBeeCommand.class);
+        ZigBeeCommand request = createCommand(false);
         Mockito.when(matcher.isTransactionMatch(command, request)).thenReturn(true);
 
-        ZigBeeTransactionFuture transactionFuture = new ZigBeeTransactionFuture(
-                Mockito.mock(ZigBeeTransactionCallback.class), Mockito.mock(ZigBeeTransaction.class));
+        ZigBeeTransactionFuture transactionFuture = new ZigBeeTransactionFuture(Mockito.mock(ZigBeeTransaction.class));
 
         ZigBeeTransaction transaction = new ZigBeeTransaction(transactionManager, command, matcher);
         transaction.setFuture(transactionFuture);
@@ -209,16 +200,13 @@ public class ZigBeeTransactionTest {
     @Test
     public void testMatchedBeforeRxAck() {
         ZigBeeTransactionManager transactionManager = Mockito.mock(ZigBeeTransactionManager.class);
-        ZigBeeCommand command = Mockito.mock(ZigBeeCommand.class);
-        Mockito.when(command.getTransactionId()).thenReturn(12);
-        Mockito.when(command.isAckRequest()).thenReturn(true);
+        ZigBeeCommand command = createCommand(true);
         ZigBeeTransactionMatcher matcher = Mockito.mock(ZigBeeTransactionMatcher.class);
 
-        ZigBeeCommand request = Mockito.mock(ZigBeeCommand.class);
+        ZigBeeCommand request = createCommand(false);
         Mockito.when(matcher.isTransactionMatch(command, request)).thenReturn(true);
 
-        ZigBeeTransactionFuture transactionFuture = new ZigBeeTransactionFuture(
-                Mockito.mock(ZigBeeTransactionCallback.class), Mockito.mock(ZigBeeTransaction.class));
+        ZigBeeTransactionFuture transactionFuture = new ZigBeeTransactionFuture(Mockito.mock(ZigBeeTransaction.class));
 
         ZigBeeTransaction transaction = new ZigBeeTransaction(transactionManager, command, matcher);
         transaction.setFuture(transactionFuture);
@@ -253,11 +241,10 @@ public class ZigBeeTransactionTest {
         Mockito.when(command.getDestinationAddress()).thenReturn(new ZigBeeEndpointAddress(1234, 5));
         ZigBeeTransactionMatcher matcher = Mockito.mock(ZigBeeTransactionMatcher.class);
 
-        ZigBeeCommand request = Mockito.mock(ZigBeeCommand.class);
+        ZigBeeCommand request = createCommand(false);
         Mockito.when(matcher.isTransactionMatch(command, request)).thenReturn(true);
 
-        ZigBeeTransactionFuture transactionFuture = new ZigBeeTransactionFuture(
-                Mockito.mock(ZigBeeTransactionCallback.class), Mockito.mock(ZigBeeTransaction.class));
+        ZigBeeTransactionFuture transactionFuture = new ZigBeeTransactionFuture(Mockito.mock(ZigBeeTransaction.class));
 
         ZigBeeTransaction transaction = new ZigBeeTransaction(transactionManager, command, matcher);
         transaction.setFuture(transactionFuture);
@@ -286,16 +273,13 @@ public class ZigBeeTransactionTest {
     @Test
     public void testMatchedBeforeRxNak() {
         ZigBeeTransactionManager transactionManager = Mockito.mock(ZigBeeTransactionManager.class);
-        ZigBeeCommand command = Mockito.mock(ZigBeeCommand.class);
-        Mockito.when(command.getTransactionId()).thenReturn(12);
-        Mockito.when(command.isAckRequest()).thenReturn(true);
+        ZigBeeCommand command = createCommand(true);
         ZigBeeTransactionMatcher matcher = Mockito.mock(ZigBeeTransactionMatcher.class);
 
-        ZigBeeCommand request = Mockito.mock(ZigBeeCommand.class);
+        ZigBeeCommand request = createCommand(false);
         Mockito.when(matcher.isTransactionMatch(command, request)).thenReturn(true);
 
-        ZigBeeTransactionFuture transactionFuture = new ZigBeeTransactionFuture(
-                Mockito.mock(ZigBeeTransactionCallback.class), Mockito.mock(ZigBeeTransaction.class));
+        ZigBeeTransactionFuture transactionFuture = new ZigBeeTransactionFuture(Mockito.mock(ZigBeeTransaction.class));
 
         ZigBeeTransaction transaction = new ZigBeeTransaction(transactionManager, command, matcher);
         transaction.setFuture(transactionFuture);
@@ -322,11 +306,9 @@ public class ZigBeeTransactionTest {
 
     public void testSendOnly(ZigBeeTransportProgressState state) {
         ZigBeeTransactionManager transactionManager = Mockito.mock(ZigBeeTransactionManager.class);
-        ZigBeeCommand command = Mockito.mock(ZigBeeCommand.class);
-        Mockito.when(command.getTransactionId()).thenReturn(12);
+        ZigBeeCommand command = createCommand(false);
 
-        ZigBeeTransactionFuture transactionFuture = new ZigBeeTransactionFuture(
-                Mockito.mock(ZigBeeTransactionCallback.class), Mockito.mock(ZigBeeTransaction.class));
+        ZigBeeTransactionFuture transactionFuture = new ZigBeeTransactionFuture(Mockito.mock(ZigBeeTransaction.class));
 
         ZigBeeTransaction transaction = new ZigBeeTransaction(transactionManager, command, null);
         transaction.setTimerPeriod1(Integer.MAX_VALUE);
@@ -365,9 +347,7 @@ public class ZigBeeTransactionTest {
     @Test
     public void testThatTxAckCompletesTransactionWhenNoApsAckRequired() {
         ZigBeeTransactionManager transactionManager = Mockito.mock(ZigBeeTransactionManager.class);
-        ZigBeeCommand command = Mockito.mock(ZigBeeCommand.class);
-        Mockito.when(command.getTransactionId()).thenReturn(12);
-        Mockito.when(command.isAckRequest()).thenReturn(false);
+        ZigBeeCommand command = createCommand(false);
         ZigBeeTransactionMatcher matcher = Mockito.mock(ZigBeeTransactionMatcher.class);
 
         ZigBeeTransaction transaction = new ZigBeeTransaction(transactionManager, command, matcher);
@@ -381,9 +361,7 @@ public class ZigBeeTransactionTest {
     @Test
     public void testThatTxAckDoesntCompletesTransactionWhenApsAckRequired() {
         ZigBeeTransactionManager transactionManager = Mockito.mock(ZigBeeTransactionManager.class);
-        ZigBeeCommand command = Mockito.mock(ZigBeeCommand.class);
-        Mockito.when(command.getTransactionId()).thenReturn(12);
-        Mockito.when(command.isAckRequest()).thenReturn(true);
+        ZigBeeCommand command = createCommand(true);
         ZigBeeTransactionMatcher matcher = Mockito.mock(ZigBeeTransactionMatcher.class);
 
         ZigBeeTransaction transaction = new ZigBeeTransaction(transactionManager, command, matcher);
@@ -398,14 +376,12 @@ public class ZigBeeTransactionTest {
         // Note that this test does not use the transport transaction state feedback,
         // so the transaction should complete as soon as the matcher is happy.
         ZigBeeTransactionManager transactionManager = Mockito.mock(ZigBeeTransactionManager.class);
-        ZigBeeCommand command = Mockito.mock(ZigBeeCommand.class);
-        Mockito.when(command.getTransactionId()).thenReturn(12);
+        ZigBeeCommand command = createCommand(false);
 
-        ZigBeeTransactionFuture transactionFuture = new ZigBeeTransactionFuture(
-                Mockito.mock(ZigBeeTransactionCallback.class), Mockito.mock(ZigBeeTransaction.class));
+        ZigBeeTransactionFuture transactionFuture = new ZigBeeTransactionFuture(Mockito.mock(ZigBeeTransaction.class));
 
-        ZigBeeCommand matchRequest = Mockito.mock(ZigBeeCommand.class);
-        ZigBeeCommand nomatchRequest = Mockito.mock(ZigBeeCommand.class);
+        ZigBeeCommand matchRequest = createCommand(false);
+        ZigBeeCommand nomatchRequest = createCommand(false);
         ZigBeeTransactionMatcher matcher = Mockito.mock(ZigBeeTransactionMatcher.class);
         Mockito.when(matcher.isTransactionMatch(command, matchRequest)).thenReturn(true);
         Mockito.when(matcher.isTransactionMatch(command, nomatchRequest)).thenReturn(false);
@@ -463,5 +439,13 @@ public class ZigBeeTransactionTest {
         IeeeAddress address = new IeeeAddress();
         transaction.setIeeeAddress(address);
         assertEquals(address, transaction.getIeeeAddress());
+    }
+
+    private ZigBeeCommand createCommand(boolean ackRequest) {
+        ZigBeeCommand command = Mockito.mock(ZigBeeCommand.class);
+        Mockito.when(command.getTransactionId()).thenReturn(12);
+        Mockito.when(command.isAckRequest()).thenReturn(ackRequest);
+        Mockito.when(command.getDestinationAddress()).thenReturn(new ZigBeeEndpointAddress(1234, 5));
+        return command;
     }
 }


### PR DESCRIPTION
This solves issues discussed in #1109 when transaction futures time out. It also closes #844.

This removes a `ZigBeeTransaction` from the `ZigBeeTransactionQueue` when it is cancelled. It adds a `ZigBeeTransactionCallback` interface which allows the `ZigBeeTransactionFuture` to remove the `ZigBeeTransaction` from the queue if the transaction is cancelled or times out.  

There is a gotcha here in that if the transaction is cancelled through other means, it can also call the `ZigBeeTransactionFuture.cancel()` method, so flags need to be set in the right order to avoid recursion.

@triller-telekom do you fancy taking a look at this. I've given it a quick test to make sure it still runs, but will do a bit more testing yet. If you can give it a review it would be appreciated.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>