### PR TITLE
Null-check Future in ZclCluster.readAttributeValue

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/ZclCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/ZclCluster.java
@@ -475,9 +475,12 @@ public abstract class ZclCluster {
      * @return and object containing the value, or null
      */
     protected Object readAttributeValue(final int attributeId) {
-        CommandResult result;
+        CommandResult result = null;
         try {
-            result = readAttribute(attributeId).get();
+            Future<CommandResult> readAttributeFuture = readAttribute(attributeId);
+            if (readAttributeFuture != null) {
+                result = readAttributeFuture.get();
+            }
         } catch (InterruptedException e) {
             logger.debug("readAttributeValue interrupted");
             return null;
@@ -486,7 +489,7 @@ public abstract class ZclCluster {
             return null;
         }
 
-        if (!result.isSuccess()) {
+        if (result == null || !result.isSuccess()) {
             return null;
         }
 


### PR DESCRIPTION
Resolves #1288 

The PR introduces a simple null-check for the Future that is returned by the `readAttribute` method. The null-check is needed as the Future can be null when the `ZigBeeTransactionManager` is shut down.