### PR TITLE
XBee: Handle interrupted/timed out requests when getting channel.

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.xbee/src/main/java/com/zsmartsystems/zigbee/dongle/xbee/ZigBeeDongleXBee.java
+++ b/com.zsmartsystems.zigbee.dongle.xbee/src/main/java/com/zsmartsystems/zigbee/dongle/xbee/ZigBeeDongleXBee.java
@@ -462,8 +462,12 @@ public class ZigBeeDongleXBee implements ZigBeeTransportTransmit, XBeeEventListe
         }
         XBeeGetOperatingChannelCommand request = new XBeeGetOperatingChannelCommand();
         XBeeOperatingChannelResponse response = (XBeeOperatingChannelResponse) frameHandler.sendRequest(request);
-
-        return ZigBeeChannel.create(response.getChannel());
+        
+        if (response == null) {
+            return ZigBeeChannel.UNKNOWN;
+        } else {
+            return ZigBeeChannel.create(response.getChannel());
+        }
     }
 
     @Override


### PR DESCRIPTION
Fixes issues #1257 

Just a simple null check, tested with OpenHAB 3.1.0 against the 1.4.0 stable release.