### PR TITLE
Improve ordering of SEClient logging

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/seclient/SmartEnergyClient.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/seclient/SmartEnergyClient.java
@@ -333,9 +333,10 @@ public class SmartEnergyClient implements ZigBeeNetworkExtension, ZigBeeCommandL
             logger.debug("Unable to find CBKE Client for endpoint {}", endpoint);
             return ZigBeeStatus.FAILURE;
         }
-        keClient.start();
 
         logger.debug("Manually starting CBKE Client for endpoint {}", endpoint);
+        keClient.start();
+
         return ZigBeeStatus.SUCCESS;
     }
 


### PR DESCRIPTION
Ensures that the "Start" log entry comes before any "Failed" log entry.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>