### PR TITLE
Fix EmberFirmwareUpdateHandler to follow the XModem-CRC protocol and also fix retry logic

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/EmberFirmwareUpdateHandler.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/EmberFirmwareUpdateHandler.java
@@ -10,6 +10,7 @@ package com.zsmartsystems.zigbee.dongle.ember.internal;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
+import java.util.concurrent.TimeUnit;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,7 +37,10 @@ public class EmberFirmwareUpdateHandler {
     private final ZigBeePort serialPort;
     private final ZigBeeTransportFirmwareCallback callback;
 
-    private final int TIMEOUT = 10000;
+    private final long TIMEOUT_IN_NANOS = TimeUnit.SECONDS.toNanos(10);
+    private final long BL_TIMEOUT_IN_NANOS = TimeUnit.SECONDS.toNanos(3);
+    private final int BYTE_READ_TIMEOUT_IN_MS = 250;
+
     private final int MENU_MAX_RETRIES = 5;
     private final int XMODEM_MAX_RETRIES = 10;
     private final int XMODEL_CRC_POLYNOMIAL = 0x1021;
@@ -49,6 +53,7 @@ public class EmberFirmwareUpdateHandler {
     private final int ACK = 0x06;
     private final int NAK = 0x15;
     private final int CAN = 0x18;
+    private final int XMODEM_CRC_READY = 0x43; // ASCII 'C'
 
     /**
      * Flag to stop the current transfer
@@ -93,90 +98,18 @@ public class EmberFirmwareUpdateHandler {
         Thread firmwareThread = new Thread("EmberFirmwareUpdateHandler") {
             @Override
             public void run() {
-                logger.debug("Ember bootloader: Starting.");
                 try {
-                    sleep(1500);
-                } catch (InterruptedException e) {
-                    // Eat me!
-                }
-                if (!serialPort.open(BOOTLOAD_BAUD_RATE, FlowControl.FLOWCONTROL_OUT_NONE)) {
-                    logger.debug("Ember bootloader: Failed to open serial port.");
-                    transferComplete(ZigBeeTransportFirmwareStatus.FIRMWARE_UPDATE_FAILED);
-                    return;
-                }
-
-                logger.debug("Ember bootloader: Serial port opened.");
-
-                // Wait for the bootload menu prompt
-                if (!getBlPrompt()) {
-                    logger.debug("Ember bootloader: Failed waiting for menu before transfer.");
-                    transferComplete(ZigBeeTransportFirmwareStatus.FIRMWARE_UPDATE_FAILED);
-                    return;
-                }
-                logger.debug("Ember bootloader: Got bootloader prompt.");
-
-                // Select option 1 to upload the file
-                serialPort.write('1');
-
-                // Short delay here to allow all bootloader menu data to be received so there's no confusion with acks.
-                try {
-                    sleep(1500);
-                } catch (InterruptedException e) {
-                    // Eat me!
-                }
-
-                callback.firmwareUpdateCallback(ZigBeeTransportFirmwareStatus.FIRMWARE_TRANSFER_STARTED);
-                boolean bootloadOk = transferFile();
-                if (bootloadOk) {
-                    callback.firmwareUpdateCallback(ZigBeeTransportFirmwareStatus.FIRMWARE_TRANSFER_COMPLETE);
-                    logger.debug("Ember bootloader: Transfer successful.");
-                } else {
-                    logger.debug("Ember bootloader: Transfer failed.");
-                }
-
-                // Short delay here to allow completion. This is mainly required if there was an abort.
-                try {
-                    sleep(5000);
-                } catch (InterruptedException e) {
-                    // Eat me!
-                }
-
-                // Transfer was completed, or aborted. Either way all we can do is run the firmware and it should return
-                // to the main prompt
-
-                logger.debug("Ember bootloader: Waiting for menu.");
-
-                // Wait for the bootload menu prompt
-                if (!getBlPrompt()) {
-                    logger.debug("Ember bootloader: Failed waiting for menu after transfer.");
-                    transferComplete(ZigBeeTransportFirmwareStatus.FIRMWARE_UPDATE_FAILED);
-                    return;
-                }
-
-                // Select 2 to run
-                logger.debug("Ember bootloader: Running firmware.");
-                serialPort.write('2');
-
-                // Short delay here to allow all bootloader to run.
-                try {
-                    sleep(500);
-                } catch (InterruptedException e) {
-                    // Eat me!
-                }
-
-                logger.debug("Ember bootloader: Done.");
-
-                // We're done - either we completed, or it was cancelled
-                if (!bootloadOk) {
-                    transferComplete(ZigBeeTransportFirmwareStatus.FIRMWARE_UPDATE_FAILED);
-                } else if (stopBootload) {
-                    transferComplete(ZigBeeTransportFirmwareStatus.FIRMWARE_UPDATE_CANCELLED);
-                } else {
-                    transferComplete(ZigBeeTransportFirmwareStatus.FIRMWARE_UPDATE_COMPLETE);
+                    doUpdate();
+                } finally {
+                    try {
+                        firmware.close();
+                    } catch (IOException e) {
+                        // ignored
+                    }
                 }
             }
         };
-
+        firmwareThread.setPriority(Thread.MAX_PRIORITY);
         firmwareThread.start();
     }
 
@@ -185,6 +118,114 @@ public class EmberFirmwareUpdateHandler {
      */
     public void cancelUpdate() {
         stopBootload = true;
+    }
+
+    /**
+     * Waits for {@link #XMODEM_CRC_READY} byte to show up.
+     * 
+     * @return true if {@link #XMODEM_CRC_READY} byte was read before {@link #TIMEOUT_IN_NANOS} was reached, false
+     *         otherwise.
+     */
+    private boolean waitForReady() {
+        long start = System.nanoTime();
+        while (serialPort.read(BYTE_READ_TIMEOUT_IN_MS) != XMODEM_CRC_READY) {
+            if ((System.nanoTime() - start) > TIMEOUT_IN_NANOS) {
+                return false;
+            }
+            try {
+                Thread.sleep(250);
+            } catch (InterruptedException e) {
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Performs the actual update
+     */
+    private void doUpdate() {
+        logger.debug("Ember bootloader: Starting.");
+        try {
+            Thread.sleep(1500);
+        } catch (InterruptedException e) {
+            // Eat me!
+        }
+        if (!serialPort.open(BOOTLOAD_BAUD_RATE, FlowControl.FLOWCONTROL_OUT_NONE)) {
+            logger.debug("Ember bootloader: Failed to open serial port.");
+            transferComplete(ZigBeeTransportFirmwareStatus.FIRMWARE_UPDATE_FAILED);
+            return;
+        }
+
+        logger.debug("Ember bootloader: Serial port opened.");
+
+        // Wait for the bootload menu prompt
+        if (!getBlPrompt()) {
+            logger.debug("Ember bootloader: Failed waiting for menu before transfer.");
+            transferComplete(ZigBeeTransportFirmwareStatus.FIRMWARE_UPDATE_FAILED);
+            return;
+        }
+        logger.debug("Ember bootloader: Got bootloader prompt.");
+
+        // Select option 1 to upload the file
+        serialPort.write('1');
+
+        // Short delay here to allow all bootloader menu data to be received so there's no confusion with acks.
+        if (!waitForReady()) {
+            logger.debug("Ember bootloader: Failed waiting for ready character before starting transfer!");
+            transferComplete(ZigBeeTransportFirmwareStatus.FIRMWARE_UPDATE_FAILED);
+            return;
+        }
+
+        callback.firmwareUpdateCallback(ZigBeeTransportFirmwareStatus.FIRMWARE_TRANSFER_STARTED);
+        boolean bootloadOk = transferFile();
+        if (bootloadOk) {
+            callback.firmwareUpdateCallback(ZigBeeTransportFirmwareStatus.FIRMWARE_TRANSFER_COMPLETE);
+            logger.debug("Ember bootloader: Transfer successful.");
+        } else {
+            logger.debug("Ember bootloader: Transfer failed.");
+        }
+
+        // Short delay here to allow completion. This is mainly required if there was an abort.
+        try {
+            Thread.sleep(5000);
+        } catch (InterruptedException e) {
+            // Eat me!
+        }
+
+        // Transfer was completed, or aborted. Either way all we can do is run the firmware and it should return
+        // to the main prompt
+
+        logger.debug("Ember bootloader: Waiting for menu.");
+
+        // Wait for the bootload menu prompt
+        if (!getBlPrompt()) {
+            logger.debug("Ember bootloader: Failed waiting for menu after transfer.");
+            transferComplete(ZigBeeTransportFirmwareStatus.FIRMWARE_UPDATE_FAILED);
+            return;
+        }
+
+        // Select 2 to run
+        logger.debug("Ember bootloader: Running firmware.");
+        serialPort.write('2');
+
+        // Short delay here to allow all bootloader to run.
+        try {
+            Thread.sleep(500);
+        } catch (InterruptedException e) {
+            // Eat me!
+        }
+
+        logger.debug("Ember bootloader: Done.");
+
+        // We're done - either we completed, or it was cancelled
+        if (!bootloadOk) {
+            transferComplete(ZigBeeTransportFirmwareStatus.FIRMWARE_UPDATE_FAILED);
+        } else if (stopBootload) {
+            transferComplete(ZigBeeTransportFirmwareStatus.FIRMWARE_UPDATE_CANCELLED);
+        } else {
+            transferComplete(ZigBeeTransportFirmwareStatus.FIRMWARE_UPDATE_COMPLETE);
+        }
     }
 
     /**
@@ -208,13 +249,16 @@ public class EmberFirmwareUpdateHandler {
             // Send CR to wake up the bootloader
             serialPort.write(CRN);
 
-            long finish = System.currentTimeMillis() + 250;
-            while (System.currentTimeMillis() < finish) {
-                int val = serialPort.read(250);
+            long start = System.nanoTime();
+            while ((System.nanoTime() - start) < BL_TIMEOUT_IN_NANOS) {
+                int val = serialPort.read(BYTE_READ_TIMEOUT_IN_MS);
                 if (val == -1) {
-                    break;
+                    continue;
                 }
-                logger.trace("GET PROMPT: {}", String.format("%02X %c", val, val));
+
+                if (logger.isTraceEnabled()) {
+                    logger.trace("Ember bootloader: get prompt read {}", String.format("%02X %c", val, val));
+                }
                 if (val != matcher[matcherCount]) {
                     matcherCount = 0;
                     continue;
@@ -245,6 +289,37 @@ public class EmberFirmwareUpdateHandler {
     }
 
     /**
+     * Sends End Of Transfer frame and waits for ACK response, retries up to {@link #XMODEM_MAX_RETRIES} times.
+     */
+    private void sendEOT() {
+        int retries = 0;
+        do {
+            serialPort.write(EOT);
+
+            try {
+                Thread.sleep(250);
+            } catch (InterruptedException e) {
+                // ignored
+            }
+        } while (getTransferResponse() != ACK && retries++ < XMODEM_MAX_RETRIES);
+    }
+
+    private String byteToHex(byte num) {
+        char[] hexDigits = new char[2];
+        hexDigits[0] = Character.forDigit((num >> 4) & 0xF, 16);
+        hexDigits[1] = Character.forDigit((num & 0xF), 16);
+        return new String(hexDigits);
+    }
+
+    private String encodeHexString(byte[] byteArray) {
+        StringBuffer hexStringBuffer = new StringBuffer();
+        for (int i = 0; i < byteArray.length; i++) {
+            hexStringBuffer.append(byteToHex(byteArray[i])).append(" ");
+        }
+        return hexStringBuffer.toString();
+    }
+
+    /**
      * Transfers the file using the XModem protocol
      *
      * @return true if the transfer completed successfully
@@ -264,29 +339,42 @@ public class EmberFirmwareUpdateHandler {
             logger.debug("Ember bootloader: Starting transfer.");
             while (!stopBootload && !cancelTransfer) {
                 retries = 0;
+                // Output DATA_CHUNK_SIZE bytes
+                ByteBuffer data = readChunk(firmware);
+                done = data.position() < DATA_CHUNK_SIZE;
 
                 do {
                     logger.debug("Ember bootloader: Transfer frame {}, attempt {}.", frame, retries);
 
                     // Send SOH
+                    if (logger.isTraceEnabled()) {
+                        logger.trace("Ember bootloader: Write SOH");
+                    }
                     serialPort.write(SOH);
 
+                    if (logger.isTraceEnabled()) {
+                        logger.trace("Ember bootloader: Write frame count");
+                    }
                     // Send frame count
                     serialPort.write(frame);
                     serialPort.write(255 - frame);
 
                     // Allow 10 retries
                     if (retries++ > XMODEM_MAX_RETRIES) {
-                        serialPort.write(EOT);
+                        sendEOT();
                         return false;
                     }
 
-                    // Output DATA_CHUNK_SIZE bytes
-                    ByteBuffer data = readChunk(firmware);
-                    done = data.position() < DATA_CHUNK_SIZE;
+                    if (logger.isTraceEnabled()) {
+                        logger.trace("Ember bootloader: Chunk data hasArray: {}", data.hasArray());
+                        logger.trace("Ember bootloader: Chunk data len: {}", data.array().length);
+                        logger.trace("Ember bootloader: Chunk data: {}, done: {}", encodeHexString(data.array()), done);
+                    }
                     int crc = 0;
+                    int countWriteCalls = 0;
                     for (int value : data.array()) {
                         serialPort.write(value);
+                        countWriteCalls++;
                         for (int i = 0; i < 8; i++) {
                             boolean bit = ((value >> (7 - i) & 1) == 1);
                             boolean c15 = ((crc >> 15 & 1) == 1);
@@ -298,12 +386,23 @@ public class EmberFirmwareUpdateHandler {
                         }
                     }
                     crc &= 0xffff;
+
+                    if (logger.isTraceEnabled()) {
+                        logger.trace("Ember bootloader: Number of serialPort.write invocations: {}", countWriteCalls);
+                        logger.trace("Ember bootloader: CRC for chunk: {}", crc);
+                        logger.trace("Ember bootloader: Write CRC");
+                    }
                     serialPort.write((crc >> 8) & 0xff);
                     serialPort.write(crc & 0xff);
 
                     // Wait for the acknowledgment
-                    response = getTransferResponse();
-                    logger.trace("Ember bootloader: Response {}.", response);
+                    do {
+                        response = getTransferResponse();
+                    } while (response == XMODEM_CRC_READY);
+
+                    if (logger.isTraceEnabled()) {
+                        logger.debug("Ember bootloader: Response {}.", response);
+                    }
                     if (response == CAN) {
                         logger.debug("Ember bootloader: Received CAN.");
                         retries = XMODEM_MAX_RETRIES;
@@ -314,7 +413,7 @@ public class EmberFirmwareUpdateHandler {
 
                 if (done) {
                     logger.debug("Ember bootloader: Transfer complete.");
-                    serialPort.write(EOT);
+                    sendEOT();
                     return true;
                 }
 
@@ -334,17 +433,29 @@ public class EmberFirmwareUpdateHandler {
      * @return the value of the received data, or NAK on timeout
      */
     private int getTransferResponse() {
-        long start = System.currentTimeMillis();
+        long start = System.nanoTime();
         while (!stopBootload) {
-            int val = serialPort.read();
+            int val = serialPort.read(BYTE_READ_TIMEOUT_IN_MS);
             if (val == -1) {
-                if (System.currentTimeMillis() - start > TIMEOUT) {
+                if ((System.nanoTime() - start) > TIMEOUT_IN_NANOS) {
+                    if (logger.isTraceEnabled()) {
+                        logger.trace("Ember bootloader: getTransferResponse timeout returning NAK.");
+                    }
+
                     return NAK;
                 }
                 continue;
             } else {
+                if (logger.isTraceEnabled()) {
+                    logger.trace("Ember bootloader: getTransferResponse read value {}", val);
+                }
+
                 return val;
             }
+        }
+
+        if (logger.isTraceEnabled()) {
+            logger.trace("Ember bootloader: NAK default case returning NAK");
         }
 
         return NAK;


### PR DESCRIPTION
This PR contains changes made to fix failing firmware updates of Ember dongle on slow machines. The main changes are:

- When selecting option 1 (transfer file) from the bootloader menu, the update handler now waits until it receives a '0x43' (XModem ready) before starting the transfer. In the previous solution, there was only one sleep (1500) before the transfer was started.
- In the transferFile method, the readChunk method is now called outside the inner do-while loop. The reason for this is that the inner do-while loop repeats sending the chunk data until it receives an ACK for it. In the current solution, the retry logic also calls readChunk again, which then reads the next chunk and makes 'forget' that the previous chunk was not acknowledged. With the new solution, you re-send the same data as long as it is not acknowledged.
- After transferring the data of a single chunk, we now wait until we get a transfer response != '0x43' (XModem ready).
- At the end of the file transfer we now repeat sending an ETO (End of Transfer) until we get an ACK.

This changes were made in collaboration with @kolkoo

Resolves #1254 