### PR TITLE
ZclOtaUpgradeServer.getCurrentFileVersion() should not use caching

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/otaserver/ZclOtaUpgradeServer.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/otaserver/ZclOtaUpgradeServer.java
@@ -529,7 +529,7 @@ public class ZclOtaUpgradeServer implements ZigBeeApplication, ZclCommandListene
      * @return the current firmware version on the remote device
      */
     public Integer getCurrentFileVersion() {
-        return (Integer) cluster.getAttribute(ZclOtaUpgradeCluster.ATTR_CURRENTFILEVERSION).readValue(Long.MAX_VALUE);
+        return (Integer) cluster.getAttribute(ZclOtaUpgradeCluster.ATTR_CURRENTFILEVERSION).readValue(0);
     }
 
     /**


### PR DESCRIPTION
Fixes #1219

Signed-off-by: Stefan Triller <stefan.triller@telekom.de>