### PR TITLE
Improve error handling during Ember network initialisation

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
@@ -509,7 +509,9 @@ public class ZigBeeDongleEzsp implements ZigBeeTransportTransmit, ZigBeeTranspor
         if (reinitialize) {
             logger.debug("Reinitialising Ember NCP network as {}", deviceType);
             if (deviceType == DeviceType.COORDINATOR) {
-                netInitialiser.formNetwork(networkParameters, linkKey, networkKey);
+                if (netInitialiser.formNetwork(networkParameters, linkKey, networkKey) != ZigBeeStatus.SUCCESS) {
+                    return ZigBeeStatus.NO_NETWORK;
+                }
             } else {
                 netInitialiser.joinNetwork(networkParameters, linkKey);
             }


### PR DESCRIPTION
This adds a check when performing the energy scan to make sure that at least one channel has a better energy value than the CCA level. If not, an error is thrown.
The error return from the network initialisation now propagates back to the startup and can cause the network start to fail in the event that the scan finds all channels are too noisy.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>
