### PR TITLE
For ZCL signed 24bit Integers, also parse negative values

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/serialization/DefaultDeserializer.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/serialization/DefaultDeserializer.java
@@ -215,8 +215,17 @@ public class DefaultDeserializer implements ZigBeeDeserializer {
                     value[0] = Integer.valueOf(shortVal & 0xFFFF);
                 }
                 break;
-            case BITMAP_24_BIT:
             case SIGNED_24_BIT_INTEGER:
+                int unsignedValue = payload[index++] + (payload[index++] << 8) + (payload[index++] << 16);
+                if (unsignedValue >> 23 == 1) {
+                    // negative value case
+                    value[0] = -1 - ((~unsignedValue) & 0xFFFFFF);
+                } else {
+                    // positive value case
+                    value[0] = unsignedValue;
+                }
+                break;
+            case BITMAP_24_BIT:
             case UNSIGNED_24_BIT_INTEGER:
                 value[0] = payload[index++] + (payload[index++] << 8) + (payload[index++] << 16);
                 break;

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/serialization/DefaultDeserializerTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/serialization/DefaultDeserializerTest.java
@@ -37,10 +37,80 @@ public class DefaultDeserializerTest {
     }
 
     @Test
-    public void testDeserialize_SIGNED_16_BIT_INTEGER() {
+    public void testDeserialize_SIGNED_16_BIT_INTEGER_positive() {
         int[] valIn = { 0x97, 0x03 };
         int valOut = 0x397;
         testDeserialize(valIn, valOut, ZclDataType.SIGNED_16_BIT_INTEGER);
+    }
+
+    @Test
+    public void testDeserialize_SIGNED_16_BIT_INTEGER_negative() {
+        int[] valIn = { 0xFF, 0xFF };
+        int valOut = -0x1;
+        testDeserialize(valIn, valOut, ZclDataType.SIGNED_16_BIT_INTEGER);
+    }
+
+    @Test
+    public void testDeserialize_SIGNED_24_BIT_INTEGER_positive_small() {
+        int[] valIn = { 0x97, 0x03, 0x00 };
+        int valOut = 0x397;
+        testDeserialize(valIn, valOut, ZclDataType.SIGNED_24_BIT_INTEGER);
+    }
+
+    @Test
+    public void testDeserialize_SIGNED_24_BIT_INTEGER_positive_largest() {
+        int[] valIn = { 0xFF, 0xFF, 0x7F };
+        int valOut = 8388607; // 2^23 - 1
+        testDeserialize(valIn, valOut, ZclDataType.SIGNED_24_BIT_INTEGER);
+    }
+
+    @Test
+    public void testDeserialize_SIGNED_24_BIT_INTEGER_negative_one() {
+        int[] valIn = { 0xFF, 0xFF, 0xFF };
+        int valOut = -0x1;
+        testDeserialize(valIn, valOut, ZclDataType.SIGNED_24_BIT_INTEGER);
+    }
+
+    @Test
+    public void testDeserialize_SIGNED_24_BIT_INTEGER_negative_small() {
+        int[] valIn = { 0xFD, 0xFF, 0xFF };
+        int valOut = -0x3;
+        testDeserialize(valIn, valOut, ZclDataType.SIGNED_24_BIT_INTEGER);
+    }
+
+    @Test
+    public void testDeserialize_SIGNED_24_BIT_INTEGER_negative_largest() {
+        int[] valIn = { 0x00, 0x00, 0x80 };
+        int valOut = -8388608; // -2^23
+        testDeserialize(valIn, valOut, ZclDataType.SIGNED_24_BIT_INTEGER);
+    }
+
+    @Test
+    public void testDeserialize_UNSIGNED_16_BIT_INTEGER_small() {
+        int[] valIn = { 0x03, 0x00 };
+        int valOut = 0x03;
+        testDeserialize(valIn, valOut, ZclDataType.UNSIGNED_16_BIT_INTEGER);
+    }
+
+    @Test
+    public void testDeserialize_UNSIGNED_16_BIT_INTEGER_large() {
+        int[] valIn = { 0xFF, 0xFF };
+        int valOut = 65535;
+        testDeserialize(valIn, valOut, ZclDataType.UNSIGNED_16_BIT_INTEGER);
+    }
+
+    @Test
+    public void testDeserialize_UNSIGNED_24_BIT_INTEGER_small() {
+        int[] valIn = { 0x03, 0x00, 0x00 };
+        int valOut = 0x03;
+        testDeserialize(valIn, valOut, ZclDataType.UNSIGNED_24_BIT_INTEGER);
+    }
+
+    @Test
+    public void testDeserialize_UNSIGNED_24_BIT_INTEGER_large() {
+        int[] valIn = { 0xFF, 0xFF, 0xFF };
+        int valOut = 16777215;
+        testDeserialize(valIn, valOut, ZclDataType.UNSIGNED_24_BIT_INTEGER);
     }
 
     @Test


### PR DESCRIPTION
Here's a suggestion for parsing ZCL signed 24bit Integer values, assuming that the ZCL also requires two's-complement representation of signed numbers (I could not find that info in the ZCL spec, but from what I see this is also used for parsing signed 8/16bit Integers).

What this implementation does is:
* First, check the most significant bit to find out whether we have a positive or a negative number.
* In the positive case, we can just do the same as in the unsigned case.
* In the negative case, we get the value by computing the two's complement and negating it. We get the two's complement by taking the one's complement plus one (i.e., take the bitwise complement, mask out the upper 8 bits of the Java-32bit Integer because we only want 24bit, and add one).

I must admit that I do not know if there is some more "standard" method of doing this (and if there is, please don't hesitate to reject this PR; in case you could provide a pointer to that more "standard" method I could use that for a replacement PR); from my unit tests this method here appears to work though.

Resolves #1118

Signed-off-by: Henning Sudbrock <henning.sudbrock@telekom.de>