### PR TITLE
Improve error reporting when decoding EZSP frame

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.ember.autocode/src/main/java/com/zsmartsystems/zigbee/dongle/ember/autocode/CommandGenerator.java
+++ b/com.zsmartsystems.zigbee.dongle.ember.autocode/src/main/java/com/zsmartsystems/zigbee/dongle/ember/autocode/CommandGenerator.java
@@ -1101,7 +1101,7 @@ public class CommandGenerator extends ClassGenerator {
         out.println("                }");
         out.println("            }");
         out.println("        } catch (ArrayIndexOutOfBoundsException e) {");
-        out.println("            logger.debug(\"Error detecting the EZSP frame type\", e);");
+        out.println("            logger.debug(\"EzspFrame error detecting the frame type: {}\", frameToString(data));");
         out.println("            return null;");
         out.println("        }");
         out.println();
@@ -1118,7 +1118,13 @@ public class CommandGenerator extends ClassGenerator {
         out.println(
                 "        } catch (SecurityException | NoSuchMethodException | IllegalArgumentException | InstantiationException");
         out.println("                | IllegalAccessException | InvocationTargetException e) {");
-        out.println("            logger.debug(\"Error creating instance of EzspFrame\", e);");
+        out.println("            Exception realE = e;");
+        out.println("            if (e instanceof InvocationTargetException) {");
+        out.println("                realE = (Exception) ((InvocationTargetException) e).getCause();");
+        out.println("            }");
+        out.println(
+                "            logger.debug(\"EzspFrame error {} creating instance of frame: {}\", realE.getClass().getSimpleName(),");
+        out.println("                    frameToString(data));");
         out.println("        }");
         out.println();
         out.println("        return null;");
@@ -1149,6 +1155,15 @@ public class CommandGenerator extends ClassGenerator {
         out.println("     */");
         out.println("    public static int getEzspVersion() {");
         out.println("        return EzspFrame.ezspVersion;");
+        out.println("    }");
+        out.println();
+
+        out.println("    private static String frameToString(int[] inputBuffer) {");
+        out.println("        StringBuilder result = new StringBuilder();");
+        out.println("        for (int data : inputBuffer) {");
+        out.println("            result.append(String.format(\"%02X \", data));");
+        out.println("        }");
+        out.println("        return result.toString();");
         out.println("    }");
 
         out.println("}");

--- a/com.zsmartsystems.zigbee.dongle.ember.autocode/src/main/resources/ezsp_protocol.xml
+++ b/com.zsmartsystems.zigbee.dongle.ember.autocode/src/main/resources/ezsp_protocol.xml
@@ -6151,7 +6151,7 @@
 			<value>
 				<name>EMBER_TRUST_CENTER_MASTER_KEY_NOT_SET</name>
 				<enum_value>0x00A7</enum_value>
-				<description> There was an attempt to form a network using commercial security without setting the Trust Center master key first.</description>
+				<description>There was an attempt to form a network using commercial security without setting the Trust Center master key first.</description>
 			</value>
 			<value>
 				<name>EMBER_SECURITY_STATE_NOT_SET</name>

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/EzspFrame.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/EzspFrame.java
@@ -484,7 +484,7 @@ public abstract class EzspFrame {
                 }
             }
         } catch (ArrayIndexOutOfBoundsException e) {
-            logger.debug("Error detecting the EZSP frame type", e);
+            logger.debug("EzspFrame error detecting the frame type: {}", frameToString(data));
             return null;
         }
 
@@ -500,7 +500,12 @@ public abstract class EzspFrame {
             return ezspFrame;
         } catch (SecurityException | NoSuchMethodException | IllegalArgumentException | InstantiationException
                 | IllegalAccessException | InvocationTargetException e) {
-            logger.debug("Error creating instance of EzspFrame", e);
+            Exception realE = e;
+            if (e instanceof InvocationTargetException) {
+                realE = (Exception) ((InvocationTargetException) e).getCause();
+            }
+            logger.debug("EzspFrame error {} creating instance of frame: {}", realE.getClass().getSimpleName(),
+                    frameToString(data));
         }
 
         return null;
@@ -528,5 +533,13 @@ public abstract class EzspFrame {
      */
     public static int getEzspVersion() {
         return EzspFrame.ezspVersion;
+    }
+
+    private static String frameToString(int[] inputBuffer) {
+        StringBuilder result = new StringBuilder();
+        for (int data : inputBuffer) {
+            result.append(String.format("%02X ", data));
+        }
+        return result.toString();
     }
 }

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/EzspFrameTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/ezsp/EzspFrameTest.java
@@ -7,6 +7,10 @@
  */
 package com.zsmartsystems.zigbee.dongle.ember.ezsp;
 
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+
 /**
  *
  * @author Chris Jackson
@@ -23,5 +27,12 @@ public class EzspFrameTest {
         }
 
         return response;
+    }
+
+    @Test
+    public void createHandler() {
+        assertNull(EzspFrame.createHandler(new int[] { 1, 2, 3, 4, 5, 6, 7, 8, 9 }));
+        assertNull(EzspFrame.createHandler(new int[] { 0 }));
+        assertNull(EzspFrame.createHandler(new int[] { 0, 67, 33 }));
     }
 }


### PR DESCRIPTION
This removes the stack dump which is mostly useless, and prints the exception class and the received data that caused the exception.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>