### PR TITLE
Fix derivation of ZigBeeProfileType

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeDeviceType.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeDeviceType.java
@@ -632,7 +632,7 @@ public enum ZigBeeDeviceType {
 
     private ZigBeeDeviceType(final ZigBeeProfileType profile, final int key) {
         this.key = key;
-        this.profilekey = key & 0xffff + (profile.ordinal() << 16);
+        this.profilekey = (key & 0xffff) + (profile.getKey() << 16);
     }
 
     public int getKey() {
@@ -640,12 +640,12 @@ public enum ZigBeeDeviceType {
     }
 
     public static ZigBeeDeviceType getByValue(final int value) {
-        int id = value & 0xffff + (ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION.ordinal() << 16);
+        int id = (value & 0xffff) + (ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION.getKey() << 16);
         return idMap.get(id);
     }
 
     public static ZigBeeDeviceType getByValue(final ZigBeeProfileType profile, final int value) {
-        int id = value & 0xffff + (profile.ordinal() << 16);
+        int id = (value & 0xffff) + (profile.getKey() << 16);
         return idMap.get(id);
     }
 }

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeDeviceTypeTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeDeviceTypeTest.java
@@ -29,6 +29,9 @@ public class ZigBeeDeviceTypeTest {
         assertEquals(ZigBeeDeviceType.DIMMABLE_LIGHT, ZigBeeDeviceType.getByValue(0x0101));
         assertEquals(ZigBeeDeviceType.COLOR_DIMMABLE_LIGHT, ZigBeeDeviceType.getByValue(0x0102));
 
+        assertEquals(ZigBeeDeviceType.ON_OFF_SWITCH,
+                ZigBeeDeviceType.getByValue(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0000));
+
         assertEquals(ZigBeeDeviceType.LEVEL_CONTROL_SWITCH,
                 ZigBeeDeviceType.getByValue(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, 0x0001));
 


### PR DESCRIPTION
This fixed a bug in the derivation of `ZigBeeProfileType`, and also uses the profile key rather than the ordinal to provide better compatibility between versions.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>