### PR TITLE
Manage multiple device types profiles.

### DIFF
--- a/com.zsmartsystems.zigbee.autocode/src/main/java/com/zsmartsystems/zigbee/autocode/xml/ZigBeeXmlConstantValue.java
+++ b/com.zsmartsystems.zigbee.autocode/src/main/java/com/zsmartsystems/zigbee/autocode/xml/ZigBeeXmlConstantValue.java
@@ -7,16 +7,15 @@
  */
 package com.zsmartsystems.zigbee.autocode.xml;
 
-import java.util.List;
+import java.math.BigInteger;
 
 /**
  *
  * @author Chris Jackson (zsmartsystems.com)
  *
  */
-public class ZigBeeXmlConstant {
+public class ZigBeeXmlConstantValue {
+    public String scope;
+    public BigInteger code;
     public String name;
-    public String className;
-    public List<ZigBeeXmlDescription> description;
-    public List<ZigBeeXmlConstantValue> values;
 }

--- a/com.zsmartsystems.zigbee.autocode/src/main/java/com/zsmartsystems/zigbee/autocode/xml/ZigBeeXmlParser.java
+++ b/com.zsmartsystems.zigbee.autocode/src/main/java/com/zsmartsystems/zigbee/autocode/xml/ZigBeeXmlParser.java
@@ -11,7 +11,6 @@ import java.io.File;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.TreeMap;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -260,7 +259,7 @@ public class ZigBeeXmlParser {
 
                 constant.className = e.getAttribute("class").trim();
 
-                constant.values = new TreeMap<>();
+                constant.values = new ArrayList<>();
 
                 for (int temp = 0; temp < nodes.getLength(); temp++) {
                     if (nodes.item(temp).getNodeName().equals("name")) {
@@ -274,9 +273,11 @@ public class ZigBeeXmlParser {
                     }
                     if (nodes.item(temp).getNodeName().equals("value")) {
                         e = (Element) nodes.item(temp);
-                        String name = e.getAttribute("name").trim();
-                        BigInteger value = getInteger(e.getAttribute("code").trim());
-                        constant.values.put(value, name);
+                        ZigBeeXmlConstantValue value = new ZigBeeXmlConstantValue();
+                        value.scope = e.getAttribute("scope").trim();
+                        value.name = e.getAttribute("name").trim();
+                        value.code = getInteger(e.getAttribute("code").trim());
+                        constant.values.add(value);
                     }
                 }
 

--- a/com.zsmartsystems.zigbee.autocode/src/main/resources/zigbee-description.xsd
+++ b/com.zsmartsystems.zigbee.autocode/src/main/resources/zigbee-description.xsd
@@ -65,12 +65,12 @@
 						<xs:sequence>
 							<xs:element type="xs:string" name="name" />
 							<xs:element type="xs:string" name="description" maxOccurs="unbounded" minOccurs="0" />
-							<xs:element name="value" maxOccurs="unbounded" minOccurs="0">
+							<xs:element name="value" maxOccurs="unbounded" minOccurs="1">
 								<xs:complexType>
 									<xs:simpleContent>
 										<xs:extension base="xs:string">
-											<xs:attribute type="xs:string" name="code" use="optional" />
-											<xs:attribute type="xs:string" name="name" use="optional" />
+											<xs:attribute type="xs:string" name="code" use="required" />
+											<xs:attribute type="xs:string" name="name" use="required" />
 										</xs:extension>
 									</xs:simpleContent>
 								</xs:complexType>
@@ -113,8 +113,9 @@
                 <xs:complexType>
                   <xs:simpleContent>
                     <xs:extension base="xs:string">
-                      <xs:attribute type="xs:string" name="code" use="optional"/>
-                      <xs:attribute type="xs:string" name="name" use="optional"/>
+                      <xs:attribute type="xs:string" name="scope" use="optional" />
+                      <xs:attribute type="xs:string" name="code" use="required"/>
+                      <xs:attribute type="xs:string" name="name" use="required"/>
                     </xs:extension>
                   </xs:simpleContent>
                 </xs:complexType>

--- a/com.zsmartsystems.zigbee.autocode/src/main/resources/zigbee_constants.xml
+++ b/com.zsmartsystems.zigbee.autocode/src/main/resources/zigbee_constants.xml
@@ -2,104 +2,129 @@
 	xsi:noNamespaceSchemaLocation="zigbee-description.xsd">
 	<constant class="ZigBeeDeviceType">
 		<name>ZigBee Device Type</name>
-        <value code="0x0000" name="On/Off Switch" />
-		<value code="0x0001" name="Level Control Switch" />
-		<value code="0x0002" name="On/Off Output" />
-		<value code="0x0003" name="Level Controllable Output" />
-		<value code="0x0004" name="Scene Selector" />
-		<value code="0x0005" name="Configuration Tool" />
-		<value code="0x0006" name="Remote Control" />
-		<value code="0x0007" name="Combined Interface" />
-		<value code="0x0008" name="Range Extender" />
-		<value code="0x0009" name="Mains Power Outlet" />
-		<value code="0x000A" name="Door Lock" />
-		<value code="0x000B" name="Door Lock Controller" />
-		<value code="0x000C" name="Simple Sensor" />
-		<value code="0x000D" name="Consumption Awareness Device" />
-		<value code="0x0010" name="Data Collection Unit" />
-		<value code="0x0020" name="ZigBee SIM Card" />
-		<value code="0x0021" name="ZigBee Mobile Terminal" />
-		<value code="0x0026" name="ZigBee Global Platform Card" />
-		<value code="0x0030" name="Customer Handheld Device" />
-		<value code="0x0031" name="Retail Associate Handheld Device " />
-		<value code="0x0032" name="Intelligent Shopping Cart" />
-		<value code="0x0033" name="Electronic Shelf Label" />
-		<value code="0x0034" name="Customer Information Point" />
-		<value code="0x0035" name="Customer Card" />
-		<value code="0x004A" name="Constructed BACnet Device" />
-		<value code="0x004B" name="BACnet Tunneled Device" />
-		<value code="0x0050" name="Home Gateway" />
-		<value code="0x0051" name="Smart Plug" />
-		<value code="0x0052" name="White Goods" />
-		<value code="0x0053" name="Meter Interface" />
-		<value code="0x0060" name="ZGP Proxy" />
-		<value code="0x0061" name="ZGP Proxy Basic" />
-		<value code="0x0062" name="ZGP Target Plus" />
-		<value code="0x0063" name="ZGP Target" />
-		<value code="0x0064" name="ZGP Commissioning Tool" />
-		<value code="0x0065" name="ZGP Combo" />
-		<value code="0x0066" name="ZGP Combo Basic" />
-		<value code="0x0067" name="Environmental Sensor" />
-		<value code="0x0100" name="On/Off Light" />
-		<value code="0x0101" name="Dimmable Light" />
-		<value code="0x0102" name="Color Dimmable Light" />
-		<value code="0x0103" name="On/Off Light Switch" />
-		<value code="0x0104" name="Dimmer Switch" />
-		<value code="0x0105" name="Color Dimmer Switch" />
-		<value code="0x0106" name="Light Sensor" />
-		<value code="0x0107" name="Occupancy Sensor" />
-		<value code="0x0108" name="On/Off Ballast" />
-		<value code="0x0109" name="Dimmable Ballast" />
-		<value code="0x010A" name="On/off plug-in unit" />
-		<value code="0x010B" name="Dimmable plug-in unit" />
-		<value code="0x010C" name="Color temperature light" />
-		<value code="0x010D" name="Extended color light" />
-		<value code="0x010E" name="Light level sensor" />
-		<value code="0x0120" name="ZigBee Access Point" />
-		<value code="0x0121" name="ZigBee Information node" />
-		<value code="0x0122" name="ZigBee Information Terminal" />
-		<value code="0x0200" name="Shade" />
-		<value code="0x0201" name="Shade Controller" />
-		<value code="0x0202" name="Window Covering Device" />
-		<value code="0x0203" name="Window Covering Controller" />
-		<value code="0x0204" name="Barrier Device" />
-		<value code="0x0205" name="Barrier Device Controller" />
-		<value code="0x0220" name="Point of sale" />
-		<value code="0x0221" name="Ticketing machine" />
-		<value code="0x0222" name="Pay controller" />
-		<value code="0x0223" name="Billing unit" />
-		<value code="0x0224" name="Charging unit" />
-		<value code="0x0300" name="Heating/Cooling Unit" />
-		<value code="0x0301" name="Thermostat" />
-		<value code="0x0302" name="Temperature Sensor" />
-		<value code="0x0303" name="Pump" />
-		<value code="0x0304" name="Pump Controller" />
-		<value code="0x0305" name="Pressure Sensor" />
-		<value code="0x0306" name="Flow Sensor" />
-		<value code="0x0307" name="Mini Split AC" />
-		<value code="0x0400" name="IAS Control and Indicating Equipment" />
-		<value code="0x0401" name="IAS Ancillary Control Equipment" />
-		<value code="0x0402" name="IAS Zone" />
-		<value code="0x0403" name="IAS Warning Device" />
-		<value code="0x0500" name="Energy Service Interface" />
-		<value code="0x0501" name="Metering Device" />
-		<value code="0x0502" name="In-Home Display" />
-		<value code="0x0503" name="Programmable Communicating Thermostat" />
-		<value code="0x0504" name="Load Control Device" />
-		<value code="0x0505" name="Smart Appliance" />
-		<value code="0x0506" name="Prepayment Terminal" />
-		<value code="0x0507" name="Physical Device" />
-		<value code="0x0508" name="Remote Communications Device" />
-		<value code="0x0509" name="ERL Interface" />
-		<value code="0x050A" name="Electric Vehicle Station Equipment" />
-		<value code="0x0800" name="Color controller" />
-		<value code="0x0810" name="Color scene controller" />
-		<value code="0x0820" name="Non-color controller" />
-		<value code="0x0830" name="Non-color scene controller" />
-		<value code="0x0840" name="Control bridge" />
-		<value code="0x0850" name="On/off sensor" />
-		<value code="0x0F00" name="Generic Multifunction Healthcare Device" />
+        <value code="0x0000" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="On/Off Switch" />
+		<value code="0x0001" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="Level Control Switch" />
+		<value code="0x0002" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="On/Off Output" />
+		<value code="0x0003" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="Level Controllable Output" />
+		<value code="0x0004" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="Scene Selector" />
+		<value code="0x0005" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="Configuration Tool" />
+		<value code="0x0006" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="Remote Control" />
+		<value code="0x0007" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="Combined Interface" />
+		<value code="0x0008" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="Range Extender" />
+		<value code="0x0009" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="Mains Power Outlet" />
+		<value code="0x000A" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="Door Lock" />
+		<value code="0x000B" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="Door Lock Controller" />
+		<value code="0x000C" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="Simple Sensor" />
+		<value code="0x000D" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="Consumption Awareness Device" />
+		<value code="0x0010" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="Data Collection Unit" />
+		<value code="0x0020" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="ZigBee SIM Card" />
+		<value code="0x0021" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="ZigBee Mobile Terminal" />
+		<value code="0x0026" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="ZigBee Global Platform Card" />
+		<value code="0x0030" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="Customer Handheld Device" />
+		<value code="0x0031" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="Retail Associate Handheld Device " />
+		<value code="0x0032" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="Intelligent Shopping Cart" />
+		<value code="0x0033" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="Electronic Shelf Label" />
+		<value code="0x0034" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="Customer Information Point" />
+		<value code="0x0035" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="Customer Card" />
+		<value code="0x004A" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="Constructed BACnet Device" />
+		<value code="0x004B" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="BACnet Tunneled Device" />
+		<value code="0x0050" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="Home Gateway" />
+		<value code="0x0051" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="Smart Plug" />
+		<value code="0x0052" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="White Goods" />
+		<value code="0x0053" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="Meter Interface" />
+		<value code="0x0060" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="ZGP Proxy" />
+		<value code="0x0061" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="ZGP Proxy Basic" />
+		<value code="0x0062" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="ZGP Target Plus" />
+		<value code="0x0063" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="ZGP Target" />
+		<value code="0x0064" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="ZGP Commissioning Tool" />
+		<value code="0x0065" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="ZGP Combo" />
+		<value code="0x0066" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="ZGP Combo Basic" />
+		<value code="0x0067" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="Environmental Sensor" />
+		<value code="0x0100" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="On/Off Light" />
+		<value code="0x0101" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="Dimmable Light" />
+		<value code="0x0102" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="Color Dimmable Light" />
+		<value code="0x0103" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="On/Off Light Switch" />
+		<value code="0x0104" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="Dimmer Switch" />
+		<value code="0x0105" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="Color Dimmer Switch" />
+		<value code="0x0106" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="Light Sensor" />
+		<value code="0x0107" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="Occupancy Sensor" />
+		<value code="0x0108" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="On/Off Ballast" />
+		<value code="0x0109" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="Dimmable Ballast" />
+		<value code="0x010A" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="On/off plug-in unit" />
+		<value code="0x010B" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="Dimmable plug-in unit" />
+		<value code="0x010C" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="Color temperature light" />
+		<value code="0x010D" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="Extended color light" />
+		<value code="0x010E" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="Light level sensor" />
+		<value code="0x0120" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="ZigBee Access Point" />
+		<value code="0x0121" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="ZigBee Information node" />
+		<value code="0x0122" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="ZigBee Information Terminal" />
+		<value code="0x0200" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="Shade" />
+		<value code="0x0201" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="Shade Controller" />
+		<value code="0x0202" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="Window Covering Device" />
+		<value code="0x0203" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="Window Covering Controller" />
+		<value code="0x0204" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="Barrier Device" />
+		<value code="0x0205" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="Barrier Device Controller" />
+		<value code="0x0220" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="Point of sale" />
+		<value code="0x0221" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="Ticketing machine" />
+		<value code="0x0222" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="Pay controller" />
+		<value code="0x0223" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="Billing unit" />
+		<value code="0x0224" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="Charging unit" />
+		<value code="0x0300" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="Heating/Cooling Unit" />
+		<value code="0x0301" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="Thermostat" />
+		<value code="0x0302" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="Temperature Sensor" />
+		<value code="0x0303" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="Pump" />
+		<value code="0x0304" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="Pump Controller" />
+		<value code="0x0305" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="Pressure Sensor" />
+		<value code="0x0306" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="Flow Sensor" />
+		<value code="0x0307" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="Mini Split AC" />
+		<value code="0x0400" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="IAS Control and Indicating Equipment" />
+		<value code="0x0401" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="IAS Ancillary Control Equipment" />
+		<value code="0x0402" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="IAS Zone" />
+		<value code="0x0403" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="IAS Warning Device" />
+		<value code="0x0500" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="Energy Service Interface" />
+		<value code="0x0501" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="Metering Device" />
+		<value code="0x0502" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="In-Home Display" />
+		<value code="0x0503" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="Programmable Communicating Thermostat" />
+		<value code="0x0504" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="Load Control Device" />
+		<value code="0x0505" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="Smart Appliance" />
+		<value code="0x0506" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="Prepayment Terminal" />
+		<value code="0x0507" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="Physical Device" />
+		<value code="0x0508" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="Remote Communications Device" />
+		<value code="0x0509" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="ERL Interface" />
+		<value code="0x050A" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="Electric Vehicle Station Equipment" />
+		<value code="0x0800" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="Color controller" />
+		<value code="0x0810" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="Color scene controller" />
+		<value code="0x0820" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="Non-color controller" />
+		<value code="0x0830" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="Non-color scene controller" />
+		<value code="0x0840" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="Control bridge" />
+		<value code="0x0850" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="On/off sensor" />
+		<value code="0x0F00" scope="ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION" name="Generic Multifunction Healthcare Device" />
+
+		<value code="0x0000" scope="ZigBeeProfileType.ZIGBEE_LIGHT_LINK" name="ZLL On/Off Light" />		
+		<value code="0x0010" scope="ZigBeeProfileType.ZIGBEE_LIGHT_LINK" name="ZLL On/Off Plug-in Unit" />		
+		<value code="0x0100" scope="ZigBeeProfileType.ZIGBEE_LIGHT_LINK" name="ZLL Dimmable Light" />		
+		<value code="0x0110" scope="ZigBeeProfileType.ZIGBEE_LIGHT_LINK" name="ZLL Dimmable Plug-in Unit" />		
+		<value code="0x0200" scope="ZigBeeProfileType.ZIGBEE_LIGHT_LINK" name="ZLL Color Light" />		
+		<value code="0x0210" scope="ZigBeeProfileType.ZIGBEE_LIGHT_LINK" name="ZLL Extended Color Light" />		
+		<value code="0x0220" scope="ZigBeeProfileType.ZIGBEE_LIGHT_LINK" name="ZLL Color Temperature Light" />		
+		<value code="0x0800" scope="ZigBeeProfileType.ZIGBEE_LIGHT_LINK" name="ZLL Color Controller" />		
+		<value code="0x0810" scope="ZigBeeProfileType.ZIGBEE_LIGHT_LINK" name="ZLL Color Scene Controller" />		
+		<value code="0x0820" scope="ZigBeeProfileType.ZIGBEE_LIGHT_LINK" name="ZLL Non-color Controller" />		
+		<value code="0x0830" scope="ZigBeeProfileType.ZIGBEE_LIGHT_LINK" name="ZLL Non-color Scene Controller" />		
+		<value code="0x0840" scope="ZigBeeProfileType.ZIGBEE_LIGHT_LINK" name="ZLL Control Bridge" />		
+		<value code="0x0850" scope="ZigBeeProfileType.ZIGBEE_LIGHT_LINK" name="ZLL On/Off Sensor" />	
+
+		<value code="0x0008" scope="ZigBeeProfileType.ZIGBEE_SMART_ENERGY" name="SEP Range Extender" />
+		<value code="0x0500" scope="ZigBeeProfileType.ZIGBEE_SMART_ENERGY" name="SEP Energy Service Interface" />
+		<value code="0x0501" scope="ZigBeeProfileType.ZIGBEE_SMART_ENERGY" name="SEP Metering Device" />
+		<value code="0x0502" scope="ZigBeeProfileType.ZIGBEE_SMART_ENERGY" name="SEP In-Home Display" />
+		<value code="0x0503" scope="ZigBeeProfileType.ZIGBEE_SMART_ENERGY" name="SEP Programmable Communicating Thermostat" />
+		<value code="0x0504" scope="ZigBeeProfileType.ZIGBEE_SMART_ENERGY" name="SEP Load Control Device" />
+		<value code="0x0505" scope="ZigBeeProfileType.ZIGBEE_SMART_ENERGY" name="SEP Smart Appliance" />
+		<value code="0x0506" scope="ZigBeeProfileType.ZIGBEE_SMART_ENERGY" name="SEP Prepayment Terminal" />
+		<value code="0x0507" scope="ZigBeeProfileType.ZIGBEE_SMART_ENERGY" name="SEP Physical Device" />	
 	</constant>
+	
 	<constant class="ZigBeeProfileType">
 		<name>ZigBee Profile Type</name>
 		<description></description>
@@ -110,6 +135,7 @@
 		<value code="0xC059" name="Manufacturer Telegesis" />
 		<value code="0xC105" name="Manufacturer Digi" />
 	</constant>
+	
 	<constant class="ZigBeeStackType">
 		<name>ZigBee Stack Type</name>
 		<description></description>

--- a/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleDescribeEndpointCommand.java
+++ b/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleDescribeEndpointCommand.java
@@ -55,7 +55,8 @@ public class ZigBeeConsoleDescribeEndpointCommand extends ZigBeeConsoleAbstractC
         final ZigBeeEndpoint endpoint = getEndpoint(networkManager, args[1]);
 
         ZigBeeProfileType profile = ZigBeeProfileType.getByValue(endpoint.getProfileId());
-        ZigBeeDeviceType device = ZigBeeDeviceType.getByValue(endpoint.getDeviceId());
+        ZigBeeDeviceType device = ZigBeeDeviceType.getByValue(ZigBeeProfileType.getByValue(endpoint.getProfileId()),
+                endpoint.getDeviceId());
 
         out.println("IEEE Address     : " + endpoint.getIeeeAddress());
         out.println("Network Address  : " + endpoint.getParentNode().getNetworkAddress());

--- a/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleDescribeNodeCommand.java
+++ b/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleDescribeNodeCommand.java
@@ -87,7 +87,8 @@ public class ZigBeeConsoleDescribeNodeCommand extends ZigBeeConsoleAbstractComma
         out.println("Profile     " + String.format("%04X ", endpoint.getProfileId())
                 + ZigBeeProfileType.getByValue(endpoint.getProfileId()));
         out.println("                 : Device Type " + String.format("%04X ", endpoint.getDeviceId())
-                + ZigBeeDeviceType.getByValue(endpoint.getDeviceId()));
+                + ZigBeeDeviceType.getByValue(ZigBeeProfileType.getByValue(endpoint.getProfileId()),
+                        endpoint.getDeviceId()));
         for (Integer clusterId : endpoint.getInputClusterIds()) {
             ZclClusterType clusterType = ZclClusterType.getValueById(clusterId);
             String clusterTypeLabel = clusterType != null ? clusterType.toString() : String.format("0x%04X", clusterId);

--- a/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleDeviceFingerprintCommand.java
+++ b/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleDeviceFingerprintCommand.java
@@ -167,7 +167,9 @@ public class ZigBeeConsoleDeviceFingerprintCommand extends ZigBeeConsoleAbstract
         out.println();
         out.print("| | |> Device Type              " + String.format("%04X", endpoint.getDeviceId()));
         if (ZigBeeDeviceType.getByValue(endpoint.getDeviceId()) != null) {
-            out.print("  " + ZigBeeDeviceType.getByValue(endpoint.getDeviceId()).toString());
+            out.print("  " + ZigBeeDeviceType
+                    .getByValue(ZigBeeProfileType.getByValue(endpoint.getProfileId()), endpoint.getDeviceId())
+                    .toString());
         }
         out.println();
 

--- a/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleNodeListCommand.java
+++ b/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleNodeListCommand.java
@@ -92,7 +92,9 @@ public class ZigBeeConsoleNodeListCommand extends ZigBeeConsoleAbstractCommand {
             if (ZigBeeDeviceType.getByValue(endpoint.getDeviceId()) == null) {
                 deviceType = String.format("%04X", endpoint.getDeviceId());
             } else {
-                deviceType = ZigBeeDeviceType.getByValue(endpoint.getDeviceId()).toString();
+                deviceType = ZigBeeDeviceType
+                        .getByValue(ZigBeeProfileType.getByValue(endpoint.getProfileId()), endpoint.getDeviceId())
+                        .toString();
             }
             boolean showManufacturerAndModel = endpoint.getParentNode().getNetworkAddress() != 0;
             String endpointInfo = String.format("%3d  %-25s  %-25s  %-15s  %-15s", endpoint.getEndpointId(),

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeDeviceType.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeDeviceType.java
@@ -17,493 +17,603 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-11-14T15:24:57Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum ZigBeeDeviceType {
 
     /**
-     * On/Off Switch
+     * On/Off Switch, 0, 0x0000
      */
-    ON_OFF_SWITCH(0x0000),
+    ON_OFF_SWITCH(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0000),
 
     /**
-     * Level Control Switch
+     * Level Control Switch, 1, 0x0001
      */
-    LEVEL_CONTROL_SWITCH(0x0001),
+    LEVEL_CONTROL_SWITCH(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0001),
 
     /**
-     * On/Off Output
+     * On/Off Output, 2, 0x0002
      */
-    ON_OFF_OUTPUT(0x0002),
+    ON_OFF_OUTPUT(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0002),
 
     /**
-     * Level Controllable Output
+     * Level Controllable Output, 3, 0x0003
      */
-    LEVEL_CONTROLLABLE_OUTPUT(0x0003),
+    LEVEL_CONTROLLABLE_OUTPUT(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0003),
 
     /**
-     * Scene Selector
+     * Scene Selector, 4, 0x0004
      */
-    SCENE_SELECTOR(0x0004),
+    SCENE_SELECTOR(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0004),
 
     /**
-     * Configuration Tool
+     * Configuration Tool, 5, 0x0005
      */
-    CONFIGURATION_TOOL(0x0005),
+    CONFIGURATION_TOOL(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0005),
 
     /**
-     * Remote Control
+     * Remote Control, 6, 0x0006
      */
-    REMOTE_CONTROL(0x0006),
+    REMOTE_CONTROL(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0006),
 
     /**
-     * Combined Interface
+     * Combined Interface, 7, 0x0007
      */
-    COMBINED_INTERFACE(0x0007),
+    COMBINED_INTERFACE(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0007),
 
     /**
-     * Range Extender
+     * Range Extender, 8, 0x0008
      */
-    RANGE_EXTENDER(0x0008),
+    RANGE_EXTENDER(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0008),
 
     /**
-     * Mains Power Outlet
+     * Mains Power Outlet, 9, 0x0009
      */
-    MAINS_POWER_OUTLET(0x0009),
+    MAINS_POWER_OUTLET(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0009),
 
     /**
-     * Door Lock
+     * Door Lock, 10, 0x000A
      */
-    DOOR_LOCK(0x000A),
+    DOOR_LOCK(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x000A),
 
     /**
-     * Door Lock Controller
+     * Door Lock Controller, 11, 0x000B
      */
-    DOOR_LOCK_CONTROLLER(0x000B),
+    DOOR_LOCK_CONTROLLER(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x000B),
 
     /**
-     * Simple Sensor
+     * Simple Sensor, 12, 0x000C
      */
-    SIMPLE_SENSOR(0x000C),
+    SIMPLE_SENSOR(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x000C),
 
     /**
-     * Consumption Awareness Device
+     * Consumption Awareness Device, 13, 0x000D
      */
-    CONSUMPTION_AWARENESS_DEVICE(0x000D),
+    CONSUMPTION_AWARENESS_DEVICE(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x000D),
 
     /**
-     * Data Collection Unit
+     * Data Collection Unit, 16, 0x0010
      */
-    DATA_COLLECTION_UNIT(0x0010),
+    DATA_COLLECTION_UNIT(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0010),
 
     /**
-     * ZigBee SIM Card
+     * ZigBee SIM Card, 32, 0x0020
      */
-    ZIGBEE_SIM_CARD(0x0020),
+    ZIGBEE_SIM_CARD(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0020),
 
     /**
-     * ZigBee Mobile Terminal
+     * ZigBee Mobile Terminal, 33, 0x0021
      */
-    ZIGBEE_MOBILE_TERMINAL(0x0021),
+    ZIGBEE_MOBILE_TERMINAL(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0021),
 
     /**
-     * ZigBee Global Platform Card
+     * ZigBee Global Platform Card, 38, 0x0026
      */
-    ZIGBEE_GLOBAL_PLATFORM_CARD(0x0026),
+    ZIGBEE_GLOBAL_PLATFORM_CARD(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0026),
 
     /**
-     * Customer Handheld Device
+     * Customer Handheld Device, 48, 0x0030
      */
-    CUSTOMER_HANDHELD_DEVICE(0x0030),
+    CUSTOMER_HANDHELD_DEVICE(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0030),
 
     /**
-     * Retail Associate Handheld Device
+     * Retail Associate Handheld Device, 49, 0x0031
      */
-    RETAIL_ASSOCIATE_HANDHELD_DEVICE(0x0031),
+    RETAIL_ASSOCIATE_HANDHELD_DEVICE(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0031),
 
     /**
-     * Intelligent Shopping Cart
+     * Intelligent Shopping Cart, 50, 0x0032
      */
-    INTELLIGENT_SHOPPING_CART(0x0032),
+    INTELLIGENT_SHOPPING_CART(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0032),
 
     /**
-     * Electronic Shelf Label
+     * Electronic Shelf Label, 51, 0x0033
      */
-    ELECTRONIC_SHELF_LABEL(0x0033),
+    ELECTRONIC_SHELF_LABEL(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0033),
 
     /**
-     * Customer Information Point
+     * Customer Information Point, 52, 0x0034
      */
-    CUSTOMER_INFORMATION_POINT(0x0034),
+    CUSTOMER_INFORMATION_POINT(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0034),
 
     /**
-     * Customer Card
+     * Customer Card, 53, 0x0035
      */
-    CUSTOMER_CARD(0x0035),
+    CUSTOMER_CARD(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0035),
 
     /**
-     * Constructed BACnet Device
+     * Constructed BACnet Device, 74, 0x004A
      */
-    CONSTRUCTED_BACNET_DEVICE(0x004A),
+    CONSTRUCTED_BACNET_DEVICE(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x004A),
 
     /**
-     * BACnet Tunneled Device
+     * BACnet Tunneled Device, 75, 0x004B
      */
-    BACNET_TUNNELED_DEVICE(0x004B),
+    BACNET_TUNNELED_DEVICE(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x004B),
 
     /**
-     * Home Gateway
+     * Home Gateway, 80, 0x0050
      */
-    HOME_GATEWAY(0x0050),
+    HOME_GATEWAY(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0050),
 
     /**
-     * Smart Plug
+     * Smart Plug, 81, 0x0051
      */
-    SMART_PLUG(0x0051),
+    SMART_PLUG(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0051),
 
     /**
-     * White Goods
+     * White Goods, 82, 0x0052
      */
-    WHITE_GOODS(0x0052),
+    WHITE_GOODS(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0052),
 
     /**
-     * Meter Interface
+     * Meter Interface, 83, 0x0053
      */
-    METER_INTERFACE(0x0053),
+    METER_INTERFACE(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0053),
 
     /**
-     * ZGP Proxy
+     * ZGP Proxy, 96, 0x0060
      */
-    ZGP_PROXY(0x0060),
+    ZGP_PROXY(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0060),
 
     /**
-     * ZGP Proxy Basic
+     * ZGP Proxy Basic, 97, 0x0061
      */
-    ZGP_PROXY_BASIC(0x0061),
+    ZGP_PROXY_BASIC(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0061),
 
     /**
-     * ZGP Target Plus
+     * ZGP Target Plus, 98, 0x0062
      */
-    ZGP_TARGET_PLUS(0x0062),
+    ZGP_TARGET_PLUS(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0062),
 
     /**
-     * ZGP Target
+     * ZGP Target, 99, 0x0063
      */
-    ZGP_TARGET(0x0063),
+    ZGP_TARGET(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0063),
 
     /**
-     * ZGP Commissioning Tool
+     * ZGP Commissioning Tool, 100, 0x0064
      */
-    ZGP_COMMISSIONING_TOOL(0x0064),
+    ZGP_COMMISSIONING_TOOL(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0064),
 
     /**
-     * ZGP Combo
+     * ZGP Combo, 101, 0x0065
      */
-    ZGP_COMBO(0x0065),
+    ZGP_COMBO(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0065),
 
     /**
-     * ZGP Combo Basic
+     * ZGP Combo Basic, 102, 0x0066
      */
-    ZGP_COMBO_BASIC(0x0066),
+    ZGP_COMBO_BASIC(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0066),
 
     /**
-     * Environmental Sensor
+     * Environmental Sensor, 103, 0x0067
      */
-    ENVIRONMENTAL_SENSOR(0x0067),
+    ENVIRONMENTAL_SENSOR(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0067),
 
     /**
-     * On/Off Light
+     * On/Off Light, 256, 0x0100
      */
-    ON_OFF_LIGHT(0x0100),
+    ON_OFF_LIGHT(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0100),
 
     /**
-     * Dimmable Light
+     * Dimmable Light, 257, 0x0101
      */
-    DIMMABLE_LIGHT(0x0101),
+    DIMMABLE_LIGHT(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0101),
 
     /**
-     * Color Dimmable Light
+     * Color Dimmable Light, 258, 0x0102
      */
-    COLOR_DIMMABLE_LIGHT(0x0102),
+    COLOR_DIMMABLE_LIGHT(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0102),
 
     /**
-     * On/Off Light Switch
+     * On/Off Light Switch, 259, 0x0103
      */
-    ON_OFF_LIGHT_SWITCH(0x0103),
+    ON_OFF_LIGHT_SWITCH(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0103),
 
     /**
-     * Dimmer Switch
+     * Dimmer Switch, 260, 0x0104
      */
-    DIMMER_SWITCH(0x0104),
+    DIMMER_SWITCH(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0104),
 
     /**
-     * Color Dimmer Switch
+     * Color Dimmer Switch, 261, 0x0105
      */
-    COLOR_DIMMER_SWITCH(0x0105),
+    COLOR_DIMMER_SWITCH(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0105),
 
     /**
-     * Light Sensor
+     * Light Sensor, 262, 0x0106
      */
-    LIGHT_SENSOR(0x0106),
+    LIGHT_SENSOR(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0106),
 
     /**
-     * Occupancy Sensor
+     * Occupancy Sensor, 263, 0x0107
      */
-    OCCUPANCY_SENSOR(0x0107),
+    OCCUPANCY_SENSOR(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0107),
 
     /**
-     * On/Off Ballast
+     * On/Off Ballast, 264, 0x0108
      */
-    ON_OFF_BALLAST(0x0108),
+    ON_OFF_BALLAST(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0108),
 
     /**
-     * Dimmable Ballast
+     * Dimmable Ballast, 265, 0x0109
      */
-    DIMMABLE_BALLAST(0x0109),
+    DIMMABLE_BALLAST(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0109),
 
     /**
-     * On/off plug-in unit
+     * On/off plug-in unit, 266, 0x010A
      */
-    ON_OFF_PLUG_IN_UNIT(0x010A),
+    ON_OFF_PLUG_IN_UNIT(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x010A),
 
     /**
-     * Dimmable plug-in unit
+     * Dimmable plug-in unit, 267, 0x010B
      */
-    DIMMABLE_PLUG_IN_UNIT(0x010B),
+    DIMMABLE_PLUG_IN_UNIT(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x010B),
 
     /**
-     * Color temperature light
+     * Color temperature light, 268, 0x010C
      */
-    COLOR_TEMPERATURE_LIGHT(0x010C),
+    COLOR_TEMPERATURE_LIGHT(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x010C),
 
     /**
-     * Extended color light
+     * Extended color light, 269, 0x010D
      */
-    EXTENDED_COLOR_LIGHT(0x010D),
+    EXTENDED_COLOR_LIGHT(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x010D),
 
     /**
-     * Light level sensor
+     * Light level sensor, 270, 0x010E
      */
-    LIGHT_LEVEL_SENSOR(0x010E),
+    LIGHT_LEVEL_SENSOR(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x010E),
 
     /**
-     * ZigBee Access Point
+     * ZigBee Access Point, 288, 0x0120
      */
-    ZIGBEE_ACCESS_POINT(0x0120),
+    ZIGBEE_ACCESS_POINT(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0120),
 
     /**
-     * ZigBee Information node
+     * ZigBee Information node, 289, 0x0121
      */
-    ZIGBEE_INFORMATION_NODE(0x0121),
+    ZIGBEE_INFORMATION_NODE(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0121),
 
     /**
-     * ZigBee Information Terminal
+     * ZigBee Information Terminal, 290, 0x0122
      */
-    ZIGBEE_INFORMATION_TERMINAL(0x0122),
+    ZIGBEE_INFORMATION_TERMINAL(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0122),
 
     /**
-     * Shade
+     * Shade, 512, 0x0200
      */
-    SHADE(0x0200),
+    SHADE(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0200),
 
     /**
-     * Shade Controller
+     * Shade Controller, 513, 0x0201
      */
-    SHADE_CONTROLLER(0x0201),
+    SHADE_CONTROLLER(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0201),
 
     /**
-     * Window Covering Device
+     * Window Covering Device, 514, 0x0202
      */
-    WINDOW_COVERING_DEVICE(0x0202),
+    WINDOW_COVERING_DEVICE(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0202),
 
     /**
-     * Window Covering Controller
+     * Window Covering Controller, 515, 0x0203
      */
-    WINDOW_COVERING_CONTROLLER(0x0203),
+    WINDOW_COVERING_CONTROLLER(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0203),
 
     /**
-     * Barrier Device
+     * Barrier Device, 516, 0x0204
      */
-    BARRIER_DEVICE(0x0204),
+    BARRIER_DEVICE(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0204),
 
     /**
-     * Barrier Device Controller
+     * Barrier Device Controller, 517, 0x0205
      */
-    BARRIER_DEVICE_CONTROLLER(0x0205),
+    BARRIER_DEVICE_CONTROLLER(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0205),
 
     /**
-     * Point of sale
+     * Point of sale, 544, 0x0220
      */
-    POINT_OF_SALE(0x0220),
+    POINT_OF_SALE(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0220),
 
     /**
-     * Ticketing machine
+     * Ticketing machine, 545, 0x0221
      */
-    TICKETING_MACHINE(0x0221),
+    TICKETING_MACHINE(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0221),
 
     /**
-     * Pay controller
+     * Pay controller, 546, 0x0222
      */
-    PAY_CONTROLLER(0x0222),
+    PAY_CONTROLLER(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0222),
 
     /**
-     * Billing unit
+     * Billing unit, 547, 0x0223
      */
-    BILLING_UNIT(0x0223),
+    BILLING_UNIT(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0223),
 
     /**
-     * Charging unit
+     * Charging unit, 548, 0x0224
      */
-    CHARGING_UNIT(0x0224),
+    CHARGING_UNIT(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0224),
 
     /**
-     * Heating/Cooling Unit
+     * Heating/Cooling Unit, 768, 0x0300
      */
-    HEATING_COOLING_UNIT(0x0300),
+    HEATING_COOLING_UNIT(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0300),
 
     /**
-     * Thermostat
+     * Thermostat, 769, 0x0301
      */
-    THERMOSTAT(0x0301),
+    THERMOSTAT(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0301),
 
     /**
-     * Temperature Sensor
+     * Temperature Sensor, 770, 0x0302
      */
-    TEMPERATURE_SENSOR(0x0302),
+    TEMPERATURE_SENSOR(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0302),
 
     /**
-     * Pump
+     * Pump, 771, 0x0303
      */
-    PUMP(0x0303),
+    PUMP(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0303),
 
     /**
-     * Pump Controller
+     * Pump Controller, 772, 0x0304
      */
-    PUMP_CONTROLLER(0x0304),
+    PUMP_CONTROLLER(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0304),
 
     /**
-     * Pressure Sensor
+     * Pressure Sensor, 773, 0x0305
      */
-    PRESSURE_SENSOR(0x0305),
+    PRESSURE_SENSOR(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0305),
 
     /**
-     * Flow Sensor
+     * Flow Sensor, 774, 0x0306
      */
-    FLOW_SENSOR(0x0306),
+    FLOW_SENSOR(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0306),
 
     /**
-     * Mini Split AC
+     * Mini Split AC, 775, 0x0307
      */
-    MINI_SPLIT_AC(0x0307),
+    MINI_SPLIT_AC(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0307),
 
     /**
-     * IAS Control and Indicating Equipment
+     * IAS Control and Indicating Equipment, 1024, 0x0400
      */
-    IAS_CONTROL_AND_INDICATING_EQUIPMENT(0x0400),
+    IAS_CONTROL_AND_INDICATING_EQUIPMENT(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0400),
 
     /**
-     * IAS Ancillary Control Equipment
+     * IAS Ancillary Control Equipment, 1025, 0x0401
      */
-    IAS_ANCILLARY_CONTROL_EQUIPMENT(0x0401),
+    IAS_ANCILLARY_CONTROL_EQUIPMENT(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0401),
 
     /**
-     * IAS Zone
+     * IAS Zone, 1026, 0x0402
      */
-    IAS_ZONE(0x0402),
+    IAS_ZONE(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0402),
 
     /**
-     * IAS Warning Device
+     * IAS Warning Device, 1027, 0x0403
      */
-    IAS_WARNING_DEVICE(0x0403),
+    IAS_WARNING_DEVICE(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0403),
 
     /**
-     * Energy Service Interface
+     * Energy Service Interface, 1280, 0x0500
      */
-    ENERGY_SERVICE_INTERFACE(0x0500),
+    ENERGY_SERVICE_INTERFACE(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0500),
 
     /**
-     * Metering Device
+     * Metering Device, 1281, 0x0501
      */
-    METERING_DEVICE(0x0501),
+    METERING_DEVICE(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0501),
 
     /**
-     * In-Home Display
+     * In-Home Display, 1282, 0x0502
      */
-    IN_HOME_DISPLAY(0x0502),
+    IN_HOME_DISPLAY(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0502),
 
     /**
-     * Programmable Communicating Thermostat
+     * Programmable Communicating Thermostat, 1283, 0x0503
      */
-    PROGRAMMABLE_COMMUNICATING_THERMOSTAT(0x0503),
+    PROGRAMMABLE_COMMUNICATING_THERMOSTAT(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0503),
 
     /**
-     * Load Control Device
+     * Load Control Device, 1284, 0x0504
      */
-    LOAD_CONTROL_DEVICE(0x0504),
+    LOAD_CONTROL_DEVICE(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0504),
 
     /**
-     * Smart Appliance
+     * Smart Appliance, 1285, 0x0505
      */
-    SMART_APPLIANCE(0x0505),
+    SMART_APPLIANCE(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0505),
 
     /**
-     * Prepayment Terminal
+     * Prepayment Terminal, 1286, 0x0506
      */
-    PREPAYMENT_TERMINAL(0x0506),
+    PREPAYMENT_TERMINAL(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0506),
 
     /**
-     * Physical Device
+     * Physical Device, 1287, 0x0507
      */
-    PHYSICAL_DEVICE(0x0507),
+    PHYSICAL_DEVICE(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0507),
 
     /**
-     * Remote Communications Device
+     * Remote Communications Device, 1288, 0x0508
      */
-    REMOTE_COMMUNICATIONS_DEVICE(0x0508),
+    REMOTE_COMMUNICATIONS_DEVICE(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0508),
 
     /**
-     * ERL Interface
+     * ERL Interface, 1289, 0x0509
      */
-    ERL_INTERFACE(0x0509),
+    ERL_INTERFACE(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0509),
 
     /**
-     * Electric Vehicle Station Equipment
+     * Electric Vehicle Station Equipment, 1290, 0x050A
      */
-    ELECTRIC_VEHICLE_STATION_EQUIPMENT(0x050A),
+    ELECTRIC_VEHICLE_STATION_EQUIPMENT(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x050A),
 
     /**
-     * Color controller
+     * Color controller, 2048, 0x0800
      */
-    COLOR_CONTROLLER(0x0800),
+    COLOR_CONTROLLER(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0800),
 
     /**
-     * Color scene controller
+     * Color scene controller, 2064, 0x0810
      */
-    COLOR_SCENE_CONTROLLER(0x0810),
+    COLOR_SCENE_CONTROLLER(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0810),
 
     /**
-     * Non-color controller
+     * Non-color controller, 2080, 0x0820
      */
-    NON_COLOR_CONTROLLER(0x0820),
+    NON_COLOR_CONTROLLER(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0820),
 
     /**
-     * Non-color scene controller
+     * Non-color scene controller, 2096, 0x0830
      */
-    NON_COLOR_SCENE_CONTROLLER(0x0830),
+    NON_COLOR_SCENE_CONTROLLER(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0830),
 
     /**
-     * Control bridge
+     * Control bridge, 2112, 0x0840
      */
-    CONTROL_BRIDGE(0x0840),
+    CONTROL_BRIDGE(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0840),
 
     /**
-     * On/off sensor
+     * On/off sensor, 2128, 0x0850
      */
-    ON_OFF_SENSOR(0x0850),
+    ON_OFF_SENSOR(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0850),
 
     /**
-     * Generic Multifunction Healthcare Device
+     * Generic Multifunction Healthcare Device, 3840, 0x0F00
      */
-    GENERIC_MULTIFUNCTION_HEALTHCARE_DEVICE(0x0F00);
+    GENERIC_MULTIFUNCTION_HEALTHCARE_DEVICE(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0F00),
+
+    /**
+     * ZLL On/Off Light, 0, 0x0000
+     */
+    ZLL_ON_OFF_LIGHT(ZigBeeProfileType.ZIGBEE_LIGHT_LINK, 0x0000),
+
+    /**
+     * ZLL On/Off Plug-in Unit, 16, 0x0010
+     */
+    ZLL_ON_OFF_PLUG_IN_UNIT(ZigBeeProfileType.ZIGBEE_LIGHT_LINK, 0x0010),
+
+    /**
+     * ZLL Dimmable Light, 256, 0x0100
+     */
+    ZLL_DIMMABLE_LIGHT(ZigBeeProfileType.ZIGBEE_LIGHT_LINK, 0x0100),
+
+    /**
+     * ZLL Dimmable Plug-in Unit, 272, 0x0110
+     */
+    ZLL_DIMMABLE_PLUG_IN_UNIT(ZigBeeProfileType.ZIGBEE_LIGHT_LINK, 0x0110),
+
+    /**
+     * ZLL Color Light, 512, 0x0200
+     */
+    ZLL_COLOR_LIGHT(ZigBeeProfileType.ZIGBEE_LIGHT_LINK, 0x0200),
+
+    /**
+     * ZLL Extended Color Light, 528, 0x0210
+     */
+    ZLL_EXTENDED_COLOR_LIGHT(ZigBeeProfileType.ZIGBEE_LIGHT_LINK, 0x0210),
+
+    /**
+     * ZLL Color Temperature Light, 544, 0x0220
+     */
+    ZLL_COLOR_TEMPERATURE_LIGHT(ZigBeeProfileType.ZIGBEE_LIGHT_LINK, 0x0220),
+
+    /**
+     * ZLL Color Controller, 2048, 0x0800
+     */
+    ZLL_COLOR_CONTROLLER(ZigBeeProfileType.ZIGBEE_LIGHT_LINK, 0x0800),
+
+    /**
+     * ZLL Color Scene Controller, 2064, 0x0810
+     */
+    ZLL_COLOR_SCENE_CONTROLLER(ZigBeeProfileType.ZIGBEE_LIGHT_LINK, 0x0810),
+
+    /**
+     * ZLL Non-color Controller, 2080, 0x0820
+     */
+    ZLL_NON_COLOR_CONTROLLER(ZigBeeProfileType.ZIGBEE_LIGHT_LINK, 0x0820),
+
+    /**
+     * ZLL Non-color Scene Controller, 2096, 0x0830
+     */
+    ZLL_NON_COLOR_SCENE_CONTROLLER(ZigBeeProfileType.ZIGBEE_LIGHT_LINK, 0x0830),
+
+    /**
+     * ZLL Control Bridge, 2112, 0x0840
+     */
+    ZLL_CONTROL_BRIDGE(ZigBeeProfileType.ZIGBEE_LIGHT_LINK, 0x0840),
+
+    /**
+     * ZLL On/Off Sensor, 2128, 0x0850
+     */
+    ZLL_ON_OFF_SENSOR(ZigBeeProfileType.ZIGBEE_LIGHT_LINK, 0x0850),
+
+    /**
+     * SEP Range Extender, 8, 0x0008
+     */
+    SEP_RANGE_EXTENDER(ZigBeeProfileType.ZIGBEE_SMART_ENERGY, 0x0008),
+
+    /**
+     * SEP Energy Service Interface, 1280, 0x0500
+     */
+    SEP_ENERGY_SERVICE_INTERFACE(ZigBeeProfileType.ZIGBEE_SMART_ENERGY, 0x0500),
+
+    /**
+     * SEP Metering Device, 1281, 0x0501
+     */
+    SEP_METERING_DEVICE(ZigBeeProfileType.ZIGBEE_SMART_ENERGY, 0x0501),
+
+    /**
+     * SEP In-Home Display, 1282, 0x0502
+     */
+    SEP_IN_HOME_DISPLAY(ZigBeeProfileType.ZIGBEE_SMART_ENERGY, 0x0502),
+
+    /**
+     * SEP Programmable Communicating Thermostat, 1283, 0x0503
+     */
+    SEP_PROGRAMMABLE_COMMUNICATING_THERMOSTAT(ZigBeeProfileType.ZIGBEE_SMART_ENERGY, 0x0503),
+
+    /**
+     * SEP Load Control Device, 1284, 0x0504
+     */
+    SEP_LOAD_CONTROL_DEVICE(ZigBeeProfileType.ZIGBEE_SMART_ENERGY, 0x0504),
+
+    /**
+     * SEP Smart Appliance, 1285, 0x0505
+     */
+    SEP_SMART_APPLIANCE(ZigBeeProfileType.ZIGBEE_SMART_ENERGY, 0x0505),
+
+    /**
+     * SEP Prepayment Terminal, 1286, 0x0506
+     */
+    SEP_PREPAYMENT_TERMINAL(ZigBeeProfileType.ZIGBEE_SMART_ENERGY, 0x0506),
+
+    /**
+     * SEP Physical Device, 1287, 0x0507
+     */
+    SEP_PHYSICAL_DEVICE(ZigBeeProfileType.ZIGBEE_SMART_ENERGY, 0x0507);
 
     /**
      * A mapping between the integer code and its corresponding ZigBeeDeviceType type to facilitate lookup by value.
@@ -513,14 +623,16 @@ public enum ZigBeeDeviceType {
     static {
         idMap = new HashMap<Integer, ZigBeeDeviceType>();
         for (ZigBeeDeviceType enumValue : values()) {
-            idMap.put(enumValue.key, enumValue);
+            idMap.put(enumValue.profilekey, enumValue);
         }
     }
 
     private final int key;
+    private final int profilekey;
 
-    private ZigBeeDeviceType(final int key) {
+    private ZigBeeDeviceType(final ZigBeeProfileType profile, final int key) {
         this.key = key;
+        this.profilekey = key & 0xffff + (profile.ordinal() << 16);
     }
 
     public int getKey() {
@@ -528,6 +640,12 @@ public enum ZigBeeDeviceType {
     }
 
     public static ZigBeeDeviceType getByValue(final int value) {
-        return idMap.get(value);
+        int id = value & 0xffff + (ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION.ordinal() << 16);
+        return idMap.get(id);
+    }
+
+    public static ZigBeeDeviceType getByValue(final ZigBeeProfileType profile, final int value) {
+        int id = value & 0xffff + (profile.ordinal() << 16);
+        return idMap.get(id);
     }
 }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
@@ -540,8 +540,10 @@ public class ZigBeeNetworkManager implements ZigBeeTransportReceive {
                     String.format("%04X", defaultDeviceId), networkState);
             return ZigBeeStatus.INVALID_STATE;
         }
-        logger.debug("Default device ID set to {} [{}]", String.format("%04X", defaultDeviceId),
-                ZigBeeDeviceType.getByValue(defaultDeviceId));
+        logger.debug("Default device ID set to {} [{}] for profile {} [{}]", String.format("%04X", defaultDeviceId),
+                ZigBeeDeviceType.getByValue(ZigBeeProfileType.getByValue(defaultProfileId), defaultDeviceId),
+                String.format("%04X", defaultProfileId),
+                ZigBeeProfileType.getByValue(defaultProfileId));
         transport.setDefaultDeviceId(defaultDeviceId);
         return ZigBeeStatus.SUCCESS;
     }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeProfileType.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeProfileType.java
@@ -17,36 +17,36 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-08-15T18:28:04Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum ZigBeeProfileType {
 
     /**
-     * ZigBee Home Automation
+     * ZigBee Home Automation, 260, 0x0104
      */
     ZIGBEE_HOME_AUTOMATION(0x0104),
 
     /**
-     * ZigBee Smart Energy
+     * ZigBee Smart Energy, 265, 0x0109
      */
     ZIGBEE_SMART_ENERGY(0x0109),
 
     /**
-     * ZigBee Green Power
+     * ZigBee Green Power, 41230, 0xA10E
      */
     ZIGBEE_GREEN_POWER(0xA10E),
 
     /**
-     * Manufacturer Telegesis
-     */
-    MANUFACTURER_TELEGESIS(0xC059),
-
-    /**
-     * ZigBee Light Link
+     * ZigBee Light Link, 49246, 0xC05E
      */
     ZIGBEE_LIGHT_LINK(0xC05E),
 
     /**
-     * Manufacturer Digi
+     * Manufacturer Telegesis, 49241, 0xC059
+     */
+    MANUFACTURER_TELEGESIS(0xC059),
+
+    /**
+     * Manufacturer Digi, 49413, 0xC105
      */
     MANUFACTURER_DIGI(0xC105);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeStackType.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeStackType.java
@@ -17,26 +17,26 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-06-15T20:20:47Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum ZigBeeStackType {
 
     /**
-     * ZigBee 2006
+     * ZigBee 2006, 0, 0x0000
      */
     ZIGBEE_2006(0x0000),
 
     /**
-     * ZigBee 2007
+     * ZigBee 2007, 1, 0x0001
      */
     ZIGBEE_2007(0x0001),
 
     /**
-     * ZigBee Pro
+     * ZigBee Pro, 2, 0x0002
      */
     ZIGBEE_PRO(0x0002),
 
     /**
-     * ZigBee IP
+     * ZigBee IP, 3, 0x0003
      */
     ZIGBEE_IP(0x0003);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/analoginputbasic/AnalogInputReliabilityEnum.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/analoginputbasic/AnalogInputReliabilityEnum.java
@@ -17,51 +17,51 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-13T12:49:59Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum AnalogInputReliabilityEnum {
 
     /**
-     * No - Fault - Detected
+     * No - Fault - Detected, 0, 0x0000
      */
     NO_FAULT_DETECTED(0x0000),
 
     /**
-     * Over - Range
+     * Over - Range, 2, 0x0002
      */
     OVER_RANGE(0x0002),
 
     /**
-     * Under - Range
+     * Under - Range, 3, 0x0003
      */
     UNDER_RANGE(0x0003),
 
     /**
-     * Open - Loop
+     * Open - Loop, 4, 0x0004
      */
     OPEN_LOOP(0x0004),
 
     /**
-     * Shorted - Loop
+     * Shorted - Loop, 5, 0x0005
      */
     SHORTED_LOOP(0x0005),
 
     /**
-     * Unreliable - Other
+     * Unreliable - Other, 7, 0x0007
      */
     UNRELIABLE_OTHER(0x0007),
 
     /**
-     * Process - Error
+     * Process - Error, 8, 0x0008
      */
     PROCESS_ERROR(0x0008),
 
     /**
-     * Multi - State - Fault
+     * Multi - State - Fault, 9, 0x0009
      */
     MULTI_STATE_FAULT(0x0009),
 
     /**
-     * Configuration - Error
+     * Configuration - Error, 10, 0x000A
      */
     CONFIGURATION_ERROR(0x000A);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/analoginputbasic/AnalogInputStatusFlagsBitmap.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/analoginputbasic/AnalogInputStatusFlagsBitmap.java
@@ -17,26 +17,26 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-13T12:49:59Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum AnalogInputStatusFlagsBitmap {
 
     /**
-     * In_Alarm
+     * In_Alarm, 1, 0x0001
      */
     IN_ALARM(0x0001),
 
     /**
-     * Fault
+     * Fault, 2, 0x0002
      */
     FAULT(0x0002),
 
     /**
-     * Overridden
+     * Overridden, 4, 0x0004
      */
     OVERRIDDEN(0x0004),
 
     /**
-     * Out Of Service
+     * Out Of Service, 8, 0x0008
      */
     OUT_OF_SERVICE(0x0008);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/basic/GenericDeviceTypeEnum.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/basic/GenericDeviceTypeEnum.java
@@ -17,121 +17,121 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-04-07T19:42:14Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum GenericDeviceTypeEnum {
 
     /**
-     * Incandescent
+     * Incandescent, 0, 0x0000
      */
     INCANDESCENT(0x0000),
 
     /**
-     * Spotlight Halogen
+     * Spotlight Halogen, 1, 0x0001
      */
     SPOTLIGHT_HALOGEN(0x0001),
 
     /**
-     * Halogen bulb
+     * Halogen bulb, 2, 0x0002
      */
     HALOGEN_BULB(0x0002),
 
     /**
-     * CFL
+     * CFL, 3, 0x0003
      */
     CFL(0x0003),
 
     /**
-     * Linear Fluorescent
+     * Linear Fluorescent, 4, 0x0004
      */
     LINEAR_FLUORESCENT(0x0004),
 
     /**
-     * LED bulb
+     * LED bulb, 5, 0x0005
      */
     LED_BULB(0x0005),
 
     /**
-     * Spotlight LED
+     * Spotlight LED, 6, 0x0006
      */
     SPOTLIGHT_LED(0x0006),
 
     /**
-     * LED strip
+     * LED strip, 7, 0x0007
      */
     LED_STRIP(0x0007),
 
     /**
-     * LED tube
+     * LED tube, 8, 0x0008
      */
     LED_TUBE(0x0008),
 
     /**
-     * Generic indoor luminaire
+     * Generic indoor luminaire, 9, 0x0009
      */
     GENERIC_INDOOR_LUMINAIRE(0x0009),
 
     /**
-     * Generic outdoor luminaire
+     * Generic outdoor luminaire, 10, 0x000A
      */
     GENERIC_OUTDOOR_LUMINAIRE(0x000A),
 
     /**
-     * Pendant luminaire
+     * Pendant luminaire, 11, 0x000B
      */
     PENDANT_LUMINAIRE(0x000B),
 
     /**
-     * Floor standing luminaire
+     * Floor standing luminaire, 12, 0x000C
      */
     FLOOR_STANDING_LUMINAIRE(0x000C),
 
     /**
-     * Generic Controller
+     * Generic Controller, 224, 0x00E0
      */
     GENERIC_CONTROLLER(0x00E0),
 
     /**
-     * Wall Switch
+     * Wall Switch, 225, 0x00E1
      */
     WALL_SWITCH(0x00E1),
 
     /**
-     * Portable remote controller
+     * Portable remote controller, 226, 0x00E2
      */
     PORTABLE_REMOTE_CONTROLLER(0x00E2),
 
     /**
-     * Motion sensor / light sensor
+     * Motion sensor / light sensor, 227, 0x00E3
      */
     MOTION_SENSOR_LIGHT_SENSOR(0x00E3),
 
     /**
-     * Generic actuator
+     * Generic actuator, 240, 0x00F0
      */
     GENERIC_ACTUATOR(0x00F0),
 
     /**
-     * Wall socket
+     * Wall socket, 241, 0x00F1
      */
     WALL_SOCKET(0x00F1),
 
     /**
-     * Gateway/Bridge
+     * Gateway/Bridge, 242, 0x00F2
      */
     GATEWAY_BRIDGE(0x00F2),
 
     /**
-     * Plug-in unit
+     * Plug-in unit, 243, 0x00F3
      */
     PLUG_IN_UNIT(0x00F3),
 
     /**
-     * Retrofit actuator
+     * Retrofit actuator, 244, 0x00F4
      */
     RETROFIT_ACTUATOR(0x00F4),
 
     /**
-     * Unspecified
+     * Unspecified, 255, 0x00FF
      */
     UNSPECIFIED(0x00FF);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/basic/PhysicalEnvironmentEnum.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/basic/PhysicalEnvironmentEnum.java
@@ -17,541 +17,541 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-09-28T13:35:09Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum PhysicalEnvironmentEnum {
 
     /**
-     * Unspecified
+     * Unspecified, 0, 0x0000
      */
     UNSPECIFIED(0x0000),
 
     /**
-     * Atrium
+     * Atrium, 1, 0x0001
      */
     ATRIUM(0x0001),
 
     /**
-     * Bar
+     * Bar, 2, 0x0002
      */
     BAR(0x0002),
 
     /**
-     * Courtyard
+     * Courtyard, 3, 0x0003
      */
     COURTYARD(0x0003),
 
     /**
-     * Bathroom
+     * Bathroom, 4, 0x0004
      */
     BATHROOM(0x0004),
 
     /**
-     * Bedroom
+     * Bedroom, 5, 0x0005
      */
     BEDROOM(0x0005),
 
     /**
-     * Billiard Room
+     * Billiard Room, 6, 0x0006
      */
     BILLIARD_ROOM(0x0006),
 
     /**
-     * Utility Room
+     * Utility Room, 7, 0x0007
      */
     UTILITY_ROOM(0x0007),
 
     /**
-     * Cellar
+     * Cellar, 8, 0x0008
      */
     CELLAR(0x0008),
 
     /**
-     * Storage Closet
+     * Storage Closet, 9, 0x0009
      */
     STORAGE_CLOSET(0x0009),
 
     /**
-     * Theater
+     * Theater, 10, 0x000A
      */
     THEATER(0x000A),
 
     /**
-     * Office
+     * Office, 11, 0x000B
      */
     OFFICE(0x000B),
 
     /**
-     * Deck
+     * Deck, 12, 0x000C
      */
     DECK(0x000C),
 
     /**
-     * Den
+     * Den, 13, 0x000D
      */
     DEN(0x000D),
 
     /**
-     * Dining Room
+     * Dining Room, 14, 0x000E
      */
     DINING_ROOM(0x000E),
 
     /**
-     * Electrical Room
+     * Electrical Room, 15, 0x000F
      */
     ELECTRICAL_ROOM(0x000F),
 
     /**
-     * Elevator
+     * Elevator, 16, 0x0010
      */
     ELEVATOR(0x0010),
 
     /**
-     * Entry
+     * Entry, 17, 0x0011
      */
     ENTRY(0x0011),
 
     /**
-     * Family Room
+     * Family Room, 18, 0x0012
      */
     FAMILY_ROOM(0x0012),
 
     /**
-     * Main Floor
+     * Main Floor, 19, 0x0013
      */
     MAIN_FLOOR(0x0013),
 
     /**
-     * Upstairs
+     * Upstairs, 20, 0x0014
      */
     UPSTAIRS(0x0014),
 
     /**
-     * Downstairs
+     * Downstairs, 21, 0x0015
      */
     DOWNSTAIRS(0x0015),
 
     /**
-     * Basement
+     * Basement, 22, 0x0016
      */
     BASEMENT(0x0016),
 
     /**
-     * Gallery
+     * Gallery, 23, 0x0017
      */
     GALLERY(0x0017),
 
     /**
-     * Game Room
+     * Game Room, 24, 0x0018
      */
     GAME_ROOM(0x0018),
 
     /**
-     * Garage
+     * Garage, 25, 0x0019
      */
     GARAGE(0x0019),
 
     /**
-     * Gym
+     * Gym, 26, 0x001A
      */
     GYM(0x001A),
 
     /**
-     * Hallway
+     * Hallway, 27, 0x001B
      */
     HALLWAY(0x001B),
 
     /**
-     * House
+     * House, 28, 0x001C
      */
     HOUSE(0x001C),
 
     /**
-     * Kitchen
+     * Kitchen, 29, 0x001D
      */
     KITCHEN(0x001D),
 
     /**
-     * Laundry Room
+     * Laundry Room, 30, 0x001E
      */
     LAUNDRY_ROOM(0x001E),
 
     /**
-     * Library
+     * Library, 31, 0x001F
      */
     LIBRARY(0x001F),
 
     /**
-     * Master Bedroom
+     * Master Bedroom, 32, 0x0020
      */
     MASTER_BEDROOM(0x0020),
 
     /**
-     * Mud Room
+     * Mud Room, 33, 0x0021
      */
     MUD_ROOM(0x0021),
 
     /**
-     * Nursery
+     * Nursery, 34, 0x0022
      */
     NURSERY(0x0022),
 
     /**
-     * Pantry
+     * Pantry, 35, 0x0023
      */
     PANTRY(0x0023),
 
     /**
-     * Office 2
+     * Office 2, 36, 0x0024
      */
     OFFICE_2(0x0024),
 
     /**
-     * Outside
+     * Outside, 37, 0x0025
      */
     OUTSIDE(0x0025),
 
     /**
-     * Pool
+     * Pool, 38, 0x0026
      */
     POOL(0x0026),
 
     /**
-     * Porch
+     * Porch, 39, 0x0027
      */
     PORCH(0x0027),
 
     /**
-     * Sewing Room
+     * Sewing Room, 40, 0x0028
      */
     SEWING_ROOM(0x0028),
 
     /**
-     * Sitting Room
+     * Sitting Room, 41, 0x0029
      */
     SITTING_ROOM(0x0029),
 
     /**
-     * Stairway
+     * Stairway, 42, 0x002A
      */
     STAIRWAY(0x002A),
 
     /**
-     * Yard
+     * Yard, 43, 0x002B
      */
     YARD(0x002B),
 
     /**
-     * Attic
+     * Attic, 44, 0x002C
      */
     ATTIC(0x002C),
 
     /**
-     * Hot Tub
+     * Hot Tub, 45, 0x002D
      */
     HOT_TUB(0x002D),
 
     /**
-     * Living Room
+     * Living Room, 46, 0x002E
      */
     LIVING_ROOM(0x002E),
 
     /**
-     * Sauna
+     * Sauna, 47, 0x002F
      */
     SAUNA(0x002F),
 
     /**
-     * Shop/Workshop
+     * Shop/Workshop, 48, 0x0030
      */
     SHOP_WORKSHOP(0x0030),
 
     /**
-     * Guest Bedroom
+     * Guest Bedroom, 49, 0x0031
      */
     GUEST_BEDROOM(0x0031),
 
     /**
-     * Guest Bath
+     * Guest Bath, 50, 0x0032
      */
     GUEST_BATH(0x0032),
 
     /**
-     * Powder Room
+     * Powder Room, 51, 0x0033
      */
     POWDER_ROOM(0x0033),
 
     /**
-     * Back Yard
+     * Back Yard, 52, 0x0034
      */
     BACK_YARD(0x0034),
 
     /**
-     * Front Yard
+     * Front Yard, 53, 0x0035
      */
     FRONT_YARD(0x0035),
 
     /**
-     * Patio
+     * Patio, 54, 0x0036
      */
     PATIO(0x0036),
 
     /**
-     * Driveway
+     * Driveway, 55, 0x0037
      */
     DRIVEWAY(0x0037),
 
     /**
-     * Sun Room
+     * Sun Room, 56, 0x0038
      */
     SUN_ROOM(0x0038),
 
     /**
-     * Living Room 2
+     * Living Room 2, 57, 0x0039
      */
     LIVING_ROOM_2(0x0039),
 
     /**
-     * Spa
+     * Spa, 58, 0x003A
      */
     SPA(0x003A),
 
     /**
-     * Whirlpool
+     * Whirlpool, 59, 0x003B
      */
     WHIRLPOOL(0x003B),
 
     /**
-     * Shed
+     * Shed, 60, 0x003C
      */
     SHED(0x003C),
 
     /**
-     * Equipment Storage
+     * Equipment Storage, 61, 0x003D
      */
     EQUIPMENT_STORAGE(0x003D),
 
     /**
-     * Hobby/Craft Room
+     * Hobby/Craft Room, 62, 0x003E
      */
     HOBBY_CRAFT_ROOM(0x003E),
 
     /**
-     * Fountain
+     * Fountain, 63, 0x003F
      */
     FOUNTAIN(0x003F),
 
     /**
-     * Pond
+     * Pond, 64, 0x0040
      */
     POND(0x0040),
 
     /**
-     * Reception Room
+     * Reception Room, 65, 0x0041
      */
     RECEPTION_ROOM(0x0041),
 
     /**
-     * Breakfast Room
+     * Breakfast Room, 66, 0x0042
      */
     BREAKFAST_ROOM(0x0042),
 
     /**
-     * Nook
+     * Nook, 67, 0x0043
      */
     NOOK(0x0043),
 
     /**
-     * Garden
+     * Garden, 68, 0x0044
      */
     GARDEN(0x0044),
 
     /**
-     * Balcony
+     * Balcony, 69, 0x0045
      */
     BALCONY(0x0045),
 
     /**
-     * Panic Room
+     * Panic Room, 70, 0x0046
      */
     PANIC_ROOM(0x0046),
 
     /**
-     * Terrace
+     * Terrace, 71, 0x0047
      */
     TERRACE(0x0047),
 
     /**
-     * Roof
+     * Roof, 72, 0x0048
      */
     ROOF(0x0048),
 
     /**
-     * Toilet
+     * Toilet, 73, 0x0049
      */
     TOILET(0x0049),
 
     /**
-     * Toilet Main
+     * Toilet Main, 74, 0x004A
      */
     TOILET_MAIN(0x004A),
 
     /**
-     * Outside Toilet
+     * Outside Toilet, 75, 0x004B
      */
     OUTSIDE_TOILET(0x004B),
 
     /**
-     * Shower room
+     * Shower room, 76, 0x004C
      */
     SHOWER_ROOM(0x004C),
 
     /**
-     * Study
+     * Study, 77, 0x004D
      */
     STUDY(0x004D),
 
     /**
-     * Front Garden
+     * Front Garden, 78, 0x004E
      */
     FRONT_GARDEN(0x004E),
 
     /**
-     * Back Garden
+     * Back Garden, 79, 0x004F
      */
     BACK_GARDEN(0x004F),
 
     /**
-     * Kettle
+     * Kettle, 80, 0x0050
      */
     KETTLE(0x0050),
 
     /**
-     * Television
+     * Television, 81, 0x0051
      */
     TELEVISION(0x0051),
 
     /**
-     * Stove
+     * Stove, 82, 0x0052
      */
     STOVE(0x0052),
 
     /**
-     * Microwave
+     * Microwave, 83, 0x0053
      */
     MICROWAVE(0x0053),
 
     /**
-     * Toaster
+     * Toaster, 84, 0x0054
      */
     TOASTER(0x0054),
 
     /**
-     * Vacuum
+     * Vacuum, 85, 0x0055
      */
     VACUUM(0x0055),
 
     /**
-     * Appliance
+     * Appliance, 86, 0x0056
      */
     APPLIANCE(0x0056),
 
     /**
-     * Front Door
+     * Front Door, 87, 0x0057
      */
     FRONT_DOOR(0x0057),
 
     /**
-     * Back Door
+     * Back Door, 88, 0x0058
      */
     BACK_DOOR(0x0058),
 
     /**
-     * Fridge Door
+     * Fridge Door, 89, 0x0059
      */
     FRIDGE_DOOR(0x0059),
 
     /**
-     * Medication Cabinet Door
+     * Medication Cabinet Door, 96, 0x0060
      */
     MEDICATION_CABINET_DOOR(0x0060),
 
     /**
-     * Wardrobe Door
+     * Wardrobe Door, 97, 0x0061
      */
     WARDROBE_DOOR(0x0061),
 
     /**
-     * Front Cupboard Door
+     * Front Cupboard Door, 98, 0x0062
      */
     FRONT_CUPBOARD_DOOR(0x0062),
 
     /**
-     * Other Door
+     * Other Door, 99, 0x0063
      */
     OTHER_DOOR(0x0063),
 
     /**
-     * Waiting Room
+     * Waiting Room, 100, 0x0064
      */
     WAITING_ROOM(0x0064),
 
     /**
-     * Triage Room
+     * Triage Room, 101, 0x0065
      */
     TRIAGE_ROOM(0x0065),
 
     /**
-     * Doctors Office
+     * Doctors Office, 102, 0x0066
      */
     DOCTORS_OFFICE(0x0066),
 
     /**
-     * Patients Private Room
+     * Patients Private Room, 103, 0x0067
      */
     PATIENTS_PRIVATE_ROOM(0x0067),
 
     /**
-     * Consultation Room
+     * Consultation Room, 104, 0x0068
      */
     CONSULTATION_ROOM(0x0068),
 
     /**
-     * Nurse Station
+     * Nurse Station, 105, 0x0069
      */
     NURSE_STATION(0x0069),
 
     /**
-     * Ward
+     * Ward, 106, 0x006A
      */
     WARD(0x006A),
 
     /**
-     * Corridor
+     * Corridor, 107, 0x006B
      */
     CORRIDOR(0x006B),
 
     /**
-     * Operating Theatre
+     * Operating Theatre, 108, 0x006C
      */
     OPERATING_THEATRE(0x006C),
 
     /**
-     * Dental Surgery Room
+     * Dental Surgery Room, 109, 0x006D
      */
     DENTAL_SURGERY_ROOM(0x006D),
 
     /**
-     * Medical Imaging Room
+     * Medical Imaging Room, 110, 0x006E
      */
     MEDICAL_IMAGING_ROOM(0x006E),
 
     /**
-     * Decontamination Room
+     * Decontamination Room, 111, 0x006F
      */
     DECONTAMINATION_ROOM(0x006F),
 
     /**
-     * Unknown
+     * Unknown, 255, 0x00FF
      */
     UNKNOWN(0x00FF);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/basic/PowerSourceEnum.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/basic/PowerSourceEnum.java
@@ -17,41 +17,41 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-02-09T15:28:08Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum PowerSourceEnum {
 
     /**
-     * Unknown
+     * Unknown, 0, 0x0000
      */
     UNKNOWN(0x0000),
 
     /**
-     * Mains Single Phase
+     * Mains Single Phase, 1, 0x0001
      */
     MAINS_SINGLE_PHASE(0x0001),
 
     /**
-     * Mains Three Phase
+     * Mains Three Phase, 2, 0x0002
      */
     MAINS_THREE_PHASE(0x0002),
 
     /**
-     * Battery
+     * Battery, 3, 0x0003
      */
     BATTERY(0x0003),
 
     /**
-     * DC Source
+     * DC Source, 4, 0x0004
      */
     DC_SOURCE(0x0004),
 
     /**
-     * Emergency Mains Constant
+     * Emergency Mains Constant, 5, 0x0005
      */
     EMERGENCY_MAINS_CONSTANT(0x0005),
 
     /**
-     * Emergency Mains Changeover
+     * Emergency Mains Changeover, 6, 0x0006
      */
     EMERGENCY_MAINS_CHANGEOVER(0x0006);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/binaryinputbasic/BinaryInputReliabilityEnum.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/binaryinputbasic/BinaryInputReliabilityEnum.java
@@ -17,51 +17,51 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-02-09T15:28:08Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum BinaryInputReliabilityEnum {
 
     /**
-     * No - Fault - Detected
+     * No - Fault - Detected, 0, 0x0000
      */
     NO_FAULT_DETECTED(0x0000),
 
     /**
-     * Over - Range
+     * Over - Range, 2, 0x0002
      */
     OVER_RANGE(0x0002),
 
     /**
-     * Under - Range
+     * Under - Range, 3, 0x0003
      */
     UNDER_RANGE(0x0003),
 
     /**
-     * Open - Loop
+     * Open - Loop, 4, 0x0004
      */
     OPEN_LOOP(0x0004),
 
     /**
-     * Shorted - Loop
+     * Shorted - Loop, 5, 0x0005
      */
     SHORTED_LOOP(0x0005),
 
     /**
-     * Unreliable - Other
+     * Unreliable - Other, 7, 0x0007
      */
     UNRELIABLE_OTHER(0x0007),
 
     /**
-     * Process - Error
+     * Process - Error, 8, 0x0008
      */
     PROCESS_ERROR(0x0008),
 
     /**
-     * Multi - State - Fault
+     * Multi - State - Fault, 9, 0x0009
      */
     MULTI_STATE_FAULT(0x0009),
 
     /**
-     * Configuration - Error
+     * Configuration - Error, 10, 0x000A
      */
     CONFIGURATION_ERROR(0x000A);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/binaryinputbasic/BinaryInputStatusFlagsBitmap.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/binaryinputbasic/BinaryInputStatusFlagsBitmap.java
@@ -17,26 +17,26 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-02-09T15:28:08Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum BinaryInputStatusFlagsBitmap {
 
     /**
-     * In_Alarm
+     * In_Alarm, 1, 0x0001
      */
     IN_ALARM(0x0001),
 
     /**
-     * Fault
+     * Fault, 2, 0x0002
      */
     FAULT(0x0002),
 
     /**
-     * Overridden
+     * Overridden, 4, 0x0004
      */
     OVERRIDDEN(0x0004),
 
     /**
-     * Out Of Service
+     * Out Of Service, 8, 0x0008
      */
     OUT_OF_SERVICE(0x0008);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/ColorCapabilitiesEnum.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/ColorCapabilitiesEnum.java
@@ -17,31 +17,31 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-02-09T15:28:08Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum ColorCapabilitiesEnum {
 
     /**
-     * Hue And Saturation
+     * Hue And Saturation, 1, 0x0001
      */
     HUE_AND_SATURATION(0x0001),
 
     /**
-     * Enhanced Hue
+     * Enhanced Hue, 2, 0x0002
      */
     ENHANCED_HUE(0x0002),
 
     /**
-     * Color Loop
+     * Color Loop, 4, 0x0004
      */
     COLOR_LOOP(0x0004),
 
     /**
-     * XY Attribute
+     * XY Attribute, 8, 0x0008
      */
     XY_ATTRIBUTE(0x0008),
 
     /**
-     * Color Temperature
+     * Color Temperature, 16, 0x0010
      */
     COLOR_TEMPERATURE(0x0010);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/ColorModeEnum.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/ColorModeEnum.java
@@ -17,21 +17,21 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-02-09T15:28:08Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum ColorModeEnum {
 
     /**
-     * Current Hue And Current Saturation
+     * Current Hue And Current Saturation, 0, 0x0000
      */
     CURRENT_HUE_AND_CURRENT_SATURATION(0x0000),
 
     /**
-     * Current X And Current Y
+     * Current X And Current Y, 1, 0x0001
      */
     CURRENT_X_AND_CURRENT_Y(0x0001),
 
     /**
-     * Color Temperature
+     * Color Temperature, 2, 0x0002
      */
     COLOR_TEMPERATURE(0x0002);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/EnhancedColorModeEnum.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/EnhancedColorModeEnum.java
@@ -17,21 +17,21 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-02-09T15:28:08Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum EnhancedColorModeEnum {
 
     /**
-     * Current Hue And Current Saturation
+     * Current Hue And Current Saturation, 0, 0x0000
      */
     CURRENT_HUE_AND_CURRENT_SATURATION(0x0000),
 
     /**
-     * Current X And Current Y
+     * Current X And Current Y, 1, 0x0001
      */
     CURRENT_X_AND_CURRENT_Y(0x0001),
 
     /**
-     * Enhanced Current Hue And Current Saturation
+     * Enhanced Current Hue And Current Saturation, 2, 0x0002
      */
     ENHANCED_CURRENT_HUE_AND_CURRENT_SATURATION(0x0002);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/StepModeEnum.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/StepModeEnum.java
@@ -17,16 +17,16 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-04-13T22:03:06Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum StepModeEnum {
 
     /**
-     * Up
+     * Up, 1, 0x0001
      */
     UP(0x0001),
 
     /**
-     * Down
+     * Down, 3, 0x0003
      */
     DOWN(0x0003);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/demandresponseandloadcontrol/CancelControlBitmap.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/demandresponseandloadcontrol/CancelControlBitmap.java
@@ -17,11 +17,11 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-02-09T15:28:08Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum CancelControlBitmap {
 
     /**
-     * Terminate With Randomization
+     * Terminate With Randomization, 1, 0x0001
      */
     TERMINATE_WITH_RANDOMIZATION(0x0001);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/demandresponseandloadcontrol/CriticalityLevelEnum.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/demandresponseandloadcontrol/CriticalityLevelEnum.java
@@ -17,81 +17,81 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-02-09T15:28:08Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum CriticalityLevelEnum {
 
     /**
-     * Green
+     * Green, 1, 0x0001
      */
     GREEN(0x0001),
 
     /**
-     * Level 1
+     * Level 1, 2, 0x0002
      */
     LEVEL_1(0x0002),
 
     /**
-     * Level 2
+     * Level 2, 3, 0x0003
      */
     LEVEL_2(0x0003),
 
     /**
-     * Level 3
+     * Level 3, 4, 0x0004
      */
     LEVEL_3(0x0004),
 
     /**
-     * Level 4
+     * Level 4, 5, 0x0005
      */
     LEVEL_4(0x0005),
 
     /**
-     * Level 5
+     * Level 5, 6, 0x0006
      */
     LEVEL_5(0x0006),
 
     /**
-     * Emergency
+     * Emergency, 7, 0x0007
      */
     EMERGENCY(0x0007),
 
     /**
-     * Planned Outage
+     * Planned Outage, 8, 0x0008
      */
     PLANNED_OUTAGE(0x0008),
 
     /**
-     * Service Disconnect
+     * Service Disconnect, 9, 0x0009
      */
     SERVICE_DISCONNECT(0x0009),
 
     /**
-     * Utility Defined 1
+     * Utility Defined 1, 10, 0x000A
      */
     UTILITY_DEFINED_1(0x000A),
 
     /**
-     * Utility Defined 2
+     * Utility Defined 2, 11, 0x000B
      */
     UTILITY_DEFINED_2(0x000B),
 
     /**
-     * Utility Defined 3
+     * Utility Defined 3, 12, 0x000C
      */
     UTILITY_DEFINED_3(0x000C),
 
     /**
-     * Utility Defined 4
+     * Utility Defined 4, 13, 0x000D
      */
     UTILITY_DEFINED_4(0x000D),
 
     /**
-     * Utility Defined 5
+     * Utility Defined 5, 14, 0x000E
      */
     UTILITY_DEFINED_5(0x000E),
 
     /**
-     * Utility Defined 6
+     * Utility Defined 6, 15, 0x000F
      */
     UTILITY_DEFINED_6(0x000F);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/demandresponseandloadcontrol/DeviceClassBitmap.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/demandresponseandloadcontrol/DeviceClassBitmap.java
@@ -20,66 +20,66 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-02-09T15:28:08Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum DeviceClassBitmap {
 
     /**
-     * Hvac Compressor Or Furnace
+     * Hvac Compressor Or Furnace, 1, 0x0001
      */
     HVAC_COMPRESSOR_OR_FURNACE(0x0001),
 
     /**
-     * Strip Heat Baseboard Heat
+     * Strip Heat Baseboard Heat, 2, 0x0002
      */
     STRIP_HEAT_BASEBOARD_HEAT(0x0002),
 
     /**
-     * Water Heater
+     * Water Heater, 4, 0x0004
      */
     WATER_HEATER(0x0004),
 
     /**
-     * Pool Pump Spa Jacuzzi
+     * Pool Pump Spa Jacuzzi, 8, 0x0008
      */
     POOL_PUMP_SPA_JACUZZI(0x0008),
 
     /**
-     * Smart Appliances
+     * Smart Appliances, 16, 0x0010
      */
     SMART_APPLIANCES(0x0010),
 
     /**
-     * Irrigation Pump
+     * Irrigation Pump, 32, 0x0020
      */
     IRRIGATION_PUMP(0x0020),
 
     /**
-     * Managed C And I Loads
+     * Managed C And I Loads, 64, 0x0040
      */
     MANAGED_C_AND_I_LOADS(0x0040),
 
     /**
-     * Simple Misc Loads
+     * Simple Misc Loads, 128, 0x0080
      */
     SIMPLE_MISC_LOADS(0x0080),
 
     /**
-     * Exterior Lighting
+     * Exterior Lighting, 256, 0x0100
      */
     EXTERIOR_LIGHTING(0x0100),
 
     /**
-     * Interior Lighting
+     * Interior Lighting, 512, 0x0200
      */
     INTERIOR_LIGHTING(0x0200),
 
     /**
-     * Electric Vehicle
+     * Electric Vehicle, 1024, 0x0400
      */
     ELECTRIC_VEHICLE(0x0400),
 
     /**
-     * Generation Systems
+     * Generation Systems, 2048, 0x0800
      */
     GENERATION_SYSTEMS(0x0800);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/demandresponseandloadcontrol/EventControlBitmap.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/demandresponseandloadcontrol/EventControlBitmap.java
@@ -17,16 +17,16 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-02-09T15:28:08Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum EventControlBitmap {
 
     /**
-     * Randomized Start Time
+     * Randomized Start Time, 1, 0x0001
      */
     RANDOMIZED_START_TIME(0x0001),
 
     /**
-     * Randomized End Time
+     * Randomized End Time, 2, 0x0002
      */
     RANDOMIZED_END_TIME(0x0002);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/demandresponseandloadcontrol/EventStatusEnum.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/demandresponseandloadcontrol/EventStatusEnum.java
@@ -17,91 +17,91 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-02-09T15:28:08Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum EventStatusEnum {
 
     /**
-     * Load Control Event Command Rx
+     * Load Control Event Command Rx, 1, 0x0001
      */
     LOAD_CONTROL_EVENT_COMMAND_RX(0x0001),
 
     /**
-     * Event Started
+     * Event Started, 2, 0x0002
      */
     EVENT_STARTED(0x0002),
 
     /**
-     * Event Completed
+     * Event Completed, 3, 0x0003
      */
     EVENT_COMPLETED(0x0003),
 
     /**
-     * User Has Choose To Opt Out
+     * User Has Choose To Opt Out, 4, 0x0004
      */
     USER_HAS_CHOOSE_TO_OPT_OUT(0x0004),
 
     /**
-     * User Has Choose To Opt In
+     * User Has Choose To Opt In, 5, 0x0005
      */
     USER_HAS_CHOOSE_TO_OPT_IN(0x0005),
 
     /**
-     * The Event Has Been Canceled
+     * The Event Has Been Canceled, 6, 0x0006
      */
     THE_EVENT_HAS_BEEN_CANCELED(0x0006),
 
     /**
-     * The Event Has Been Superseded
+     * The Event Has Been Superseded, 7, 0x0007
      */
     THE_EVENT_HAS_BEEN_SUPERSEDED(0x0007),
 
     /**
-     * Event Partially Completed With User Opt Out
+     * Event Partially Completed With User Opt Out, 8, 0x0008
      */
     EVENT_PARTIALLY_COMPLETED_WITH_USER_OPT_OUT(0x0008),
 
     /**
-     * Event Partially Completed Due To User Opt In
+     * Event Partially Completed Due To User Opt In, 9, 0x0009
      */
     EVENT_PARTIALLY_COMPLETED_DUE_TO_USER_OPT_IN(0x0009),
 
     /**
-     * Event Completed No User Participation Previous Opt Out
+     * Event Completed No User Participation Previous Opt Out, 10, 0x000A
      */
     EVENT_COMPLETED_NO_USER_PARTICIPATION_PREVIOUS_OPT_OUT(0x000A),
 
     /**
-     * Invalid Opt Out
+     * Invalid Opt Out, 246, 0x00F6
      */
     INVALID_OPT_OUT(0x00F6),
 
     /**
-     * Event Not Found
+     * Event Not Found, 247, 0x00F7
      */
     EVENT_NOT_FOUND(0x00F7),
 
     /**
-     * Rejected Invalid Cancel Command
+     * Rejected Invalid Cancel Command, 248, 0x00F8
      */
     REJECTED_INVALID_CANCEL_COMMAND(0x00F8),
 
     /**
-     * Rejected Invalid Cancel Command Invalid Effective Time
+     * Rejected Invalid Cancel Command Invalid Effective Time, 249, 0x00F9
      */
     REJECTED_INVALID_CANCEL_COMMAND_INVALID_EFFECTIVE_TIME(0x00F9),
 
     /**
-     * Rejected Event Expired
+     * Rejected Event Expired, 251, 0x00FB
      */
     REJECTED_EVENT_EXPIRED(0x00FB),
 
     /**
-     * Rejected Invalid Cancel Undefined Event
+     * Rejected Invalid Cancel Undefined Event, 253, 0x00FD
      */
     REJECTED_INVALID_CANCEL_UNDEFINED_EVENT(0x00FD),
 
     /**
-     * Load Control Event Command Rejected
+     * Load Control Event Command Rejected, 254, 0x00FE
      */
     LOAD_CONTROL_EVENT_COMMAND_REJECTED(0x00FE);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/demandresponseandloadcontrol/SignatureTypeEnum.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/demandresponseandloadcontrol/SignatureTypeEnum.java
@@ -17,11 +17,11 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-02-09T15:28:08Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum SignatureTypeEnum {
 
     /**
-     * ECDSA
+     * ECDSA, 1, 0x0001
      */
     ECDSA(0x0001);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/electricalmeasurement/MeasurementTypeEnum.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/electricalmeasurement/MeasurementTypeEnum.java
@@ -17,51 +17,51 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-02-09T15:28:08Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum MeasurementTypeEnum {
 
     /**
-     * AC Active Measurement
+     * AC Active Measurement, 0, 0x0000
      */
     AC_ACTIVE_MEASUREMENT(0x0000),
 
     /**
-     * AC Reactive Measurement
+     * AC Reactive Measurement, 1, 0x0001
      */
     AC_REACTIVE_MEASUREMENT(0x0001),
 
     /**
-     * AC Apparent Measurement
+     * AC Apparent Measurement, 2, 0x0002
      */
     AC_APPARENT_MEASUREMENT(0x0002),
 
     /**
-     * Phase A Measurement
+     * Phase A Measurement, 4, 0x0004
      */
     PHASE_A_MEASUREMENT(0x0004),
 
     /**
-     * Phase B Measurement
+     * Phase B Measurement, 8, 0x0008
      */
     PHASE_B_MEASUREMENT(0x0008),
 
     /**
-     * Phase C Measurement
+     * Phase C Measurement, 16, 0x0010
      */
     PHASE_C_MEASUREMENT(0x0010),
 
     /**
-     * DC Measurement
+     * DC Measurement, 32, 0x0020
      */
     DC_MEASUREMENT(0x0020),
 
     /**
-     * Harmonics Measurement
+     * Harmonics Measurement, 64, 0x0040
      */
     HARMONICS_MEASUREMENT(0x0040),
 
     /**
-     * Power Quality Measurement
+     * Power Quality Measurement, 128, 0x0080
      */
     POWER_QUALITY_MEASUREMENT(0x0080);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpApplicationInformationBitmap.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpApplicationInformationBitmap.java
@@ -17,26 +17,26 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-07-04T21:54:11Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum GpApplicationInformationBitmap {
 
     /**
-     * Manufacture ID Present
+     * Manufacture ID Present, 1, 0x0001
      */
     MANUFACTURE_ID_PRESENT(0x0001),
 
     /**
-     * Model ID Present
+     * Model ID Present, 2, 0x0002
      */
     MODEL_ID_PRESENT(0x0002),
 
     /**
-     * Gpd Commands Present
+     * Gpd Commands Present, 4, 0x0004
      */
     GPD_COMMANDS_PRESENT(0x0004),
 
     /**
-     * Cluster List Present
+     * Cluster List Present, 8, 0x0008
      */
     CLUSTER_LIST_PRESENT(0x0008);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpCommissioningNotificationOptionBitmap.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpCommissioningNotificationOptionBitmap.java
@@ -17,41 +17,41 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-07-04T21:54:11Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum GpCommissioningNotificationOptionBitmap {
 
     /**
-     * Application ID
+     * Application ID, 7, 0x0007
      */
     APPLICATION_ID(0x0007),
 
     /**
-     * Rx After Tx
+     * Rx After Tx, 8, 0x0008
      */
     RX_AFTER_TX(0x0008),
 
     /**
-     * Security Level
+     * Security Level, 48, 0x0030
      */
     SECURITY_LEVEL(0x0030),
 
     /**
-     * Security Key Type
+     * Security Key Type, 448, 0x01C0
      */
     SECURITY_KEY_TYPE(0x01C0),
 
     /**
-     * Security Processing Failed
+     * Security Processing Failed, 512, 0x0200
      */
     SECURITY_PROCESSING_FAILED(0x0200),
 
     /**
-     * Bidirectional Capability
+     * Bidirectional Capability, 1024, 0x0400
      */
     BIDIRECTIONAL_CAPABILITY(0x0400),
 
     /**
-     * Proxy Info Present
+     * Proxy Info Present, 2048, 0x0800
      */
     PROXY_INFO_PRESENT(0x0800);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpDeviceIdEnum.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpDeviceIdEnum.java
@@ -17,26 +17,26 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-07-04T21:54:11Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum GpDeviceIdEnum {
 
     /**
-     * Gp Simple Generice Two State Switch
+     * Gp Simple Generice Two State Switch, 0, 0x0000
      */
     GP_SIMPLE_GENERICE_TWO_STATE_SWITCH(0x0000),
 
     /**
-     * Gp On Off Switch
+     * Gp On Off Switch, 8, 0x0008
      */
     GP_ON_OFF_SWITCH(0x0008),
 
     /**
-     * Gp Level Control Switch
+     * Gp Level Control Switch, 16, 0x0010
      */
     GP_LEVEL_CONTROL_SWITCH(0x0010),
 
     /**
-     * Gp Indoor Environment Snesor
+     * Gp Indoor Environment Snesor, 24, 0x0018
      */
     GP_INDOOR_ENVIRONMENT_SNESOR(0x0018);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpNotificationOptionBitmap.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpNotificationOptionBitmap.java
@@ -17,56 +17,56 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-07-04T21:54:11Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum GpNotificationOptionBitmap {
 
     /**
-     * Application ID
+     * Application ID, 7, 0x0007
      */
     APPLICATION_ID(0x0007),
 
     /**
-     * Also Unicast
+     * Also Unicast, 8, 0x0008
      */
     ALSO_UNICAST(0x0008),
 
     /**
-     * Also Derived Group
+     * Also Derived Group, 16, 0x0010
      */
     ALSO_DERIVED_GROUP(0x0010),
 
     /**
-     * Also Commissioned Group
+     * Also Commissioned Group, 32, 0x0020
      */
     ALSO_COMMISSIONED_GROUP(0x0020),
 
     /**
-     * Security Level
+     * Security Level, 192, 0x00C0
      */
     SECURITY_LEVEL(0x00C0),
 
     /**
-     * Security Key Type
+     * Security Key Type, 1792, 0x0700
      */
     SECURITY_KEY_TYPE(0x0700),
 
     /**
-     * Rx After Tx
+     * Rx After Tx, 2048, 0x0800
      */
     RX_AFTER_TX(0x0800),
 
     /**
-     * Gp Tx Queue Full
+     * Gp Tx Queue Full, 4096, 0x1000
      */
     GP_TX_QUEUE_FULL(0x1000),
 
     /**
-     * Bidirectional Capability
+     * Bidirectional Capability, 8192, 0x2000
      */
     BIDIRECTIONAL_CAPABILITY(0x2000),
 
     /**
-     * Proxy Info Present
+     * Proxy Info Present, 16384, 0x4000
      */
     PROXY_INFO_PRESENT(0x4000);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpNotificationResponseOptionBitmap.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpNotificationResponseOptionBitmap.java
@@ -17,21 +17,21 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-07-04T21:54:11Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum GpNotificationResponseOptionBitmap {
 
     /**
-     * Application ID
+     * Application ID, 7, 0x0007
      */
     APPLICATION_ID(0x0007),
 
     /**
-     * First To Forward
+     * First To Forward, 8, 0x0008
      */
     FIRST_TO_FORWARD(0x0008),
 
     /**
-     * No Pairing
+     * No Pairing, 16, 0x0010
      */
     NO_PAIRING(0x0010);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpPairingConfigurationActionsBitmap.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpPairingConfigurationActionsBitmap.java
@@ -17,16 +17,16 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-07-04T21:54:11Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum GpPairingConfigurationActionsBitmap {
 
     /**
-     * Action
+     * Action, 7, 0x0007
      */
     ACTION(0x0007),
 
     /**
-     * Send Gp Pairing
+     * Send Gp Pairing, 8, 0x0008
      */
     SEND_GP_PAIRING(0x0008);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpPairingConfigurationOptionBitmap.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpPairingConfigurationOptionBitmap.java
@@ -17,46 +17,46 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-07-04T21:54:11Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum GpPairingConfigurationOptionBitmap {
 
     /**
-     * Application ID
+     * Application ID, 7, 0x0007
      */
     APPLICATION_ID(0x0007),
 
     /**
-     * Communication Mode
+     * Communication Mode, 24, 0x0018
      */
     COMMUNICATION_MODE(0x0018),
 
     /**
-     * Sequence Number Capabilities
+     * Sequence Number Capabilities, 32, 0x0020
      */
     SEQUENCE_NUMBER_CAPABILITIES(0x0020),
 
     /**
-     * Rx On Capability
+     * Rx On Capability, 64, 0x0040
      */
     RX_ON_CAPABILITY(0x0040),
 
     /**
-     * Fixed Location
+     * Fixed Location, 128, 0x0080
      */
     FIXED_LOCATION(0x0080),
 
     /**
-     * Assigned Alias
+     * Assigned Alias, 256, 0x0100
      */
     ASSIGNED_ALIAS(0x0100),
 
     /**
-     * Security Use
+     * Security Use, 512, 0x0200
      */
     SECURITY_USE(0x0200),
 
     /**
-     * Application Information Present
+     * Application Information Present, 1024, 0x0400
      */
     APPLICATION_INFORMATION_PRESENT(0x0400);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpPairingOptionBitmap.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpPairingOptionBitmap.java
@@ -17,66 +17,66 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-07-04T21:54:11Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum GpPairingOptionBitmap {
 
     /**
-     * Application ID
+     * Application ID, 7, 0x0007
      */
     APPLICATION_ID(0x0007),
 
     /**
-     * Add Sink
+     * Add Sink, 8, 0x0008
      */
     ADD_SINK(0x0008),
 
     /**
-     * Remove Gpd
+     * Remove Gpd, 16, 0x0010
      */
     REMOVE_GPD(0x0010),
 
     /**
-     * Communication Mode
+     * Communication Mode, 96, 0x0060
      */
     COMMUNICATION_MODE(0x0060),
 
     /**
-     * Gpd Fixed
+     * Gpd Fixed, 128, 0x0080
      */
     GPD_FIXED(0x0080),
 
     /**
-     * Gpd MAC Sequence Number Capabilities
+     * Gpd MAC Sequence Number Capabilities, 256, 0x0100
      */
     GPD_MAC_SEQUENCE_NUMBER_CAPABILITIES(0x0100),
 
     /**
-     * Security Level
+     * Security Level, 1536, 0x0600
      */
     SECURITY_LEVEL(0x0600),
 
     /**
-     * Security Key Type
+     * Security Key Type, 14336, 0x3800
      */
     SECURITY_KEY_TYPE(0x3800),
 
     /**
-     * Gpd Security Frame Counter Present
+     * Gpd Security Frame Counter Present, 16384, 0x4000
      */
     GPD_SECURITY_FRAME_COUNTER_PRESENT(0x4000),
 
     /**
-     * Gpd Security Key Present
+     * Gpd Security Key Present, 32768, 0x8000
      */
     GPD_SECURITY_KEY_PRESENT(0x8000),
 
     /**
-     * Assigned Alias Present
+     * Assigned Alias Present, 65536, 0x10000
      */
     ASSIGNED_ALIAS_PRESENT(0x10000),
 
     /**
-     * Forwarding Radius Present
+     * Forwarding Radius Present, 131072, 0x20000
      */
     FORWARDING_RADIUS_PRESENT(0x20000);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpPairingSearchOptionBitmap.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpPairingSearchOptionBitmap.java
@@ -17,36 +17,36 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-07-04T21:54:11Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum GpPairingSearchOptionBitmap {
 
     /**
-     * Application ID
+     * Application ID, 7, 0x0007
      */
     APPLICATION_ID(0x0007),
 
     /**
-     * Request Unicast Sinks
+     * Request Unicast Sinks, 8, 0x0008
      */
     REQUEST_UNICAST_SINKS(0x0008),
 
     /**
-     * Request Derived Groupcast Sinks
+     * Request Derived Groupcast Sinks, 16, 0x0010
      */
     REQUEST_DERIVED_GROUPCAST_SINKS(0x0010),
 
     /**
-     * Request Commissioned Groupcast Sinks
+     * Request Commissioned Groupcast Sinks, 32, 0x0020
      */
     REQUEST_COMMISSIONED_GROUPCAST_SINKS(0x0020),
 
     /**
-     * Request Gpd Security Frame Counter
+     * Request Gpd Security Frame Counter, 64, 0x0040
      */
     REQUEST_GPD_SECURITY_FRAME_COUNTER(0x0040),
 
     /**
-     * Request Gpd Security Key
+     * Request Gpd Security Key, 128, 0x0080
      */
     REQUEST_GPD_SECURITY_KEY(0x0080);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpProxyCommissioningModeOptionBitmap.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpProxyCommissioningModeOptionBitmap.java
@@ -17,26 +17,26 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-07-04T21:54:11Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum GpProxyCommissioningModeOptionBitmap {
 
     /**
-     * Action
+     * Action, 1, 0x0001
      */
     ACTION(0x0001),
 
     /**
-     * Exit Mode
+     * Exit Mode, 14, 0x000E
      */
     EXIT_MODE(0x000E),
 
     /**
-     * Channel Present
+     * Channel Present, 16, 0x0010
      */
     CHANNEL_PRESENT(0x0010),
 
     /**
-     * Unicast Communication
+     * Unicast Communication, 32, 0x0020
      */
     UNICAST_COMMUNICATION(0x0020);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpProxyTableRequestOptionsBitmap.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpProxyTableRequestOptionsBitmap.java
@@ -17,16 +17,16 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-07-04T21:54:11Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum GpProxyTableRequestOptionsBitmap {
 
     /**
-     * Application ID
+     * Application ID, 7, 0x0007
      */
     APPLICATION_ID(0x0007),
 
     /**
-     * Request Type
+     * Request Type, 24, 0x0018
      */
     REQUEST_TYPE(0x0018);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpProxyTableResponseStatusEnum.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpProxyTableResponseStatusEnum.java
@@ -17,16 +17,16 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-07-04T21:54:11Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum GpProxyTableResponseStatusEnum {
 
     /**
-     * Success
+     * Success, 0, 0x0000
      */
     SUCCESS(0x0000),
 
     /**
-     * Not_Found
+     * Not_Found, 139, 0x008B
      */
     NOT_FOUND(0x008B);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpResponseOptionBitmap.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpResponseOptionBitmap.java
@@ -17,11 +17,11 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-07-04T21:54:11Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum GpResponseOptionBitmap {
 
     /**
-     * Application ID
+     * Application ID, 7, 0x0007
      */
     APPLICATION_ID(0x0007);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpSinkCommissioningModeOptionsBitmap.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpSinkCommissioningModeOptionsBitmap.java
@@ -17,26 +17,26 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-07-04T21:54:11Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum GpSinkCommissioningModeOptionsBitmap {
 
     /**
-     * Action
+     * Action, 1, 0x0001
      */
     ACTION(0x0001),
 
     /**
-     * Involve Gpm In Security
+     * Involve Gpm In Security, 2, 0x0002
      */
     INVOLVE_GPM_IN_SECURITY(0x0002),
 
     /**
-     * Involve Gpm In Pairing
+     * Involve Gpm In Pairing, 4, 0x0004
      */
     INVOLVE_GPM_IN_PAIRING(0x0004),
 
     /**
-     * Involve Proxies
+     * Involve Proxies, 8, 0x0008
      */
     INVOLVE_PROXIES(0x0008);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpSinkTableRequestOptionsBitmap.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpSinkTableRequestOptionsBitmap.java
@@ -17,16 +17,16 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-07-04T21:54:11Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum GpSinkTableRequestOptionsBitmap {
 
     /**
-     * Application ID
+     * Application ID, 7, 0x0007
      */
     APPLICATION_ID(0x0007),
 
     /**
-     * Request Type
+     * Request Type, 24, 0x0018
      */
     REQUEST_TYPE(0x0018);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpTranslationTableUpdateOptionBitmap.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpTranslationTableUpdateOptionBitmap.java
@@ -17,21 +17,21 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-07-04T21:54:11Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum GpTranslationTableUpdateOptionBitmap {
 
     /**
-     * Application ID
+     * Application ID, 7, 0x0007
      */
     APPLICATION_ID(0x0007),
 
     /**
-     * Action
+     * Action, 24, 0x0018
      */
     ACTION(0x0018),
 
     /**
-     * Number Of Translations
+     * Number Of Translations, 224, 0x00E0
      */
     NUMBER_OF_TRANSLATIONS(0x00E0);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpTunnelingStopOptionBitmap.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpTunnelingStopOptionBitmap.java
@@ -17,21 +17,21 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-07-04T21:54:11Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum GpTunnelingStopOptionBitmap {
 
     /**
-     * Application ID
+     * Application ID, 7, 0x0007
      */
     APPLICATION_ID(0x0007),
 
     /**
-     * Also Derived Group
+     * Also Derived Group, 8, 0x0008
      */
     ALSO_DERIVED_GROUP(0x0008),
 
     /**
-     * Also Commissioned Group
+     * Also Commissioned Group, 16, 0x0010
      */
     ALSO_COMMISSIONED_GROUP(0x0010);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/IasAceAlarmStatusEnum.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/IasAceAlarmStatusEnum.java
@@ -17,41 +17,41 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-02-09T15:28:08Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum IasAceAlarmStatusEnum {
 
     /**
-     * No Alarm
+     * No Alarm, 0, 0x0000
      */
     NO_ALARM(0x0000),
 
     /**
-     * Burglar
+     * Burglar, 1, 0x0001
      */
     BURGLAR(0x0001),
 
     /**
-     * Fire
+     * Fire, 2, 0x0002
      */
     FIRE(0x0002),
 
     /**
-     * Emergency
+     * Emergency, 3, 0x0003
      */
     EMERGENCY(0x0003),
 
     /**
-     * Police Panic
+     * Police Panic, 4, 0x0004
      */
     POLICE_PANIC(0x0004),
 
     /**
-     * Fire Panic
+     * Fire Panic, 5, 0x0005
      */
     FIRE_PANIC(0x0005),
 
     /**
-     * Emergency Panic
+     * Emergency Panic, 6, 0x0006
      */
     EMERGENCY_PANIC(0x0006);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/IasAceArmModeEnum.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/IasAceArmModeEnum.java
@@ -17,26 +17,26 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-02-09T15:28:08Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum IasAceArmModeEnum {
 
     /**
-     * Disarm
+     * Disarm, 0, 0x0000
      */
     DISARM(0x0000),
 
     /**
-     * Arm Day Home Zones Only
+     * Arm Day Home Zones Only, 1, 0x0001
      */
     ARM_DAY_HOME_ZONES_ONLY(0x0001),
 
     /**
-     * Arm Night Sleep Zones Only
+     * Arm Night Sleep Zones Only, 2, 0x0002
      */
     ARM_NIGHT_SLEEP_ZONES_ONLY(0x0002),
 
     /**
-     * Arm All Zones
+     * Arm All Zones, 3, 0x0003
      */
     ARM_ALL_ZONES(0x0003);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/IasAceArmNotificationEnum.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/IasAceArmNotificationEnum.java
@@ -17,41 +17,41 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-02-09T15:28:08Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum IasAceArmNotificationEnum {
 
     /**
-     * All Zones Disarmed
+     * All Zones Disarmed, 0, 0x0000
      */
     ALL_ZONES_DISARMED(0x0000),
 
     /**
-     * Only Day Home Zones Armed
+     * Only Day Home Zones Armed, 1, 0x0001
      */
     ONLY_DAY_HOME_ZONES_ARMED(0x0001),
 
     /**
-     * Only Night Sleep Zones Armed
+     * Only Night Sleep Zones Armed, 2, 0x0002
      */
     ONLY_NIGHT_SLEEP_ZONES_ARMED(0x0002),
 
     /**
-     * All Zones Armed
+     * All Zones Armed, 3, 0x0003
      */
     ALL_ZONES_ARMED(0x0003),
 
     /**
-     * Invalid Arm Disarm Code
+     * Invalid Arm Disarm Code, 4, 0x0004
      */
     INVALID_ARM_DISARM_CODE(0x0004),
 
     /**
-     * Not Ready To Arm
+     * Not Ready To Arm, 5, 0x0005
      */
     NOT_READY_TO_ARM(0x0005),
 
     /**
-     * Already Disarmed
+     * Already Disarmed, 6, 0x0006
      */
     ALREADY_DISARMED(0x0006);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/IasAceAudibleNotificationEnum.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/IasAceAudibleNotificationEnum.java
@@ -17,16 +17,16 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-02-09T15:28:08Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum IasAceAudibleNotificationEnum {
 
     /**
-     * Mute
+     * Mute, 0, 0x0000
      */
     MUTE(0x0000),
 
     /**
-     * Default Sound
+     * Default Sound, 1, 0x0001
      */
     DEFAULT_SOUND(0x0001);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/IasAcePanelStatusEnum.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/IasAcePanelStatusEnum.java
@@ -17,61 +17,61 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-02-09T15:28:08Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum IasAcePanelStatusEnum {
 
     /**
-     * Panel Disarmed
+     * Panel Disarmed, 0, 0x0000
      */
     PANEL_DISARMED(0x0000),
 
     /**
-     * Armed Stay
+     * Armed Stay, 1, 0x0001
      */
     ARMED_STAY(0x0001),
 
     /**
-     * Armed Night
+     * Armed Night, 2, 0x0002
      */
     ARMED_NIGHT(0x0002),
 
     /**
-     * Armed Away
+     * Armed Away, 3, 0x0003
      */
     ARMED_AWAY(0x0003),
 
     /**
-     * Exit Delay
+     * Exit Delay, 4, 0x0004
      */
     EXIT_DELAY(0x0004),
 
     /**
-     * Entry Delay
+     * Entry Delay, 5, 0x0005
      */
     ENTRY_DELAY(0x0005),
 
     /**
-     * Not Ready To Arm
+     * Not Ready To Arm, 6, 0x0006
      */
     NOT_READY_TO_ARM(0x0006),
 
     /**
-     * In Alarm
+     * In Alarm, 7, 0x0007
      */
     IN_ALARM(0x0007),
 
     /**
-     * Arming Stay
+     * Arming Stay, 8, 0x0008
      */
     ARMING_STAY(0x0008),
 
     /**
-     * Arming Night
+     * Arming Night, 9, 0x0009
      */
     ARMING_NIGHT(0x0009),
 
     /**
-     * Arming Away
+     * Arming Away, 10, 0x000A
      */
     ARMING_AWAY(0x000A);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iaswd/SquawkInfoBitmap.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iaswd/SquawkInfoBitmap.java
@@ -17,21 +17,21 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-02-09T15:28:08Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum SquawkInfoBitmap {
 
     /**
-     * Level
+     * Level, 3, 0x0003
      */
     LEVEL(0x0003),
 
     /**
-     * Strobe
+     * Strobe, 8, 0x0008
      */
     STROBE(0x0008),
 
     /**
-     * Mode
+     * Mode, 240, 0x00F0
      */
     MODE(0x00F0);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iaszone/IasEnrollResponseCodeEnum.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iaszone/IasEnrollResponseCodeEnum.java
@@ -17,26 +17,26 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-02-09T15:28:08Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum IasEnrollResponseCodeEnum {
 
     /**
-     * Success
+     * Success, 0, 0x0000
      */
     SUCCESS(0x0000),
 
     /**
-     * Not Supported
+     * Not Supported, 1, 0x0001
      */
     NOT_SUPPORTED(0x0001),
 
     /**
-     * No Enroll Permit
+     * No Enroll Permit, 2, 0x0002
      */
     NO_ENROLL_PERMIT(0x0002),
 
     /**
-     * Too Many Zones
+     * Too Many Zones, 3, 0x0003
      */
     TOO_MANY_ZONES(0x0003);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iaszone/IasZoneStatusBitmap.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iaszone/IasZoneStatusBitmap.java
@@ -17,56 +17,56 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-02-09T15:28:08Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum IasZoneStatusBitmap {
 
     /**
-     * Alarm 1
+     * Alarm 1, 1, 0x0001
      */
     ALARM_1(0x0001),
 
     /**
-     * Alarm 2
+     * Alarm 2, 2, 0x0002
      */
     ALARM_2(0x0002),
 
     /**
-     * Tamper
+     * Tamper, 4, 0x0004
      */
     TAMPER(0x0004),
 
     /**
-     * Battery
+     * Battery, 8, 0x0008
      */
     BATTERY(0x0008),
 
     /**
-     * Supervision Reports
+     * Supervision Reports, 16, 0x0010
      */
     SUPERVISION_REPORTS(0x0010),
 
     /**
-     * Restore Reports
+     * Restore Reports, 32, 0x0020
      */
     RESTORE_REPORTS(0x0020),
 
     /**
-     * Trouble
+     * Trouble, 64, 0x0040
      */
     TROUBLE(0x0040),
 
     /**
-     * AC
+     * AC, 128, 0x0080
      */
     AC(0x0080),
 
     /**
-     * Test
+     * Test, 256, 0x0100
      */
     TEST(0x0100),
 
     /**
-     * Battery Defect
+     * Battery Defect, 512, 0x0200
      */
     BATTERY_DEFECT(0x0200);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iaszone/IasZoneTypeEnum.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iaszone/IasZoneTypeEnum.java
@@ -17,86 +17,86 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-02-09T15:28:08Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum IasZoneTypeEnum {
 
     /**
-     * Standard CIE
+     * Standard CIE, 0, 0x0000
      */
     STANDARD_CIE(0x0000),
 
     /**
-     * Motion Sensor
+     * Motion Sensor, 13, 0x000D
      */
     MOTION_SENSOR(0x000D),
 
     /**
-     * Contact Switch
+     * Contact Switch, 21, 0x0015
      */
     CONTACT_SWITCH(0x0015),
 
     /**
-     * Fire Sensor
+     * Fire Sensor, 40, 0x0028
      */
     FIRE_SENSOR(0x0028),
 
     /**
-     * Water Sensor
+     * Water Sensor, 42, 0x002A
      */
     WATER_SENSOR(0x002A),
 
     /**
-     * Gas Sensor
+     * Gas Sensor, 43, 0x002B
      */
     GAS_SENSOR(0x002B),
 
     /**
-     * Personal Emergency Device
+     * Personal Emergency Device, 44, 0x002C
      */
     PERSONAL_EMERGENCY_DEVICE(0x002C),
 
     /**
-     * Vibration Movement Sensor
+     * Vibration Movement Sensor, 45, 0x002D
      */
     VIBRATION_MOVEMENT_SENSOR(0x002D),
 
     /**
-     * Remote Control
+     * Remote Control, 271, 0x010F
      */
     REMOTE_CONTROL(0x010F),
 
     /**
-     * Key Fob
+     * Key Fob, 277, 0x0115
      */
     KEY_FOB(0x0115),
 
     /**
-     * Keypad
+     * Keypad, 541, 0x021D
      */
     KEYPAD(0x021D),
 
     /**
-     * Standard Warning Device
+     * Standard Warning Device, 549, 0x0225
      */
     STANDARD_WARNING_DEVICE(0x0225),
 
     /**
-     * Glass Break Sensor
+     * Glass Break Sensor, 550, 0x0226
      */
     GLASS_BREAK_SENSOR(0x0226),
 
     /**
-     * Carbon Monoxide Sensor
+     * Carbon Monoxide Sensor, 551, 0x0227
      */
     CARBON_MONOXIDE_SENSOR(0x0227),
 
     /**
-     * Security Repeater
+     * Security Repeater, 553, 0x0229
      */
     SECURITY_REPEATER(0x0229),
 
     /**
-     * Invalid Zone Type
+     * Invalid Zone Type, 65535, 0xFFFF
      */
     INVALID_ZONE_TYPE(0xFFFF);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iaszone/ZoneStateEnum.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iaszone/ZoneStateEnum.java
@@ -17,16 +17,16 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-02-09T15:28:08Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum ZoneStateEnum {
 
     /**
-     * Not Enrolled
+     * Not Enrolled, 0, 0x0000
      */
     NOT_ENROLLED(0x0000),
 
     /**
-     * Enrolled
+     * Enrolled, 1, 0x0001
      */
     ENROLLED(0x0001);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iaszone/ZoneTypeEnum.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iaszone/ZoneTypeEnum.java
@@ -17,76 +17,76 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-02-09T15:28:08Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum ZoneTypeEnum {
 
     /**
-     * Standard CIE
+     * Standard CIE, 0, 0x0000
      */
     STANDARD_CIE(0x0000),
 
     /**
-     * Motion Sensor
+     * Motion Sensor, 13, 0x000D
      */
     MOTION_SENSOR(0x000D),
 
     /**
-     * Contact Switch
+     * Contact Switch, 21, 0x0015
      */
     CONTACT_SWITCH(0x0015),
 
     /**
-     * Fire Sensor
+     * Fire Sensor, 40, 0x0028
      */
     FIRE_SENSOR(0x0028),
 
     /**
-     * Water Sensor
+     * Water Sensor, 42, 0x002A
      */
     WATER_SENSOR(0x002A),
 
     /**
-     * CO Sensor
+     * CO Sensor, 43, 0x002B
      */
     CO_SENSOR(0x002B),
 
     /**
-     * Personal Emergency Device
+     * Personal Emergency Device, 44, 0x002C
      */
     PERSONAL_EMERGENCY_DEVICE(0x002C),
 
     /**
-     * Vibration Movement Sensor
+     * Vibration Movement Sensor, 45, 0x002D
      */
     VIBRATION_MOVEMENT_SENSOR(0x002D),
 
     /**
-     * Remote Control
+     * Remote Control, 271, 0x010F
      */
     REMOTE_CONTROL(0x010F),
 
     /**
-     * Key Fob
+     * Key Fob, 277, 0x0115
      */
     KEY_FOB(0x0115),
 
     /**
-     * Key Pad
+     * Key Pad, 541, 0x021D
      */
     KEY_PAD(0x021D),
 
     /**
-     * Standard Warning Device
+     * Standard Warning Device, 549, 0x0225
      */
     STANDARD_WARNING_DEVICE(0x0225),
 
     /**
-     * Glass Break Sensor
+     * Glass Break Sensor, 550, 0x0226
      */
     GLASS_BREAK_SENSOR(0x0226),
 
     /**
-     * Security Repeater
+     * Security Repeater, 553, 0x0229
      */
     SECURITY_REPEATER(0x0229);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/keyestablishment/KeyEstablishmentStatusEnum.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/keyestablishment/KeyEstablishmentStatusEnum.java
@@ -17,36 +17,36 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-02-09T15:28:08Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum KeyEstablishmentStatusEnum {
 
     /**
-     * Unknown Issuer
+     * Unknown Issuer, 1, 0x0001
      */
     UNKNOWN_ISSUER(0x0001),
 
     /**
-     * Bad Key Confirm
+     * Bad Key Confirm, 2, 0x0002
      */
     BAD_KEY_CONFIRM(0x0002),
 
     /**
-     * Bad Message
+     * Bad Message, 3, 0x0003
      */
     BAD_MESSAGE(0x0003),
 
     /**
-     * No Resources
+     * No Resources, 4, 0x0004
      */
     NO_RESOURCES(0x0004),
 
     /**
-     * Unsupported Suite
+     * Unsupported Suite, 5, 0x0005
      */
     UNSUPPORTED_SUITE(0x0005),
 
     /**
-     * Invalid Certificate
+     * Invalid Certificate, 6, 0x0006
      */
     INVALID_CERTIFICATE(0x0006);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/keyestablishment/KeyEstablishmentSuiteBitmap.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/keyestablishment/KeyEstablishmentSuiteBitmap.java
@@ -17,16 +17,16 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-02-09T15:28:08Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum KeyEstablishmentSuiteBitmap {
 
     /**
-     * Crypto Suite 1
+     * Crypto Suite 1, 1, 0x0001
      */
     CRYPTO_SUITE_1(0x0001),
 
     /**
-     * Crypto Suite 2
+     * Crypto Suite 2, 2, 0x0002
      */
     CRYPTO_SUITE_2(0x0002);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/messaging/MessagingControlMaskBitmap.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/messaging/MessagingControlMaskBitmap.java
@@ -17,26 +17,26 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-02-09T15:28:08Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum MessagingControlMaskBitmap {
 
     /**
-     * Trans Mechanism
+     * Trans Mechanism, 3, 0x0003
      */
     TRANS_MECHANISM(0x0003),
 
     /**
-     * Message Urgency
+     * Message Urgency, 12, 0x000C
      */
     MESSAGE_URGENCY(0x000C),
 
     /**
-     * Enhanced Confirmation Request
+     * Enhanced Confirmation Request, 32, 0x0020
      */
     ENHANCED_CONFIRMATION_REQUEST(0x0020),
 
     /**
-     * Message Confirmation
+     * Message Confirmation, 128, 0x0080
      */
     MESSAGE_CONFIRMATION(0x0080);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/messaging/MessagingExtendedControlMaskBitmap.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/messaging/MessagingExtendedControlMaskBitmap.java
@@ -17,11 +17,11 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-02-09T15:28:08Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum MessagingExtendedControlMaskBitmap {
 
     /**
-     * Message Confirmation Status
+     * Message Confirmation Status, 1, 0x0001
      */
     MESSAGE_CONFIRMATION_STATUS(0x0001);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/meteridentification/DataQualityEnum.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/meteridentification/DataQualityEnum.java
@@ -17,26 +17,26 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-11-19T09:19:31Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum DataQualityEnum {
 
     /**
-     * All Data Certified
+     * All Data Certified, 0, 0x0000
      */
     ALL_DATA_CERTIFIED(0x0000),
 
     /**
-     * Only Instantaneous Power not Certified
+     * Only Instantaneous Power not Certified, 1, 0x0001
      */
     ONLY_INSTANTANEOUS_POWER_NOT_CERTIFIED(0x0001),
 
     /**
-     * Only Cumulated Consumption not Certified
+     * Only Cumulated Consumption not Certified, 2, 0x0002
      */
     ONLY_CUMULATED_CONSUMPTION_NOT_CERTIFIED(0x0002),
 
     /**
-     * Not Certified data
+     * Not Certified data, 3, 0x0003
      */
     NOT_CERTIFIED_DATA(0x0003);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/meteridentification/MeterTypeEnum.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/meteridentification/MeterTypeEnum.java
@@ -17,41 +17,41 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-11-19T09:19:31Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum MeterTypeEnum {
 
     /**
-     * Utility Primary Meter
+     * Utility Primary Meter, 0, 0x0000
      */
     UTILITY_PRIMARY_METER(0x0000),
 
     /**
-     * Utility Production Meter
+     * Utility Production Meter, 1, 0x0001
      */
     UTILITY_PRODUCTION_METER(0x0001),
 
     /**
-     * Utility Secondary Meter
+     * Utility Secondary Meter, 2, 0x0002
      */
     UTILITY_SECONDARY_METER(0x0002),
 
     /**
-     * Private Primary Meter
+     * Private Primary Meter, 256, 0x0100
      */
     PRIVATE_PRIMARY_METER(0x0100),
 
     /**
-     * Private Production Meter
+     * Private Production Meter, 257, 0x0101
      */
     PRIVATE_PRODUCTION_METER(0x0101),
 
     /**
-     * Private Secondary Meters
+     * Private Secondary Meters, 258, 0x0102
      */
     PRIVATE_SECONDARY_METERS(0x0102),
 
     /**
-     * Generic Meter
+     * Generic Meter, 272, 0x0110
      */
     GENERIC_METER(0x0110);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/GetProfileStatusEnum.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/GetProfileStatusEnum.java
@@ -17,36 +17,36 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-02-09T15:28:08Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum GetProfileStatusEnum {
 
     /**
-     * Success
+     * Success, 0, 0x0000
      */
     SUCCESS(0x0000),
 
     /**
-     * Undefined Interval Channel Requested
+     * Undefined Interval Channel Requested, 1, 0x0001
      */
     UNDEFINED_INTERVAL_CHANNEL_REQUESTED(0x0001),
 
     /**
-     * Interval Channel Not Supported
+     * Interval Channel Not Supported, 2, 0x0002
      */
     INTERVAL_CHANNEL_NOT_SUPPORTED(0x0002),
 
     /**
-     * Invalid End Time
+     * Invalid End Time, 3, 0x0003
      */
     INVALID_END_TIME(0x0003),
 
     /**
-     * More Periods Requested Than Can Be Returned
+     * More Periods Requested Than Can Be Returned, 4, 0x0004
      */
     MORE_PERIODS_REQUESTED_THAN_CAN_BE_RETURNED(0x0004),
 
     /**
-     * No Intervals Available For The Requested Time
+     * No Intervals Available For The Requested Time, 5, 0x0005
      */
     NO_INTERVALS_AVAILABLE_FOR_THE_REQUESTED_TIME(0x0005);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/IntervalChannelEnum.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/IntervalChannelEnum.java
@@ -17,16 +17,16 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-02-09T15:28:08Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum IntervalChannelEnum {
 
     /**
-     * Consumption Delivered
+     * Consumption Delivered, 0, 0x0000
      */
     CONSUMPTION_DELIVERED(0x0000),
 
     /**
-     * Consumption Received
+     * Consumption Received, 1, 0x0001
      */
     CONSUMPTION_RECEIVED(0x0001);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/IntervalPeriodEnum.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/IntervalPeriodEnum.java
@@ -17,46 +17,46 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-02-09T15:28:08Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum IntervalPeriodEnum {
 
     /**
-     * Daily
+     * Daily, 0, 0x0000
      */
     DAILY(0x0000),
 
     /**
-     * Minutes 60
+     * Minutes 60, 1, 0x0001
      */
     MINUTES_60(0x0001),
 
     /**
-     * Minutes 30
+     * Minutes 30, 2, 0x0002
      */
     MINUTES_30(0x0002),
 
     /**
-     * Minutes 15
+     * Minutes 15, 3, 0x0003
      */
     MINUTES_15(0x0003),
 
     /**
-     * Minutes 10
+     * Minutes 10, 4, 0x0004
      */
     MINUTES_10(0x0004),
 
     /**
-     * Minutes 7p 5
+     * Minutes 7p 5, 5, 0x0005
      */
     MINUTES_7P_5(0x0005),
 
     /**
-     * Minutes 5
+     * Minutes 5, 6, 0x0006
      */
     MINUTES_5(0x0006),
 
     /**
-     * Minutes 2p 5
+     * Minutes 2p 5, 7, 0x0007
      */
     MINUTES_2P_5(0x0007);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/MeteringDeviceTypeEnum.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/MeteringDeviceTypeEnum.java
@@ -17,71 +17,71 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-10-26T17:06:24Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum MeteringDeviceTypeEnum {
 
     /**
-     * Electric Metering
+     * Electric Metering, 0, 0x0000
      */
     ELECTRIC_METERING(0x0000),
 
     /**
-     * Gas Metering
+     * Gas Metering, 1, 0x0001
      */
     GAS_METERING(0x0001),
 
     /**
-     * Water Metering
+     * Water Metering, 2, 0x0002
      */
     WATER_METERING(0x0002),
 
     /**
-     * Thermal Metering
+     * Thermal Metering, 3, 0x0003
      */
     THERMAL_METERING(0x0003),
 
     /**
-     * Pressure Metering
+     * Pressure Metering, 4, 0x0004
      */
     PRESSURE_METERING(0x0004),
 
     /**
-     * Heat Metering
+     * Heat Metering, 5, 0x0005
      */
     HEAT_METERING(0x0005),
 
     /**
-     * Cooling Metering
+     * Cooling Metering, 6, 0x0006
      */
     COOLING_METERING(0x0006),
 
     /**
-     * Mirrored Gas Metering
+     * Mirrored Gas Metering, 128, 0x0080
      */
     MIRRORED_GAS_METERING(0x0080),
 
     /**
-     * Mirrored Water Metering
+     * Mirrored Water Metering, 129, 0x0081
      */
     MIRRORED_WATER_METERING(0x0081),
 
     /**
-     * Mirrored Thermal Metering
+     * Mirrored Thermal Metering, 130, 0x0082
      */
     MIRRORED_THERMAL_METERING(0x0082),
 
     /**
-     * Mirrored Pressure Metering
+     * Mirrored Pressure Metering, 131, 0x0083
      */
     MIRRORED_PRESSURE_METERING(0x0083),
 
     /**
-     * Mirrored Heat Metering
+     * Mirrored Heat Metering, 132, 0x0084
      */
     MIRRORED_HEAT_METERING(0x0084),
 
     /**
-     * Mirrored Cooling Metering
+     * Mirrored Cooling Metering, 133, 0x0085
      */
     MIRRORED_COOLING_METERING(0x0085);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/MeteringSupplyStatusEnum.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/MeteringSupplyStatusEnum.java
@@ -17,21 +17,21 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-02-09T15:28:08Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum MeteringSupplyStatusEnum {
 
     /**
-     * Supply Off
+     * Supply Off, 0, 0x0000
      */
     SUPPLY_OFF(0x0000),
 
     /**
-     * Supply Off Armed
+     * Supply Off Armed, 1, 0x0001
      */
     SUPPLY_OFF_ARMED(0x0001),
 
     /**
-     * Supply On
+     * Supply On, 2, 0x0002
      */
     SUPPLY_ON(0x0002);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/ProposedSupplyStatusEnum.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/ProposedSupplyStatusEnum.java
@@ -17,16 +17,16 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-02-09T15:28:08Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum ProposedSupplyStatusEnum {
 
     /**
-     * Supply Off Armed
+     * Supply Off Armed, 1, 0x0001
      */
     SUPPLY_OFF_ARMED(0x0001),
 
     /**
-     * Supply On
+     * Supply On, 2, 0x0002
      */
     SUPPLY_ON(0x0002);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/SampleTypeEnum.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/SampleTypeEnum.java
@@ -17,11 +17,11 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-02-09T15:28:08Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum SampleTypeEnum {
 
     /**
-     * Consumption Delivered
+     * Consumption Delivered, 0, 0x0000
      */
     CONSUMPTION_DELIVERED(0x0000);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/SnapshotCauseBitmap.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/SnapshotCauseBitmap.java
@@ -17,96 +17,96 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-02-09T15:28:08Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum SnapshotCauseBitmap {
 
     /**
-     * General
+     * General, 1, 0x0001
      */
     GENERAL(0x0001),
 
     /**
-     * End Of Billing Period
+     * End Of Billing Period, 2, 0x0002
      */
     END_OF_BILLING_PERIOD(0x0002),
 
     /**
-     * End Of Block Period
+     * End Of Block Period, 4, 0x0004
      */
     END_OF_BLOCK_PERIOD(0x0004),
 
     /**
-     * Change Of Tariff Information
+     * Change Of Tariff Information, 8, 0x0008
      */
     CHANGE_OF_TARIFF_INFORMATION(0x0008),
 
     /**
-     * Change Of Price Matrix
+     * Change Of Price Matrix, 16, 0x0010
      */
     CHANGE_OF_PRICE_MATRIX(0x0010),
 
     /**
-     * Change Of Block Thresholds
+     * Change Of Block Thresholds, 32, 0x0020
      */
     CHANGE_OF_BLOCK_THRESHOLDS(0x0020),
 
     /**
-     * Change Of Cv
+     * Change Of Cv, 64, 0x0040
      */
     CHANGE_OF_CV(0x0040),
 
     /**
-     * Change Of Cf
+     * Change Of Cf, 128, 0x0080
      */
     CHANGE_OF_CF(0x0080),
 
     /**
-     * Change Of Calendar
+     * Change Of Calendar, 256, 0x0100
      */
     CHANGE_OF_CALENDAR(0x0100),
 
     /**
-     * Critical Peak Pricing
+     * Critical Peak Pricing, 512, 0x0200
      */
     CRITICAL_PEAK_PRICING(0x0200),
 
     /**
-     * Manually Triggered From Client
+     * Manually Triggered From Client, 1024, 0x0400
      */
     MANUALLY_TRIGGERED_FROM_CLIENT(0x0400),
 
     /**
-     * End Of Resolve Period
+     * End Of Resolve Period, 2048, 0x0800
      */
     END_OF_RESOLVE_PERIOD(0x0800),
 
     /**
-     * Change Of Tenancy
+     * Change Of Tenancy, 4096, 0x1000
      */
     CHANGE_OF_TENANCY(0x1000),
 
     /**
-     * Change Of Supplier
+     * Change Of Supplier, 8192, 0x2000
      */
     CHANGE_OF_SUPPLIER(0x2000),
 
     /**
-     * Change Of Mode
+     * Change Of Mode, 16384, 0x4000
      */
     CHANGE_OF_MODE(0x4000),
 
     /**
-     * Debt Payment
+     * Debt Payment, 32768, 0x8000
      */
     DEBT_PAYMENT(0x8000),
 
     /**
-     * Scheduled Snapshot
+     * Scheduled Snapshot, 65536, 0x10000
      */
     SCHEDULED_SNAPSHOT(0x10000),
 
     /**
-     * Ota Firmware Download
+     * Ota Firmware Download, 131072, 0x20000
      */
     OTA_FIRMWARE_DOWNLOAD(0x20000);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/SnapshotConfirmationEnum.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/SnapshotConfirmationEnum.java
@@ -17,16 +17,16 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-02-09T15:28:08Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum SnapshotConfirmationEnum {
 
     /**
-     * Accepted
+     * Accepted, 0, 0x0000
      */
     ACCEPTED(0x0000),
 
     /**
-     * Snapshot Cause Not Supported
+     * Snapshot Cause Not Supported, 1, 0x0001
      */
     SNAPSHOT_CAUSE_NOT_SUPPORTED(0x0001);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/SnapshotPayloadTypeEnum.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/SnapshotPayloadTypeEnum.java
@@ -17,51 +17,51 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-02-09T15:28:08Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum SnapshotPayloadTypeEnum {
 
     /**
-     * Tou Information Set Delivered Registers
+     * Tou Information Set Delivered Registers, 0, 0x0000
      */
     TOU_INFORMATION_SET_DELIVERED_REGISTERS(0x0000),
 
     /**
-     * Tou Information Set Received Registers
+     * Tou Information Set Received Registers, 1, 0x0001
      */
     TOU_INFORMATION_SET_RECEIVED_REGISTERS(0x0001),
 
     /**
-     * Block Tier Information Set Delivered
+     * Block Tier Information Set Delivered, 2, 0x0002
      */
     BLOCK_TIER_INFORMATION_SET_DELIVERED(0x0002),
 
     /**
-     * Block Tier Information Set Received
+     * Block Tier Information Set Received, 3, 0x0003
      */
     BLOCK_TIER_INFORMATION_SET_RECEIVED(0x0003),
 
     /**
-     * Tou Information Set Delivered Registers No Billing
+     * Tou Information Set Delivered Registers No Billing, 4, 0x0004
      */
     TOU_INFORMATION_SET_DELIVERED_REGISTERS_NO_BILLING(0x0004),
 
     /**
-     * Tou Information Set Received Register No Billings
+     * Tou Information Set Received Register No Billings, 5, 0x0005
      */
     TOU_INFORMATION_SET_RECEIVED_REGISTER_NO_BILLINGS(0x0005),
 
     /**
-     * Block Tier Information Set Delivered No Billing
+     * Block Tier Information Set Delivered No Billing, 6, 0x0006
      */
     BLOCK_TIER_INFORMATION_SET_DELIVERED_NO_BILLING(0x0006),
 
     /**
-     * Block Tier Information Set Received No Billing
+     * Block Tier Information Set Received No Billing, 7, 0x0007
      */
     BLOCK_TIER_INFORMATION_SET_RECEIVED_NO_BILLING(0x0007),
 
     /**
-     * Data Unavailable
+     * Data Unavailable, 128, 0x0080
      */
     DATA_UNAVAILABLE(0x0080);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/SupplyControlBitsBitmap.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/SupplyControlBitsBitmap.java
@@ -17,11 +17,11 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-02-09T15:28:08Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum SupplyControlBitsBitmap {
 
     /**
-     * Acknowledge Required
+     * Acknowledge Required, 1, 0x0001
      */
     ACKNOWLEDGE_REQUIRED(0x0001);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/SupplyStatusEnum.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/SupplyStatusEnum.java
@@ -17,26 +17,26 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-02-09T15:28:08Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum SupplyStatusEnum {
 
     /**
-     * Supply Off
+     * Supply Off, 0, 0x0000
      */
     SUPPLY_OFF(0x0000),
 
     /**
-     * Supply Off Armed
+     * Supply Off Armed, 1, 0x0001
      */
     SUPPLY_OFF_ARMED(0x0001),
 
     /**
-     * Supply On
+     * Supply On, 2, 0x0002
      */
     SUPPLY_ON(0x0002),
 
     /**
-     * Supply Unchanged
+     * Supply Unchanged, 3, 0x0003
      */
     SUPPLY_UNCHANGED(0x0003);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/TemperatureUnitOfMeasureEnum.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/TemperatureUnitOfMeasureEnum.java
@@ -17,36 +17,36 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-10-26T17:06:24Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum TemperatureUnitOfMeasureEnum {
 
     /**
-     * Degrees Kelvin
+     * Degrees Kelvin, 0, 0x0000
      */
     DEGREES_KELVIN(0x0000),
 
     /**
-     * Degrees Celsius
+     * Degrees Celsius, 1, 0x0001
      */
     DEGREES_CELSIUS(0x0001),
 
     /**
-     * Degrees Fahrenheit
+     * Degrees Fahrenheit, 2, 0x0002
      */
     DEGREES_FAHRENHEIT(0x0002),
 
     /**
-     * Degrees Kelvin BCD
+     * Degrees Kelvin BCD, 128, 0x0080
      */
     DEGREES_KELVIN_BCD(0x0080),
 
     /**
-     * Degrees Celsius BCD
+     * Degrees Celsius BCD, 129, 0x0081
      */
     DEGREES_CELSIUS_BCD(0x0081),
 
     /**
-     * Degrees Fahrenheit BCD
+     * Degrees Fahrenheit BCD, 130, 0x0082
      */
     DEGREES_FAHRENHEIT_BCD(0x0082);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/UnitOfMeasureEnum.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/UnitOfMeasureEnum.java
@@ -17,146 +17,146 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-02-09T15:28:08Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum UnitOfMeasureEnum {
 
     /**
-     * Kilo Watt Hours
+     * Kilo Watt Hours, 0, 0x0000
      */
     KILO_WATT_HOURS(0x0000),
 
     /**
-     * Cubic Meter Per Hour
+     * Cubic Meter Per Hour, 1, 0x0001
      */
     CUBIC_METER_PER_HOUR(0x0001),
 
     /**
-     * Cubic Feet Per Hour
+     * Cubic Feet Per Hour, 2, 0x0002
      */
     CUBIC_FEET_PER_HOUR(0x0002),
 
     /**
-     * Centum Cubic Feet Per Hour
+     * Centum Cubic Feet Per Hour, 3, 0x0003
      */
     CENTUM_CUBIC_FEET_PER_HOUR(0x0003),
 
     /**
-     * Us Gallons Per Hour
+     * Us Gallons Per Hour, 4, 0x0004
      */
     US_GALLONS_PER_HOUR(0x0004),
 
     /**
-     * Imperial Gallons Per Hour
+     * Imperial Gallons Per Hour, 5, 0x0005
      */
     IMPERIAL_GALLONS_PER_HOUR(0x0005),
 
     /**
-     * Bt Us Or Btu Per Hour
+     * Bt Us Or Btu Per Hour, 6, 0x0006
      */
     BT_US_OR_BTU_PER_HOUR(0x0006),
 
     /**
-     * Liters Or Liters Per Hour
+     * Liters Or Liters Per Hour, 7, 0x0007
      */
     LITERS_OR_LITERS_PER_HOUR(0x0007),
 
     /**
-     * Kpa Gauge
+     * Kpa Gauge, 8, 0x0008
      */
     KPA_GAUGE(0x0008),
 
     /**
-     * Kpa Absolute
+     * Kpa Absolute, 9, 0x0009
      */
     KPA_ABSOLUTE(0x0009),
 
     /**
-     * Mcf Or Mcf Per Second
+     * Mcf Or Mcf Per Second, 10, 0x000A
      */
     MCF_OR_MCF_PER_SECOND(0x000A),
 
     /**
-     * Unitless
+     * Unitless, 11, 0x000B
      */
     UNITLESS(0x000B),
 
     /**
-     * Mj Or Mj Per Second
+     * Mj Or Mj Per Second, 12, 0x000C
      */
     MJ_OR_MJ_PER_SECOND(0x000C),
 
     /**
-     * K Var Or K Var Hours
+     * K Var Or K Var Hours, 13, 0x000D
      */
     K_VAR_OR_K_VAR_HOURS(0x000D),
 
     /**
-     * Kilo Watt Hours Bcd
+     * Kilo Watt Hours Bcd, 128, 0x0080
      */
     KILO_WATT_HOURS_BCD(0x0080),
 
     /**
-     * Cubic Meter Per Hour Bcd
+     * Cubic Meter Per Hour Bcd, 129, 0x0081
      */
     CUBIC_METER_PER_HOUR_BCD(0x0081),
 
     /**
-     * Cubic Feet Per Hour Bcd
+     * Cubic Feet Per Hour Bcd, 130, 0x0082
      */
     CUBIC_FEET_PER_HOUR_BCD(0x0082),
 
     /**
-     * Centum Cubic Feet Per Hour Bcd
+     * Centum Cubic Feet Per Hour Bcd, 131, 0x0083
      */
     CENTUM_CUBIC_FEET_PER_HOUR_BCD(0x0083),
 
     /**
-     * Us Gallons Per Hour Bcd
+     * Us Gallons Per Hour Bcd, 132, 0x0084
      */
     US_GALLONS_PER_HOUR_BCD(0x0084),
 
     /**
-     * Imperial Gallons Per Hour Bcd
+     * Imperial Gallons Per Hour Bcd, 133, 0x0085
      */
     IMPERIAL_GALLONS_PER_HOUR_BCD(0x0085),
 
     /**
-     * Bt Us Or Btu Per Hour Bcd
+     * Bt Us Or Btu Per Hour Bcd, 134, 0x0086
      */
     BT_US_OR_BTU_PER_HOUR_BCD(0x0086),
 
     /**
-     * Liters Or Liters Per Hour Bcd
+     * Liters Or Liters Per Hour Bcd, 135, 0x0087
      */
     LITERS_OR_LITERS_PER_HOUR_BCD(0x0087),
 
     /**
-     * Kpa Guage Bcd
+     * Kpa Guage Bcd, 136, 0x0088
      */
     KPA_GUAGE_BCD(0x0088),
 
     /**
-     * Kpa Absolute Bcd
+     * Kpa Absolute Bcd, 137, 0x0089
      */
     KPA_ABSOLUTE_BCD(0x0089),
 
     /**
-     * Mcf Or Mcf Per Second Bcd
+     * Mcf Or Mcf Per Second Bcd, 138, 0x008A
      */
     MCF_OR_MCF_PER_SECOND_BCD(0x008A),
 
     /**
-     * Unitless Bcd
+     * Unitless Bcd, 139, 0x008B
      */
     UNITLESS_BCD(0x008B),
 
     /**
-     * Mj Or Mj Per Second Bcd
+     * Mj Or Mj Per Second Bcd, 140, 0x008C
      */
     MJ_OR_MJ_PER_SECOND_BCD(0x008C),
 
     /**
-     * K Var Or K Var Hours Bcd
+     * K Var Or K Var Hours Bcd, 141, 0x008D
      */
     K_VAR_OR_K_VAR_HOURS_BCD(0x008D);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/multistateinputbasic/MultistateInputReliabilityEnum.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/multistateinputbasic/MultistateInputReliabilityEnum.java
@@ -17,51 +17,51 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-02-09T15:28:08Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum MultistateInputReliabilityEnum {
 
     /**
-     * No - Fault - Detected
+     * No - Fault - Detected, 0, 0x0000
      */
     NO_FAULT_DETECTED(0x0000),
 
     /**
-     * Over - Range
+     * Over - Range, 2, 0x0002
      */
     OVER_RANGE(0x0002),
 
     /**
-     * Under - Range
+     * Under - Range, 3, 0x0003
      */
     UNDER_RANGE(0x0003),
 
     /**
-     * Open - Loop
+     * Open - Loop, 4, 0x0004
      */
     OPEN_LOOP(0x0004),
 
     /**
-     * Shorted - Loop
+     * Shorted - Loop, 5, 0x0005
      */
     SHORTED_LOOP(0x0005),
 
     /**
-     * Unreliable - Other
+     * Unreliable - Other, 7, 0x0007
      */
     UNRELIABLE_OTHER(0x0007),
 
     /**
-     * Process - Error
+     * Process - Error, 8, 0x0008
      */
     PROCESS_ERROR(0x0008),
 
     /**
-     * Multi - State - Fault
+     * Multi - State - Fault, 9, 0x0009
      */
     MULTI_STATE_FAULT(0x0009),
 
     /**
-     * Configuration - Error
+     * Configuration - Error, 10, 0x000A
      */
     CONFIGURATION_ERROR(0x000A);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/multistateinputbasic/MultistateInputStatusFlagsBitmap.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/multistateinputbasic/MultistateInputStatusFlagsBitmap.java
@@ -17,26 +17,26 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-02-09T15:28:08Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum MultistateInputStatusFlagsBitmap {
 
     /**
-     * In_Alarm
+     * In_Alarm, 1, 0x0001
      */
     IN_ALARM(0x0001),
 
     /**
-     * Fault
+     * Fault, 2, 0x0002
      */
     FAULT(0x0002),
 
     /**
-     * Overridden
+     * Overridden, 4, 0x0004
      */
     OVERRIDDEN(0x0004),
 
     /**
-     * Out Of Service
+     * Out Of Service, 8, 0x0008
      */
     OUT_OF_SERVICE(0x0008);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/multistateoutputbasic/MultistateOutputReliabilityEnum.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/multistateoutputbasic/MultistateOutputReliabilityEnum.java
@@ -17,51 +17,51 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-02-09T15:28:08Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum MultistateOutputReliabilityEnum {
 
     /**
-     * No - Fault - Detected
+     * No - Fault - Detected, 0, 0x0000
      */
     NO_FAULT_DETECTED(0x0000),
 
     /**
-     * Over - Range
+     * Over - Range, 2, 0x0002
      */
     OVER_RANGE(0x0002),
 
     /**
-     * Under - Range
+     * Under - Range, 3, 0x0003
      */
     UNDER_RANGE(0x0003),
 
     /**
-     * Open - Loop
+     * Open - Loop, 4, 0x0004
      */
     OPEN_LOOP(0x0004),
 
     /**
-     * Shorted - Loop
+     * Shorted - Loop, 5, 0x0005
      */
     SHORTED_LOOP(0x0005),
 
     /**
-     * Unreliable - Other
+     * Unreliable - Other, 7, 0x0007
      */
     UNRELIABLE_OTHER(0x0007),
 
     /**
-     * Process - Error
+     * Process - Error, 8, 0x0008
      */
     PROCESS_ERROR(0x0008),
 
     /**
-     * Multi - State - Fault
+     * Multi - State - Fault, 9, 0x0009
      */
     MULTI_STATE_FAULT(0x0009),
 
     /**
-     * Configuration - Error
+     * Configuration - Error, 10, 0x000A
      */
     CONFIGURATION_ERROR(0x000A);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/multistateoutputbasic/MultistateOutputStatusFlagsBitmap.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/multistateoutputbasic/MultistateOutputStatusFlagsBitmap.java
@@ -17,26 +17,26 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-02-09T15:28:08Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum MultistateOutputStatusFlagsBitmap {
 
     /**
-     * In_Alarm
+     * In_Alarm, 1, 0x0001
      */
     IN_ALARM(0x0001),
 
     /**
-     * Fault
+     * Fault, 2, 0x0002
      */
     FAULT(0x0002),
 
     /**
-     * Overridden
+     * Overridden, 4, 0x0004
      */
     OVERRIDDEN(0x0004),
 
     /**
-     * Out Of Service
+     * Out Of Service, 8, 0x0008
      */
     OUT_OF_SERVICE(0x0008);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/multistatevaluebasic/MultistateValueReliabilityEnum.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/multistatevaluebasic/MultistateValueReliabilityEnum.java
@@ -17,51 +17,51 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-02-09T15:28:08Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum MultistateValueReliabilityEnum {
 
     /**
-     * No - Fault - Detected
+     * No - Fault - Detected, 0, 0x0000
      */
     NO_FAULT_DETECTED(0x0000),
 
     /**
-     * Over - Range
+     * Over - Range, 2, 0x0002
      */
     OVER_RANGE(0x0002),
 
     /**
-     * Under - Range
+     * Under - Range, 3, 0x0003
      */
     UNDER_RANGE(0x0003),
 
     /**
-     * Open - Loop
+     * Open - Loop, 4, 0x0004
      */
     OPEN_LOOP(0x0004),
 
     /**
-     * Shorted - Loop
+     * Shorted - Loop, 5, 0x0005
      */
     SHORTED_LOOP(0x0005),
 
     /**
-     * Unreliable - Other
+     * Unreliable - Other, 7, 0x0007
      */
     UNRELIABLE_OTHER(0x0007),
 
     /**
-     * Process - Error
+     * Process - Error, 8, 0x0008
      */
     PROCESS_ERROR(0x0008),
 
     /**
-     * Multi - State - Fault
+     * Multi - State - Fault, 9, 0x0009
      */
     MULTI_STATE_FAULT(0x0009),
 
     /**
-     * Configuration - Error
+     * Configuration - Error, 10, 0x000A
      */
     CONFIGURATION_ERROR(0x000A);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/multistatevaluebasic/MultistateValueStatusFlagsBitmap.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/multistatevaluebasic/MultistateValueStatusFlagsBitmap.java
@@ -17,26 +17,26 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-02-09T15:28:08Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum MultistateValueStatusFlagsBitmap {
 
     /**
-     * In_Alarm
+     * In_Alarm, 1, 0x0001
      */
     IN_ALARM(0x0001),
 
     /**
-     * Fault
+     * Fault, 2, 0x0002
      */
     FAULT(0x0002),
 
     /**
-     * Overridden
+     * Overridden, 4, 0x0004
      */
     OVERRIDDEN(0x0004),
 
     /**
-     * Out Of Service
+     * Out Of Service, 8, 0x0008
      */
     OUT_OF_SERVICE(0x0008);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/onoffswitchconfiguration/SwitchActionsEnum.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/onoffswitchconfiguration/SwitchActionsEnum.java
@@ -17,21 +17,21 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-02-09T15:28:08Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum SwitchActionsEnum {
 
     /**
-     * On
+     * On, 0, 0x0000
      */
     ON(0x0000),
 
     /**
-     * Off
+     * Off, 1, 0x0001
      */
     OFF(0x0001),
 
     /**
-     * Toggle
+     * Toggle, 2, 0x0002
      */
     TOGGLE(0x0002);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/onoffswitchconfiguration/SwitchTypeEnum.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/onoffswitchconfiguration/SwitchTypeEnum.java
@@ -17,21 +17,21 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-02-09T15:28:08Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum SwitchTypeEnum {
 
     /**
-     * Toggle
+     * Toggle, 0, 0x0000
      */
     TOGGLE(0x0000),
 
     /**
-     * Momentary
+     * Momentary, 1, 0x0001
      */
     MOMENTARY(0x0001),
 
     /**
-     * Multifunction
+     * Multifunction, 2, 0x0002
      */
     MULTIFUNCTION(0x0002);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/otaupgrade/StatusEnum.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/otaupgrade/StatusEnum.java
@@ -17,201 +17,201 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-02-09T15:28:08Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum StatusEnum {
 
     /**
-     * Success
+     * Success, 0, 0x0000
      */
     SUCCESS(0x0000),
 
     /**
-     * Failure
+     * Failure, 1, 0x0001
      */
     FAILURE(0x0001),
 
     /**
-     * Request_Denied
+     * Request_Denied, 112, 0x0070
      */
     REQUEST_DENIED(0x0070),
 
     /**
-     * Multiple_Request_Not_Allowed
+     * Multiple_Request_Not_Allowed, 113, 0x0071
      */
     MULTIPLE_REQUEST_NOT_ALLOWED(0x0071),
 
     /**
-     * Indication_Redirection_To_Ap
+     * Indication_Redirection_To_Ap, 114, 0x0072
      */
     INDICATION_REDIRECTION_TO_AP(0x0072),
 
     /**
-     * Preference_Denied
+     * Preference_Denied, 115, 0x0073
      */
     PREFERENCE_DENIED(0x0073),
 
     /**
-     * Preference_Ignored
+     * Preference_Ignored, 116, 0x0074
      */
     PREFERENCE_IGNORED(0x0074),
 
     /**
-     * Not_Authorized
+     * Not_Authorized, 126, 0x007E
      */
     NOT_AUTHORIZED(0x007E),
 
     /**
-     * Reserved_Field_Not_Zero
+     * Reserved_Field_Not_Zero, 127, 0x007F
      */
     RESERVED_FIELD_NOT_ZERO(0x007F),
 
     /**
-     * Malformed_Command
+     * Malformed_Command, 128, 0x0080
      */
     MALFORMED_COMMAND(0x0080),
 
     /**
-     * Unsup_Cluster_Command
+     * Unsup_Cluster_Command, 129, 0x0081
      */
     UNSUP_CLUSTER_COMMAND(0x0081),
 
     /**
-     * Unsup_General_Command
+     * Unsup_General_Command, 130, 0x0082
      */
     UNSUP_GENERAL_COMMAND(0x0082),
 
     /**
-     * Unsup_Manuf_Cluster_Command
+     * Unsup_Manuf_Cluster_Command, 131, 0x0083
      */
     UNSUP_MANUF_CLUSTER_COMMAND(0x0083),
 
     /**
-     * Unsup_Manuf_General_Command
+     * Unsup_Manuf_General_Command, 132, 0x0084
      */
     UNSUP_MANUF_GENERAL_COMMAND(0x0084),
 
     /**
-     * Invalid_Field
+     * Invalid_Field, 133, 0x0085
      */
     INVALID_FIELD(0x0085),
 
     /**
-     * Unsupported_Attribute
+     * Unsupported_Attribute, 134, 0x0086
      */
     UNSUPPORTED_ATTRIBUTE(0x0086),
 
     /**
-     * Invalid_Value
+     * Invalid_Value, 135, 0x0087
      */
     INVALID_VALUE(0x0087),
 
     /**
-     * Read_Only
+     * Read_Only, 136, 0x0088
      */
     READ_ONLY(0x0088),
 
     /**
-     * Insufficient_Space
+     * Insufficient_Space, 137, 0x0089
      */
     INSUFFICIENT_SPACE(0x0089),
 
     /**
-     * Duplicate_Exists
+     * Duplicate_Exists, 138, 0x008A
      */
     DUPLICATE_EXISTS(0x008A),
 
     /**
-     * Not_Found
+     * Not_Found, 139, 0x008B
      */
     NOT_FOUND(0x008B),
 
     /**
-     * Unreportable_Attribute
+     * Unreportable_Attribute, 140, 0x008C
      */
     UNREPORTABLE_ATTRIBUTE(0x008C),
 
     /**
-     * Invalid_Data_Type
+     * Invalid_Data_Type, 141, 0x008D
      */
     INVALID_DATA_TYPE(0x008D),
 
     /**
-     * Invalid_Selector
+     * Invalid_Selector, 142, 0x008E
      */
     INVALID_SELECTOR(0x008E),
 
     /**
-     * Write_Only
+     * Write_Only, 143, 0x008F
      */
     WRITE_ONLY(0x008F),
 
     /**
-     * Inconsistent_Startup_State
+     * Inconsistent_Startup_State, 144, 0x0090
      */
     INCONSISTENT_STARTUP_STATE(0x0090),
 
     /**
-     * Defined_Out_Of_Band
+     * Defined_Out_Of_Band, 145, 0x0091
      */
     DEFINED_OUT_OF_BAND(0x0091),
 
     /**
-     * Inconsistent
+     * Inconsistent, 146, 0x0092
      */
     INCONSISTENT(0x0092),
 
     /**
-     * Action_Denied
+     * Action_Denied, 147, 0x0093
      */
     ACTION_DENIED(0x0093),
 
     /**
-     * Timeout
+     * Timeout, 148, 0x0094
      */
     TIMEOUT(0x0094),
 
     /**
-     * Abort
+     * Abort, 149, 0x0095
      */
     ABORT(0x0095),
 
     /**
-     * Invalid_Image
+     * Invalid_Image, 150, 0x0096
      */
     INVALID_IMAGE(0x0096),
 
     /**
-     * Wait_For_Data
+     * Wait_For_Data, 151, 0x0097
      */
     WAIT_FOR_DATA(0x0097),
 
     /**
-     * No_Image_Available
+     * No_Image_Available, 152, 0x0098
      */
     NO_IMAGE_AVAILABLE(0x0098),
 
     /**
-     * Require_More_Image
+     * Require_More_Image, 153, 0x0099
      */
     REQUIRE_MORE_IMAGE(0x0099),
 
     /**
-     * Hardware_Failure
+     * Hardware_Failure, 192, 0x00C0
      */
     HARDWARE_FAILURE(0x00C0),
 
     /**
-     * Software_Failure
+     * Software_Failure, 193, 0x00C1
      */
     SOFTWARE_FAILURE(0x00C1),
 
     /**
-     * Calibration_Error
+     * Calibration_Error, 194, 0x00C2
      */
     CALIBRATION_ERROR(0x00C2),
 
     /**
-     * Unsupported_Cluster
+     * Unsupported_Cluster, 195, 0x00C3
      */
     UNSUPPORTED_CLUSTER(0x00C3);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/powerconfiguration/BatterySizeEnum.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/powerconfiguration/BatterySizeEnum.java
@@ -17,56 +17,56 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-02-09T15:28:08Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum BatterySizeEnum {
 
     /**
-     * No Battery
+     * No Battery, 0, 0x0000
      */
     NO_BATTERY(0x0000),
 
     /**
-     * Build In
+     * Build In, 1, 0x0001
      */
     BUILD_IN(0x0001),
 
     /**
-     * Other
+     * Other, 2, 0x0002
      */
     OTHER(0x0002),
 
     /**
-     * AA Cell
+     * AA Cell, 3, 0x0003
      */
     AA_CELL(0x0003),
 
     /**
-     * AAA Cell
+     * AAA Cell, 4, 0x0004
      */
     AAA_CELL(0x0004),
 
     /**
-     * C Cell
+     * C Cell, 5, 0x0005
      */
     C_CELL(0x0005),
 
     /**
-     * D Cell
+     * D Cell, 6, 0x0006
      */
     D_CELL(0x0006),
 
     /**
-     * CR 2 Cell
+     * CR 2 Cell, 7, 0x0007
      */
     CR_2_CELL(0x0007),
 
     /**
-     * CR 123 A Cell
+     * CR 123 A Cell, 8, 0x0008
      */
     CR_123_A_CELL(0x0008),
 
     /**
-     * Unknown
+     * Unknown, 255, 0x00FF
      */
     UNKNOWN(0x00FF);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/CreditAdjustmentTypeEnum.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/CreditAdjustmentTypeEnum.java
@@ -17,16 +17,16 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-02-09T15:28:08Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum CreditAdjustmentTypeEnum {
 
     /**
-     * Credit Incremental
+     * Credit Incremental, 0, 0x0000
      */
     CREDIT_INCREMENTAL(0x0000),
 
     /**
-     * Credit Absolute
+     * Credit Absolute, 1, 0x0001
      */
     CREDIT_ABSOLUTE(0x0001);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/DebtAmountTypeEnum.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/DebtAmountTypeEnum.java
@@ -17,36 +17,36 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-02-09T15:28:08Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum DebtAmountTypeEnum {
 
     /**
-     * Type 1 Absolute
+     * Type 1 Absolute, 0, 0x0000
      */
     TYPE_1_ABSOLUTE(0x0000),
 
     /**
-     * Type 1 Incremental
+     * Type 1 Incremental, 1, 0x0001
      */
     TYPE_1_INCREMENTAL(0x0001),
 
     /**
-     * Type 2 Absolute
+     * Type 2 Absolute, 2, 0x0002
      */
     TYPE_2_ABSOLUTE(0x0002),
 
     /**
-     * Type 2 Incremental
+     * Type 2 Incremental, 3, 0x0003
      */
     TYPE_2_INCREMENTAL(0x0003),
 
     /**
-     * Type 3 Absolute
+     * Type 3 Absolute, 4, 0x0004
      */
     TYPE_3_ABSOLUTE(0x0004),
 
     /**
-     * Type 3 Incremental
+     * Type 3 Incremental, 5, 0x0005
      */
     TYPE_3_INCREMENTAL(0x0005);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/DebtRecoveryFrequencyEnum.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/DebtRecoveryFrequencyEnum.java
@@ -17,31 +17,31 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-02-09T15:28:08Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum DebtRecoveryFrequencyEnum {
 
     /**
-     * Per Hour
+     * Per Hour, 0, 0x0000
      */
     PER_HOUR(0x0000),
 
     /**
-     * Per Day
+     * Per Day, 1, 0x0001
      */
     PER_DAY(0x0001),
 
     /**
-     * Per Week
+     * Per Week, 2, 0x0002
      */
     PER_WEEK(0x0002),
 
     /**
-     * Per Month
+     * Per Month, 3, 0x0003
      */
     PER_MONTH(0x0003),
 
     /**
-     * Per Quarter
+     * Per Quarter, 4, 0x0004
      */
     PER_QUARTER(0x0004);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/DebtRecoveryMethodEnum.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/DebtRecoveryMethodEnum.java
@@ -17,21 +17,21 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-02-09T15:28:08Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum DebtRecoveryMethodEnum {
 
     /**
-     * Time Based
+     * Time Based, 0, 0x0000
      */
     TIME_BASED(0x0000),
 
     /**
-     * Percentage Based
+     * Percentage Based, 1, 0x0001
      */
     PERCENTAGE_BASED(0x0001),
 
     /**
-     * Catch Up Based
+     * Catch Up Based, 2, 0x0002
      */
     CATCH_UP_BASED(0x0002);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/FriendlyCreditBitmap.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/FriendlyCreditBitmap.java
@@ -17,11 +17,11 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-02-09T15:28:08Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum FriendlyCreditBitmap {
 
     /**
-     * Friendly Credit Enabled
+     * Friendly Credit Enabled, 1, 0x0001
      */
     FRIENDLY_CREDIT_ENABLED(0x0001);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/OriginatingDeviceEnum.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/OriginatingDeviceEnum.java
@@ -17,21 +17,21 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-02-09T15:28:08Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum OriginatingDeviceEnum {
 
     /**
-     * Energy Service Interface
+     * Energy Service Interface, 0, 0x0000
      */
     ENERGY_SERVICE_INTERFACE(0x0000),
 
     /**
-     * Meter
+     * Meter, 1, 0x0001
      */
     METER(0x0001),
 
     /**
-     * In Home Display Device
+     * In Home Display Device, 2, 0x0002
      */
     IN_HOME_DISPLAY_DEVICE(0x0002);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/PaymentControlConfigurationBitmap.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/PaymentControlConfigurationBitmap.java
@@ -17,56 +17,56 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-02-09T15:28:08Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum PaymentControlConfigurationBitmap {
 
     /**
-     * Disconnection Enabled
+     * Disconnection Enabled, 1, 0x0001
      */
     DISCONNECTION_ENABLED(0x0001),
 
     /**
-     * Prepayment Enabled
+     * Prepayment Enabled, 2, 0x0002
      */
     PREPAYMENT_ENABLED(0x0002),
 
     /**
-     * Credit Management Enabled
+     * Credit Management Enabled, 4, 0x0004
      */
     CREDIT_MANAGEMENT_ENABLED(0x0004),
 
     /**
-     * Credit Display Enabled
+     * Credit Display Enabled, 16, 0x0010
      */
     CREDIT_DISPLAY_ENABLED(0x0010),
 
     /**
-     * Account Base
+     * Account Base, 64, 0x0040
      */
     ACCOUNT_BASE(0x0040),
 
     /**
-     * Contactor Fitted
+     * Contactor Fitted, 128, 0x0080
      */
     CONTACTOR_FITTED(0x0080),
 
     /**
-     * Standing Charge Configuration
+     * Standing Charge Configuration, 256, 0x0100
      */
     STANDING_CHARGE_CONFIGURATION(0x0100),
 
     /**
-     * Emergency Standing Charge Configuration
+     * Emergency Standing Charge Configuration, 512, 0x0200
      */
     EMERGENCY_STANDING_CHARGE_CONFIGURATION(0x0200),
 
     /**
-     * Debt Configuration
+     * Debt Configuration, 1024, 0x0400
      */
     DEBT_CONFIGURATION(0x0400),
 
     /**
-     * Emergency Debt Configuration
+     * Emergency Debt Configuration, 2048, 0x0800
      */
     EMERGENCY_DEBT_CONFIGURATION(0x0800);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/PrepaySnapshotPayloadCauseBitmap.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/PrepaySnapshotPayloadCauseBitmap.java
@@ -17,51 +17,51 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-02-09T15:28:08Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum PrepaySnapshotPayloadCauseBitmap {
 
     /**
-     * General
+     * General, 1, 0x0001
      */
     GENERAL(0x0001),
 
     /**
-     * Change Of Tariff Information
+     * Change Of Tariff Information, 8, 0x0008
      */
     CHANGE_OF_TARIFF_INFORMATION(0x0008),
 
     /**
-     * Change Of Price Matrix
+     * Change Of Price Matrix, 16, 0x0010
      */
     CHANGE_OF_PRICE_MATRIX(0x0010),
 
     /**
-     * Manually Triggered From Client
+     * Manually Triggered From Client, 1024, 0x0400
      */
     MANUALLY_TRIGGERED_FROM_CLIENT(0x0400),
 
     /**
-     * Change Of Tenancy
+     * Change Of Tenancy, 4096, 0x1000
      */
     CHANGE_OF_TENANCY(0x1000),
 
     /**
-     * Change Of Supplier
+     * Change Of Supplier, 8192, 0x2000
      */
     CHANGE_OF_SUPPLIER(0x2000),
 
     /**
-     * Change Of Meter Mode
+     * Change Of Meter Mode, 16384, 0x4000
      */
     CHANGE_OF_METER_MODE(0x4000),
 
     /**
-     * Top Up Addition
+     * Top Up Addition, 262144, 0x40000
      */
     TOP_UP_ADDITION(0x40000),
 
     /**
-     * Debt Credit Addition
+     * Debt Credit Addition, 524288, 0x80000
      */
     DEBT_CREDIT_ADDITION(0x80000);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/PrepaySnapshotPayloadTypeEnum.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/PrepaySnapshotPayloadTypeEnum.java
@@ -17,16 +17,16 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-02-09T15:28:08Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum PrepaySnapshotPayloadTypeEnum {
 
     /**
-     * Debt Credit Status
+     * Debt Credit Status, 0, 0x0000
      */
     DEBT_CREDIT_STATUS(0x0000),
 
     /**
-     * Not Used
+     * Not Used, 255, 0x00FF
      */
     NOT_USED(0x00FF);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/RepaymentDebtTypeEnum.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/RepaymentDebtTypeEnum.java
@@ -17,26 +17,26 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-02-09T15:28:08Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum RepaymentDebtTypeEnum {
 
     /**
-     * Debt 1
+     * Debt 1, 0, 0x0000
      */
     DEBT_1(0x0000),
 
     /**
-     * Debt 2
+     * Debt 2, 1, 0x0001
      */
     DEBT_2(0x0001),
 
     /**
-     * Debt 3
+     * Debt 3, 2, 0x0002
      */
     DEBT_3(0x0002),
 
     /**
-     * All Debts
+     * All Debts, 255, 0x00FF
      */
     ALL_DEBTS(0x00FF);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/ResultTypeEnum.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/ResultTypeEnum.java
@@ -17,56 +17,56 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-02-09T15:28:08Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum ResultTypeEnum {
 
     /**
-     * Accepted
+     * Accepted, 0, 0x0000
      */
     ACCEPTED(0x0000),
 
     /**
-     * Rejected Invalid Top Up
+     * Rejected Invalid Top Up, 1, 0x0001
      */
     REJECTED_INVALID_TOP_UP(0x0001),
 
     /**
-     * Rejected Duplicate Top Up
+     * Rejected Duplicate Top Up, 2, 0x0002
      */
     REJECTED_DUPLICATE_TOP_UP(0x0002),
 
     /**
-     * Rejected Error
+     * Rejected Error, 3, 0x0003
      */
     REJECTED_ERROR(0x0003),
 
     /**
-     * Rejected Max Credit Reached
+     * Rejected Max Credit Reached, 4, 0x0004
      */
     REJECTED_MAX_CREDIT_REACHED(0x0004),
 
     /**
-     * Rejected Keypad Lock
+     * Rejected Keypad Lock, 5, 0x0005
      */
     REJECTED_KEYPAD_LOCK(0x0005),
 
     /**
-     * Rejected Top Up Value Too Large
+     * Rejected Top Up Value Too Large, 6, 0x0006
      */
     REJECTED_TOP_UP_VALUE_TOO_LARGE(0x0006),
 
     /**
-     * Accepted Supply Enabled
+     * Accepted Supply Enabled, 16, 0x0010
      */
     ACCEPTED_SUPPLY_ENABLED(0x0010),
 
     /**
-     * Accepted Supply Disabled
+     * Accepted Supply Disabled, 17, 0x0011
      */
     ACCEPTED_SUPPLY_DISABLED(0x0011),
 
     /**
-     * Accepted Supply Armed
+     * Accepted Supply Armed, 18, 0x0012
      */
     ACCEPTED_SUPPLY_ARMED(0x0012);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/CreditPaymentStatusEnum.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/CreditPaymentStatusEnum.java
@@ -17,31 +17,31 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-02-09T15:28:08Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum CreditPaymentStatusEnum {
 
     /**
-     * Pending
+     * Pending, 0, 0x0000
      */
     PENDING(0x0000),
 
     /**
-     * Received/Paid
+     * Received/Paid, 1, 0x0001
      */
     RECEIVED_PAID(0x0001),
 
     /**
-     * Overdue
+     * Overdue, 2, 0x0002
      */
     OVERDUE(0x0002),
 
     /**
-     * Two Payments Overdue
+     * Two Payments Overdue, 3, 0x0003
      */
     TWO_PAYMENTS_OVERDUE(0x0003),
 
     /**
-     * Three Payments Overdue
+     * Three Payments Overdue, 4, 0x0004
      */
     THREE_PAYMENTS_OVERDUE(0x0004);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/CurrencyChangeControlEnum.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/CurrencyChangeControlEnum.java
@@ -17,26 +17,26 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-02-09T15:28:08Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum CurrencyChangeControlEnum {
 
     /**
-     * Clear Billing Info
+     * Clear Billing Info, 1, 0x0001
      */
     CLEAR_BILLING_INFO(0x0001),
 
     /**
-     * Convert Billing Info Using New Currency
+     * Convert Billing Info Using New Currency, 2, 0x0002
      */
     CONVERT_BILLING_INFO_USING_NEW_CURRENCY(0x0002),
 
     /**
-     * Clear Old Consumption Data
+     * Clear Old Consumption Data, 4, 0x0004
      */
     CLEAR_OLD_CONSUMPTION_DATA(0x0004),
 
     /**
-     * Convert Old Consumption Data Using New Currency
+     * Convert Old Consumption Data Using New Currency, 8, 0x0008
      */
     CONVERT_OLD_CONSUMPTION_DATA_USING_NEW_CURRENCY(0x0008);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/ExtendedNumberOfPriceTiersEnum.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/ExtendedNumberOfPriceTiersEnum.java
@@ -17,176 +17,176 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-02-09T15:28:08Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum ExtendedNumberOfPriceTiersEnum {
 
     /**
-     * Refer To Number Of Price Tiers Field
+     * Refer To Number Of Price Tiers Field, 0, 0x0000
      */
     REFER_TO_NUMBER_OF_PRICE_TIERS_FIELD(0x0000),
 
     /**
-     * Number Of Price Tiers 16
+     * Number Of Price Tiers 16, 1, 0x0001
      */
     NUMBER_OF_PRICE_TIERS_16(0x0001),
 
     /**
-     * Number Of Price Tiers 17
+     * Number Of Price Tiers 17, 2, 0x0002
      */
     NUMBER_OF_PRICE_TIERS_17(0x0002),
 
     /**
-     * Number Of Price Tiers 18
+     * Number Of Price Tiers 18, 3, 0x0003
      */
     NUMBER_OF_PRICE_TIERS_18(0x0003),
 
     /**
-     * Number Of Price Tiers 19
+     * Number Of Price Tiers 19, 4, 0x0004
      */
     NUMBER_OF_PRICE_TIERS_19(0x0004),
 
     /**
-     * Number Of Price Tiers 20
+     * Number Of Price Tiers 20, 5, 0x0005
      */
     NUMBER_OF_PRICE_TIERS_20(0x0005),
 
     /**
-     * Number Of Price Tiers 21
+     * Number Of Price Tiers 21, 6, 0x0006
      */
     NUMBER_OF_PRICE_TIERS_21(0x0006),
 
     /**
-     * Number Of Price Tiers 22
+     * Number Of Price Tiers 22, 7, 0x0007
      */
     NUMBER_OF_PRICE_TIERS_22(0x0007),
 
     /**
-     * Number Of Price Tiers 23
+     * Number Of Price Tiers 23, 8, 0x0008
      */
     NUMBER_OF_PRICE_TIERS_23(0x0008),
 
     /**
-     * Number Of Price Tiers 24
+     * Number Of Price Tiers 24, 9, 0x0009
      */
     NUMBER_OF_PRICE_TIERS_24(0x0009),
 
     /**
-     * Number Of Price Tiers 25
+     * Number Of Price Tiers 25, 10, 0x000A
      */
     NUMBER_OF_PRICE_TIERS_25(0x000A),
 
     /**
-     * Number Of Price Tiers 26
+     * Number Of Price Tiers 26, 11, 0x000B
      */
     NUMBER_OF_PRICE_TIERS_26(0x000B),
 
     /**
-     * Number Of Price Tiers 27
+     * Number Of Price Tiers 27, 12, 0x000C
      */
     NUMBER_OF_PRICE_TIERS_27(0x000C),
 
     /**
-     * Number Of Price Tiers 28
+     * Number Of Price Tiers 28, 13, 0x000D
      */
     NUMBER_OF_PRICE_TIERS_28(0x000D),
 
     /**
-     * Number Of Price Tiers 29
+     * Number Of Price Tiers 29, 14, 0x000E
      */
     NUMBER_OF_PRICE_TIERS_29(0x000E),
 
     /**
-     * Number Of Price Tiers 30
+     * Number Of Price Tiers 30, 15, 0x000F
      */
     NUMBER_OF_PRICE_TIERS_30(0x000F),
 
     /**
-     * Number Of Price Tiers 31
+     * Number Of Price Tiers 31, 16, 0x0010
      */
     NUMBER_OF_PRICE_TIERS_31(0x0010),
 
     /**
-     * Number Of Price Tiers 32
+     * Number Of Price Tiers 32, 17, 0x0011
      */
     NUMBER_OF_PRICE_TIERS_32(0x0011),
 
     /**
-     * Number Of Price Tiers 33
+     * Number Of Price Tiers 33, 18, 0x0012
      */
     NUMBER_OF_PRICE_TIERS_33(0x0012),
 
     /**
-     * Number Of Price Tiers 34
+     * Number Of Price Tiers 34, 19, 0x0013
      */
     NUMBER_OF_PRICE_TIERS_34(0x0013),
 
     /**
-     * Number Of Price Tiers 35
+     * Number Of Price Tiers 35, 20, 0x0014
      */
     NUMBER_OF_PRICE_TIERS_35(0x0014),
 
     /**
-     * Number Of Price Tiers 36
+     * Number Of Price Tiers 36, 21, 0x0015
      */
     NUMBER_OF_PRICE_TIERS_36(0x0015),
 
     /**
-     * Number Of Price Tiers 37
+     * Number Of Price Tiers 37, 22, 0x0016
      */
     NUMBER_OF_PRICE_TIERS_37(0x0016),
 
     /**
-     * Number Of Price Tiers 38
+     * Number Of Price Tiers 38, 23, 0x0017
      */
     NUMBER_OF_PRICE_TIERS_38(0x0017),
 
     /**
-     * Number Of Price Tiers 39
+     * Number Of Price Tiers 39, 24, 0x0018
      */
     NUMBER_OF_PRICE_TIERS_39(0x0018),
 
     /**
-     * Number Of Price Tiers 40
+     * Number Of Price Tiers 40, 25, 0x0019
      */
     NUMBER_OF_PRICE_TIERS_40(0x0019),
 
     /**
-     * Number Of Price Tiers 41
+     * Number Of Price Tiers 41, 26, 0x001A
      */
     NUMBER_OF_PRICE_TIERS_41(0x001A),
 
     /**
-     * Number Of Price Tiers 42
+     * Number Of Price Tiers 42, 27, 0x001B
      */
     NUMBER_OF_PRICE_TIERS_42(0x001B),
 
     /**
-     * Number Of Price Tiers 43
+     * Number Of Price Tiers 43, 28, 0x001C
      */
     NUMBER_OF_PRICE_TIERS_43(0x001C),
 
     /**
-     * Number Of Price Tiers 44
+     * Number Of Price Tiers 44, 29, 0x001D
      */
     NUMBER_OF_PRICE_TIERS_44(0x001D),
 
     /**
-     * Number Of Price Tiers 45
+     * Number Of Price Tiers 45, 30, 0x001E
      */
     NUMBER_OF_PRICE_TIERS_45(0x001E),
 
     /**
-     * Number Of Price Tiers 46
+     * Number Of Price Tiers 46, 31, 0x001F
      */
     NUMBER_OF_PRICE_TIERS_46(0x001F),
 
     /**
-     * Number Of Price Tiers 47
+     * Number Of Price Tiers 47, 32, 0x0020
      */
     NUMBER_OF_PRICE_TIERS_47(0x0020),
 
     /**
-     * Number Of Price Tiers 48
+     * Number Of Price Tiers 48, 33, 0x0021
      */
     NUMBER_OF_PRICE_TIERS_48(0x0021);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/ExtendedPriceTierEnum.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/ExtendedPriceTierEnum.java
@@ -17,176 +17,176 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-02-09T15:28:08Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum ExtendedPriceTierEnum {
 
     /**
-     * Refer To Price Tier Field
+     * Refer To Price Tier Field, 0, 0x0000
      */
     REFER_TO_PRICE_TIER_FIELD(0x0000),
 
     /**
-     * Tier 16 Price Label
+     * Tier 16 Price Label, 1, 0x0001
      */
     TIER_16_PRICE_LABEL(0x0001),
 
     /**
-     * Tier 17 Price Label
+     * Tier 17 Price Label, 2, 0x0002
      */
     TIER_17_PRICE_LABEL(0x0002),
 
     /**
-     * Tier 18 Price Label
+     * Tier 18 Price Label, 3, 0x0003
      */
     TIER_18_PRICE_LABEL(0x0003),
 
     /**
-     * Tier 19 Price Label
+     * Tier 19 Price Label, 4, 0x0004
      */
     TIER_19_PRICE_LABEL(0x0004),
 
     /**
-     * Tier 20 Price Label
+     * Tier 20 Price Label, 5, 0x0005
      */
     TIER_20_PRICE_LABEL(0x0005),
 
     /**
-     * Tier 21 Price Label
+     * Tier 21 Price Label, 6, 0x0006
      */
     TIER_21_PRICE_LABEL(0x0006),
 
     /**
-     * Tier 22 Price Label
+     * Tier 22 Price Label, 7, 0x0007
      */
     TIER_22_PRICE_LABEL(0x0007),
 
     /**
-     * Tier 23 Price Label
+     * Tier 23 Price Label, 8, 0x0008
      */
     TIER_23_PRICE_LABEL(0x0008),
 
     /**
-     * Tier 24 Price Label
+     * Tier 24 Price Label, 9, 0x0009
      */
     TIER_24_PRICE_LABEL(0x0009),
 
     /**
-     * Tier 25 Price Label
+     * Tier 25 Price Label, 10, 0x000A
      */
     TIER_25_PRICE_LABEL(0x000A),
 
     /**
-     * Tier 26 Price Label
+     * Tier 26 Price Label, 11, 0x000B
      */
     TIER_26_PRICE_LABEL(0x000B),
 
     /**
-     * Tier 27 Price Label
+     * Tier 27 Price Label, 12, 0x000C
      */
     TIER_27_PRICE_LABEL(0x000C),
 
     /**
-     * Tier 28 Price Label
+     * Tier 28 Price Label, 13, 0x000D
      */
     TIER_28_PRICE_LABEL(0x000D),
 
     /**
-     * Tier 29 Price Label
+     * Tier 29 Price Label, 14, 0x000E
      */
     TIER_29_PRICE_LABEL(0x000E),
 
     /**
-     * Tier 30 Price Label
+     * Tier 30 Price Label, 15, 0x000F
      */
     TIER_30_PRICE_LABEL(0x000F),
 
     /**
-     * Tier 31 Price Label
+     * Tier 31 Price Label, 16, 0x0010
      */
     TIER_31_PRICE_LABEL(0x0010),
 
     /**
-     * Tier 32 Price Label
+     * Tier 32 Price Label, 17, 0x0011
      */
     TIER_32_PRICE_LABEL(0x0011),
 
     /**
-     * Tier 33 Price Label
+     * Tier 33 Price Label, 18, 0x0012
      */
     TIER_33_PRICE_LABEL(0x0012),
 
     /**
-     * Tier 34 Price Label
+     * Tier 34 Price Label, 19, 0x0013
      */
     TIER_34_PRICE_LABEL(0x0013),
 
     /**
-     * Tier 35 Price Label
+     * Tier 35 Price Label, 20, 0x0014
      */
     TIER_35_PRICE_LABEL(0x0014),
 
     /**
-     * Tier 36 Price Label
+     * Tier 36 Price Label, 21, 0x0015
      */
     TIER_36_PRICE_LABEL(0x0015),
 
     /**
-     * Tier 37 Price Label
+     * Tier 37 Price Label, 22, 0x0016
      */
     TIER_37_PRICE_LABEL(0x0016),
 
     /**
-     * Tier 38 Price Label
+     * Tier 38 Price Label, 23, 0x0017
      */
     TIER_38_PRICE_LABEL(0x0017),
 
     /**
-     * Tier 39 Price Label
+     * Tier 39 Price Label, 24, 0x0018
      */
     TIER_39_PRICE_LABEL(0x0018),
 
     /**
-     * Tier 40 Price Label
+     * Tier 40 Price Label, 25, 0x0019
      */
     TIER_40_PRICE_LABEL(0x0019),
 
     /**
-     * Tier 41 Price Label
+     * Tier 41 Price Label, 26, 0x001A
      */
     TIER_41_PRICE_LABEL(0x001A),
 
     /**
-     * Tier 42 Price Label
+     * Tier 42 Price Label, 27, 0x001B
      */
     TIER_42_PRICE_LABEL(0x001B),
 
     /**
-     * Tier 43 Price Label
+     * Tier 43 Price Label, 28, 0x001C
      */
     TIER_43_PRICE_LABEL(0x001C),
 
     /**
-     * Tier 44 Price Label
+     * Tier 44 Price Label, 29, 0x001D
      */
     TIER_44_PRICE_LABEL(0x001D),
 
     /**
-     * Tier 45 Price Label
+     * Tier 45 Price Label, 30, 0x001E
      */
     TIER_45_PRICE_LABEL(0x001E),
 
     /**
-     * Tier 46 Price Label
+     * Tier 46 Price Label, 31, 0x001F
      */
     TIER_46_PRICE_LABEL(0x001F),
 
     /**
-     * Tier 47 Price Label
+     * Tier 47 Price Label, 32, 0x0020
      */
     TIER_47_PRICE_LABEL(0x0020),
 
     /**
-     * Tier 48 Price Label
+     * Tier 48 Price Label, 33, 0x0021
      */
     TIER_48_PRICE_LABEL(0x0021);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/ExtendedRegisterTierEnum.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/ExtendedRegisterTierEnum.java
@@ -17,176 +17,176 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-02-09T15:28:08Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum ExtendedRegisterTierEnum {
 
     /**
-     * Refer To Register Tier Field
+     * Refer To Register Tier Field, 0, 0x0000
      */
     REFER_TO_REGISTER_TIER_FIELD(0x0000),
 
     /**
-     * Current Tier 16 Summation Delivered Attribute
+     * Current Tier 16 Summation Delivered Attribute, 1, 0x0001
      */
     CURRENT_TIER_16_SUMMATION_DELIVERED_ATTRIBUTE(0x0001),
 
     /**
-     * Current Tier 17 Summation Delivered Attribute
+     * Current Tier 17 Summation Delivered Attribute, 2, 0x0002
      */
     CURRENT_TIER_17_SUMMATION_DELIVERED_ATTRIBUTE(0x0002),
 
     /**
-     * Current Tier 18 Summation Delivered Attribute
+     * Current Tier 18 Summation Delivered Attribute, 3, 0x0003
      */
     CURRENT_TIER_18_SUMMATION_DELIVERED_ATTRIBUTE(0x0003),
 
     /**
-     * Current Tier 19 Summation Delivered Attribute
+     * Current Tier 19 Summation Delivered Attribute, 4, 0x0004
      */
     CURRENT_TIER_19_SUMMATION_DELIVERED_ATTRIBUTE(0x0004),
 
     /**
-     * Current Tier 20 Summation Delivered Attribute
+     * Current Tier 20 Summation Delivered Attribute, 5, 0x0005
      */
     CURRENT_TIER_20_SUMMATION_DELIVERED_ATTRIBUTE(0x0005),
 
     /**
-     * Current Tier 21 Summation Delivered Attribute
+     * Current Tier 21 Summation Delivered Attribute, 6, 0x0006
      */
     CURRENT_TIER_21_SUMMATION_DELIVERED_ATTRIBUTE(0x0006),
 
     /**
-     * Current Tier 22 Summation Delivered Attribute
+     * Current Tier 22 Summation Delivered Attribute, 7, 0x0007
      */
     CURRENT_TIER_22_SUMMATION_DELIVERED_ATTRIBUTE(0x0007),
 
     /**
-     * Current Tier 23 Summation Delivered Attribute
+     * Current Tier 23 Summation Delivered Attribute, 8, 0x0008
      */
     CURRENT_TIER_23_SUMMATION_DELIVERED_ATTRIBUTE(0x0008),
 
     /**
-     * Current Tier 24 Summation Delivered Attribute
+     * Current Tier 24 Summation Delivered Attribute, 9, 0x0009
      */
     CURRENT_TIER_24_SUMMATION_DELIVERED_ATTRIBUTE(0x0009),
 
     /**
-     * Current Tier 25 Summation Delivered Attribute
+     * Current Tier 25 Summation Delivered Attribute, 10, 0x000A
      */
     CURRENT_TIER_25_SUMMATION_DELIVERED_ATTRIBUTE(0x000A),
 
     /**
-     * Current Tier 26 Summation Delivered Attribute
+     * Current Tier 26 Summation Delivered Attribute, 11, 0x000B
      */
     CURRENT_TIER_26_SUMMATION_DELIVERED_ATTRIBUTE(0x000B),
 
     /**
-     * Current Tier 27 Summation Delivered Attribute
+     * Current Tier 27 Summation Delivered Attribute, 12, 0x000C
      */
     CURRENT_TIER_27_SUMMATION_DELIVERED_ATTRIBUTE(0x000C),
 
     /**
-     * Current Tier 28 Summation Delivered Attribute
+     * Current Tier 28 Summation Delivered Attribute, 13, 0x000D
      */
     CURRENT_TIER_28_SUMMATION_DELIVERED_ATTRIBUTE(0x000D),
 
     /**
-     * Current Tier 29 Summation Delivered Attribute
+     * Current Tier 29 Summation Delivered Attribute, 14, 0x000E
      */
     CURRENT_TIER_29_SUMMATION_DELIVERED_ATTRIBUTE(0x000E),
 
     /**
-     * Current Tier 30 Summation Delivered Attribute
+     * Current Tier 30 Summation Delivered Attribute, 15, 0x000F
      */
     CURRENT_TIER_30_SUMMATION_DELIVERED_ATTRIBUTE(0x000F),
 
     /**
-     * Current Tier 31 Summation Delivered Attribute
+     * Current Tier 31 Summation Delivered Attribute, 16, 0x0010
      */
     CURRENT_TIER_31_SUMMATION_DELIVERED_ATTRIBUTE(0x0010),
 
     /**
-     * Current Tier 32 Summation Delivered Attribute
+     * Current Tier 32 Summation Delivered Attribute, 17, 0x0011
      */
     CURRENT_TIER_32_SUMMATION_DELIVERED_ATTRIBUTE(0x0011),
 
     /**
-     * Current Tier 33 Summation Delivered Attribute
+     * Current Tier 33 Summation Delivered Attribute, 18, 0x0012
      */
     CURRENT_TIER_33_SUMMATION_DELIVERED_ATTRIBUTE(0x0012),
 
     /**
-     * Current Tier 34 Summation Delivered Attribute
+     * Current Tier 34 Summation Delivered Attribute, 19, 0x0013
      */
     CURRENT_TIER_34_SUMMATION_DELIVERED_ATTRIBUTE(0x0013),
 
     /**
-     * Current Tier 35 Summation Delivered Attribute
+     * Current Tier 35 Summation Delivered Attribute, 20, 0x0014
      */
     CURRENT_TIER_35_SUMMATION_DELIVERED_ATTRIBUTE(0x0014),
 
     /**
-     * Current Tier 36 Summation Delivered Attribute
+     * Current Tier 36 Summation Delivered Attribute, 21, 0x0015
      */
     CURRENT_TIER_36_SUMMATION_DELIVERED_ATTRIBUTE(0x0015),
 
     /**
-     * Current Tier 37 Summation Delivered Attribute
+     * Current Tier 37 Summation Delivered Attribute, 22, 0x0016
      */
     CURRENT_TIER_37_SUMMATION_DELIVERED_ATTRIBUTE(0x0016),
 
     /**
-     * Current Tier 38 Summation Delivered Attribute
+     * Current Tier 38 Summation Delivered Attribute, 23, 0x0017
      */
     CURRENT_TIER_38_SUMMATION_DELIVERED_ATTRIBUTE(0x0017),
 
     /**
-     * Current Tier 39 Summation Delivered Attribute
+     * Current Tier 39 Summation Delivered Attribute, 24, 0x0018
      */
     CURRENT_TIER_39_SUMMATION_DELIVERED_ATTRIBUTE(0x0018),
 
     /**
-     * Current Tier 40 Summation Delivered Attribute
+     * Current Tier 40 Summation Delivered Attribute, 25, 0x0019
      */
     CURRENT_TIER_40_SUMMATION_DELIVERED_ATTRIBUTE(0x0019),
 
     /**
-     * Current Tier 41 Summation Delivered Attribute
+     * Current Tier 41 Summation Delivered Attribute, 26, 0x001A
      */
     CURRENT_TIER_41_SUMMATION_DELIVERED_ATTRIBUTE(0x001A),
 
     /**
-     * Current Tier 42 Summation Delivered Attribute
+     * Current Tier 42 Summation Delivered Attribute, 27, 0x001B
      */
     CURRENT_TIER_42_SUMMATION_DELIVERED_ATTRIBUTE(0x001B),
 
     /**
-     * Current Tier 43 Summation Delivered Attribute
+     * Current Tier 43 Summation Delivered Attribute, 28, 0x001C
      */
     CURRENT_TIER_43_SUMMATION_DELIVERED_ATTRIBUTE(0x001C),
 
     /**
-     * Current Tier 44 Summation Delivered Attribute
+     * Current Tier 44 Summation Delivered Attribute, 29, 0x001D
      */
     CURRENT_TIER_44_SUMMATION_DELIVERED_ATTRIBUTE(0x001D),
 
     /**
-     * Current Tier 45 Summation Delivered Attribute
+     * Current Tier 45 Summation Delivered Attribute, 30, 0x001E
      */
     CURRENT_TIER_45_SUMMATION_DELIVERED_ATTRIBUTE(0x001E),
 
     /**
-     * Current Tier 46 Summation Delivered Attribute
+     * Current Tier 46 Summation Delivered Attribute, 31, 0x001F
      */
     CURRENT_TIER_46_SUMMATION_DELIVERED_ATTRIBUTE(0x001F),
 
     /**
-     * Current Tier 47 Summation Delivered Attribute
+     * Current Tier 47 Summation Delivered Attribute, 32, 0x0020
      */
     CURRENT_TIER_47_SUMMATION_DELIVERED_ATTRIBUTE(0x0020),
 
     /**
-     * Current Tier 48 Summation Delivered Attribute
+     * Current Tier 48 Summation Delivered Attribute, 33, 0x0021
      */
     CURRENT_TIER_48_SUMMATION_DELIVERED_ATTRIBUTE(0x0021);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/GenerationTierEnum.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/GenerationTierEnum.java
@@ -17,246 +17,246 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-02-09T15:28:08Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum GenerationTierEnum {
 
     /**
-     * Current Tier 1 Summation Received Attribute
+     * Current Tier 1 Summation Received Attribute, 1, 0x0001
      */
     CURRENT_TIER_1_SUMMATION_RECEIVED_ATTRIBUTE(0x0001),
 
     /**
-     * Current Tier 2 Summation Received Attribute
+     * Current Tier 2 Summation Received Attribute, 2, 0x0002
      */
     CURRENT_TIER_2_SUMMATION_RECEIVED_ATTRIBUTE(0x0002),
 
     /**
-     * Current Tier 3 Summation Received Attribute
+     * Current Tier 3 Summation Received Attribute, 3, 0x0003
      */
     CURRENT_TIER_3_SUMMATION_RECEIVED_ATTRIBUTE(0x0003),
 
     /**
-     * Current Tier 4 Summation Received Attribute
+     * Current Tier 4 Summation Received Attribute, 4, 0x0004
      */
     CURRENT_TIER_4_SUMMATION_RECEIVED_ATTRIBUTE(0x0004),
 
     /**
-     * Current Tier 5 Summation Received Attribute
+     * Current Tier 5 Summation Received Attribute, 5, 0x0005
      */
     CURRENT_TIER_5_SUMMATION_RECEIVED_ATTRIBUTE(0x0005),
 
     /**
-     * Current Tier 6 Summation Received Attribute
+     * Current Tier 6 Summation Received Attribute, 6, 0x0006
      */
     CURRENT_TIER_6_SUMMATION_RECEIVED_ATTRIBUTE(0x0006),
 
     /**
-     * Current Tier 7 Summation Received Attribute
+     * Current Tier 7 Summation Received Attribute, 7, 0x0007
      */
     CURRENT_TIER_7_SUMMATION_RECEIVED_ATTRIBUTE(0x0007),
 
     /**
-     * Current Tier 8 Summation Received Attribute
+     * Current Tier 8 Summation Received Attribute, 8, 0x0008
      */
     CURRENT_TIER_8_SUMMATION_RECEIVED_ATTRIBUTE(0x0008),
 
     /**
-     * Current Tier 9 Summation Received Attribute
+     * Current Tier 9 Summation Received Attribute, 9, 0x0009
      */
     CURRENT_TIER_9_SUMMATION_RECEIVED_ATTRIBUTE(0x0009),
 
     /**
-     * Current Tier 10 Summation Received Attribute
+     * Current Tier 10 Summation Received Attribute, 10, 0x000A
      */
     CURRENT_TIER_10_SUMMATION_RECEIVED_ATTRIBUTE(0x000A),
 
     /**
-     * Current Tier 11 Summation Received Attribute
+     * Current Tier 11 Summation Received Attribute, 11, 0x000B
      */
     CURRENT_TIER_11_SUMMATION_RECEIVED_ATTRIBUTE(0x000B),
 
     /**
-     * Current Tier 12 Summation Received Attribute
+     * Current Tier 12 Summation Received Attribute, 12, 0x000C
      */
     CURRENT_TIER_12_SUMMATION_RECEIVED_ATTRIBUTE(0x000C),
 
     /**
-     * Current Tier 13 Summation Received Attribute
+     * Current Tier 13 Summation Received Attribute, 13, 0x000D
      */
     CURRENT_TIER_13_SUMMATION_RECEIVED_ATTRIBUTE(0x000D),
 
     /**
-     * Current Tier 14 Summation Received Attribute
+     * Current Tier 14 Summation Received Attribute, 14, 0x000E
      */
     CURRENT_TIER_14_SUMMATION_RECEIVED_ATTRIBUTE(0x000E),
 
     /**
-     * Current Tier 15 Summation Received Attribute
+     * Current Tier 15 Summation Received Attribute, 15, 0x000F
      */
     CURRENT_TIER_15_SUMMATION_RECEIVED_ATTRIBUTE(0x000F),
 
     /**
-     * Current Tier 16 Summation Received Attribute
+     * Current Tier 16 Summation Received Attribute, 16, 0x0010
      */
     CURRENT_TIER_16_SUMMATION_RECEIVED_ATTRIBUTE(0x0010),
 
     /**
-     * Current Tier 17 Summation Received Attribute
+     * Current Tier 17 Summation Received Attribute, 17, 0x0011
      */
     CURRENT_TIER_17_SUMMATION_RECEIVED_ATTRIBUTE(0x0011),
 
     /**
-     * Current Tier 18 Summation Received Attribute
+     * Current Tier 18 Summation Received Attribute, 18, 0x0012
      */
     CURRENT_TIER_18_SUMMATION_RECEIVED_ATTRIBUTE(0x0012),
 
     /**
-     * Current Tier 19 Summation Received Attribute
+     * Current Tier 19 Summation Received Attribute, 19, 0x0013
      */
     CURRENT_TIER_19_SUMMATION_RECEIVED_ATTRIBUTE(0x0013),
 
     /**
-     * Current Tier 20 Summation Received Attribute
+     * Current Tier 20 Summation Received Attribute, 20, 0x0014
      */
     CURRENT_TIER_20_SUMMATION_RECEIVED_ATTRIBUTE(0x0014),
 
     /**
-     * Current Tier 21 Summation Received Attribute
+     * Current Tier 21 Summation Received Attribute, 21, 0x0015
      */
     CURRENT_TIER_21_SUMMATION_RECEIVED_ATTRIBUTE(0x0015),
 
     /**
-     * Current Tier 22 Summation Received Attribute
+     * Current Tier 22 Summation Received Attribute, 22, 0x0016
      */
     CURRENT_TIER_22_SUMMATION_RECEIVED_ATTRIBUTE(0x0016),
 
     /**
-     * Current Tier 23 Summation Received Attribute
+     * Current Tier 23 Summation Received Attribute, 23, 0x0017
      */
     CURRENT_TIER_23_SUMMATION_RECEIVED_ATTRIBUTE(0x0017),
 
     /**
-     * Current Tier 24 Summation Received Attribute
+     * Current Tier 24 Summation Received Attribute, 24, 0x0018
      */
     CURRENT_TIER_24_SUMMATION_RECEIVED_ATTRIBUTE(0x0018),
 
     /**
-     * Current Tier 25 Summation Received Attribute
+     * Current Tier 25 Summation Received Attribute, 25, 0x0019
      */
     CURRENT_TIER_25_SUMMATION_RECEIVED_ATTRIBUTE(0x0019),
 
     /**
-     * Current Tier 26 Summation Received Attribute
+     * Current Tier 26 Summation Received Attribute, 26, 0x001A
      */
     CURRENT_TIER_26_SUMMATION_RECEIVED_ATTRIBUTE(0x001A),
 
     /**
-     * Current Tier 27 Summation Received Attribute
+     * Current Tier 27 Summation Received Attribute, 27, 0x001B
      */
     CURRENT_TIER_27_SUMMATION_RECEIVED_ATTRIBUTE(0x001B),
 
     /**
-     * Current Tier 28 Summation Received Attribute
+     * Current Tier 28 Summation Received Attribute, 28, 0x001C
      */
     CURRENT_TIER_28_SUMMATION_RECEIVED_ATTRIBUTE(0x001C),
 
     /**
-     * Current Tier 29 Summation Received Attribute
+     * Current Tier 29 Summation Received Attribute, 29, 0x001D
      */
     CURRENT_TIER_29_SUMMATION_RECEIVED_ATTRIBUTE(0x001D),
 
     /**
-     * Current Tier 30 Summation Received Attribute
+     * Current Tier 30 Summation Received Attribute, 30, 0x001E
      */
     CURRENT_TIER_30_SUMMATION_RECEIVED_ATTRIBUTE(0x001E),
 
     /**
-     * Current Tier 31 Summation Received Attribute
+     * Current Tier 31 Summation Received Attribute, 31, 0x001F
      */
     CURRENT_TIER_31_SUMMATION_RECEIVED_ATTRIBUTE(0x001F),
 
     /**
-     * Current Tier 32 Summation Received Attribute
+     * Current Tier 32 Summation Received Attribute, 32, 0x0020
      */
     CURRENT_TIER_32_SUMMATION_RECEIVED_ATTRIBUTE(0x0020),
 
     /**
-     * Current Tier 33 Summation Received Attribute
+     * Current Tier 33 Summation Received Attribute, 33, 0x0021
      */
     CURRENT_TIER_33_SUMMATION_RECEIVED_ATTRIBUTE(0x0021),
 
     /**
-     * Current Tier 34 Summation Received Attribute
+     * Current Tier 34 Summation Received Attribute, 34, 0x0022
      */
     CURRENT_TIER_34_SUMMATION_RECEIVED_ATTRIBUTE(0x0022),
 
     /**
-     * Current Tier 35 Summation Received Attribute
+     * Current Tier 35 Summation Received Attribute, 35, 0x0023
      */
     CURRENT_TIER_35_SUMMATION_RECEIVED_ATTRIBUTE(0x0023),
 
     /**
-     * Current Tier 36 Summation Received Attribute
+     * Current Tier 36 Summation Received Attribute, 36, 0x0024
      */
     CURRENT_TIER_36_SUMMATION_RECEIVED_ATTRIBUTE(0x0024),
 
     /**
-     * Current Tier 37 Summation Received Attribute
+     * Current Tier 37 Summation Received Attribute, 37, 0x0025
      */
     CURRENT_TIER_37_SUMMATION_RECEIVED_ATTRIBUTE(0x0025),
 
     /**
-     * Current Tier 38 Summation Received Attribute
+     * Current Tier 38 Summation Received Attribute, 38, 0x0026
      */
     CURRENT_TIER_38_SUMMATION_RECEIVED_ATTRIBUTE(0x0026),
 
     /**
-     * Current Tier 39 Summation Received Attribute
+     * Current Tier 39 Summation Received Attribute, 39, 0x0027
      */
     CURRENT_TIER_39_SUMMATION_RECEIVED_ATTRIBUTE(0x0027),
 
     /**
-     * Current Tier 40 Summation Received Attribute
+     * Current Tier 40 Summation Received Attribute, 40, 0x0028
      */
     CURRENT_TIER_40_SUMMATION_RECEIVED_ATTRIBUTE(0x0028),
 
     /**
-     * Current Tier 41 Summation Received Attribute
+     * Current Tier 41 Summation Received Attribute, 41, 0x0029
      */
     CURRENT_TIER_41_SUMMATION_RECEIVED_ATTRIBUTE(0x0029),
 
     /**
-     * Current Tier 42 Summation Received Attribute
+     * Current Tier 42 Summation Received Attribute, 42, 0x002A
      */
     CURRENT_TIER_42_SUMMATION_RECEIVED_ATTRIBUTE(0x002A),
 
     /**
-     * Current Tier 43 Summation Received Attribute
+     * Current Tier 43 Summation Received Attribute, 43, 0x002B
      */
     CURRENT_TIER_43_SUMMATION_RECEIVED_ATTRIBUTE(0x002B),
 
     /**
-     * Current Tier 44 Summation Received Attribute
+     * Current Tier 44 Summation Received Attribute, 44, 0x002C
      */
     CURRENT_TIER_44_SUMMATION_RECEIVED_ATTRIBUTE(0x002C),
 
     /**
-     * Current Tier 45 Summation Received Attribute
+     * Current Tier 45 Summation Received Attribute, 45, 0x002D
      */
     CURRENT_TIER_45_SUMMATION_RECEIVED_ATTRIBUTE(0x002D),
 
     /**
-     * Current Tier 46 Summation Received Attribute
+     * Current Tier 46 Summation Received Attribute, 46, 0x002E
      */
     CURRENT_TIER_46_SUMMATION_RECEIVED_ATTRIBUTE(0x002E),
 
     /**
-     * Current Tier 47 Summation Received Attribute
+     * Current Tier 47 Summation Received Attribute, 47, 0x002F
      */
     CURRENT_TIER_47_SUMMATION_RECEIVED_ATTRIBUTE(0x002F),
 
     /**
-     * Current Tier 48 Summation Received Attribute
+     * Current Tier 48 Summation Received Attribute, 48, 0x0030
      */
     CURRENT_TIER_48_SUMMATION_RECEIVED_ATTRIBUTE(0x0030);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PaymentDiscountPeriodEnum.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PaymentDiscountPeriodEnum.java
@@ -17,31 +17,31 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-02-09T15:28:08Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum PaymentDiscountPeriodEnum {
 
     /**
-     * Current Billing Period
+     * Current Billing Period, 0, 0x0000
      */
     CURRENT_BILLING_PERIOD(0x0000),
 
     /**
-     * Current Consolidated Bill
+     * Current Consolidated Bill, 1, 0x0001
      */
     CURRENT_CONSOLIDATED_BILL(0x0001),
 
     /**
-     * One Month
+     * One Month, 2, 0x0002
      */
     ONE_MONTH(0x0002),
 
     /**
-     * One Quarter
+     * One Quarter, 3, 0x0003
      */
     ONE_QUARTER(0x0003),
 
     /**
-     * One Year
+     * One Year, 4, 0x0004
      */
     ONE_YEAR(0x0004);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PriceControlMaskBitmap.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PriceControlMaskBitmap.java
@@ -17,16 +17,16 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-02-09T15:28:08Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum PriceControlMaskBitmap {
 
     /**
-     * Price Acknowledgement Required
+     * Price Acknowledgement Required, 1, 0x0001
      */
     PRICE_ACKNOWLEDGEMENT_REQUIRED(0x0001),
 
     /**
-     * Total Tiers Exceeds 15
+     * Total Tiers Exceeds 15, 2, 0x0002
      */
     TOTAL_TIERS_EXCEEDS_15(0x0002);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PriceMatrixSubPayloadControlBitmap.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PriceMatrixSubPayloadControlBitmap.java
@@ -17,11 +17,11 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-02-09T15:28:08Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum PriceMatrixSubPayloadControlBitmap {
 
     /**
-     * Tou Based
+     * Tou Based, 1, 0x0001
      */
     TOU_BASED(0x0001);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PriceNumberOfPriceTiersAndRegisterTierBitmap.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PriceNumberOfPriceTiersAndRegisterTierBitmap.java
@@ -17,16 +17,16 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-02-09T15:28:08Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum PriceNumberOfPriceTiersAndRegisterTierBitmap {
 
     /**
-     * Register Tier
+     * Register Tier, 15, 0x000F
      */
     REGISTER_TIER(0x000F),
 
     /**
-     * Number Of Price Tiers
+     * Number Of Price Tiers, 240, 0x00F0
      */
     NUMBER_OF_PRICE_TIERS(0x00F0);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PriceTrailingDigitAndPriceTierBitmap.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PriceTrailingDigitAndPriceTierBitmap.java
@@ -17,16 +17,16 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-02-09T15:28:08Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum PriceTrailingDigitAndPriceTierBitmap {
 
     /**
-     * Price Tier
+     * Price Tier, 15, 0x000F
      */
     PRICE_TIER(0x000F),
 
     /**
-     * Trailing Digit
+     * Trailing Digit, 240, 0x00F0
      */
     TRAILING_DIGIT(0x00F0);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PriceTrailingDigitBitmap.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PriceTrailingDigitBitmap.java
@@ -17,11 +17,11 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-02-09T15:28:08Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum PriceTrailingDigitBitmap {
 
     /**
-     * Trailing Digit
+     * Trailing Digit, 240, 0x00F0
      */
     TRAILING_DIGIT(0x00F0);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishCppEventCppAuthEnum.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishCppEventCppAuthEnum.java
@@ -17,26 +17,26 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-02-09T15:28:08Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum PublishCppEventCppAuthEnum {
 
     /**
-     * Pending
+     * Pending, 0, 0x0000
      */
     PENDING(0x0000),
 
     /**
-     * Accepted
+     * Accepted, 1, 0x0001
      */
     ACCEPTED(0x0001),
 
     /**
-     * Rejected
+     * Rejected, 2, 0x0002
      */
     REJECTED(0x0002),
 
     /**
-     * Forced
+     * Forced, 3, 0x0003
      */
     FORCED(0x0003);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/TariffTypeChargingSchemeBitmap.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/TariffTypeChargingSchemeBitmap.java
@@ -17,16 +17,16 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-02-09T15:28:08Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum TariffTypeChargingSchemeBitmap {
 
     /**
-     * Tariff Type
+     * Tariff Type, 15, 0x000F
      */
     TARIFF_TYPE(0x000F),
 
     /**
-     * Tariff Charging Scheme
+     * Tariff Charging Scheme, 240, 0x00F0
      */
     TARIFF_CHARGING_SCHEME(0x00F0);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/TariffTypeEnum.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/TariffTypeEnum.java
@@ -17,21 +17,21 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-02-09T15:28:08Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum TariffTypeEnum {
 
     /**
-     * Delivered Tariff
+     * Delivered Tariff, 0, 0x0000
      */
     DELIVERED_TARIFF(0x0000),
 
     /**
-     * Received Tariff
+     * Received Tariff, 1, 0x0001
      */
     RECEIVED_TARIFF(0x0001),
 
     /**
-     * Delivered And Received Tariff
+     * Delivered And Received Tariff, 2, 0x0002
      */
     DELIVERED_AND_RECEIVED_TARIFF(0x0002);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/TierBlockModeEnum.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/TierBlockModeEnum.java
@@ -17,26 +17,26 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-02-09T15:28:08Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum TierBlockModeEnum {
 
     /**
-     * Active Block
+     * Active Block, 0, 0x0000
      */
     ACTIVE_BLOCK(0x0000),
 
     /**
-     * Active Block Price Tier
+     * Active Block Price Tier, 1, 0x0001
      */
     ACTIVE_BLOCK_PRICE_TIER(0x0001),
 
     /**
-     * Active Block Price Tier Threshold
+     * Active Block Price Tier Threshold, 2, 0x0002
      */
     ACTIVE_BLOCK_PRICE_TIER_THRESHOLD(0x0002),
 
     /**
-     * Not Used
+     * Not Used, 255, 0x00FF
      */
     NOT_USED(0x00FF);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/smartenergytunneling/TransferDataStatusEnum.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/smartenergytunneling/TransferDataStatusEnum.java
@@ -17,21 +17,21 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-02-09T15:28:08Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum TransferDataStatusEnum {
 
     /**
-     * No Such Tunnel
+     * No Such Tunnel, 0, 0x0000
      */
     NO_SUCH_TUNNEL(0x0000),
 
     /**
-     * Wrong Device
+     * Wrong Device, 1, 0x0001
      */
     WRONG_DEVICE(0x0001),
 
     /**
-     * Data Overflow
+     * Data Overflow, 2, 0x0002
      */
     DATA_OVERFLOW(0x0002);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/smartenergytunneling/TunnelStatusEnum.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/smartenergytunneling/TunnelStatusEnum.java
@@ -17,31 +17,31 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-02-09T15:28:08Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum TunnelStatusEnum {
 
     /**
-     * Success
+     * Success, 0, 0x0000
      */
     SUCCESS(0x0000),
 
     /**
-     * Busy
+     * Busy, 1, 0x0001
      */
     BUSY(0x0001),
 
     /**
-     * No More Tunnel Ids
+     * No More Tunnel Ids, 2, 0x0002
      */
     NO_MORE_TUNNEL_IDS(0x0002),
 
     /**
-     * Protocol Not Supported
+     * Protocol Not Supported, 3, 0x0003
      */
     PROTOCOL_NOT_SUPPORTED(0x0003),
 
     /**
-     * Flow Control Not Supported
+     * Flow Control Not Supported, 4, 0x0004
      */
     FLOW_CONTROL_NOT_SUPPORTED(0x0004);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/thermostat/ACCapacityFormatEnum.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/thermostat/ACCapacityFormatEnum.java
@@ -17,11 +17,11 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-12-20T07:40:15Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum ACCapacityFormatEnum {
 
     /**
-     * BTUh
+     * BTUh, 0, 0x0000
      */
     BTUH(0x0000);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/thermostat/ACCompressorTypeEnum.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/thermostat/ACCompressorTypeEnum.java
@@ -17,26 +17,26 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-12-20T07:52:29Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum ACCompressorTypeEnum {
 
     /**
-     * Reserved
+     * Reserved, 0, 0x0000
      */
     RESERVED(0x0000),
 
     /**
-     * T1
+     * T1, 1, 0x0001
      */
     T1(0x0001),
 
     /**
-     * T2
+     * T2, 2, 0x0002
      */
     T2(0x0002),
 
     /**
-     * T3
+     * T3, 3, 0x0003
      */
     T3(0x0003);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/thermostat/ACLouverPositionEnum.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/thermostat/ACLouverPositionEnum.java
@@ -17,31 +17,31 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-12-20T07:40:15Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum ACLouverPositionEnum {
 
     /**
-     * Fully Closed
+     * Fully Closed, 1, 0x0001
      */
     FULLY_CLOSED(0x0001),
 
     /**
-     * Fully Open
+     * Fully Open, 2, 0x0002
      */
     FULLY_OPEN(0x0002),
 
     /**
-     * Quarter Open
+     * Quarter Open, 3, 0x0003
      */
     QUARTER_OPEN(0x0003),
 
     /**
-     * Half Open
+     * Half Open, 4, 0x0004
      */
     HALF_OPEN(0x0004),
 
     /**
-     * Three Quarters Open
+     * Three Quarters Open, 5, 0x0005
      */
     THREE_QUARTERS_OPEN(0x0005);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/thermostat/ACRefrigerantTypeEnum.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/thermostat/ACRefrigerantTypeEnum.java
@@ -17,26 +17,26 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-12-20T07:40:15Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum ACRefrigerantTypeEnum {
 
     /**
-     * Reserved
+     * Reserved, 0, 0x0000
      */
     RESERVED(0x0000),
 
     /**
-     * R22
+     * R22, 1, 0x0001
      */
     R22(0x0001),
 
     /**
-     * R410a
+     * R410a, 2, 0x0002
      */
     R410A(0x0002),
 
     /**
-     * R407c
+     * R407c, 3, 0x0003
      */
     R407C(0x0003);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/thermostat/ACTypeEnum.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/thermostat/ACTypeEnum.java
@@ -17,31 +17,31 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-12-20T07:40:15Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum ACTypeEnum {
 
     /**
-     * Reserved
+     * Reserved, 0, 0x0000
      */
     RESERVED(0x0000),
 
     /**
-     * Cooling and Fixed Speed
+     * Cooling and Fixed Speed, 1, 0x0001
      */
     COOLING_AND_FIXED_SPEED(0x0001),
 
     /**
-     * Heat Pump and Fixed Speed
+     * Heat Pump and Fixed Speed, 2, 0x0002
      */
     HEAT_PUMP_AND_FIXED_SPEED(0x0002),
 
     /**
-     * Cooling and Inverter
+     * Cooling and Inverter, 3, 0x0003
      */
     COOLING_AND_INVERTER(0x0003),
 
     /**
-     * Heat Pump and Inverter
+     * Heat Pump and Inverter, 4, 0x0004
      */
     HEAT_PUMP_AND_INVERTER(0x0004);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/thermostat/DayOfWeekBitmap.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/thermostat/DayOfWeekBitmap.java
@@ -17,46 +17,46 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-02-09T15:28:08Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum DayOfWeekBitmap {
 
     /**
-     * Sunday
+     * Sunday, 1, 0x0001
      */
     SUNDAY(0x0001),
 
     /**
-     * Monday
+     * Monday, 2, 0x0002
      */
     MONDAY(0x0002),
 
     /**
-     * Tuesday
+     * Tuesday, 4, 0x0004
      */
     TUESDAY(0x0004),
 
     /**
-     * Wednesday
+     * Wednesday, 8, 0x0008
      */
     WEDNESDAY(0x0008),
 
     /**
-     * Thursday
+     * Thursday, 16, 0x0010
      */
     THURSDAY(0x0010),
 
     /**
-     * Friday
+     * Friday, 32, 0x0020
      */
     FRIDAY(0x0020),
 
     /**
-     * Saturday
+     * Saturday, 64, 0x0040
      */
     SATURDAY(0x0040),
 
     /**
-     * Away Or Vacation
+     * Away Or Vacation, 128, 0x0080
      */
     AWAY_OR_VACATION(0x0080);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/thermostat/ModeForSequenceBitmap.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/thermostat/ModeForSequenceBitmap.java
@@ -17,16 +17,16 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-02-09T15:28:08Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum ModeForSequenceBitmap {
 
     /**
-     * Heat Setpoint Field Present
+     * Heat Setpoint Field Present, 1, 0x0001
      */
     HEAT_SETPOINT_FIELD_PRESENT(0x0001),
 
     /**
-     * Cool Setpoint Field Present
+     * Cool Setpoint Field Present, 2, 0x0002
      */
     COOL_SETPOINT_FIELD_PRESENT(0x0002);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/thermostat/SetpointAdjustModeEnum.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/thermostat/SetpointAdjustModeEnum.java
@@ -17,21 +17,21 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-02-09T15:28:08Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum SetpointAdjustModeEnum {
 
     /**
-     * Heat Setpoint
+     * Heat Setpoint, 0, 0x0000
      */
     HEAT_SETPOINT(0x0000),
 
     /**
-     * Cool Setpoint
+     * Cool Setpoint, 1, 0x0001
      */
     COOL_SETPOINT(0x0001),
 
     /**
-     * Heat And Cool Setpoints
+     * Heat And Cool Setpoints, 2, 0x0002
      */
     HEAT_AND_COOL_SETPOINTS(0x0002);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/thermostat/SetpointChangeSourceEnum.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/thermostat/SetpointChangeSourceEnum.java
@@ -17,21 +17,21 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-12-20T07:40:15Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum SetpointChangeSourceEnum {
 
     /**
-     * Manual user-initiated
+     * Manual user-initiated, 0, 0x0000
      */
     MANUAL_USER_INITIATED(0x0000),
 
     /**
-     * Schedule/internal programming-initiated
+     * Schedule/internal programming-initiated, 1, 0x0001
      */
     SCHEDULE_INTERNAL_PROGRAMMING_INITIATED(0x0001),
 
     /**
-     * Externally-initiated
+     * Externally-initiated, 2, 0x0002
      */
     EXTERNALLY_INITIATED(0x0002);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/thermostat/StartOfWeekEnum.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/thermostat/StartOfWeekEnum.java
@@ -17,41 +17,41 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-12-20T07:40:15Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum StartOfWeekEnum {
 
     /**
-     * Sunday
+     * Sunday, 0, 0x0000
      */
     SUNDAY(0x0000),
 
     /**
-     * Monday
+     * Monday, 1, 0x0001
      */
     MONDAY(0x0001),
 
     /**
-     * Tuesday
+     * Tuesday, 2, 0x0002
      */
     TUESDAY(0x0002),
 
     /**
-     * Wednesday
+     * Wednesday, 3, 0x0003
      */
     WEDNESDAY(0x0003),
 
     /**
-     * Thursday
+     * Thursday, 4, 0x0004
      */
     THURSDAY(0x0004),
 
     /**
-     * Friday
+     * Friday, 5, 0x0005
      */
     FRIDAY(0x0005),
 
     /**
-     * Saturday
+     * Saturday, 6, 0x0006
      */
     SATURDAY(0x0006);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/thermostat/TemperatureSetpointHoldEnum.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/thermostat/TemperatureSetpointHoldEnum.java
@@ -17,16 +17,16 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-12-20T07:40:15Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum TemperatureSetpointHoldEnum {
 
     /**
-     * Setpoint Hold Off
+     * Setpoint Hold Off, 0, 0x0000
      */
     SETPOINT_HOLD_OFF(0x0000),
 
     /**
-     * Setpoint Hold On
+     * Setpoint Hold On, 1, 0x0001
      */
     SETPOINT_HOLD_ON(0x0001);
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/time/TimeStatusBitmap.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/time/TimeStatusBitmap.java
@@ -17,26 +17,26 @@ import javax.annotation.Generated;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2019-02-09T15:28:08Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-15T11:25:03Z")
 public enum TimeStatusBitmap {
 
     /**
-     * Master
+     * Master, 1, 0x0001
      */
     MASTER(0x0001),
 
     /**
-     * Synchronized
+     * Synchronized, 2, 0x0002
      */
     SYNCHRONIZED(0x0002),
 
     /**
-     * Master Zone DST
+     * Master Zone DST, 4, 0x0004
      */
     MASTER_ZONE_DST(0x0004),
 
     /**
-     * Superseding
+     * Superseding, 8, 0x0008
      */
     SUPERSEDING(0x0008);
 

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeDeviceTypeTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeDeviceTypeTest.java
@@ -20,13 +20,19 @@ public class ZigBeeDeviceTypeTest {
 
     @Test
     public void test() {
-        assertEquals(ZigBeeDeviceType.ON_OFF_SWITCH, ZigBeeDeviceType.getByValue(0x0000));
+        // assertEquals(ZigBeeDeviceType.ON_OFF_SWITCH, ZigBeeDeviceType.getByValue(0x0000));
         assertEquals(ZigBeeDeviceType.LEVEL_CONTROL_SWITCH, ZigBeeDeviceType.getByValue(0x0001));
         assertEquals(ZigBeeDeviceType.MAINS_POWER_OUTLET, ZigBeeDeviceType.getByValue(0x0009));
         assertEquals(ZigBeeDeviceType.HOME_GATEWAY, ZigBeeDeviceType.getByValue(0x0050));
         assertEquals(ZigBeeDeviceType.SMART_PLUG, ZigBeeDeviceType.getByValue(0x0051));
         assertEquals(ZigBeeDeviceType.DIMMABLE_LIGHT, ZigBeeDeviceType.getByValue(0x0101));
         assertEquals(ZigBeeDeviceType.COLOR_DIMMABLE_LIGHT, ZigBeeDeviceType.getByValue(0x0102));
+
+        assertEquals(ZigBeeDeviceType.LEVEL_CONTROL_SWITCH,
+                ZigBeeDeviceType.getByValue(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0001));
+
+        assertEquals(ZigBeeDeviceType.ZLL_ON_OFF_LIGHT,
+                ZigBeeDeviceType.getByValue(ZigBeeProfileType.ZIGBEE_LIGHT_LINK, 0x0000));
 
         assertEquals(0x000A, ZigBeeDeviceType.DOOR_LOCK.getKey());
         assertEquals(0x0107, ZigBeeDeviceType.OCCUPANCY_SENSOR.getKey());


### PR DESCRIPTION
This modifies the auto coder for the constant generator to allow the `ZigBeeDeviceType` constant to take the profile as well as the device id.

A new variant of the `ZigBeeDeviceType.getByValue` method has been added to take the `ZigBeeProfileType` as well to allow device types from different profiles to be differentiated.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>