### PR TITLE
Use thread-safe list type for outstandingQueues

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransactionManager.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransactionManager.java
@@ -15,6 +15,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
@@ -154,7 +155,7 @@ public class ZigBeeTransactionManager implements ZigBeeNetworkNodeListener {
     /**
      * A List of queues with outstanding commands. This is used for random access when sending transactions.
      */
-    private final List<ZigBeeTransactionQueue> outstandingQueues = new ArrayList<>();
+    private final List<ZigBeeTransactionQueue> outstandingQueues = new CopyOnWriteArrayList<>();
 
     private final ZigBeeTransactionQueue defaultQueue;
     private final ZigBeeTransactionQueue broadcastQueue;


### PR DESCRIPTION
Resolves #1290 

This PR fixes an issue where a `ConcurrentModificationException` rises when iterating over `outstandingQueues`. `outstandingQueues` is now an instance of `CopyOnWriteArrayList` instead of an `ArrayList`.

Signed-off-by: Tommaso Travaglino <tommaso.travaglino@telekom.de>