### PR TITLE
Output queue size in ZigBeeTransactionQueue.toString()

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransactionQueue.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransactionQueue.java
@@ -325,14 +325,14 @@ public class ZigBeeTransactionQueue {
         LinkedList<ZigBeeTransaction> transactions = new LinkedList<>();
 
         synchronized (queue) {
-            ZigBeeTransaction zt = null;
-            while ((zt = queue.poll()) != null) {
-                if (!Objects.equals(zt.getDestinationAddress().getAddress(), newAddress)) {
+            ZigBeeTransaction transaction = null;
+            while ((transaction = queue.poll()) != null) {
+                if (!Objects.equals(transaction.getDestinationAddress().getAddress(), newAddress)) {
                     logger.debug("Rewriting transaction destination address from {} to {} in transaction={}",
-                            zt.getDestinationAddress().getAddress(), newAddress, zt);
-                    zt.getDestinationAddress().setAddress(newAddress);
+                            transaction.getDestinationAddress().getAddress(), newAddress, transaction);
+                    transaction.getDestinationAddress().setAddress(newAddress);
                 }
-                transactions.add(zt);
+                transactions.add(transaction);
             }
 
             for (ZigBeeTransaction trans : transactions) {
@@ -344,7 +344,8 @@ public class ZigBeeTransactionQueue {
     @Override
     public String toString() {
         return "ZigBeeTransactionQueue [queueName=" + queueName + ", deviceIeeeAddress=" + deviceIeeeAdress
-                + ", sleepy=" + sleepy + ", outstandingTransactions=" + outstandingTransactions.size() + ", profile="
+                + ", sleepy=" + sleepy + ", queued=" + queue.size() + ", outstandingTransactions="
+                + outstandingTransactions.size() + ", profile="
                 + profile
                 + "]";
     }


### PR DESCRIPTION
This simply prints the queue size in the `toString()` method of the `ZigBeeTransactionQueue`.

There is also a console command to dump all the queues. I've put this internal to the console rather than making a separate CLI class as it's using reflection so is a little nasty and considered only for low level debug at this stage. If we think it's useful, then we could add a public method to `ZigBeeNetworkManager` to get the `ZigBeeTransactionManager`, but that's for another day.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>