### PR TITLE
Fix signed 24bit integer serialization test

### DIFF
--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/serialization/SerializerIntegrationTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/serialization/SerializerIntegrationTest.java
@@ -214,8 +214,14 @@ public class SerializerIntegrationTest {
     }
 
     @Test
-    public void testDeserialize_SIGNED_24_BIT_INTEGER() {
-        int valIn = 0x997186;
+    public void testDeserialize_SIGNED_24_BIT_INTEGER_positive_value() {
+        int valIn = 0x797186;
+        testSerializer(valIn, ZclDataType.SIGNED_24_BIT_INTEGER);
+    }
+
+    @Test
+    public void testDeserialize_SIGNED_24_BIT_INTEGER_negative_value() {
+        int valIn = -0x797186;
         testSerializer(valIn, ZclDataType.SIGNED_24_BIT_INTEGER);
     }
 


### PR DESCRIPTION
The old version of the test tried to serialize the number `0x997186`, which is larger than the largest signed 24bit integer (`0x7FFFFF`).

Resolves #1120 