### PR TITLE
Remove deprecated methods from discovery and improve naming consistency

### DIFF
--- a/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleDeviceFingerprintCommand.java
+++ b/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleDeviceFingerprintCommand.java
@@ -57,7 +57,7 @@ public class ZigBeeConsoleDeviceFingerprintCommand extends ZigBeeConsoleAbstract
 
     @Override
     public String getSyntax() {
-        return "ADRESS";
+        return "ADDRESS";
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
@@ -17,7 +17,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -959,7 +958,7 @@ public class ZigBeeNetworkManager implements ZigBeeTransportReceive {
         int sourceAddress = apsFrame.getSourceAddress();
         ZigBeeNode zigBeeNode = getNode(sourceAddress);
         if (zigBeeNode != null) {
-            ZigBeeNode updatedNode = new ZigBeeNode(this, zigBeeNode.getIeeeAddress(), sourceAddress);
+            ZigBeeNode updatedNode = new ZigBeeNode(this, zigBeeNode.getIeeeAddress());
             updatedNode.setNodeState(ZigBeeNodeState.ONLINE);
             refreshNode(updatedNode);
         }
@@ -1824,12 +1823,14 @@ public class ZigBeeNetworkManager implements ZigBeeTransportReceive {
                     logger.trace("{}: Refresh Node notifyListener LATCH Complete", currentNode.getIeeeAddress());
                     return true;
                 } else {
-                    logger.trace("{}: Refresh Node notifyListener LATCH Timeout, remaining = {}", currentNode.getIeeeAddress(),
+                    logger.trace("{}: Refresh Node notifyListener LATCH Timeout, remaining = {}",
+                            currentNode.getIeeeAddress(),
                             latch.getCount());
                     return false;
                 }
             } catch (InterruptedException e) {
-                logger.trace("{}: Refresh Node notifyListener LATCH Interrupted, remaining = {}", currentNode.getIeeeAddress(),
+                logger.trace("{}: Refresh Node notifyListener LATCH Interrupted, remaining = {}",
+                        currentNode.getIeeeAddress(),
                         latch.getCount());
                 return false;
             }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNode.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNode.java
@@ -890,6 +890,11 @@ public class ZigBeeNode {
         return dao;
     }
 
+    /**
+     * Sets the states of this node given the {@link ZigBeeNodeDao} used to serialise the node information
+     *
+     * @param dao the {@link ZigBeeNodeDao} used to serialise the node information
+     */
     public void setDao(ZigBeeNodeDao dao) {
         ieeeAddress = dao.getIeeeAddress();
         setNetworkAddress(dao.getNetworkAddress());

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeDiscoveryExtension.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeDiscoveryExtension.java
@@ -150,8 +150,20 @@ public class ZigBeeDiscoveryExtension
      * subsequent mesh updates. Setting the period to 0 will disable mesh updates.
      *
      * @param updatePeriod number of seconds between mesh updates. Setting to 0 will stop updates.
+     * @deprecated User {@link setUpdateMeshPeriod} instead
      */
+    @Deprecated
     public void setUpdatePeriod(final int updatePeriod) {
+        setUpdateMeshPeriod(updatePeriod);
+    }
+
+    /**
+     * Sets the update period for the mesh update service. This is the number of seconds between
+     * subsequent mesh updates. Setting the period to 0 will disable mesh updates.
+     *
+     * @param updatePeriod number of seconds between mesh updates. Setting to 0 will stop updates.
+     */
+    public void setUpdateMeshPeriod(final int updatePeriod) {
         this.updatePeriod = updatePeriod;
 
         if (!extensionStarted) {
@@ -202,8 +214,20 @@ public class ZigBeeDiscoveryExtension
      * @return number of seconds between mesh updates. 0 indicates no automatic updates.
      *
      */
-    public int getUpdatePeriod() {
+    public int getUpdateMeshPeriod() {
         return updatePeriod;
+    }
+
+    /**
+     * Gets the current period at which the mesh data is being updated (in seconds). A return value of 0 indicates that
+     * automatic updates are currently disabled.
+     *
+     * @return number of seconds between mesh updates. 0 indicates no automatic updates.
+     * @deprecated User {@link getUpdateMeshPeriod} instead
+     */
+    @Deprecated
+    public int getUpdatePeriod() {
+        return getUpdateMeshPeriod();
     }
 
     /**

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeNetworkDiscoverer.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeNetworkDiscoverer.java
@@ -111,27 +111,6 @@ public class ZigBeeNetworkDiscoverer implements ZigBeeCommandListener, ZigBeeAnn
     }
 
     /**
-     * Sets the retry period in milliseconds. This is the amount of time the service will wait following a failed
-     * request before performing a retry.
-     *
-     * @param retryPeriod the period in milliseconds between retries
-     * @deprecated Retires are handled in the transaction manager
-     */
-    @Deprecated
-    protected void setRetryPeriod(int retryPeriod) {
-    }
-
-    /**
-     * Sets the maximum number of retries the service will perform at any stage before failing.
-     *
-     * @param retryCount the maximum number of retries.
-     * @deprecated Retires are handled in the transaction manager
-     */
-    @Deprecated
-    protected void setRetryCount(int retryCount) {
-    }
-
-    /**
      * Sets the minimum period between requeries on each node
      *
      * @param requeryPeriod the requery period in milliseconds

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeDiscoveryExtensionTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeDiscoveryExtensionTest.java
@@ -76,19 +76,19 @@ public class ZigBeeDiscoveryExtensionTest {
         extension.setUpdateMeshTasks(
                 Arrays.asList(new NodeDiscoveryTask[] { NodeDiscoveryTask.ROUTES, NodeDiscoveryTask.NEIGHBORS }));
 
-        extension.setUpdatePeriod(0);
+        extension.setUpdateMeshPeriod(0);
 
         assertEquals(ZigBeeStatus.SUCCESS, extension.extensionInitialize(networkManager));
         assertEquals(ZigBeeStatus.SUCCESS, extension.extensionStartup());
         assertEquals(ZigBeeStatus.INVALID_STATE, extension.extensionStartup());
 
-        extension.setUpdatePeriod(0);
+        extension.setUpdateMeshPeriod(0);
         Mockito.verify(extension, Mockito.times(1)).stopScheduler();
-        assertEquals(0, extension.getUpdatePeriod());
+        assertEquals(0, extension.getUpdateMeshPeriod());
 
-        extension.setUpdatePeriod(1);
+        extension.setUpdateMeshPeriod(1);
         Mockito.verify(extension, Mockito.times(1)).startScheduler(1);
-        assertEquals(1, extension.getUpdatePeriod());
+        assertEquals(1, extension.getUpdateMeshPeriod());
 
         Mockito.verify(networkManager, Mockito.timeout(TIMEOUT).atLeast(1))
                 .addNetworkNodeListener(ArgumentMatchers.any(ZigBeeNetworkNodeListener.class));

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeNetworkDiscovererTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeNetworkDiscovererTest.java
@@ -138,7 +138,6 @@ public class ZigBeeNetworkDiscovererTest {
             }
         }).when(networkManager).getNode(ArgumentMatchers.anyInt());
 
-        discoverer.setRetryPeriod(Integer.MAX_VALUE);
         discoverer.startup();
 
         // Check it registers listeners
@@ -154,7 +153,6 @@ public class ZigBeeNetworkDiscovererTest {
         assertEquals(new IeeeAddress("1234567890ABCDEF"), node.getIeeeAddress());
         assertEquals(0, node.getEndpoints().size());
 
-        discoverer.setRetryCount(0);
         discoverer.setRequeryPeriod(0);
         discoverer.shutdown();
     }
@@ -167,9 +165,7 @@ public class ZigBeeNetworkDiscovererTest {
         announce.setSourceAddress(new ZigBeeEndpointAddress(1));
 
         ZigBeeNetworkDiscoverer discoverer = new ZigBeeNetworkDiscoverer(networkManager);
-        discoverer.setRetryPeriod(0);
         discoverer.setRequeryPeriod(0);
-        discoverer.setRetryCount(0);
 
         discoverer.commandReceived(announce);
         Mockito.verify(networkManager, Mockito.times(1)).updateNode(ArgumentMatchers.any());
@@ -184,9 +180,7 @@ public class ZigBeeNetworkDiscovererTest {
     @Test
     public void deviceStatusUpdate() {
         ZigBeeNetworkDiscoverer discoverer = new ZigBeeNetworkDiscoverer(networkManager);
-        discoverer.setRetryPeriod(0);
         discoverer.setRequeryPeriod(0);
-        discoverer.setRetryCount(0);
 
         discoverer.deviceStatusUpdate(ZigBeeNodeStatus.UNSECURED_JOIN, 2222, new IeeeAddress("1111111111111111"));
 


### PR DESCRIPTION
This removes some deprecated methods from the service discovery class that were empty and renames the `getUpdatePeriod` methods to `getUpdateMeshPeriod` for consistency with other methods in the class. The original methods are retained and deprecated and will be removed at a later time.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>