### PR TITLE
Improve handling of outstanding transaction counter in ZigBeeTransactionQueue

### DIFF
--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransactionManagerTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransactionManagerTest.java
@@ -33,6 +33,7 @@ import org.mockito.Mockito;
 import com.zsmartsystems.zigbee.CommandResult;
 import com.zsmartsystems.zigbee.IeeeAddress;
 import com.zsmartsystems.zigbee.TestUtilities;
+import com.zsmartsystems.zigbee.ZigBeeAddress;
 import com.zsmartsystems.zigbee.ZigBeeBroadcastDestination;
 import com.zsmartsystems.zigbee.ZigBeeCommand;
 import com.zsmartsystems.zigbee.ZigBeeEndpointAddress;
@@ -200,7 +201,14 @@ public class ZigBeeTransactionManagerTest {
         Mockito.when(networkManager.getNotificationService()).thenReturn(new NotificationService());
         ZigBeeTransactionManager transactionManager = new ZigBeeTransactionManager(networkManager);
 
+        ZigBeeNode node = Mockito.mock(ZigBeeNode.class);
+        Mockito.when(networkManager.getNode(ArgumentMatchers.anyInt())).thenReturn(node);
+        Mockito.when(node.getIeeeAddress()).thenReturn(new IeeeAddress("1234567890ABCDEF"));
+
+        ZigBeeAddress address = new ZigBeeEndpointAddress(0, 0);
         ZigBeeTransaction transaction = Mockito.mock(ZigBeeTransaction.class);
+        Mockito.when(transaction.getIeeeAddress()).thenReturn(new IeeeAddress("1234567890ABCDEF"));
+        Mockito.when(transaction.getDestinationAddress()).thenReturn(address);
 
         IeeeAddress ieeeAddress = new IeeeAddress("1234567890ABCDEF");
         ZigBeeTransactionQueue queue = Mockito.mock(ZigBeeTransactionQueue.class);

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransactionQueueTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransactionQueueTest.java
@@ -7,7 +7,11 @@
  */
 package com.zsmartsystems.zigbee.transaction;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
 import java.util.concurrent.Future;
@@ -100,12 +104,20 @@ public class ZigBeeTransactionQueueTest {
         assertNull(queue.getTransaction());
         assertEquals(0, queue.size());
         assertTrue(queue.isEmpty());
+        System.out.println(queue);
+
+        // Completing transactions that are not outstanding will be cancelled
+        ZigBeeTransaction transactionUnqueued = Mockito.mock(ZigBeeTransaction.class);
+        queue.transactionComplete(transactionUnqueued, TransactionState.TRANSMITTED);
+        Mockito.verify(transactionUnqueued, Mockito.times(1)).cancel();
 
         System.out.println(queue);
         queue.shutdown();
 
+        // Can't add transactions after shutdown
         assertNull(queue.addToQueue(Mockito.mock(ZigBeeTransaction.class)));
 
+        // Unknown transactions, or transactions after shutdown are cancelled
         ZigBeeTransaction transactionShutdown = Mockito.mock(ZigBeeTransaction.class);
         queue.transactionComplete(transactionShutdown, TransactionState.TRANSMITTED);
         Mockito.verify(transactionShutdown, Mockito.times(1)).cancel();


### PR DESCRIPTION
This ensures that the `outstandingTransaction` count in the `ZigBeeTransactionQueue` correctly counts transactions by storing them in a `Set` so that we can ensure that if a transaction were to somehow be completed twice, this does not result in double accounting.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>