### PR TITLE
Improve group management response reporting

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeDeviceType.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeDeviceType.java
@@ -632,7 +632,7 @@ public enum ZigBeeDeviceType {
 
     private ZigBeeDeviceType(final ZigBeeProfileType profile, final int key) {
         this.key = key;
-        this.profilekey = key & 0xffff + (profile.ordinal() << 16);
+        this.profilekey = (key & 0xffff) + (profile.getKey() << 16);
     }
 
     public int getKey() {
@@ -640,12 +640,12 @@ public enum ZigBeeDeviceType {
     }
 
     public static ZigBeeDeviceType getByValue(final int value) {
-        int id = value & 0xffff + (ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION.ordinal() << 16);
+        int id = (value & 0xffff) + (ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION.getKey() << 16);
         return idMap.get(id);
     }
 
     public static ZigBeeDeviceType getByValue(final ZigBeeProfileType profile, final int value) {
-        int id = value & 0xffff + (profile.ordinal() << 16);
+        int id = (value & 0xffff) + (profile.getKey() << 16);
         return idMap.get(id);
     }
 }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/groups/ZigBeeGroup.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/groups/ZigBeeGroup.java
@@ -20,7 +20,9 @@ import com.zsmartsystems.zigbee.CommandResult;
 import com.zsmartsystems.zigbee.ZigBeeEndpoint;
 import com.zsmartsystems.zigbee.ZigBeeNetworkManager;
 import com.zsmartsystems.zigbee.ZigBeeNode;
+import com.zsmartsystems.zigbee.ZigBeeStatus;
 import com.zsmartsystems.zigbee.zcl.ZclCommand;
+import com.zsmartsystems.zigbee.zcl.ZclStatus;
 import com.zsmartsystems.zigbee.zcl.ZclTransactionMatcher;
 import com.zsmartsystems.zigbee.zcl.clusters.ZclGroupsCluster;
 import com.zsmartsystems.zigbee.zcl.clusters.groups.AddGroupCommand;
@@ -190,83 +192,121 @@ public class ZigBeeGroup implements Comparable<Object> {
 
     /**
      * Add a {@link ZigBeeEndpoint} as a member of the group. This will update the groups within the device.
+     * <p>
+     * Note that this is a blocking call and will not return until after the command response from the remote device.
      *
      * @param endpoint the {@link ZigBeeEndpoint} to add as he group member
-     * @return true if this set did not already contain the specified element
+     * @return {@link ZigBeeStatus} containing the status of the operation
      */
-    public boolean addMember(ZigBeeEndpoint endpoint) {
+    public ZigBeeStatus addMember(ZigBeeEndpoint endpoint) {
         ZigBeeGroupMember address = new ZigBeeGroupMember(endpoint.getIeeeAddress(), endpoint.getEndpointId());
-        addGroup(address);
-        return members.add(address);
+        ZigBeeStatus result = addGroup(address);
+        if (result == ZigBeeStatus.SUCCESS) {
+            members.add(address);
+        }
+        return result;
     }
 
     /**
      * Removes a {@link ZigBeeEndpoint} as a member of the group
+     * <p>
+     * Note that this is a blocking call and will not return until after the command response from the remote device.
      *
      * @param endpoint the {@link ZigBeeEndpoint} to remove from the group
-     * @return
+     * @return {@link ZigBeeStatus} containing the status of the operation
      */
-    public boolean removeMember(ZigBeeEndpoint endpoint) {
+    public ZigBeeStatus removeMember(ZigBeeEndpoint endpoint) {
         ZigBeeGroupMember address = new ZigBeeGroupMember(endpoint.getIeeeAddress(), endpoint.getEndpointId());
-        removeGroup(address);
-        return members.remove(address);
+        ZigBeeStatus result = removeGroup(address);
+        if (result == ZigBeeStatus.SUCCESS) {
+            members.remove(address);
+        }
+        return result;
     }
 
-    private void addGroup(ZigBeeGroupMember address) {
+    private ZigBeeStatus addGroup(ZigBeeGroupMember address) {
         ZclGroupsCluster cluster = getGroupsCluster(address);
         if (cluster == null) {
-            return;
+            return ZigBeeStatus.UNSUPPORTED;
         }
 
         CommandResult cmdResult;
         try {
             cmdResult = cluster.sendCommand(new AddGroupCommand(groupId, (label == null ? "" : label))).get();
+            if (cmdResult.isTimeout()) {
+                logger.debug("{}: Unable to add group {} - timeout", address.getAddress(), groupId);
+                return ZigBeeStatus.NO_RESPONSE;
+            }
             if (cmdResult.isError()) {
-                logger.debug("{}: Unable to add group {}", address.getAddress(), groupId);
-                return;
+                ZclStatus zclStatus = ZclStatus.getStatus(cmdResult.getStatusCode());
+                if (zclStatus == null) {
+                    zclStatus = ZclStatus.UNKNOWN;
+                }
+                logger.debug("{}: Unable to add group {} - error {}", address.getAddress(), groupId, zclStatus);
+                switch (zclStatus) {
+                    case INSUFFICIENT_SPACE:
+                        return ZigBeeStatus.NO_RESOURCES;
+                    default:
+                        return ZigBeeStatus.FAILURE;
+                }
             }
             logger.debug("{}: Added group {} successfully", address.getAddress(), groupId);
+            return ZigBeeStatus.SUCCESS;
         } catch (InterruptedException | ExecutionException e) {
             logger.debug("{}: Interrupted adding group {}", address.getAddress(), groupId);
+            return ZigBeeStatus.FAILURE;
         }
     }
 
-    private void removeGroup(ZigBeeGroupMember address) {
+    private ZigBeeStatus removeGroup(ZigBeeGroupMember address) {
         ZclGroupsCluster cluster = getGroupsCluster(address);
         if (cluster == null) {
-            return;
+            return ZigBeeStatus.UNSUPPORTED;
         }
 
         CommandResult cmdResult;
         try {
             cmdResult = cluster.sendCommand(new RemoveGroupCommand(groupId)).get();
+            if (cmdResult.isTimeout()) {
+                logger.debug("{}: Unable to remove group {} - timeout", address.getAddress(), groupId);
+                return ZigBeeStatus.NO_RESPONSE;
+            }
             if (cmdResult.isError()) {
-                logger.debug("{}: Unable to remove group {}", address.getAddress(), groupId);
-                return;
+                ZclStatus zclStatus = ZclStatus.getStatus(cmdResult.getStatusCode());
+                if (zclStatus == null) {
+                    zclStatus = ZclStatus.UNKNOWN;
+                }
+                logger.debug("{}: Unable to remove group {} - error {}", address.getAddress(), groupId, zclStatus);
+                switch (zclStatus) {
+                    default:
+                        return ZigBeeStatus.FAILURE;
+                }
             }
             logger.debug("{}: Removed group {} successfully", address.getAddress(), groupId);
+            return ZigBeeStatus.SUCCESS;
         } catch (InterruptedException | ExecutionException e) {
             logger.debug("{}: Interrupted removing group {}", address.getAddress(), groupId);
+            return ZigBeeStatus.FAILURE;
         }
     }
 
     private ZclGroupsCluster getGroupsCluster(ZigBeeGroupMember address) {
         ZigBeeNode node = networkManager.getNode(address.getAddress());
         if (node == null) {
-            logger.debug("{}: Unable to find node while removing group", address.getAddress());
+            logger.debug("{}: Unable to find node while maninging group", address.getAddress());
             return null;
         }
 
         ZigBeeEndpoint endpoint = node.getEndpoint(address.getEndpointId());
         if (endpoint == null) {
-            logger.debug("{}: Unable to find endpoint {} while removing group", address.getAddress(),
+            logger.debug("{}: Unable to find endpoint {} while maninging group", address.getAddress(),
                     address.getEndpointId());
             return null;
         }
 
         ZclGroupsCluster cluster = (ZclGroupsCluster) endpoint.getInputCluster(ZclGroupsCluster.CLUSTER_ID);
         if (cluster == null) {
-            logger.debug("{}: Unable to find Groups Cluster on endpoint {} while removing group", address.getAddress(),
+            logger.debug("{}: Unable to find Groups Cluster on endpoint {} while maninging group", address.getAddress(),
                     address.getEndpointId());
             return null;
         }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/groups/ZigBeeGroup.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/groups/ZigBeeGroup.java
@@ -26,7 +26,9 @@ import com.zsmartsystems.zigbee.zcl.ZclStatus;
 import com.zsmartsystems.zigbee.zcl.ZclTransactionMatcher;
 import com.zsmartsystems.zigbee.zcl.clusters.ZclGroupsCluster;
 import com.zsmartsystems.zigbee.zcl.clusters.groups.AddGroupCommand;
+import com.zsmartsystems.zigbee.zcl.clusters.groups.AddGroupResponse;
 import com.zsmartsystems.zigbee.zcl.clusters.groups.RemoveGroupCommand;
+import com.zsmartsystems.zigbee.zcl.clusters.groups.RemoveGroupResponse;
 
 /**
  * ZigBee group definition. This maintains the group ID and label, along with the group members.
@@ -237,11 +239,13 @@ public class ZigBeeGroup implements Comparable<Object> {
                 logger.debug("{}: Unable to add group {} - timeout", address.getAddress(), groupId);
                 return ZigBeeStatus.NO_RESPONSE;
             }
+            ZclStatus zclStatus;
             if (cmdResult.isError()) {
-                ZclStatus zclStatus = ZclStatus.getStatus(cmdResult.getStatusCode());
-                if (zclStatus == null) {
-                    zclStatus = ZclStatus.UNKNOWN;
-                }
+                zclStatus = ZclStatus.UNKNOWN;
+            } else {
+                zclStatus = ((AddGroupResponse) cmdResult.getResponse()).getStatus();
+            }
+            if (zclStatus != ZclStatus.SUCCESS) {
                 logger.debug("{}: Unable to add group {} - error {}", address.getAddress(), groupId, zclStatus);
                 switch (zclStatus) {
                     case INSUFFICIENT_SPACE:
@@ -250,6 +254,7 @@ public class ZigBeeGroup implements Comparable<Object> {
                         return ZigBeeStatus.FAILURE;
                 }
             }
+
             logger.debug("{}: Added group {} successfully", address.getAddress(), groupId);
             return ZigBeeStatus.SUCCESS;
         } catch (InterruptedException | ExecutionException e) {
@@ -271,17 +276,20 @@ public class ZigBeeGroup implements Comparable<Object> {
                 logger.debug("{}: Unable to remove group {} - timeout", address.getAddress(), groupId);
                 return ZigBeeStatus.NO_RESPONSE;
             }
+            ZclStatus zclStatus;
             if (cmdResult.isError()) {
-                ZclStatus zclStatus = ZclStatus.getStatus(cmdResult.getStatusCode());
-                if (zclStatus == null) {
-                    zclStatus = ZclStatus.UNKNOWN;
-                }
+                zclStatus = ZclStatus.UNKNOWN;
+            } else {
+                zclStatus = ((RemoveGroupResponse) cmdResult.getResponse()).getStatus();
+            }
+            if (zclStatus != ZclStatus.SUCCESS) {
                 logger.debug("{}: Unable to remove group {} - error {}", address.getAddress(), groupId, zclStatus);
                 switch (zclStatus) {
                     default:
                         return ZigBeeStatus.FAILURE;
                 }
             }
+
             logger.debug("{}: Removed group {} successfully", address.getAddress(), groupId);
             return ZigBeeStatus.SUCCESS;
         } catch (InterruptedException | ExecutionException e) {

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/groups/ZigBeeGroupTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/groups/ZigBeeGroupTest.java
@@ -11,10 +11,22 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
 import org.junit.Test;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
+import com.zsmartsystems.zigbee.CommandResult;
+import com.zsmartsystems.zigbee.IeeeAddress;
+import com.zsmartsystems.zigbee.ZigBeeEndpoint;
 import com.zsmartsystems.zigbee.ZigBeeNetworkManager;
+import com.zsmartsystems.zigbee.ZigBeeNode;
+import com.zsmartsystems.zigbee.ZigBeeStatus;
+import com.zsmartsystems.zigbee.zcl.ZclStatus;
+import com.zsmartsystems.zigbee.zcl.clusters.ZclGroupsCluster;
+import com.zsmartsystems.zigbee.zcl.clusters.groups.ZclGroupsCommand;
 
 /**
  * Tests for {@link ZigBeeGroup}
@@ -67,4 +79,70 @@ public class ZigBeeGroupTest {
         group.setGroupId(0xfff8);
     }
 
+    @Test
+    public void addMember() throws InterruptedException, ExecutionException {
+        ZigBeeNetworkManager networkManager = Mockito.mock(ZigBeeNetworkManager.class);
+
+        ZigBeeGroup group = new ZigBeeGroup(networkManager, 1);
+        ZigBeeEndpoint endpoint = Mockito.mock(ZigBeeEndpoint.class);
+
+        IeeeAddress ieeeAddress = new IeeeAddress("1234567890ABCDEF");
+        Mockito.when(endpoint.getIeeeAddress()).thenReturn(ieeeAddress);
+        Mockito.when(endpoint.getEndpointId()).thenReturn(1);
+        assertEquals(ZigBeeStatus.UNSUPPORTED, group.addMember(endpoint));
+
+        ZigBeeNode node = Mockito.mock(ZigBeeNode.class);
+        Mockito.when(node.getEndpoint(1)).thenReturn(endpoint);
+        Mockito.when(networkManager.getNode(ieeeAddress)).thenReturn(node);
+
+        ZclGroupsCluster cluster = Mockito.mock(ZclGroupsCluster.class);
+        Mockito.when(endpoint.getInputCluster(ZclGroupsCluster.CLUSTER_ID)).thenReturn(cluster);
+
+        Future future = Mockito.mock(Future.class);
+        CommandResult response = Mockito.mock(CommandResult.class);
+
+        Mockito.when(cluster.sendCommand(ArgumentMatchers.any(ZclGroupsCommand.class))).thenReturn(future);
+        Mockito.when(future.get()).thenReturn(response);
+
+        assertEquals(ZigBeeStatus.SUCCESS, group.addMember(endpoint));
+
+        Mockito.when(response.isError()).thenReturn(true);
+        Mockito.when(response.getStatusCode()).thenReturn(99);
+        assertEquals(ZigBeeStatus.FAILURE, group.addMember(endpoint));
+
+        Mockito.when(response.getStatusCode()).thenReturn(ZclStatus.INSUFFICIENT_SPACE.getId());
+        assertEquals(ZigBeeStatus.NO_RESOURCES, group.addMember(endpoint));
+    }
+
+    @Test
+    public void removeMember() throws InterruptedException, ExecutionException {
+        ZigBeeNetworkManager networkManager = Mockito.mock(ZigBeeNetworkManager.class);
+
+        ZigBeeGroup group = new ZigBeeGroup(networkManager, 1);
+        ZigBeeEndpoint endpoint = Mockito.mock(ZigBeeEndpoint.class);
+
+        IeeeAddress ieeeAddress = new IeeeAddress("1234567890ABCDEF");
+        Mockito.when(endpoint.getIeeeAddress()).thenReturn(ieeeAddress);
+        Mockito.when(endpoint.getEndpointId()).thenReturn(1);
+        assertEquals(ZigBeeStatus.UNSUPPORTED, group.removeMember(endpoint));
+
+        ZigBeeNode node = Mockito.mock(ZigBeeNode.class);
+        Mockito.when(node.getEndpoint(1)).thenReturn(endpoint);
+        Mockito.when(networkManager.getNode(ieeeAddress)).thenReturn(node);
+
+        ZclGroupsCluster cluster = Mockito.mock(ZclGroupsCluster.class);
+        Mockito.when(endpoint.getInputCluster(ZclGroupsCluster.CLUSTER_ID)).thenReturn(cluster);
+
+        Future future = Mockito.mock(Future.class);
+        CommandResult response = Mockito.mock(CommandResult.class);
+
+        Mockito.when(cluster.sendCommand(ArgumentMatchers.any(ZclGroupsCommand.class))).thenReturn(future);
+        Mockito.when(future.get()).thenReturn(response);
+
+        assertEquals(ZigBeeStatus.SUCCESS, group.removeMember(endpoint));
+
+        Mockito.when(response.isError()).thenReturn(true);
+        Mockito.when(response.getStatusCode()).thenReturn(99);
+        assertEquals(ZigBeeStatus.FAILURE, group.removeMember(endpoint));
+    }
 }

--- a/com.zsmartsystems.zigbee/src/test/resource/logs/cluster-0004-Groups.txt
+++ b/com.zsmartsystems.zigbee/src/test/resource/logs/cluster-0004-Groups.txt
@@ -23,3 +23,6 @@ ViewGroupCommand [Groups: 0/0 -> 0/1, cluster=0004, TID=10, groupId=1]
 
 ZigBeeApsFrame [sourceAddress=0/1, destinationAddress=0/1, profile=0104, cluster=0004, addressMode=DEVICE, radius=0, apsSecurity=false, apsCounter=51, payload=19 10 01 00 01 00 00]
 ViewGroupResponse [Groups: 0/1 -> 0/1, cluster=0004, TID=10, status=SUCCESS, groupId=1, groupName=]
+
+ZigBeeApsFrame [sourceAddress=0/1, destinationAddress=0/1, profile=0104, cluster=0004, addressMode=DEVICE, radius=0, apsSecurity=false, ackRequest=false, apsCounter=9D, rssi=-67, lqi=84, payload=19 32 00 89 14 00]
+AddGroupResponse [Groups: 0/1 -> 0/1, cluster=0004, TID=32, status=INSUFFICIENT_SPACE, groupId=20]


### PR DESCRIPTION
Note that this change is a breaking change to the API as it now returns a `ZigBeeStatus` rather than a `boolean` for the add/remove group member methods.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>