### PR TITLE
channel default UNKNOWN so that quietest channel is selected

### DIFF
--- a/com.zsmartsystems.zigbee.console.main/src/main/java/com/zsmartsystems/zigbee/console/main/ZigBeeConsoleMain.java
+++ b/com.zsmartsystems.zigbee.console.main/src/main/java/com/zsmartsystems/zigbee/console/main/ZigBeeConsoleMain.java
@@ -325,7 +325,7 @@ public class ZigBeeConsoleMain {
             if (cmdline.hasOption("channel")) {
                 channel = parseDecimalOrHexInt(cmdline.getOptionValue("channel"));
             } else {
-                channel = 11;
+                channel = -1;
             }
             if (cmdline.hasOption("pan")) {
                 pan = parseDecimalOrHexInt(cmdline.getOptionValue("pan"));


### PR DESCRIPTION
Currently, using the console application, we could trigger selection of the quietest channel by specifying channel -1. However, I think it would be more intuitive to not provide channel argument at all so that quietest channel is selected.