### PR TITLE
Fix gpepIncomingMessageHandler definition

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.ember.autocode/src/main/resources/ezsp_protocol.xml
+++ b/com.zsmartsystems.zigbee.dongle.ember.autocode/src/main/resources/ezsp_protocol.xml
@@ -3279,9 +3279,9 @@
 				<description>Whether the incoming GPDF had the auto-commissioning bit set.</description>
 			</parameter>
 			<parameter>
-				<data_type>bool</data_type>
-				<name>rxAfterTx</name>
-				<description>Whether the incoming GPDF had the rxAfterTx bit set.</description>
+				<data_type>uint8_t</data_type>
+				<name>bidirectionalInfo</name>
+				<description>Bidirectional information represented in bitfields, where bit0 holds the rxAfterTx of incoming gpdf and bit1 holds if tx queue is available for outgoing gpdf.</description>
 			</parameter>
 			<parameter>
 				<data_type>uint32_t</data_type>
@@ -4418,15 +4418,11 @@
 		<description>A GP address structure.</description>
 		<parameters>
 			<parameter>
-				<data_type>EmberEUI64</data_type>
-				<name>gpdIeeeAddress</name>
-				<description>The GPD's EUI64.</description>
-			</parameter>
-			<parameter>
-				<data_type>uint32_t</data_type>
-				<name>sourceId</name>
-				<description>The GPD's source ID.</description>
-				<display>hex[8]</display>
+				<data_type>uint8_t[8]</data_type>
+				<name>gpdSource</name>
+				<description>The GPD's EUI64. The IEEE address is used when the application identifier is EMBER_GP_APPLICATION_IEEE_ADDRESS.</description>
+				<description>The GPD's source ID. The 32-bit source identifier is used when the application identifier is EMBER_GP_APPLICATION_SOURCE_ID.</description>
+				<display>hex[2]</display>
 			</parameter>
 			<parameter>
 				<data_type>EmberGpApplicationId</data_type>

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGpepIncomingMessageHandler.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGpepIncomingMessageHandler.java
@@ -77,11 +77,12 @@ public class EzspGpepIncomingMessageHandler extends EzspFrameResponse {
     private boolean autoCommissioning;
 
     /**
-     * Whether the incoming GPDF had the rxAfterTx bit set.
+     * Bidirectional information represented in bitfields, where bit0 holds the rxAfterTx of
+     * incoming gpdf and bit1 holds if tx queue is available for outgoing gpdf.
      * <p>
-     * EZSP type is <i>bool</i> - Java type is {@link boolean}
+     * EZSP type is <i>uint8_t</i> - Java type is {@link int}
      */
-    private boolean rxAfterTx;
+    private int bidirectionalInfo;
 
     /**
      * The security frame counter of the incoming GDPF.
@@ -133,7 +134,7 @@ public class EzspGpepIncomingMessageHandler extends EzspFrameResponse {
         gpdfSecurityLevel = deserializer.deserializeEmberGpSecurityLevel();
         gpdfSecurityKeyType = deserializer.deserializeEmberGpKeyType();
         autoCommissioning = deserializer.deserializeBool();
-        rxAfterTx = deserializer.deserializeBool();
+        bidirectionalInfo = deserializer.deserializeUInt8();
         gpdSecurityFrameCounter = deserializer.deserializeUInt32();
         gpdCommandId = deserializer.deserializeUInt8();
         mic = deserializer.deserializeUInt32();
@@ -283,23 +284,25 @@ public class EzspGpepIncomingMessageHandler extends EzspFrameResponse {
     }
 
     /**
-     * Whether the incoming GPDF had the rxAfterTx bit set.
+     * Bidirectional information represented in bitfields, where bit0 holds the rxAfterTx of
+     * incoming gpdf and bit1 holds if tx queue is available for outgoing gpdf.
      * <p>
-     * EZSP type is <i>bool</i> - Java type is {@link boolean}
+     * EZSP type is <i>uint8_t</i> - Java type is {@link int}
      *
-     * @return the current rxAfterTx as {@link boolean}
+     * @return the current bidirectionalInfo as {@link int}
      */
-    public boolean getRxAfterTx() {
-        return rxAfterTx;
+    public int getBidirectionalInfo() {
+        return bidirectionalInfo;
     }
 
     /**
-     * Whether the incoming GPDF had the rxAfterTx bit set.
+     * Bidirectional information represented in bitfields, where bit0 holds the rxAfterTx of
+     * incoming gpdf and bit1 holds if tx queue is available for outgoing gpdf.
      *
-     * @param rxAfterTx the rxAfterTx to set as {@link boolean}
+     * @param bidirectionalInfo the bidirectionalInfo to set as {@link int}
      */
-    public void setRxAfterTx(boolean rxAfterTx) {
-        this.rxAfterTx = rxAfterTx;
+    public void setBidirectionalInfo(int bidirectionalInfo) {
+        this.bidirectionalInfo = bidirectionalInfo;
     }
 
     /**
@@ -421,8 +424,8 @@ public class EzspGpepIncomingMessageHandler extends EzspFrameResponse {
         builder.append(gpdfSecurityKeyType);
         builder.append(", autoCommissioning=");
         builder.append(autoCommissioning);
-        builder.append(", rxAfterTx=");
-        builder.append(rxAfterTx);
+        builder.append(", bidirectionalInfo=");
+        builder.append(bidirectionalInfo);
         builder.append(", gpdSecurityFrameCounter=");
         builder.append(gpdSecurityFrameCounter);
         builder.append(", gpdCommandId=");

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/structure/EmberGpAddress.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/structure/EmberGpAddress.java
@@ -7,7 +7,6 @@
  */
 package com.zsmartsystems.zigbee.dongle.ember.ezsp.structure;
 
-import com.zsmartsystems.zigbee.IeeeAddress;
 import com.zsmartsystems.zigbee.dongle.ember.internal.serializer.EzspDeserializer;
 import com.zsmartsystems.zigbee.dongle.ember.internal.serializer.EzspSerializer;
 
@@ -23,18 +22,12 @@ import com.zsmartsystems.zigbee.dongle.ember.internal.serializer.EzspSerializer;
 public class EmberGpAddress {
 
     /**
-     * The GPD's EUI64.
+     * The GPD's source ID. The 32-bit source identifier is used when the application identifier is
+     * EMBER_GP_APPLICATION_SOURCE_ID.
      * <p>
-     * EZSP type is <i>EmberEUI64</i> - Java type is {@link IeeeAddress}
+     * EZSP type is <i>uint8_t[8]</i> - Java type is {@link int[]}
      */
-    private IeeeAddress gpdIeeeAddress;
-
-    /**
-     * The GPD's source ID.
-     * <p>
-     * EZSP type is <i>uint32_t</i> - Java type is {@link int}
-     */
-    private int sourceId;
+    private int[] gpdSource;
 
     /**
      * The GPD Application ID.
@@ -61,43 +54,25 @@ public class EmberGpAddress {
     }
 
     /**
-     * The GPD's EUI64.
+     * The GPD's source ID. The 32-bit source identifier is used when the application identifier is
+     * EMBER_GP_APPLICATION_SOURCE_ID.
      * <p>
-     * EZSP type is <i>EmberEUI64</i> - Java type is {@link IeeeAddress}
+     * EZSP type is <i>uint8_t[8]</i> - Java type is {@link int[]}
      *
-     * @return the current gpdIeeeAddress as {@link IeeeAddress}
+     * @return the current gpdSource as {@link int[]}
      */
-    public IeeeAddress getGpdIeeeAddress() {
-        return gpdIeeeAddress;
+    public int[] getGpdSource() {
+        return gpdSource;
     }
 
     /**
-     * The GPD's EUI64.
+     * The GPD's source ID. The 32-bit source identifier is used when the application identifier is
+     * EMBER_GP_APPLICATION_SOURCE_ID.
      *
-     * @param gpdIeeeAddress the gpdIeeeAddress to set as {@link IeeeAddress}
+     * @param gpdSource the gpdSource to set as {@link int[]}
      */
-    public void setGpdIeeeAddress(IeeeAddress gpdIeeeAddress) {
-        this.gpdIeeeAddress = gpdIeeeAddress;
-    }
-
-    /**
-     * The GPD's source ID.
-     * <p>
-     * EZSP type is <i>uint32_t</i> - Java type is {@link int}
-     *
-     * @return the current sourceId as {@link int}
-     */
-    public int getSourceId() {
-        return sourceId;
-    }
-
-    /**
-     * The GPD's source ID.
-     *
-     * @param sourceId the sourceId to set as {@link int}
-     */
-    public void setSourceId(int sourceId) {
-        this.sourceId = sourceId;
+    public void setGpdSource(int[] gpdSource) {
+        this.gpdSource = gpdSource;
     }
 
     /**
@@ -147,8 +122,7 @@ public class EmberGpAddress {
      */
     public int[] serialize(EzspSerializer serializer) {
         // Serialize the fields
-        serializer.serializeEmberEui64(gpdIeeeAddress);
-        serializer.serializeUInt32(sourceId);
+        serializer.serializeUInt8Array(gpdSource);
         serializer.serializeEmberGpApplicationId(applicationId);
         serializer.serializeUInt8(endpoint);
         return serializer.getPayload();
@@ -161,19 +135,27 @@ public class EmberGpAddress {
      */
     public void deserialize(EzspDeserializer deserializer) {
         // Deserialize the fields
-        gpdIeeeAddress = deserializer.deserializeEmberEui64();
-        sourceId = deserializer.deserializeUInt32();
+        gpdSource = deserializer.deserializeUInt8Array(8);
         applicationId = deserializer.deserializeEmberGpApplicationId();
         endpoint = deserializer.deserializeUInt8();
     }
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder(117);
-        builder.append("EmberGpAddress [gpdIeeeAddress=");
-        builder.append(gpdIeeeAddress);
-        builder.append(", sourceId=");
-        builder.append(String.format("%08X", sourceId));
+        final StringBuilder builder = new StringBuilder(92);
+        builder.append("EmberGpAddress [gpdSource=");
+        builder.append('{');
+        if (gpdSource == null) {
+            builder.append("null");
+        } else {
+            for (int cnt = 0; cnt < gpdSource.length; cnt++) {
+                if (cnt != 0) {
+                    builder.append(' ');
+                }
+                builder.append(String.format("%02X", gpdSource[cnt]));
+            }
+        }
+        builder.append('}');
         builder.append(", applicationId=");
         builder.append(applicationId);
         builder.append(", endpoint=");

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/structure/EmberStatus.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/structure/EmberStatus.java
@@ -532,7 +532,7 @@ public enum EmberStatus {
     EMBER_APS_ENCRYPTION_ERROR(0x00A6),
 
     /**
-     *  There was an attempt to form a network using commercial security without setting the Trust
+     * There was an attempt to form a network using commercial security without setting the Trust
      * Center master key first.
      */
     EMBER_TRUST_CENTER_MASTER_KEY_NOT_SET(0x00A7),

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGpepIncomingMessageHandlerTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/command/EzspGpepIncomingMessageHandlerTest.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2016-2022 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.dongle.ember.ezsp.command;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+import org.junit.Test;
+
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.EzspFrame;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.EzspFrameTest;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EmberStatus;
+
+/**
+ * @author Chris Jackson
+ */
+public class EzspGpepIncomingMessageHandlerTest extends EzspFrameTest {
+
+    @Test
+    public void testReceive1() {
+        EzspFrame.setEzspVersion(4);
+        EzspGpepIncomingMessageHandler incomingMessageHandler = new EzspGpepIncomingMessageHandler(
+                getPacketData(
+                        "90 01 C5 7F D7 54 00 14 8A 70 01 14 8A 70 01 54 02 01 00 00 54 07 00 00 65 2C 15 E8 75 FF 00"));
+
+        System.out.println(incomingMessageHandler);
+
+        assertEquals(0xC5, incomingMessageHandler.getFrameId());
+        assertFalse(incomingMessageHandler.isResponse());
+        assertEquals(EmberStatus.EMBER_UNPROCESSED, incomingMessageHandler.getStatus());
+    }
+}


### PR DESCRIPTION
Silabs advise that the `EmberGPAddress` is a union, not a flat structure as defined in the documentation. The C file shows this -:

```
typedef struct {
  union {
    /** The IEEE address is used when the application identifier is
     *  ::EMBER_GP_APPLICATION_IEEE_ADDRESS.
     */
    EmberEUI64 gpdIeeeAddress;
    /** The 32-bit source identifier is used when the application identifier is
     *  ::EMBER_GP_APPLICATION_SOURCE_ID.
     *
     */
    EmberGpSourceId sourceId;
  } id;
  /** Application identifier of the GPD. */
  EmberGpApplicationId applicationId;
  uint8_t endpoint;
} EmberGpAddress;
```

This changes the address to an 8 byte array and the dongle handler will need to manage the address appropriately when GP processing is added.

This should fix #1301.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>