### PR TITLE
Add option to not perform mesh update when devices join/leave

### DIFF
--- a/com.zsmartsystems.zigbee.console.main/src/main/java/com/zsmartsystems/zigbee/console/main/ZigBeeConsoleMain.java
+++ b/com.zsmartsystems.zigbee.console.main/src/main/java/com/zsmartsystems/zigbee/console/main/ZigBeeConsoleMain.java
@@ -378,6 +378,7 @@ public class ZigBeeConsoleMain {
 
         ZigBeeDiscoveryExtension discoveryExtension = new ZigBeeDiscoveryExtension();
         discoveryExtension.setUpdatePeriod(0);
+        discoveryExtension.setUpdateOnChange(false);
         networkManager.addExtension(discoveryExtension);
 
         supportedClientClusters.stream().forEach(clusterId -> networkManager.addSupportedClientCluster(clusterId));


### PR DESCRIPTION
This allows the mesh update to be disabled when an `Announce` is received. In larger networks this can cause considerable traffic, so this is disabled by default and enabled by system designers who understand their network choices.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>