### PR TITLE
Improve error handling in Ember NCP

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/EmberNcp.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/EmberNcp.java
@@ -236,6 +236,9 @@ public class EmberNcp {
         EzspTransaction transaction = protocolHandler
                 .sendEzspTransaction(new EzspSingleResponseTransaction(request, EzspNetworkInitResponse.class));
         EzspNetworkInitResponse response = (EzspNetworkInitResponse) transaction.getResponse();
+        if (response == null) {
+            return EmberStatus.UNKNOWN;
+        }
         logger.debug(response.toString());
 
         return response.getStatus();
@@ -256,6 +259,9 @@ public class EmberNcp {
         EzspTransaction transaction = protocolHandler
                 .sendEzspTransaction(new EzspSingleResponseTransaction(request, EzspLeaveNetworkResponse.class));
         EzspLeaveNetworkResponse response = (EzspLeaveNetworkResponse) transaction.getResponse();
+        if (response == null) {
+            return EmberStatus.UNKNOWN;
+        }
         logger.debug(response.toString());
 
         return response.getStatus();
@@ -271,6 +277,9 @@ public class EmberNcp {
         EzspTransaction transaction = protocolHandler.sendEzspTransaction(
                 new EzspSingleResponseTransaction(request, EzspGetCurrentSecurityStateResponse.class));
         EzspGetCurrentSecurityStateResponse response = (EzspGetCurrentSecurityStateResponse) transaction.getResponse();
+        if (response == null) {
+            return null;
+        }
         logger.debug(response.toString());
         lastStatus = response.getStatus();
         return response.getState();
@@ -279,7 +288,7 @@ public class EmberNcp {
     /**
      * Gets the current network parameters, or an empty parameters class if there's an error
      *
-     * @return {@link EzspGetNetworkParametersResponse}
+     * @return {@link EzspGetNetworkParametersResponse} or null on error
      */
     public EzspGetNetworkParametersResponse getNetworkParameters() {
         EzspGetNetworkParametersRequest request = new EzspGetNetworkParametersRequest();
@@ -291,7 +300,7 @@ public class EmberNcp {
     /**
      * Returns a value indicating whether the node is joining, joined to, or leaving a network.
      *
-     * @return the {@link EmberNetworkStatus}
+     * @return the {@link EmberNetworkStatus} or null on error
      */
     public EmberNetworkStatus getNetworkState() {
         EzspNetworkStateRequest request = new EzspNetworkStateRequest();
@@ -299,6 +308,9 @@ public class EmberNcp {
                 .sendEzspTransaction(new EzspSingleResponseTransaction(request, EzspNetworkStateResponse.class));
         EzspNetworkStateResponse response = (EzspNetworkStateResponse) transaction.getResponse();
         lastStatus = null;
+        if (response == null) {
+            return null;
+        }
 
         return response.getStatus();
     }
@@ -306,7 +318,7 @@ public class EmberNcp {
     /**
      * Returns information about the children of the local node and the parent of the local node.
      *
-     * @return the {@link EzspGetParentChildParametersResponse}
+     * @return the {@link EzspGetParentChildParametersResponse} or null on error
      */
     public EzspGetParentChildParametersResponse getChildParameters() {
         EzspGetParentChildParametersRequest request = new EzspGetParentChildParametersRequest();
@@ -315,6 +327,9 @@ public class EmberNcp {
         EzspGetParentChildParametersResponse response = (EzspGetParentChildParametersResponse) transaction
                 .getResponse();
         lastStatus = null;
+        if (response == null) {
+            return null;
+        }
 
         return response;
     }
@@ -331,6 +346,9 @@ public class EmberNcp {
         EzspTransaction transaction = protocolHandler
                 .sendEzspTransaction(new EzspSingleResponseTransaction(request, EzspGetChildDataResponse.class));
         EzspGetChildDataResponse response = (EzspGetChildDataResponse) transaction.getResponse();
+        if (response == null) {
+            return null;
+        }
         logger.debug(response.toString());
         lastStatus = response.getStatus();
         if (lastStatus != EmberStatus.EMBER_SUCCESS) {
@@ -363,6 +381,9 @@ public class EmberNcp {
         EzspTransaction transaction = protocolHandler
                 .sendEzspTransaction(new EzspSingleResponseTransaction(request, EzspAddEndpointResponse.class));
         EzspAddEndpointResponse response = (EzspAddEndpointResponse) transaction.getResponse();
+        if (response == null) {
+            return EzspStatus.UNKNOWN;
+        }
 
         logger.debug(response.toString());
         lastStatus = null;
@@ -380,6 +401,9 @@ public class EmberNcp {
         EzspTransaction transaction = protocolHandler
                 .sendEzspTransaction(new EzspSingleResponseTransaction(request, EzspReadCountersResponse.class));
         EzspReadCountersResponse response = (EzspReadCountersResponse) transaction.getResponse();
+        if (response == null) {
+            return null;
+        }
         logger.debug(response.toString());
         lastStatus = null;
         return response.getValues();
@@ -395,6 +419,9 @@ public class EmberNcp {
         EzspTransaction transaction = protocolHandler
                 .sendEzspTransaction(new EzspSingleResponseTransaction(request, EzspClearKeyTableResponse.class));
         EzspClearKeyTableResponse response = (EzspClearKeyTableResponse) transaction.getResponse();
+        if (response == null) {
+            return null;
+        }
         logger.debug(response.toString());
         lastStatus = response.getStatus();
         return lastStatus;
@@ -412,6 +439,9 @@ public class EmberNcp {
         EzspTransaction transaction = protocolHandler
                 .sendEzspTransaction(new EzspSingleResponseTransaction(request, EzspGetKeyResponse.class));
         EzspGetKeyResponse response = (EzspGetKeyResponse) transaction.getResponse();
+        if (response == null) {
+            return null;
+        }
         logger.debug(response.toString());
         lastStatus = response.getStatus();
         if (lastStatus != EmberStatus.EMBER_SUCCESS) {
@@ -432,6 +462,9 @@ public class EmberNcp {
         EzspTransaction transaction = protocolHandler
                 .sendEzspTransaction(new EzspSingleResponseTransaction(request, EzspGetKeyTableEntryResponse.class));
         EzspGetKeyTableEntryResponse response = (EzspGetKeyTableEntryResponse) transaction.getResponse();
+        if (response == null) {
+            return null;
+        }
         logger.debug(response.toString());
         lastStatus = response.getStatus();
         if (lastStatus != EmberStatus.EMBER_SUCCESS) {
@@ -454,11 +487,11 @@ public class EmberNcp {
                 new EzspSingleResponseTransaction(request, EzspGetConfigurationValueResponse.class));
         EzspGetConfigurationValueResponse response = (EzspGetConfigurationValueResponse) transaction.getResponse();
         lastStatus = null;
-        logger.debug(response.toString());
 
-        if (response.getStatus() != EzspStatus.EZSP_SUCCESS) {
+        if (response == null || response.getStatus() != EzspStatus.EZSP_SUCCESS) {
             return null;
         }
+        logger.debug(response.toString());
 
         return response.getValue();
     }
@@ -504,6 +537,9 @@ public class EmberNcp {
         EzspTransaction transaction = protocolHandler
                 .sendEzspTransaction(new EzspSingleResponseTransaction(setPolicyRequest, EzspSetPolicyResponse.class));
         EzspSetPolicyResponse setPolicyResponse = (EzspSetPolicyResponse) transaction.getResponse();
+        if (setPolicyResponse == null) {
+            return EzspStatus.UNKNOWN;
+        }
         lastStatus = null;
         logger.debug(setPolicyResponse.toString());
         if (setPolicyResponse.getStatus() != EzspStatus.EZSP_SUCCESS) {
@@ -527,6 +563,9 @@ public class EmberNcp {
         EzspTransaction transaction = protocolHandler
                 .sendEzspTransaction(new EzspSingleResponseTransaction(setPolicyRequest, EzspSetPolicyResponse.class));
         EzspSetPolicyResponse setPolicyResponse = (EzspSetPolicyResponse) transaction.getResponse();
+        if (setPolicyResponse == null) {
+            return EzspStatus.UNKNOWN;
+        }
         lastStatus = null;
         logger.debug(setPolicyResponse.toString());
         if (setPolicyResponse.getStatus() != EzspStatus.EZSP_SUCCESS) {
@@ -549,6 +588,9 @@ public class EmberNcp {
         EzspTransaction transaction = protocolHandler
                 .sendEzspTransaction(new EzspSingleResponseTransaction(getPolicyRequest, EzspGetPolicyResponse.class));
         EzspGetPolicyResponse getPolicyResponse = (EzspGetPolicyResponse) transaction.getResponse();
+        if (getPolicyResponse == null) {
+            return null;
+        }
         lastStatus = null;
         logger.debug(getPolicyResponse.toString());
         if (getPolicyResponse.getStatus() != EzspStatus.EZSP_SUCCESS) {
@@ -573,6 +615,9 @@ public class EmberNcp {
         EzspTransaction transaction = protocolHandler
                 .sendEzspTransaction(new EzspSingleResponseTransaction(request, EzspSetValueResponse.class));
         EzspSetValueResponse response = (EzspSetValueResponse) transaction.getResponse();
+        if (response == null) {
+            return EzspStatus.UNKNOWN;
+        }
         lastStatus = null;
         logger.debug(response.toString());
         if (response.getStatus() != EzspStatus.EZSP_SUCCESS) {
@@ -594,6 +639,9 @@ public class EmberNcp {
         EzspTransaction transaction = protocolHandler
                 .sendEzspTransaction(new EzspSingleResponseTransaction(request, EzspGetValueResponse.class));
         EzspGetValueResponse response = (EzspGetValueResponse) transaction.getResponse();
+        if (response == null) {
+            return null;
+        }
         lastStatus = null;
         logger.debug(response.toString());
         if (response.getStatus() != EzspStatus.EZSP_SUCCESS) {
@@ -620,6 +668,9 @@ public class EmberNcp {
         EzspTransaction transaction = protocolHandler
                 .sendEzspTransaction(new EzspSingleResponseTransaction(request, EzspAddTransientLinkKeyResponse.class));
         EzspAddTransientLinkKeyResponse response = (EzspAddTransientLinkKeyResponse) transaction.getResponse();
+        if (response == null) {
+            return EmberStatus.UNKNOWN;
+        }
         lastStatus = response.getStatus();
         logger.debug(response.toString());
         if (response.getStatus() != EmberStatus.EMBER_SUCCESS) {
@@ -667,6 +718,9 @@ public class EmberNcp {
                 .sendEzspTransaction(new EzspSingleResponseTransaction(request, EzspGetTransientLinkKeyResponse.class));
         EzspGetTransientLinkKeyResponse response = (EzspGetTransientLinkKeyResponse) transaction
                 .getResponse();
+        if (response == null) {
+            return null;
+        }
         logger.debug(response.toString());
         lastStatus = response.getStatus();
         if (lastStatus != EmberStatus.EMBER_SUCCESS) {
@@ -687,6 +741,9 @@ public class EmberNcp {
         EzspTransaction transaction = protocolHandler
                 .sendEzspTransaction(new EzspSingleResponseTransaction(request, EzspGetCertificateResponse.class));
         EzspGetCertificateResponse response = (EzspGetCertificateResponse) transaction.getResponse();
+        if (response == null) {
+            return null;
+        }
         lastStatus = response.getStatus();
         if (response.getStatus() != EmberStatus.EMBER_SUCCESS) {
             logger.debug("Error getting 163k1 certificate: {}", response);
@@ -706,6 +763,9 @@ public class EmberNcp {
         EzspTransaction transaction = protocolHandler
                 .sendEzspTransaction(new EzspSingleResponseTransaction(request, EzspGetCertificate283k1Response.class));
         EzspGetCertificate283k1Response response = (EzspGetCertificate283k1Response) transaction.getResponse();
+        if (response == null) {
+            return null;
+        }
         lastStatus = response.getStatus();
         if (response.getStatus() != EmberStatus.EMBER_SUCCESS) {
             logger.debug("Error getting 283k1 certificate: {}", response);
@@ -754,6 +814,9 @@ public class EmberNcp {
         EzspTransaction transaction = protocolHandler
                 .sendEzspTransaction(new EzspSingleResponseTransaction(request, EzspGetEui64Response.class));
         EzspGetEui64Response response = (EzspGetEui64Response) transaction.getResponse();
+        if (response == null) {
+            return null;
+        }
         return response.getEui64();
     }
 
@@ -789,6 +852,9 @@ public class EmberNcp {
         EzspTransaction transaction = protocolHandler
                 .sendEzspTransaction(new EzspSingleResponseTransaction(request, EzspSetRadioPowerResponse.class));
         EzspSetRadioPowerResponse response = (EzspSetRadioPowerResponse) transaction.getResponse();
+        if (response == null) {
+            return EmberStatus.UNKNOWN;
+        }
         return response.getStatus();
     }
 
@@ -803,6 +869,9 @@ public class EmberNcp {
         EzspTransaction transaction = protocolHandler
                 .sendEzspTransaction(new EzspSingleResponseTransaction(request, EzspGetLibraryStatusResponse.class));
         EzspGetLibraryStatusResponse response = (EzspGetLibraryStatusResponse) transaction.getResponse();
+        if (response == null) {
+            return EmberLibraryStatus.UNKNOWN;
+        }
         return response.getStatus();
     }
 
@@ -829,6 +898,9 @@ public class EmberNcp {
                 new EzspSingleResponseTransaction(request, EzspAddOrUpdateKeyTableEntryResponse.class));
         EzspAddOrUpdateKeyTableEntryResponse response = (EzspAddOrUpdateKeyTableEntryResponse) transaction
                 .getResponse();
+        if (response == null) {
+            return EmberStatus.UNKNOWN;
+        }
         return response.getStatus();
     }
 
@@ -845,6 +917,9 @@ public class EmberNcp {
                 new EzspSingleResponseTransaction(request, EzspGetRouteTableEntryResponse.class));
         EzspGetRouteTableEntryResponse response = (EzspGetRouteTableEntryResponse) transaction
                 .getResponse();
+        if (response == null) {
+            return null;
+        }
         if (response.getStatus() != EmberStatus.EMBER_SUCCESS) {
             logger.debug("Error request route table entry: {}", response);
             return null;
@@ -865,7 +940,7 @@ public class EmberNcp {
                 new EzspSingleResponseTransaction(request, EzspGetSourceRouteTableEntryResponse.class));
         EzspGetSourceRouteTableEntryResponse response = (EzspGetSourceRouteTableEntryResponse) transaction
                 .getResponse();
-        if (response.getStatus() != EmberStatus.EMBER_SUCCESS) {
+        if (response == null || response.getStatus() != EmberStatus.EMBER_SUCCESS) {
             return null;
         }
         // response.get
@@ -1156,7 +1231,7 @@ public class EmberNcp {
         EzspTransaction transaction = protocolHandler
                 .sendEzspTransaction(new EzspSingleResponseTransaction(request, EzspGetXncpInfoResponse.class));
         EzspGetXncpInfoResponse response = (EzspGetXncpInfoResponse) transaction.getResponse();
-        if (response.getStatus() != EzspStatus.EZSP_SUCCESS) {
+        if (response == null || response.getStatus() != EzspStatus.EZSP_SUCCESS) {
             logger.debug("Error sending xncp info: {}", response);
             return null;
         }
@@ -1175,7 +1250,7 @@ public class EmberNcp {
                 .sendEzspTransaction(new EzspSingleResponseTransaction(request, EzspCustomFrameResponse.class));
         EzspCustomFrameResponse response = (EzspCustomFrameResponse) transaction.getResponse();
         lastStatus = response.getStatus();
-        if (response.getStatus() != EmberStatus.EMBER_SUCCESS) {
+        if (response == null || response.getStatus() != EmberStatus.EMBER_SUCCESS) {
             logger.debug("Error sending custom frame: {}", response);
             return null;
         }
@@ -1215,6 +1290,9 @@ public class EmberNcp {
                         new EzspSingleResponseTransaction(request, EzspSendManyToOneRouteRequestResponse.class));
         EzspSendManyToOneRouteRequestResponse response = (EzspSendManyToOneRouteRequestResponse) transaction
                 .getResponse();
+        if (response == null) {
+            return EmberStatus.UNKNOWN;
+        }
         return response.getStatus();
     }
 
@@ -1230,6 +1308,9 @@ public class EmberNcp {
                         new EzspSingleResponseTransaction(request, EzspResetToFactoryDefaultsResponse.class));
         EzspResetToFactoryDefaultsResponse response = (EzspResetToFactoryDefaultsResponse) transaction
                 .getResponse();
+        if (response == null) {
+            return EzspStatus.UNKNOWN;
+        }
         return response.getStatus();
     }
 
@@ -1255,6 +1336,9 @@ public class EmberNcp {
         EzspTransaction transaction = protocolHandler
                 .sendEzspTransaction(new EzspSingleResponseTransaction(request, EzspGetMfgTokenResponse.class));
         EzspGetMfgTokenResponse response = (EzspGetMfgTokenResponse) transaction.getResponse();
+        if (response == null) {
+            return null;
+        }
         return response.getTokenData();
     }
 
@@ -1272,6 +1356,9 @@ public class EmberNcp {
         EzspTransaction transaction = protocolHandler
                 .sendEzspTransaction(new EzspSingleResponseTransaction(request, EzspSetMfgTokenResponse.class));
         EzspSetMfgTokenResponse response = (EzspSetMfgTokenResponse) transaction.getResponse();
+        if (response == null) {
+            return EmberStatus.UNKNOWN;
+        }
         return response.getStatus();
     }
 
@@ -1292,6 +1379,9 @@ public class EmberNcp {
         EzspTransaction transaction = protocolHandler
                 .sendEzspTransaction(new EzspSingleResponseTransaction(request, EzspSetRadioChannelResponse.class));
         EzspSetRadioChannelResponse response = (EzspSetRadioChannelResponse) transaction.getResponse();
+        if (response == null) {
+            return EmberStatus.UNKNOWN;
+        }
         return response.getStatus();
     }
 
@@ -1309,7 +1399,7 @@ public class EmberNcp {
 
         EzspGetMulticastTableEntryResponse response = (EzspGetMulticastTableEntryResponse) transaction.getResponse();
 
-        if (response.getStatus() != EmberStatus.EMBER_SUCCESS) {
+        if (response == null || response.getStatus() != EmberStatus.EMBER_SUCCESS) {
             logger.debug("Error request multicast table entry: {}", response);
             return null;
         }
@@ -1330,6 +1420,9 @@ public class EmberNcp {
                 .sendEzspTransaction(
                         new EzspSingleResponseTransaction(request, EzspSetMulticastTableEntryResponse.class));
         EzspSetMulticastTableEntryResponse response = (EzspSetMulticastTableEntryResponse) transaction.getResponse();
+        if (response == null) {
+            return EmberStatus.UNKNOWN;
+        }
         return response.getStatus();
     }
 
@@ -1351,6 +1444,9 @@ public class EmberNcp {
                         new EzspSingleResponseTransaction(request, EzspAddressTableEntryIsActiveResponse.class));
         EzspAddressTableEntryIsActiveResponse response = (EzspAddressTableEntryIsActiveResponse) transaction
                 .getResponse();
+        if (response == null) {
+            return false;
+        }
         return response.getActive();
 
     }

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/ash/AshFrameHandler.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/ash/AshFrameHandler.java
@@ -397,6 +397,9 @@ public class AshFrameHandler implements EzspProtocolHandler {
                     logger.trace("ASH took EZSP frame from receive queue. Queue length {}", recvQueue.size());
                     notifyTransactionComplete(ezspFrame);
                     frameHandler.handlePacket(ezspFrame);
+                } catch (final InterruptedException e) {
+                    logger.debug("AshFrameHandler InterruptedException processing EZSP frame");
+                    break;
                 } catch (final Exception e) {
                     logger.error("AshFrameHandler Exception processing EZSP frame: ", e);
                 }
@@ -565,7 +568,7 @@ public class AshFrameHandler implements EzspProtocolHandler {
 
         // Send the data
         int[] outputBuffer = ashFrame.getOutputBuffer();
-        if(logger.isTraceEnabled()) {
+        if (logger.isTraceEnabled()) {
             for (int val : outputBuffer) {
                 logger.trace("ASH TX: {}", String.format("%02X", val));
             }


### PR DESCRIPTION
This adds null return checks in `EmberNcp` class. This can happen on error - eg if the frame handler gets closed. Probably this will just propagate the error to the next level in many cases but at least we can look to resolve any further issues.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>