### PR TITLE
Add TransitionTime field to RecallScene command

### DIFF
--- a/com.zsmartsystems.zigbee.autocode/src/main/resources/0005_Scenes.xml
+++ b/com.zsmartsystems.zigbee.autocode/src/main/resources/0005_Scenes.xml
@@ -68,6 +68,10 @@
         <field type="UNSIGNED_8_BIT_INTEGER">
             <name>Scene ID</name>
         </field>
+        <field type="UNSIGNED_16_BIT_INTEGER">
+            <name>Transition Time</name>
+            <description>If the Transition Time field is present in the command payload and its value is not equal to 0xFFFF, this field SHALL indicate the transition time in 1/10ths of a second. In all other cases (command payload field not present or value equal to 0xFFFF), The scene transition time field of the Scene Table entry SHALL indicate the transition time. The transition time determines how long the transition takes from the old cluster state to the new cluster state.</description>
+        </field>
     </command>
     <command code="0x06" source="client">
         <name>Get Scene Membership Command</name>

--- a/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleSceneCommand.java
+++ b/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleSceneCommand.java
@@ -235,7 +235,7 @@ public class ZigBeeConsoleSceneCommand extends ZigBeeConsoleAbstractCommand {
 
         ZclScenesCluster scenesCluster = (ZclScenesCluster) endpoint.getInputCluster(ZclScenesCluster.CLUSTER_ID);
 
-        RecallSceneCommand recall = new RecallSceneCommand(groupId, sceneId);
+        RecallSceneCommand recall = new RecallSceneCommand(groupId, sceneId, 0xffff);
         scenesCluster.sendCommand(recall);
     }
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclScenesCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclScenesCluster.java
@@ -58,7 +58,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-01-29T21:31:36Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-02-12T14:13:22Z")
 public class ZclScenesCluster extends ZclCluster {
     /**
      * The ZigBee Cluster Library Cluster ID
@@ -760,6 +760,7 @@ public class ZclScenesCluster extends ZclCluster {
      *
      * @param groupId {@link Integer} Group ID
      * @param sceneId {@link Integer} Scene ID
+     * @param transitionTime {@link Integer} Transition Time
      * @return the {@link Future<CommandResult>} command result future
      * @deprecated As of release 1.3.0.
      * Use extended ZclCommand class constructors to instantiate the command
@@ -771,12 +772,13 @@ public class ZclScenesCluster extends ZclCluster {
      * with <code>cluster.sendCommand(new recallSceneCommand(parameters ...))</code>
      */
     @Deprecated
-    public Future<CommandResult> recallSceneCommand(Integer groupId, Integer sceneId) {
+    public Future<CommandResult> recallSceneCommand(Integer groupId, Integer sceneId, Integer transitionTime) {
         RecallSceneCommand command = new RecallSceneCommand();
 
         // Set the fields
         command.setGroupId(groupId);
         command.setSceneId(sceneId);
+        command.setTransitionTime(transitionTime);
 
         return sendCommand(command);
     }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/RecallSceneCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/RecallSceneCommand.java
@@ -24,7 +24,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-12-25T10:11:19Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2021-02-12T14:13:22Z")
 public class RecallSceneCommand extends ZclScenesCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -47,6 +47,18 @@ public class RecallSceneCommand extends ZclScenesCommand {
     private Integer sceneId;
 
     /**
+     * Transition Time command message field.
+     * <p>
+     * If the Transition Time field is present in the command payload and its value is not equal
+     * to 0xFFFF, this field shall indicate the transition time in 1/10ths of a second. In all
+     * other cases (command payload field not present or value equal to 0xFFFF), The scene
+     * transition time field of the Scene Table entry shall indicate the transition time. The
+     * transition time determines how long the transition takes from the old cluster state to
+     * the new cluster state.
+     */
+    private Integer transitionTime;
+
+    /**
      * Default constructor.
      *
      * @deprecated from release 1.3.0. Use the parameterised constructor instead of the default constructor and setters.
@@ -64,10 +76,12 @@ public class RecallSceneCommand extends ZclScenesCommand {
      *
      * @param groupId {@link Integer} Group ID
      * @param sceneId {@link Integer} Scene ID
+     * @param transitionTime {@link Integer} Transition Time
      */
     public RecallSceneCommand(
             Integer groupId,
-            Integer sceneId) {
+            Integer sceneId,
+            Integer transitionTime) {
 
         clusterId = CLUSTER_ID;
         commandId = COMMAND_ID;
@@ -76,6 +90,7 @@ public class RecallSceneCommand extends ZclScenesCommand {
 
         this.groupId = groupId;
         this.sceneId = sceneId;
+        this.transitionTime = transitionTime;
     }
 
     /**
@@ -118,27 +133,65 @@ public class RecallSceneCommand extends ZclScenesCommand {
         this.sceneId = sceneId;
     }
 
+    /**
+     * Gets Transition Time.
+     * <p>
+     * If the Transition Time field is present in the command payload and its value is not equal
+     * to 0xFFFF, this field shall indicate the transition time in 1/10ths of a second. In all
+     * other cases (command payload field not present or value equal to 0xFFFF), The scene
+     * transition time field of the Scene Table entry shall indicate the transition time. The
+     * transition time determines how long the transition takes from the old cluster state to
+     * the new cluster state.
+     *
+     * @return the Transition Time
+     */
+    public Integer getTransitionTime() {
+        return transitionTime;
+    }
+
+    /**
+     * Sets Transition Time.
+     * <p>
+     * If the Transition Time field is present in the command payload and its value is not equal
+     * to 0xFFFF, this field shall indicate the transition time in 1/10ths of a second. In all
+     * other cases (command payload field not present or value equal to 0xFFFF), The scene
+     * transition time field of the Scene Table entry shall indicate the transition time. The
+     * transition time determines how long the transition takes from the old cluster state to
+     * the new cluster state.
+     *
+     * @param transitionTime the Transition Time
+     * @deprecated as of 1.3.0. Use the parameterised constructor instead to ensure that all mandatory fields are provided.
+     */
+    @Deprecated
+    public void setTransitionTime(final Integer transitionTime) {
+        this.transitionTime = transitionTime;
+    }
+
     @Override
     public void serialize(final ZclFieldSerializer serializer) {
         serializer.serialize(groupId, ZclDataType.UNSIGNED_16_BIT_INTEGER);
         serializer.serialize(sceneId, ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        serializer.serialize(transitionTime, ZclDataType.UNSIGNED_16_BIT_INTEGER);
     }
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
         groupId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
         sceneId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        transitionTime = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
     }
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(75);
+        final StringBuilder builder = new StringBuilder(109);
         builder.append("RecallSceneCommand [");
         builder.append(super.toString());
         builder.append(", groupId=");
         builder.append(groupId);
         builder.append(", sceneId=");
         builder.append(sceneId);
+        builder.append(", transitionTime=");
+        builder.append(transitionTime);
         builder.append(']');
         return builder.toString();
     }


### PR DESCRIPTION
Adding the `TransitionTime` field to the `RecallScene` command. Note that this is optional and if it isn't used then this should be set to `0xFFFF`.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>