### PR TITLE
Set default argument for join enable to 254

### DIFF
--- a/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleNetworkJoinCommand.java
+++ b/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleNetworkJoinCommand.java
@@ -47,7 +47,7 @@ public class ZigBeeConsoleNetworkJoinCommand extends ZigBeeConsoleAbstractComman
 
         final int join;
         if ("enable".equalsIgnoreCase(args[1])) {
-            join = 255;
+            join = 254;
         } else if ("disable".equalsIgnoreCase(args[1])) {
             join = 0;
         } else {


### PR DESCRIPTION
> As per ZigBee 3, a value of 255 is not permitted and will be ignored

Addresses https://github.com/zsmartsystems/com.zsmartsystems.zigbee/issues/1157#issuecomment-805187856
