### PR TITLE
Fix the logging of the node state update

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNode.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNode.java
@@ -786,6 +786,7 @@ public class ZigBeeNode {
         boolean updated = false;
 
         if (node.getNodeState() != ZigBeeNodeState.UNKNOWN && nodeState != node.getNodeState()) {
+            logger.debug("{}: Node state updated from {} to {}", ieeeAddress, nodeState, node.getNodeState());
             nodeState = node.getNodeState();
             updated = true;
         }
@@ -935,7 +936,6 @@ public class ZigBeeNode {
         if (nodeState.equals(state)) {
             return false;
         }
-        logger.debug("{}: Node state updated from {} to {}", ieeeAddress, nodeState, state);
         nodeState = state;
         return true;
     }


### PR DESCRIPTION
#1193 ensured the node state is updated when a packet is received. However the logging shows that the state is updated as it prints it for the new node that is created, and not the node that is being updated.
This PR just moves the logging so the updated message is only printed if the node is really updated.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>