### PR TITLE
Add getZigBeeAddress method to ZclAttribute

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/ZclAttribute.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/ZclAttribute.java
@@ -244,6 +244,15 @@ public class ZclAttribute {
     }
 
     /**
+     * Returns the {@link ZigBeeEndpointAddress} of the endpoint of this attribute
+     *
+     * @return the {@link ZigBeeEndpointAddress} of the cluster
+     */
+    public ZigBeeEndpointAddress getZigBeeAddress() {
+        return cluster.getZigBeeAddress();
+    }
+
+    /**
      * Gets the attribute ID
      *
      * @return the attribute ID


### PR DESCRIPTION
This allows the parent cluster of the attribute to be established by using `getZigBeeAddress` and `getClusterType`.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>