### PR TITLE
Update EZSP frames with no parameters to print networkId

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.ember.autocode/src/main/java/com/zsmartsystems/zigbee/dongle/ember/autocode/CommandGenerator.java
+++ b/com.zsmartsystems.zigbee.dongle.ember.autocode/src/main/java/com/zsmartsystems/zigbee/dongle/ember/autocode/CommandGenerator.java
@@ -235,35 +235,32 @@ public class CommandGenerator extends ClassGenerator {
         out.println("    @Override");
         out.println("    public String toString() {");
 
-        if (parameters == null || parameters.size() == 0) {
-            out.println("        return \"" + className + " []\";");
-        } else {
-            out.println("        final StringBuilder builder = new StringBuilder("
-                    + (className.length() + 3 + (parameters.size() + 1) * 25) + ");");
+        out.println("        final StringBuilder builder = new StringBuilder("
+                + (className.length() + 3 + (parameters.size() + 1) * 25) + ");");
 
-            out.println("        builder.append(\"" + className + " [networkId=\");");
-            out.println("        builder.append(networkId);");
+        out.println("        builder.append(\"" + className + " [networkId=\");");
+        out.println("        builder.append(networkId);");
 
-            for (Parameter parameter : parameters) {
-                if (parameter.auto_size != null) {
-                    continue;
-                }
-
-                out.println("        builder.append(\", " + parameter.name + "=\");");
-                if (parameter.data_type.contains("[")) {
-                    out.println("        for (int cnt = 0; cnt < " + parameter.name + ".length; cnt++) {");
-                    out.println("            if (cnt > 0) {");
-                    out.println("                builder.append(' ');");
-                    out.println("            }");
-                    out.println("            builder.append(" + formatParameterString(parameter) + ");");
-                    out.println("        }");
-                } else {
-                    out.println("        builder.append(" + formatParameterString(parameter) + ");");
-                }
+        for (Parameter parameter : parameters) {
+            if (parameter.auto_size != null) {
+                continue;
             }
-            out.println("        builder.append(']');");
-            out.println("        return builder.toString();");
+
+            out.println("        builder.append(\", " + parameter.name + "=\");");
+            if (parameter.data_type.contains("[")) {
+                out.println("        for (int cnt = 0; cnt < " + parameter.name + ".length; cnt++) {");
+                out.println("            if (cnt > 0) {");
+                out.println("                builder.append(' ');");
+                out.println("            }");
+                out.println("            builder.append(" + formatParameterString(parameter) + ");");
+                out.println("        }");
+            } else {
+                out.println("        builder.append(" + formatParameterString(parameter) + ");");
+            }
         }
+        out.println("        builder.append(']');");
+        out.println("        return builder.toString();");
+
         out.println("    }");
 
         out.println("}");

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspCallbackRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspCallbackRequest.java
@@ -48,6 +48,10 @@ public class EzspCallbackRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        return "EzspCallbackRequest []";
+        final StringBuilder builder = new StringBuilder(47);
+        builder.append("EzspCallbackRequest [networkId=");
+        builder.append(networkId);
+        builder.append(']');
+        return builder.toString();
     }
 }

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspCallbackResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspCallbackResponse.java
@@ -35,6 +35,10 @@ public class EzspCallbackResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        return "EzspCallbackResponse []";
+        final StringBuilder builder = new StringBuilder(48);
+        builder.append("EzspCallbackResponse [networkId=");
+        builder.append(networkId);
+        builder.append(']');
+        return builder.toString();
     }
 }

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspClearBindingTableRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspClearBindingTableRequest.java
@@ -48,6 +48,10 @@ public class EzspClearBindingTableRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        return "EzspClearBindingTableRequest []";
+        final StringBuilder builder = new StringBuilder(56);
+        builder.append("EzspClearBindingTableRequest [networkId=");
+        builder.append(networkId);
+        builder.append(']');
+        return builder.toString();
     }
 }

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspClearKeyTableRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspClearKeyTableRequest.java
@@ -48,6 +48,10 @@ public class EzspClearKeyTableRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        return "EzspClearKeyTableRequest []";
+        final StringBuilder builder = new StringBuilder(52);
+        builder.append("EzspClearKeyTableRequest [networkId=");
+        builder.append(networkId);
+        builder.append(']');
+        return builder.toString();
     }
 }

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspClearStoredBeaconsRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspClearStoredBeaconsRequest.java
@@ -48,6 +48,10 @@ public class EzspClearStoredBeaconsRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        return "EzspClearStoredBeaconsRequest []";
+        final StringBuilder builder = new StringBuilder(57);
+        builder.append("EzspClearStoredBeaconsRequest [networkId=");
+        builder.append(networkId);
+        builder.append(']');
+        return builder.toString();
     }
 }

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspClearStoredBeaconsResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspClearStoredBeaconsResponse.java
@@ -35,6 +35,10 @@ public class EzspClearStoredBeaconsResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        return "EzspClearStoredBeaconsResponse []";
+        final StringBuilder builder = new StringBuilder(58);
+        builder.append("EzspClearStoredBeaconsResponse [networkId=");
+        builder.append(networkId);
+        builder.append(']');
+        return builder.toString();
     }
 }

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspClearTransientLinkKeysRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspClearTransientLinkKeysRequest.java
@@ -48,6 +48,10 @@ public class EzspClearTransientLinkKeysRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        return "EzspClearTransientLinkKeysRequest []";
+        final StringBuilder builder = new StringBuilder(61);
+        builder.append("EzspClearTransientLinkKeysRequest [networkId=");
+        builder.append(networkId);
+        builder.append(']');
+        return builder.toString();
     }
 }

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspClearTransientLinkKeysResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspClearTransientLinkKeysResponse.java
@@ -35,6 +35,10 @@ public class EzspClearTransientLinkKeysResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        return "EzspClearTransientLinkKeysResponse []";
+        final StringBuilder builder = new StringBuilder(62);
+        builder.append("EzspClearTransientLinkKeysResponse [networkId=");
+        builder.append(networkId);
+        builder.append(']');
+        return builder.toString();
     }
 }

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGenerateCbkeKeys283k1Request.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGenerateCbkeKeys283k1Request.java
@@ -50,6 +50,10 @@ public class EzspGenerateCbkeKeys283k1Request extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        return "EzspGenerateCbkeKeys283k1Request []";
+        final StringBuilder builder = new StringBuilder(60);
+        builder.append("EzspGenerateCbkeKeys283k1Request [networkId=");
+        builder.append(networkId);
+        builder.append(']');
+        return builder.toString();
     }
 }

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGenerateCbkeKeysRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGenerateCbkeKeysRequest.java
@@ -49,6 +49,10 @@ public class EzspGenerateCbkeKeysRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        return "EzspGenerateCbkeKeysRequest []";
+        final StringBuilder builder = new StringBuilder(55);
+        builder.append("EzspGenerateCbkeKeysRequest [networkId=");
+        builder.append(networkId);
+        builder.append(']');
+        return builder.toString();
     }
 }

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetCertificate283k1Request.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetCertificate283k1Request.java
@@ -48,6 +48,10 @@ public class EzspGetCertificate283k1Request extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        return "EzspGetCertificate283k1Request []";
+        final StringBuilder builder = new StringBuilder(58);
+        builder.append("EzspGetCertificate283k1Request [networkId=");
+        builder.append(networkId);
+        builder.append(']');
+        return builder.toString();
     }
 }

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetCertificateRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetCertificateRequest.java
@@ -48,6 +48,10 @@ public class EzspGetCertificateRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        return "EzspGetCertificateRequest []";
+        final StringBuilder builder = new StringBuilder(53);
+        builder.append("EzspGetCertificateRequest [networkId=");
+        builder.append(networkId);
+        builder.append(']');
+        return builder.toString();
     }
 }

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetCurrentSecurityStateRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetCurrentSecurityStateRequest.java
@@ -48,6 +48,10 @@ public class EzspGetCurrentSecurityStateRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        return "EzspGetCurrentSecurityStateRequest []";
+        final StringBuilder builder = new StringBuilder(62);
+        builder.append("EzspGetCurrentSecurityStateRequest [networkId=");
+        builder.append(networkId);
+        builder.append(']');
+        return builder.toString();
     }
 }

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetEui64Request.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetEui64Request.java
@@ -48,6 +48,10 @@ public class EzspGetEui64Request extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        return "EzspGetEui64Request []";
+        final StringBuilder builder = new StringBuilder(47);
+        builder.append("EzspGetEui64Request [networkId=");
+        builder.append(networkId);
+        builder.append(']');
+        return builder.toString();
     }
 }

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetFirstBeaconRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetFirstBeaconRequest.java
@@ -49,6 +49,10 @@ public class EzspGetFirstBeaconRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        return "EzspGetFirstBeaconRequest []";
+        final StringBuilder builder = new StringBuilder(53);
+        builder.append("EzspGetFirstBeaconRequest [networkId=");
+        builder.append(networkId);
+        builder.append(']');
+        return builder.toString();
     }
 }

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetNetworkParametersRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetNetworkParametersRequest.java
@@ -48,6 +48,10 @@ public class EzspGetNetworkParametersRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        return "EzspGetNetworkParametersRequest []";
+        final StringBuilder builder = new StringBuilder(59);
+        builder.append("EzspGetNetworkParametersRequest [networkId=");
+        builder.append(networkId);
+        builder.append(']');
+        return builder.toString();
     }
 }

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetNextBeaconRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetNextBeaconRequest.java
@@ -49,6 +49,10 @@ public class EzspGetNextBeaconRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        return "EzspGetNextBeaconRequest []";
+        final StringBuilder builder = new StringBuilder(52);
+        builder.append("EzspGetNextBeaconRequest [networkId=");
+        builder.append(networkId);
+        builder.append(']');
+        return builder.toString();
     }
 }

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetNodeIdRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetNodeIdRequest.java
@@ -48,6 +48,10 @@ public class EzspGetNodeIdRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        return "EzspGetNodeIdRequest []";
+        final StringBuilder builder = new StringBuilder(48);
+        builder.append("EzspGetNodeIdRequest [networkId=");
+        builder.append(networkId);
+        builder.append(']');
+        return builder.toString();
     }
 }

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetNumStoredBeaconsRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetNumStoredBeaconsRequest.java
@@ -48,6 +48,10 @@ public class EzspGetNumStoredBeaconsRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        return "EzspGetNumStoredBeaconsRequest []";
+        final StringBuilder builder = new StringBuilder(58);
+        builder.append("EzspGetNumStoredBeaconsRequest [networkId=");
+        builder.append(networkId);
+        builder.append(']');
+        return builder.toString();
     }
 }

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetParentChildParametersRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetParentChildParametersRequest.java
@@ -48,6 +48,10 @@ public class EzspGetParentChildParametersRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        return "EzspGetParentChildParametersRequest []";
+        final StringBuilder builder = new StringBuilder(63);
+        builder.append("EzspGetParentChildParametersRequest [networkId=");
+        builder.append(networkId);
+        builder.append(']');
+        return builder.toString();
     }
 }

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetStandaloneBootloaderVersionPlatMicroPhyRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetStandaloneBootloaderVersionPlatMicroPhyRequest.java
@@ -50,6 +50,10 @@ public class EzspGetStandaloneBootloaderVersionPlatMicroPhyRequest extends EzspF
 
     @Override
     public String toString() {
-        return "EzspGetStandaloneBootloaderVersionPlatMicroPhyRequest []";
+        final StringBuilder builder = new StringBuilder(81);
+        builder.append("EzspGetStandaloneBootloaderVersionPlatMicroPhyRequest [networkId=");
+        builder.append(networkId);
+        builder.append(']');
+        return builder.toString();
     }
 }

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetXncpInfoRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGetXncpInfoRequest.java
@@ -50,6 +50,10 @@ public class EzspGetXncpInfoRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        return "EzspGetXncpInfoRequest []";
+        final StringBuilder builder = new StringBuilder(50);
+        builder.append("EzspGetXncpInfoRequest [networkId=");
+        builder.append(networkId);
+        builder.append(']');
+        return builder.toString();
     }
 }

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGpSinkTableClearAllRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGpSinkTableClearAllRequest.java
@@ -48,6 +48,10 @@ public class EzspGpSinkTableClearAllRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        return "EzspGpSinkTableClearAllRequest []";
+        final StringBuilder builder = new StringBuilder(58);
+        builder.append("EzspGpSinkTableClearAllRequest [networkId=");
+        builder.append(networkId);
+        builder.append(']');
+        return builder.toString();
     }
 }

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGpSinkTableClearAllResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGpSinkTableClearAllResponse.java
@@ -35,6 +35,10 @@ public class EzspGpSinkTableClearAllResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        return "EzspGpSinkTableClearAllResponse []";
+        final StringBuilder builder = new StringBuilder(59);
+        builder.append("EzspGpSinkTableClearAllResponse [networkId=");
+        builder.append(networkId);
+        builder.append(']');
+        return builder.toString();
     }
 }

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGpSinkTableInitRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGpSinkTableInitRequest.java
@@ -48,6 +48,10 @@ public class EzspGpSinkTableInitRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        return "EzspGpSinkTableInitRequest []";
+        final StringBuilder builder = new StringBuilder(54);
+        builder.append("EzspGpSinkTableInitRequest [networkId=");
+        builder.append(networkId);
+        builder.append(']');
+        return builder.toString();
     }
 }

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGpSinkTableInitResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGpSinkTableInitResponse.java
@@ -35,6 +35,10 @@ public class EzspGpSinkTableInitResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        return "EzspGpSinkTableInitResponse []";
+        final StringBuilder builder = new StringBuilder(55);
+        builder.append("EzspGpSinkTableInitResponse [networkId=");
+        builder.append(networkId);
+        builder.append(']');
+        return builder.toString();
     }
 }

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGpSinkTableRemoveEntryResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGpSinkTableRemoveEntryResponse.java
@@ -35,6 +35,10 @@ public class EzspGpSinkTableRemoveEntryResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        return "EzspGpSinkTableRemoveEntryResponse []";
+        final StringBuilder builder = new StringBuilder(62);
+        builder.append("EzspGpSinkTableRemoveEntryResponse [networkId=");
+        builder.append(networkId);
+        builder.append(']');
+        return builder.toString();
     }
 }

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspInvalidCommandRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspInvalidCommandRequest.java
@@ -48,6 +48,10 @@ public class EzspInvalidCommandRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        return "EzspInvalidCommandRequest []";
+        final StringBuilder builder = new StringBuilder(53);
+        builder.append("EzspInvalidCommandRequest [networkId=");
+        builder.append(networkId);
+        builder.append(']');
+        return builder.toString();
     }
 }

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspLeaveNetworkRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspLeaveNetworkRequest.java
@@ -50,6 +50,10 @@ public class EzspLeaveNetworkRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        return "EzspLeaveNetworkRequest []";
+        final StringBuilder builder = new StringBuilder(51);
+        builder.append("EzspLeaveNetworkRequest [networkId=");
+        builder.append(networkId);
+        builder.append(']');
+        return builder.toString();
     }
 }

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspMfglibEndRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspMfglibEndRequest.java
@@ -49,6 +49,10 @@ public class EzspMfglibEndRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        return "EzspMfglibEndRequest []";
+        final StringBuilder builder = new StringBuilder(48);
+        builder.append("EzspMfglibEndRequest [networkId=");
+        builder.append(networkId);
+        builder.append(']');
+        return builder.toString();
     }
 }

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspMfglibGetChannelRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspMfglibGetChannelRequest.java
@@ -48,6 +48,10 @@ public class EzspMfglibGetChannelRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        return "EzspMfglibGetChannelRequest []";
+        final StringBuilder builder = new StringBuilder(55);
+        builder.append("EzspMfglibGetChannelRequest [networkId=");
+        builder.append(networkId);
+        builder.append(']');
+        return builder.toString();
     }
 }

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspMfglibGetPowerRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspMfglibGetPowerRequest.java
@@ -48,6 +48,10 @@ public class EzspMfglibGetPowerRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        return "EzspMfglibGetPowerRequest []";
+        final StringBuilder builder = new StringBuilder(53);
+        builder.append("EzspMfglibGetPowerRequest [networkId=");
+        builder.append(networkId);
+        builder.append(']');
+        return builder.toString();
     }
 }

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspMfglibStartStreamRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspMfglibStartStreamRequest.java
@@ -49,6 +49,10 @@ public class EzspMfglibStartStreamRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        return "EzspMfglibStartStreamRequest []";
+        final StringBuilder builder = new StringBuilder(56);
+        builder.append("EzspMfglibStartStreamRequest [networkId=");
+        builder.append(networkId);
+        builder.append(']');
+        return builder.toString();
     }
 }

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspMfglibStartToneRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspMfglibStartToneRequest.java
@@ -51,6 +51,10 @@ public class EzspMfglibStartToneRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        return "EzspMfglibStartToneRequest []";
+        final StringBuilder builder = new StringBuilder(54);
+        builder.append("EzspMfglibStartToneRequest [networkId=");
+        builder.append(networkId);
+        builder.append(']');
+        return builder.toString();
     }
 }

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspMfglibStopStreamRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspMfglibStopStreamRequest.java
@@ -48,6 +48,10 @@ public class EzspMfglibStopStreamRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        return "EzspMfglibStopStreamRequest []";
+        final StringBuilder builder = new StringBuilder(55);
+        builder.append("EzspMfglibStopStreamRequest [networkId=");
+        builder.append(networkId);
+        builder.append(']');
+        return builder.toString();
     }
 }

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspMfglibStopToneRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspMfglibStopToneRequest.java
@@ -48,6 +48,10 @@ public class EzspMfglibStopToneRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        return "EzspMfglibStopToneRequest []";
+        final StringBuilder builder = new StringBuilder(53);
+        builder.append("EzspMfglibStopToneRequest [networkId=");
+        builder.append(networkId);
+        builder.append(']');
+        return builder.toString();
     }
 }

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspNeighborCountRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspNeighborCountRequest.java
@@ -48,6 +48,10 @@ public class EzspNeighborCountRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        return "EzspNeighborCountRequest []";
+        final StringBuilder builder = new StringBuilder(52);
+        builder.append("EzspNeighborCountRequest [networkId=");
+        builder.append(networkId);
+        builder.append(']');
+        return builder.toString();
     }
 }

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspNetworkInitRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspNetworkInitRequest.java
@@ -50,6 +50,10 @@ public class EzspNetworkInitRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        return "EzspNetworkInitRequest []";
+        final StringBuilder builder = new StringBuilder(50);
+        builder.append("EzspNetworkInitRequest [networkId=");
+        builder.append(networkId);
+        builder.append(']');
+        return builder.toString();
     }
 }

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspNetworkStateRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspNetworkStateRequest.java
@@ -48,6 +48,10 @@ public class EzspNetworkStateRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        return "EzspNetworkStateRequest []";
+        final StringBuilder builder = new StringBuilder(51);
+        builder.append("EzspNetworkStateRequest [networkId=");
+        builder.append(networkId);
+        builder.append(']');
+        return builder.toString();
     }
 }

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspNoCallbacksRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspNoCallbacksRequest.java
@@ -48,6 +48,10 @@ public class EzspNoCallbacksRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        return "EzspNoCallbacksRequest []";
+        final StringBuilder builder = new StringBuilder(50);
+        builder.append("EzspNoCallbacksRequest [networkId=");
+        builder.append(networkId);
+        builder.append(']');
+        return builder.toString();
     }
 }

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspNoCallbacksResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspNoCallbacksResponse.java
@@ -35,6 +35,10 @@ public class EzspNoCallbacksResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        return "EzspNoCallbacksResponse []";
+        final StringBuilder builder = new StringBuilder(51);
+        builder.append("EzspNoCallbacksResponse [networkId=");
+        builder.append(networkId);
+        builder.append(']');
+        return builder.toString();
     }
 }

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspNopRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspNopRequest.java
@@ -49,6 +49,10 @@ public class EzspNopRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        return "EzspNopRequest []";
+        final StringBuilder builder = new StringBuilder(42);
+        builder.append("EzspNopRequest [networkId=");
+        builder.append(networkId);
+        builder.append(']');
+        return builder.toString();
     }
 }

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspNopResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspNopResponse.java
@@ -36,6 +36,10 @@ public class EzspNopResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        return "EzspNopResponse []";
+        final StringBuilder builder = new StringBuilder(43);
+        builder.append("EzspNopResponse [networkId=");
+        builder.append(networkId);
+        builder.append(']');
+        return builder.toString();
     }
 }

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspReadAndClearCountersRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspReadAndClearCountersRequest.java
@@ -49,6 +49,10 @@ public class EzspReadAndClearCountersRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        return "EzspReadAndClearCountersRequest []";
+        final StringBuilder builder = new StringBuilder(59);
+        builder.append("EzspReadAndClearCountersRequest [networkId=");
+        builder.append(networkId);
+        builder.append(']');
+        return builder.toString();
     }
 }

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspReadCountersRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspReadCountersRequest.java
@@ -48,6 +48,10 @@ public class EzspReadCountersRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        return "EzspReadCountersRequest []";
+        final StringBuilder builder = new StringBuilder(51);
+        builder.append("EzspReadCountersRequest [networkId=");
+        builder.append(networkId);
+        builder.append(']');
+        return builder.toString();
     }
 }

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspResetToFactoryDefaultsRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspResetToFactoryDefaultsRequest.java
@@ -48,6 +48,10 @@ public class EzspResetToFactoryDefaultsRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        return "EzspResetToFactoryDefaultsRequest []";
+        final StringBuilder builder = new StringBuilder(61);
+        builder.append("EzspResetToFactoryDefaultsRequest [networkId=");
+        builder.append(networkId);
+        builder.append(']');
+        return builder.toString();
     }
 }

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetBindingRemoteNodeIdResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetBindingRemoteNodeIdResponse.java
@@ -36,6 +36,10 @@ public class EzspSetBindingRemoteNodeIdResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        return "EzspSetBindingRemoteNodeIdResponse []";
+        final StringBuilder builder = new StringBuilder(62);
+        builder.append("EzspSetBindingRemoteNodeIdResponse [networkId=");
+        builder.append(networkId);
+        builder.append(']');
+        return builder.toString();
     }
 }

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetExtendedTimeoutResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetExtendedTimeoutResponse.java
@@ -42,6 +42,10 @@ public class EzspSetExtendedTimeoutResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        return "EzspSetExtendedTimeoutResponse []";
+        final StringBuilder builder = new StringBuilder(58);
+        builder.append("EzspSetExtendedTimeoutResponse [networkId=");
+        builder.append(networkId);
+        builder.append(']');
+        return builder.toString();
     }
 }

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetManufacturerCodeResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetManufacturerCodeResponse.java
@@ -36,6 +36,10 @@ public class EzspSetManufacturerCodeResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        return "EzspSetManufacturerCodeResponse []";
+        final StringBuilder builder = new StringBuilder(59);
+        builder.append("EzspSetManufacturerCodeResponse [networkId=");
+        builder.append(networkId);
+        builder.append(']');
+        return builder.toString();
     }
 }

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetPowerDescriptorResponse.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetPowerDescriptorResponse.java
@@ -36,6 +36,10 @@ public class EzspSetPowerDescriptorResponse extends EzspFrameResponse {
 
     @Override
     public String toString() {
-        return "EzspSetPowerDescriptorResponse []";
+        final StringBuilder builder = new StringBuilder(58);
+        builder.append("EzspSetPowerDescriptorResponse [networkId=");
+        builder.append(networkId);
+        builder.append(']');
+        return builder.toString();
     }
 }

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetPreinstalledCbkeData283k1Request.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspSetPreinstalledCbkeData283k1Request.java
@@ -50,6 +50,10 @@ public class EzspSetPreinstalledCbkeData283k1Request extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        return "EzspSetPreinstalledCbkeData283k1Request []";
+        final StringBuilder builder = new StringBuilder(67);
+        builder.append("EzspSetPreinstalledCbkeData283k1Request [networkId=");
+        builder.append(networkId);
+        builder.append(']');
+        return builder.toString();
     }
 }

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspStopScanRequest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspStopScanRequest.java
@@ -48,6 +48,10 @@ public class EzspStopScanRequest extends EzspFrameRequest {
 
     @Override
     public String toString() {
-        return "EzspStopScanRequest []";
+        final StringBuilder builder = new StringBuilder(47);
+        builder.append("EzspStopScanRequest [networkId=");
+        builder.append(networkId);
+        builder.append(']');
+        return builder.toString();
     }
 }


### PR DESCRIPTION
This simply adds `networkId` to EZSP commands that missed that previously as the autocoder didn't generate this if the command had no parameters.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>