### PR TITLE
Changed shutdown methods of drivers to always close handlers

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
@@ -662,14 +662,11 @@ public class ZigBeeDongleEzsp implements ZigBeeTransportTransmit, ZigBeeTranspor
         logger.debug("EZSP Dongle: Shutdown");
 
         synchronized (isConfiguredSync) {
-            if (!isConfigured) {
-                logger.debug("EZSP Dongle: Shutdown. isConfigured is false. No shutdown necessary.");
-                return;
-            }
-
             isConfigured = false;
 
-            frameHandler.setClosing();
+            if (frameHandler != null) {
+                frameHandler.setClosing();
+            }
 
             if (mfglibListener != null) {
                 mfglibListener = null;
@@ -683,8 +680,14 @@ public class ZigBeeDongleEzsp implements ZigBeeTransportTransmit, ZigBeeTranspor
                 executorService.shutdownNow();
             }
 
-            frameHandler.close();
-            serialPort.close();
+            if (frameHandler != null) {
+                frameHandler.close();
+            }
+
+            if (serialPort != null) {
+                serialPort.close();
+            }
+
             frameHandler = null;
         }
     }

--- a/com.zsmartsystems.zigbee.dongle.telegesis/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/ZigBeeDongleTelegesis.java
+++ b/com.zsmartsystems.zigbee.dongle.telegesis/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/ZigBeeDongleTelegesis.java
@@ -520,27 +520,33 @@ public class ZigBeeDongleTelegesis
     @Override
     public void shutdown() {
         synchronized (isConfiguredSync) {
-            if (!isConfigured) {
-                logger.debug("Telegesis dongle: Shutdown. isConfigured is false. No shutdown necessary.");
-                return;
-            }
-
             isConfigured = false;
 
             if (pollingTimer != null) {
                 pollingTimer.cancel(true);
             }
+
             if (executorService != null) {
                 executorService.shutdownNow();
             }
 
             commandScheduler.shutdownNow();
 
-            frameHandler.removeEventListener(this);
-            frameHandler.setClosing();
+            if (frameHandler != null) {
+                frameHandler.removeEventListener(this);
+                frameHandler.setClosing();
+            }
+
             zigbeeTransportReceive.setTransportState(ZigBeeTransportState.OFFLINE);
-            serialPort.close();
-            frameHandler.close();
+
+            if (frameHandler != null) {
+                frameHandler.close();
+            }
+
+            if (serialPort != null) {
+                serialPort.close();
+            }
+
             frameHandler = null;
         }
 


### PR DESCRIPTION
Resolves #1305 

This PR fixes the issue where `shutdown` doesn't close the handlers when the initialization was not successful. 