### PR TITLE
Improve fingerprint command to also read attribute values

### DIFF
--- a/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleDeviceFingerprintCommand.java
+++ b/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleDeviceFingerprintCommand.java
@@ -12,7 +12,6 @@ import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
-import java.util.Set;
 import java.util.concurrent.ExecutionException;
 
 import com.zsmartsystems.zigbee.CommandResult;
@@ -252,6 +251,14 @@ public class ZigBeeConsoleDeviceFingerprintCommand extends ZigBeeConsoleAbstract
             getAttributes(out, cluster, cluster.getSupportedAttributes());
         } else {
             out.println("| | | | | |> " + success);
+
+            out.println("| | | | |");
+            out.println("| | | | |>| Attribute Values");
+            if (success == ZigBeeStatus.SUCCESS) {
+                getAttributes(out, cluster.getAttributes());
+            } else {
+                out.println("| | | | | |> " + success);
+            }
         }
     }
 
@@ -271,17 +278,34 @@ public class ZigBeeConsoleDeviceFingerprintCommand extends ZigBeeConsoleAbstract
         return command.getClass().getSimpleName();
     }
 
-    private void getAttributes(PrintStream out, ZclCluster cluster, Set<Integer> attributeIds) {
+    private void getAttributes(PrintStream out, ZclCluster cluster, Collection<Integer> attributeIds) {
         for (int attributeId : attributeIds) {
             ZclAttribute attribute = cluster.getAttribute(attributeId);
-            out.println(String.format("| | | | | |> %04X", attributeId) + " " + (attribute == null ? "Unknown"
-                    : attribute.getName()));
-            if (attribute != null && !attribute.isWritable()) {
-                // Object object = attribute.readValue(0);
-                // if (object != null) {
-                // out.println("| | | | | | |> " + object.toString());
-                // }
+            Object value = null;
+            if (attribute.isReadable()) {
+                value = attribute.readValue(60L);
+            } else {
+                value = "";
             }
+
+            out.println(String.format("| | | | | |> %04X  %-40s  %s", attributeId, (attribute == null ? "Unknown"
+                    : attribute.getName()), (value == null ? "" : (">> " + value.toString()))));
+        }
+    }
+
+    private void getAttributes(PrintStream out, Collection<ZclAttribute> attributes) {
+        for (ZclAttribute attribute : attributes) {
+            Object value = null;
+            if (!attribute.isReadable()) {
+                continue;
+            }
+
+            value = attribute.readValue(60L);
+            if (value == null) {
+                continue;
+            }
+            out.println(String.format("| | | | | |> %04X  %-40s  >> %s", attribute.getId(), attribute.getName(),
+                    value.toString()));
         }
     }
 


### PR DESCRIPTION
This improves the `fingerprint` console command to also read the attribute values from the device.  If the device responds to the `attributes supported` request, then it will read the attribute values. If not, it will request all known attributes for the cluster and print any that receive a response.

Attribute data will only be read from the device if it was not received in the past 60 seconds.

```
| | | | |>| Attributes Supported
| | | | | |> 0000  Scene Count                               >> 0
| | | | | |> 0001  Current Scene                             >> 0
| | | | | |> 0002  Current Group                             >> 0
| | | | | |> 0003  Scene Valid                               >> false
| | | | | |> 0004  Name Support                              >> 0
| | | | | |> FFFD  Cluster Revision                          >> 2
```

Signed-off-by: Chris Jackson <chris@cd-jackson.com>