### PR TITLE
Set shutdown flag in telegesis and ezsp dongle implementation

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzspTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzspTest.java
@@ -478,6 +478,8 @@ public class ZigBeeDongleEzspTest {
         ScheduledExecutorService executorService = Executors.newScheduledThreadPool(1);
         TestUtilities.setField(ZigBeeDongleEzsp.class, dongle, "executorService", executorService);
 
+        TestUtilities.setField(ZigBeeDongleEzsp.class, dongle, "isConfigured", true);
+
         ZigBeeApsFrame apsFrame = new ZigBeeApsFrame();
         apsFrame.setCluster(0);
         apsFrame.setProfile(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION.getKey());
@@ -503,6 +505,8 @@ public class ZigBeeDongleEzspTest {
         ScheduledExecutorService executorService = Executors.newScheduledThreadPool(1);
         TestUtilities.setField(ZigBeeDongleEzsp.class, dongle, "executorService", executorService);
 
+        TestUtilities.setField(ZigBeeDongleEzsp.class, dongle, "isConfigured", true);
+
         ZigBeeApsFrame apsFrame = new ZigBeeApsFrame();
         apsFrame.setCluster(0);
         apsFrame.setProfile(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION.getKey());
@@ -515,6 +519,25 @@ public class ZigBeeDongleEzspTest {
         dongle.sendCommand(1, apsFrame);
         Mockito.verify(handler, Mockito.timeout(TIMEOUT).times(1))
                 .sendEzspTransaction(ArgumentMatchers.any(EzspTransaction.class));
+    }
+
+    @Test
+    public void doNotSendCommandWhenNotConfigured() throws Exception {
+        System.out.println("--- " + Thread.currentThread().getStackTrace()[1].getMethodName());
+        ZigBeeDongleEzsp dongle = new ZigBeeDongleEzsp(null);
+
+        EzspProtocolHandler handler = Mockito.mock(EzspProtocolHandler.class);
+        TestUtilities.setField(ZigBeeDongleEzsp.class, dongle, "frameHandler", handler);
+
+        ScheduledExecutorService executorService = Executors.newScheduledThreadPool(1);
+        TestUtilities.setField(ZigBeeDongleEzsp.class, dongle, "executorService", executorService);
+
+        TestUtilities.setField(ZigBeeDongleEzsp.class, dongle, "isConfigured", true);
+
+        ZigBeeApsFrame apsFrame = new ZigBeeApsFrame();
+
+        dongle.sendCommand(1, apsFrame);
+        Mockito.verify(handler, Mockito.never()).sendEzspTransaction(ArgumentMatchers.any(EzspTransaction.class));
     }
 
     @Test

--- a/com.zsmartsystems.zigbee.dongle.telegesis/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/ZigBeeDongleTelegesis.java
+++ b/com.zsmartsystems.zigbee.dongle.telegesis/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/ZigBeeDongleTelegesis.java
@@ -170,6 +170,13 @@ public class ZigBeeDongleTelegesis
      */
     private boolean startupComplete = false;
 
+    /**
+     * Flag will be set to true when initialize() was successful will be set to false when shutdown() method has been
+     * called.
+     */
+    private boolean isConfigured = false;
+    private final Object isConfiguredSync = new Object();
+
     private ScheduledExecutorService executorService;
 
     private ScheduledFuture<?> pollingTimer;
@@ -426,6 +433,8 @@ public class ZigBeeDongleTelegesis
             logger.info("Unable to read Telegesis dongle firmware version");
         }
 
+        isConfigured = true;
+
         return ZigBeeStatus.SUCCESS;
     }
 
@@ -441,7 +450,7 @@ public class ZigBeeDongleTelegesis
         logger.debug("Telegesis dongle startup.");
 
         // If frameHandler is null then the serial port didn't initialise
