### PR TITLE
Only perform energy scan if channel is UNKNOWN

### DIFF
--- a/com.zsmartsystems.zigbee.console.ember/src/main/java/com/zsmartsystems/zigbee/console/ember/EmberConsoleNcpScanCommand.java
+++ b/com.zsmartsystems.zigbee.console.ember/src/main/java/com/zsmartsystems/zigbee/console/ember/EmberConsoleNcpScanCommand.java
@@ -91,7 +91,8 @@ public class EmberConsoleNcpScanCommand extends EmberConsoleAbstractCommand {
 
         if (energy) {
             out.println("Performing energy scan...");
-            Collection<EzspEnergyScanResultHandler> channels = ncp.doEnergyScan(ZigBeeChannelMask.CHANNEL_MASK_2GHZ, 6);
+            Collection<EzspEnergyScanResultHandler> channels = ncp.doEnergyScan(ZigBeeChannelMask.CHANNEL_MASK_2GHZ,
+                    0);
             if (channels == null) {
                 out.println("Error performing energy scan");
             } else {

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeProfileTypeTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeProfileTypeTest.java
@@ -22,6 +22,6 @@ public class ZigBeeProfileTypeTest {
     public void testTypes() {
         assertEquals(ZigBeeProfileType.ZIGBEE_HOME_AUTOMATION, ZigBeeProfileType.getByValue(0x0104));
         assertEquals(ZigBeeProfileType.ZIGBEE_LIGHT_LINK, ZigBeeProfileType.getByValue(0xC05E));
-        assertNull(ZigBeeProfileType.getByValue(0));
+        assertNull(ZigBeeProfileType.getByValue(1));
     }
 }


### PR DESCRIPTION
This removes the energy and active scans from the Ember startup code if a channel is specified. The scans are therefore only performed if the channel is UNKNOWN as it allows the selection of the quietest channel.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>