### PR TITLE
Improve robustness of active scan handler

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/EmberNcp.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/EmberNcp.java
@@ -1018,12 +1018,17 @@ public class EmberNcp {
                 Arrays.asList(EzspStartScanResponse.class, EzspNetworkFoundHandler.class));
         EzspTransaction transaction = protocolHandler.sendEzspTransaction(
                 new EzspMultiResponseTransaction(activeScan, EzspScanCompleteHandler.class, relatedResponses));
-        EzspScanCompleteHandler activeScanCompleteResponse = (EzspScanCompleteHandler) transaction.getResponse();
-        logger.debug(activeScanCompleteResponse.toString());
+        logger.debug("Active scan response: {}", transaction.getResponse());
+        if (transaction.getResponse() instanceof EzspScanCompleteHandler) {
+            EzspScanCompleteHandler activeScanCompleteResponse = (EzspScanCompleteHandler) transaction.getResponse();
 
-        if (activeScanCompleteResponse.getStatus() != EmberStatus.EMBER_SUCCESS) {
-            lastStatus = activeScanCompleteResponse.getStatus();
-            logger.debug("Error during active scan: {}", activeScanCompleteResponse);
+            if (activeScanCompleteResponse.getStatus() != EmberStatus.EMBER_SUCCESS) {
+                lastStatus = activeScanCompleteResponse.getStatus();
+                logger.debug("Error during active scan: {}", activeScanCompleteResponse);
+                return null;
+            }
+        } else {
+            logger.debug("Invalid response during active scan: {}", transaction.getResponse());
             return null;
         }
 


### PR DESCRIPTION
Since the `EzspMultiResponseTransaction` can return a couple of different types of response, it seems wise not to assume that the transaction completed successfully. If the transaction aborts and no `EzspScanCompleteHandler` is received, then a `ClassCastException` is thrown.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>