-        if (frameHandler == null) {
+        if (!isConfigured) {
             logger.error("Initialising Telegesis Dongle but low level handler is not initialised.");
             return ZigBeeStatus.INVALID_STATE;
         }
@@ -510,25 +519,31 @@ public class ZigBeeDongleTelegesis
 
     @Override
     public void shutdown() {
-        if (frameHandler == null) {
-            return;
+        synchronized (isConfiguredSync) {
+            if (!isConfigured) {
+                logger.debug("Telegesis dongle: Shutdown. isConfigured is false. No shutdown necessary.");
+                return;
+            }
+
+            isConfigured = false;
+
+            if (pollingTimer != null) {
+                pollingTimer.cancel(true);
+            }
+            if (executorService != null) {
+                executorService.shutdownNow();
+            }
+
+            commandScheduler.shutdownNow();
+
+            frameHandler.removeEventListener(this);
+            frameHandler.setClosing();
+            zigbeeTransportReceive.setTransportState(ZigBeeTransportState.OFFLINE);
+            serialPort.close();
+            frameHandler.close();
+            frameHandler = null;
         }
 
-        if (pollingTimer != null) {
-            pollingTimer.cancel(true);
-        }
-        if (executorService != null) {
-            executorService.shutdownNow();
-        }
-
-        commandScheduler.shutdownNow();
-
-        frameHandler.removeEventListener(this);
-        frameHandler.setClosing();
-        zigbeeTransportReceive.setTransportState(ZigBeeTransportState.OFFLINE);
-        serialPort.close();
-        frameHandler.close();
-        frameHandler = null;
         logger.debug("Telegesis dongle shutdown.");
     }
 
@@ -673,12 +688,10 @@ public class ZigBeeDongleTelegesis
 
     @Override
     public void sendCommand(final int msgTag, final ZigBeeApsFrame apsFrame) {
-        if (frameHandler == null) {
-            logger.debug("Telegesis frame handler not set for send.");
+        if (!isConfigured) {
+            logger.debug("Telegesis dongle is shutdown. Frame not sent: {}", apsFrame);
             return;
         }
-
-        lastSendCommand = System.currentTimeMillis();
 
         TelegesisCommand command;
         if (apsFrame.getAddressMode() == ZigBeeNwkAddressMode.DEVICE
@@ -720,20 +733,28 @@ public class ZigBeeDongleTelegesis
         commandScheduler.execute(new Runnable() {
             @Override
             public void run() {
-                frameHandler.sendRequest(command);
+                synchronized (isConfiguredSync) {
+                    if (!isConfigured) {
+                        logger.debug("Telegesis dongle is not configured. Frame not sent: {}", apsFrame);
+                        return;
+                    }
 
-                // Let the stack know the frame is sent
-                zigbeeTransportReceive.receiveCommandState(msgTag,
-                        command.getStatus() == TelegesisStatusCode.SUCCESS ? ZigBeeTransportProgressState.TX_ACK
-                                : ZigBeeTransportProgressState.TX_NAK);
+                    lastSendCommand = System.currentTimeMillis();
+                    frameHandler.sendRequest(command);
 
-                // Multicast doesn't have a sequence returned, so nothing more to do here
-                if (command instanceof TelegesisSendMulticastCommand) {
-                    return;
-                }
+                    // Let the stack know the frame is sent
+                    zigbeeTransportReceive.receiveCommandState(msgTag,
+                            command.getStatus() == TelegesisStatusCode.SUCCESS ? ZigBeeTransportProgressState.TX_ACK
+                                    : ZigBeeTransportProgressState.TX_NAK);
 
-                if (((TelegesisSendUnicastCommand) command).getMessageId() != null) {
-                    messageIdMap.put(((TelegesisSendUnicastCommand) command).getMessageId(), msgTag);
+                    // Multicast doesn't have a sequence returned, so nothing more to do here
+                    if (command instanceof TelegesisSendMulticastCommand) {
+                        return;
+                    }
+
+                    if (((TelegesisSendUnicastCommand) command).getMessageId() != null) {
+                        messageIdMap.put(((TelegesisSendUnicastCommand) command).getMessageId(), msgTag);
+                    }
                 }
             }
         });

--- a/com.zsmartsystems.zigbee.dongle.telegesis/src/test/java/com/zsmartsystems/zigbee/dongle/telegesis/ZigBeeDongleTelegesisTest.java
+++ b/com.zsmartsystems.zigbee.dongle.telegesis/src/test/java/com/zsmartsystems/zigbee/dongle/telegesis/ZigBeeDongleTelegesisTest.java
@@ -218,6 +218,7 @@ public class ZigBeeDongleTelegesisTest {
         TestUtilities.setField(ZigBeeDongleTelegesis.class, dongle, "frameHandler", handler);
         TestUtilities.setField(ZigBeeDongleTelegesis.class, dongle, "zigbeeTransportReceive",
                 Mockito.mock(ZigBeeTransportReceive.class));
+        TestUtilities.setField(ZigBeeDongleTelegesis.class, dongle, "isConfigured", true);
 
         ZigBeeApsFrame apsFrame = new ZigBeeApsFrame();
         apsFrame.setCluster(0);
@@ -253,6 +254,7 @@ public class ZigBeeDongleTelegesisTest {
         TestUtilities.setField(ZigBeeDongleTelegesis.class, dongle, "frameHandler", handler);
         TestUtilities.setField(ZigBeeDongleTelegesis.class, dongle, "zigbeeTransportReceive",
                 Mockito.mock(ZigBeeTransportReceive.class));
+        TestUtilities.setField(ZigBeeDongleTelegesis.class, dongle, "isConfigured", true);
 
         ZigBeeApsFrame apsFrame = new ZigBeeApsFrame();
         apsFrame.setCluster(0);
@@ -267,4 +269,21 @@ public class ZigBeeDongleTelegesisTest {
         Mockito.verify(handler, Mockito.timeout(TIMEOUT).times(1))
                 .sendRequest(ArgumentMatchers.any(TelegesisSendMulticastCommand.class));
     }
+
+    @Test
+    public void doNotSendCommandWhenNotConfigured() throws Exception {
+        ZigBeeDongleTelegesis dongle = new ZigBeeDongleTelegesis(null);
+        TelegesisFrameHandler handler = Mockito.mock(TelegesisFrameHandler.class);
+
+        TestUtilities.setField(ZigBeeDongleTelegesis.class, dongle, "frameHandler", handler);
+        TestUtilities.setField(ZigBeeDongleTelegesis.class, dongle, "zigbeeTransportReceive",
+                Mockito.mock(ZigBeeTransportReceive.class));
+        TestUtilities.setField(ZigBeeDongleTelegesis.class, dongle, "isConfigured", false);
+
+        ZigBeeApsFrame apsFrame = new ZigBeeApsFrame();
+
+        dongle.sendCommand(1, apsFrame);
+        Mockito.verify(handler, Mockito.never()).sendRequest(ArgumentMatchers.any(TelegesisSendMulticastCommand.class));
+    }
+
 }


### PR DESCRIPTION
Resolves #1286 

This PR introduces a flag in ZigBeeDongleTelegesis and ZigBeeDongleEzsp to check if the shutdown method was called. The flag is used in the sendCommand in order to avoid using a shutdown or terminated Executor.

@cdjackson Please take a look and share your opinion.