### PR TITLE
Use default endpoint

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
@@ -847,7 +847,7 @@ public class ZigBeeNetworkManager implements ZigBeeTransportReceive {
             // The ZCL packet is serialised here.
             ZclCommand zclCommand = (ZclCommand) command;
 
-            apsFrame.setSourceEndpoint(1);
+            apsFrame.setSourceEndpoint(localEndpointId);
 
             // Set the profile
             apsFrame.setProfile(defaultProfileId);


### PR DESCRIPTION
Follow on from #1143 as I missed one place where the hard coded endpoint was used.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>