### PR TITLE
Read Ember NCP Network parameters when network goes ONLINE

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
@@ -1010,6 +1010,11 @@ public class ZigBeeDongleEzsp implements ZigBeeTransportTransmit, ZigBeeTranspor
                     logger.debug("Ember: Link State up running");
 
                     EmberNcp ncp = getEmberNcp();
+
+                    // Ensure we synchronise the network parameters
+                    // This allows the system to read back the actual network parameters
+                    networkParameters = ncp.getNetworkParameters().getParameters();
+
                     int addr = ncp.getNwkAddress();
                     if (addr != 0xFFFE) {
                         nwkAddress = addr;


### PR DESCRIPTION
Ensures that the `networkParameters` are read back from the NCP when the network goes ONLINE so that when users read back network parameters, they reflect the current settings.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>