### PR TITLE
Fix NPE in EmberNCP::setConfiguration

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/EmberNcp.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/EmberNcp.java
@@ -456,6 +456,12 @@ public class EmberNcp {
                 new EzspSingleResponseTransaction(request, EzspSetConfigurationValueResponse.class));
         EzspSetConfigurationValueResponse response = (EzspSetConfigurationValueResponse) transaction.getResponse();
         lastStatus = null;
+
+        if(response == null)
+        {
+            return null;
+        }
+
         logger.debug(response.toString());
 
         return response.getStatus();


### PR DESCRIPTION
This change fixes a NullPointerException in EmberNCP::setConfiguration when the response is null.
See #982.