### PR TITLE
Fix sending AddGroupCommand when label is not set

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/groups/ZigBeeGroup.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/groups/ZigBeeGroup.java
@@ -220,7 +220,7 @@ public class ZigBeeGroup implements Comparable<Object> {
 
         CommandResult cmdResult;
         try {
-            cmdResult = cluster.sendCommand(new AddGroupCommand(groupId, label)).get();
+            cmdResult = cluster.sendCommand(new AddGroupCommand(groupId, (label == null ? "" : label))).get();
             if (cmdResult.isError()) {
                 logger.debug("{}: Unable to add group {}", address.getAddress(), groupId);
                 return;


### PR DESCRIPTION
Ensure null is not passed into the command if the group label is not set.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>