### PR TITLE
Add ZigBeeUtcTime class and client/server

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ Currently implemented extensions include -:
 - IAS CIE client (`ZigBeeIasCieExtension`)
 - OTA Upgrade Server (`ZigBeeOtaUpgradeExtension`)
 - Basic Cluster Server (`ZigBeeBasicServerExtension`)
+- Time management (`ZigBeeTimeExtension`)
 
 These provide basic functionality and can be extended as required to meet the application needs.
 

--- a/com.zsmartsystems.zigbee.autocode/src/main/java/com/zsmartsystems/zigbee/autocode/ZclDataType.java
+++ b/com.zsmartsystems.zigbee.autocode/src/main/java/com/zsmartsystems/zigbee/autocode/ZclDataType.java
@@ -111,7 +111,7 @@ public class ZclDataType {
         dataTypeMapping.put("CHARACTER_STRING", new DataTypeMap("String", 0x42, -1, false));
         dataTypeMapping.put("LONG_OCTET_STRING", new DataTypeMap("ByteArray", 0x43, -1, false));
         dataTypeMapping.put("LONG_CHARACTER_STRING", new DataTypeMap("String", 0x44, -1, false));
-        dataTypeMapping.put("UTCTIME", new DataTypeMap("Calendar", 0xe2, 4, true, 0xffffffff));
+        dataTypeMapping.put("UTCTIME", new DataTypeMap("ZigBeeUtcTime", 0xe2, 4, true, 0xffffffff));
         dataTypeMapping.put("ZDO_STATUS", new DataTypeMap("ZdoStatus", 0, 0, false));
         dataTypeMapping.put("ZCL_STATUS", new DataTypeMap("ZclStatus", 0, 0, false));
         dataTypeMapping.put("ZIGBEE_DATA_TYPE", new DataTypeMap("ZclDataType", 0, 0, false));

--- a/com.zsmartsystems.zigbee.autocode/src/main/resources/000A_Time.xml
+++ b/com.zsmartsystems.zigbee.autocode/src/main/resources/000A_Time.xml
@@ -24,7 +24,6 @@
         <description>The DstEnd attribute indicates the DST end time in seconds. The value 0xffffffff indicates an invalid DST end time.</description>
         <description>Note that the three attributes DstStart, DstEnd and DstShift are optional, but if any one of them is implemented the other two must also be implemented. Note that this attribute should be set to a new value once every year.</description>
         <description>Note that this attribute should be set to a new value once every year, and should be written synchronously with the DstStart attribute. The DstEnd attribute indicates the DST end time in seconds. The value 0xffffffff indicates an invalid DST end time.</description>
-        <description>Note that this attribute should be set to a new value once every year, and should be written synchronously with the DstStart attribute</description>
     </attribute>
     <attribute code="0x0005" type="SIGNED_32_BIT_INTEGER" side="server" optional="true" writable="true" reportable="false">
         <name>DST Shift</name>

--- a/com.zsmartsystems.zigbee.console.main/src/main/java/com/zsmartsystems/zigbee/console/main/ZigBeeConsole.java
+++ b/com.zsmartsystems.zigbee.console.main/src/main/java/com/zsmartsystems/zigbee/console/main/ZigBeeConsole.java
@@ -76,6 +76,7 @@ import com.zsmartsystems.zigbee.console.ZigBeeConsoleSmartEnergyCommand;
 import com.zsmartsystems.zigbee.console.ZigBeeConsoleSwitchLevelCommand;
 import com.zsmartsystems.zigbee.console.ZigBeeConsoleSwitchOffCommand;
 import com.zsmartsystems.zigbee.console.ZigBeeConsoleSwitchOnCommand;
+import com.zsmartsystems.zigbee.console.ZigBeeConsoleTimeCommand;
 import com.zsmartsystems.zigbee.console.ZigBeeConsoleTrustCentreCommand;
 import com.zsmartsystems.zigbee.console.ZigBeeConsoleUnbindCommand;
 import com.zsmartsystems.zigbee.console.ZigBeeConsoleWindowCoveringCommand;
@@ -204,6 +205,7 @@ public final class ZigBeeConsole {
 
         newCommands.put("otaupgrade", new ZigBeeConsoleOtaUpgradeCommand());
         newCommands.put("channel", new ZigBeeConsoleChannelCommand());
+        newCommands.put("time", new ZigBeeConsoleTimeCommand());
 
         newCommands.put("smartenergy", new ZigBeeConsoleSmartEnergyCommand());
         newCommands.put("cbke", new ZigBeeConsoleCbkeCommand());

--- a/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleCommand.java
+++ b/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleCommand.java
@@ -54,11 +54,11 @@ public interface ZigBeeConsoleCommand {
      * @param args the command arguments. arg[0] is the command
      * @param out the output PrintStream
      * @return true if the command executed successfully
-     * @throws IllegalArgumentException if any commands are incorrectly formatted, or the incorrect number of commands
-     *             are provided
-     * @throws IllegalStateException if the network is not in a state that allows the command to be executed
-     * @throws InterruptedException if the command was interrupted
-     * @throws ExecutionException if the command failed
+     * @throws {@link IllegalArgumentException} if any commands are incorrectly formatted, or the incorrect number of
+     *             commands are provided
+     * @throws {@link IllegalStateException} if the network is not in a state that allows the command to be executed
+     * @throws {@link InterruptedException} if the command was interrupted
+     * @throws {@link ExecutionException} if the command failed
      */
     public void process(final ZigBeeNetworkManager networkManager, final String[] args, PrintStream out)
             throws IllegalArgumentException, IllegalStateException, ExecutionException, InterruptedException;

--- a/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleSmartEnergyCommand.java
+++ b/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleSmartEnergyCommand.java
@@ -8,7 +8,6 @@
 package com.zsmartsystems.zigbee.console;
 
 import java.io.PrintStream;
-import java.util.Calendar;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
@@ -20,9 +19,15 @@ import com.zsmartsystems.zigbee.app.seclient.SmartEnergyClient;
 import com.zsmartsystems.zigbee.security.ZigBeeCbkeProvider;
 import com.zsmartsystems.zigbee.zcl.clusters.ZclMeteringCluster;
 import com.zsmartsystems.zigbee.zcl.clusters.ZclPriceCluster;
-import com.zsmartsystems.zigbee.zcl.clusters.metering.*;
+import com.zsmartsystems.zigbee.zcl.clusters.metering.GetProfile;
+import com.zsmartsystems.zigbee.zcl.clusters.metering.GetProfileResponse;
+import com.zsmartsystems.zigbee.zcl.clusters.metering.GetProfileStatusEnum;
+import com.zsmartsystems.zigbee.zcl.clusters.metering.IntervalPeriodEnum;
+import com.zsmartsystems.zigbee.zcl.clusters.metering.RequestFastPollMode;
+import com.zsmartsystems.zigbee.zcl.clusters.metering.RequestFastPollModeResponse;
 import com.zsmartsystems.zigbee.zcl.clusters.price.GetCurrentPriceCommand;
 import com.zsmartsystems.zigbee.zcl.clusters.price.PublishPriceCommand;
+import com.zsmartsystems.zigbee.zcl.field.ZigBeeUtcTime;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclClusterType;
 
 /**
@@ -126,7 +131,7 @@ public class ZigBeeConsoleSmartEnergyCommand extends ZigBeeConsoleAbstractComman
 
         try {
             for (int cnt = 0; cnt < repeatCycles; cnt++) {
-                CommandResult result = cluster.sendCommand(new GetProfile(0, Calendar.getInstance(), 1)).get();
+                CommandResult result = cluster.sendCommand(new GetProfile(0, ZigBeeUtcTime.now(), 1)).get();
                 GetProfileResponse response = (GetProfileResponse) result.getResponse();
                 if (response.getStatus() != 0) {
                     out.println(

--- a/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleTimeCommand.java
+++ b/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleTimeCommand.java
@@ -1,0 +1,174 @@
+/**
+ * Copyright (c) 2016-2023 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.console;
+
+import java.io.PrintStream;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.concurrent.ExecutionException;
+
+import com.zsmartsystems.zigbee.ZigBeeEndpoint;
+import com.zsmartsystems.zigbee.ZigBeeEndpointAddress;
+import com.zsmartsystems.zigbee.ZigBeeNetworkManager;
+import com.zsmartsystems.zigbee.app.time.ZclTimeClient;
+import com.zsmartsystems.zigbee.app.time.ZigBeeTimeExtension;
+import com.zsmartsystems.zigbee.zcl.field.ZigBeeUtcTime;
+
+/**
+ * Provides information about time servers on the network
+ *
+ * @author Chris Jackson
+ *
+ */
+public class ZigBeeConsoleTimeCommand extends ZigBeeConsoleAbstractCommand {
+    private static final String NOT_SET = "Not Set";
+    private static final String SECONDS = " seconds";
+    private static final String MINUTES = " minutes";
+
+    @Override
+    public String getCommand() {
+        return "time";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Gets information about time servers";
+    }
+
+    @Override
+    public String getSyntax() {
+        return "[MANAGER | ENDPOINT] [POLL | GET | SET] [VALUE]";
+    }
+
+    @Override
+    public String getHelp() {
+        return "";
+    }
+
+    @Override
+    public void process(ZigBeeNetworkManager networkManager, String[] args, PrintStream out)
+            throws IllegalArgumentException, InterruptedException, ExecutionException {
+
+        ZigBeeTimeExtension extension = (ZigBeeTimeExtension) networkManager.getExtension(ZigBeeTimeExtension.class);
+        if (extension == null) {
+            throw new IllegalStateException("Time extension not found");
+        }
+
+        if (args.length == 1) {
+            ZigBeeUtcTime dstStart = extension.getDstStart();
+            ZigBeeUtcTime dstEnd = extension.getDstEnd();
+
+            out.println("Current Time : " + ZigBeeUtcTime.now().toString());
+            out.println("DST Start    : " + ((dstStart == null) ? NOT_SET : dstStart.toString()));
+            out.println("DST Finish   : " + ((dstEnd == null) ? NOT_SET : dstEnd.toString()));
+            out.println("DST Offset   : " + extension.getDstOffset() / 60 + MINUTES);
+            out.println("Update delta : " + extension.getUpdateDelta() + SECONDS);
+            out.println("Poll period  : " + extension.getPollPeriod() + SECONDS);
+            out.println("Master       : " + extension.isMaster());
+            out.println("Superceding  : " + extension.isSuperceding());
+            out.println();
+            showClient(out, extension);
+            return;
+        }
+
+        if (args[1].equalsIgnoreCase("manager")) {
+            processManagerOptions(extension, args, out);
+            return;
+        }
+
+        final ZigBeeEndpoint endpoint = getEndpoint(networkManager, args[1]);
+
+        if (args.length == 2) {
+            return;
+        }
+
+        final ZclTimeClient client = extension.getTimeClient(endpoint.getEndpointAddress());
+        if (client == null) {
+            throw new IllegalStateException(
+                    "Time client not found for endpoint " + endpoint.getEndpointAddress().toString());
+        }
+
+        switch (args[2].toLowerCase()) {
+            case "set":
+                break;
+            case "get":
+                break;
+            default:
+                throw new IllegalArgumentException("Unknown endpoint command option " + args[2]);
+        }
+    }
+
+    private void processManagerOptions(ZigBeeTimeExtension extension, String[] args, PrintStream out) {
+        if (args.length < 4) {
+            throw new IllegalArgumentException("Invalid number of arguments");
+        }
+
+        switch (args[2].toLowerCase()) {
+            case "set":
+                processManagerSettings(extension, args, out);
+                break;
+            default:
+                throw new IllegalArgumentException("Unknown manager command option " + args[2]);
+        }
+    }
+
+    private void processManagerSettings(ZigBeeTimeExtension extension, String[] args, PrintStream out) {
+        if (args.length < 5) {
+            throw new IllegalArgumentException("Invalid number of arguments");
+        }
+
+        switch (args[3].toLowerCase()) {
+            case "poll":
+                extension.setPollPeriod(parseInteger(args[4]));
+                out.println("Time manager poll period set to " + extension.getPollPeriod() + SECONDS);
+                break;
+            case "delta":
+                extension.setUpdateDelta(parseInteger(args[4]));
+                out.println("Time manager update delta set to " + extension.getUpdateDelta() + SECONDS);
+                break;
+            case "master":
+                extension.setMaster(Boolean.parseBoolean(args[4]));
+                out.println("Time manager set master clock source to " + extension.isMaster());
+                break;
+            case "superceding":
+                extension.setSuperceding(Boolean.parseBoolean(args[4]));
+                out.println("Time manager set superceding clock source to " + extension.isSuperceding());
+                break;
+            default:
+                throw new IllegalArgumentException("Unknown manager setting option " + args[2]);
+        }
+    }
+
+    private void showClient(PrintStream out, ZigBeeTimeExtension extension) {
+        Map<ZigBeeEndpointAddress, ZclTimeClient> clients = new TreeMap<>();
+
+        // Provide a sorted output, sorted by address
+        for (ZclTimeClient client : extension.getTimeClients()) {
+            clients.put(client.getZigBeeAddress(), client);
+        }
+
+        out.println(
+                "Address    Last Poll             Dif  Last Update           By      Delta  s/24hr  Valid Until           DST Set  Synced  Master  Master-DST  Superceded");
+
+        for (ZclTimeClient client : clients.values()) {
+            ZigBeeUtcTime lastRequestedTime = client.getLastRequestedTime();
+            ZigBeeUtcTime lastUpdateTime = extension.getLastUpdateTime(client.getZigBeeAddress());
+            ZigBeeUtcTime validUntil = client.getValidUntil();
+            out.println(String.format(
+                    "%-9s  %-20s  %3s  %-20s  %-6s  % 2dsec  %+6.1f  %-20s  %-5b    %-5b   %-5b   %-5b       %-5b",
+                    client.getZigBeeAddress().toString(),
+                    ((lastRequestedTime == null) ? NOT_SET : lastRequestedTime.toString()),
+                    ((lastRequestedTime == null) ? "" : Integer.toString(client.getCurrentDelta())),
+                    ((lastUpdateTime == null) ? NOT_SET : lastUpdateTime.toString()),
+                    extension.getLastUpdateMethod(client.getZigBeeAddress()).toString(), client.getLastDelta(),
+                    client.getDailyDriftRate(), ((validUntil == null) ? NOT_SET : validUntil.toString()),
+                    client.isDstSet(), client.isRemoteSynchronized(), client.isRemoteMaster(),
+                    client.isRemoteMasterDst(), client.isRemoteSuperceding()));
+        }
+    }
+}

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/time/ZclTimeClient.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/time/ZclTimeClient.java
@@ -1,0 +1,408 @@
+/**
+ * Copyright (c) 2016-2023 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.app.time;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.concurrent.ExecutionException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.zsmartsystems.zigbee.CommandResult;
+import com.zsmartsystems.zigbee.ZigBeeEndpointAddress;
+import com.zsmartsystems.zigbee.zcl.clusters.ZclTimeCluster;
+import com.zsmartsystems.zigbee.zcl.clusters.time.TimeStatusBitmap;
+import com.zsmartsystems.zigbee.zcl.field.ZigBeeUtcTime;
+
+/**
+ * Time client used to set the time on a time server.
+ * <p>
+ * This class provides methods used by the {@link ZigBeeTimeExtension} to maintain the remote device clock.
+ * {@link #doPoll()} is used to periodically get the remote time in order to observe the remote clock, and
+ * {@link #doUpdate()} is used to set the remote clock.
+ * <p>
+ * This class will attempt to calculate the drift rate of the clock on the remote device, and will estimate the time at
+ * which the clock will be out of specification.
+ *
+ * @author Chris Jackson
+ *
+ */
+public class ZclTimeClient {
+    /**
+     * The {@link Logger}.
+     */
+    private final Logger logger = LoggerFactory.getLogger(ZclTimeClient.class);
+
+    /**
+     * Don't use interval data of less than MINIMUM_USABLE_DELTA_DURATION seconds in the drift calculation unless the
+     * drift is above MINIMUM_USABLE_DELTA_DRIFT seconds.
+     */
+    private final static int MINIMUM_USABLE_DELTA_DURATION = 1800;
+
+    /**
+     * Don't use interval data of less than MINIMUM_USABLE_DELTA_DURATION seconds in the drift calculation unless the
+     * drift is above MINIMUM_USABLE_DELTA_DRIFT seconds.
+     */
+    private final static int MINIMUM_USABLE_DELTA_DRIFT = 10;
+
+    /**
+     * The time cluster linked to the remote server
+     */
+    private final ZclTimeCluster timeCluster;
+
+    private ZigBeeUtcTime dstStart;
+    private ZigBeeUtcTime dstEnd;
+    private int dstOffset;
+
+    /**
+     * Calculation of the daily drift rate. This is updated following each time set or poll.
+     */
+    private double dailyDriftRate;
+
+    /**
+     * The local time we last synchronised the remote
+     */
+    private ZigBeeUtcTime lastUpdate;
+
+    private Integer lastStatus = Integer.valueOf(0);
+    private final Set<TimeStatusBitmap> statusBitmap = new HashSet<>();
+
+    /**
+     * The local time we last read the remote time
+     */
+    private ZigBeeUtcTime lastRequestedTime;
+
+    /**
+     * The time the remote device last set its time - as reported by the remote
+     */
+    private ZigBeeUtcTime lastSetTime;
+
+    /**
+     * The number of seconds difference between the remote and local times at the last time sync
+     */
+    private int lastTimeDelta = 0;
+
+    /**
+     * The number of seconds difference between the remote and local times at the last poll
+     */
+    private int currentTimeDelta = 0;
+
+    /**
+     * Flag that denotes if we need to update the daylight savings configuration.
+     * This is set to false if the DST data is updated,
+     * and then set to true when the remote is configured with this data.
+     */
+    private boolean dstUpdated = true;
+
+    /**
+     * A map used to calculate the remote clock drift. We save subsequent updates into this map so we don't have to work
+     * just with the current time which only has a precision of 1 second. This would make 24hr drift calculations very
+     * inaccurate over short intervals.
+     */
+    private final Map<ZigBeeUtcTime, ZigBeeUtcTime> driftMap = new TreeMap<>();
+
+    protected ZclTimeClient(ZclTimeCluster timeCluster) {
+        this.timeCluster = timeCluster;
+    }
+
+    /**
+     * Set the daylight savings time parameters, including the start and end of daylight saving, and the offset. This
+     * will be passed on to all remote nodes at the next update.
+     *
+     * @param dstStart an {@link ZigBeeUtcTime} defining the time daylight savings time starts
+     * @param dstEnd an {@link ZigBeeUtcTime} defining the time daylight savings time ends
+     * @param dstOffset the number of seconds that daylight savings is adjusted
+     */
+    protected void setDst(ZigBeeUtcTime dstStart, ZigBeeUtcTime dstEnd, int dstOffset) {
+        this.dstStart = dstStart;
+        this.dstEnd = dstEnd;
+        this.dstOffset = dstOffset;
+
+        /**
+         * Remember that we need to update the DST next time we update the time
+         */
+        dstUpdated = false;
+    }
+
+    /**
+     * Gets the current state of the DST setting on the remote device. If the client has set the DST data on the remote
+     * device this will return true.
+     * <p>
+     * This is a client side status as opposed to the {@link #isRemoteMasterDst()} method which is a server side status
+     *
+     * @return true if the DST data has been set by the client on the remote device
+     */
+    public boolean isDstSet() {
+        return dstUpdated;
+    }
+
+    /**
+     * Get the {@link ZigBeeEndpointAddress} for this client
+     *
+     * @return the {@link ZigBeeEndpointAddress} for this client
+     */
+    public ZigBeeEndpointAddress getZigBeeAddress() {
+        return timeCluster.getZigBeeAddress();
+    }
+
+    /**
+     * Reads the current time from the remote device
+     *
+     * @return the {@link ZigBeeUtcTime} from the remote device
+     */
+    public ZigBeeUtcTime getTime() {
+        return timeCluster.getTime(0);
+    }
+
+    /**
+     * Gets the time returned from the device after it is updated
+     *
+     * @return
+     */
+    public ZigBeeUtcTime getLastSetTime() {
+        return lastSetTime;
+    }
+
+    /**
+     * Returns the last update {@link ZigBeeUtcTime} that the client last completed the time synchronisation
+     *
+     * @return the last update {@link ZigBeeUtcTime} that the client last completed the time synchronisation
+     */
+    public ZigBeeUtcTime getLastUpdate() {
+        return lastUpdate;
+    }
+
+    /**
+     * Returns the last {@link ZigBeeUtcTime} that the client last requested the remote time.
+     *
+     * @return the last {@link ZigBeeUtcTime} that the client last requested the remote time, or null if the time has
+     *         never
+     *         been requested
+     */
+    public ZigBeeUtcTime getLastRequestedTime() {
+        return lastRequestedTime;
+    }
+
+    /**
+     * Gets the number of seconds difference between local time and remote time at the point the time was last set on
+     * the remote.
+     *
+     * @return remote time difference when the time was last updated
+     */
+    public int getLastDelta() {
+        return lastTimeDelta;
+    }
+
+    /**
+     * Gets the number of seconds difference between local time and remote time at the last poll
+     *
+     * @return remote time difference when the time was last polled
+     */
+    public int getCurrentDelta() {
+        return currentTimeDelta;
+    }
+
+    /**
+     * Gets the time up until when we have calculated the remote device clock will remain valid.
+     *
+     * @return {@link ZigBeeUtcTime} defining the time we expect the clock will drift out of spec
+     */
+    public ZigBeeUtcTime getValidUntil() {
+        return null;
+    }
+
+    /**
+     * Returns true if the remote device time is synchronised
+     *
+     * @return true if the remote device time is synchronised
+     */
+    public boolean isRemoteSynchronized() {
+        return statusBitmap.contains(TimeStatusBitmap.SYNCHRONIZED);
+    }
+
+    /**
+     * Returns true if the remote device is a master time server
+     *
+     * @return true if the remote device is a master time server
+     */
+    public boolean isRemoteMaster() {
+        return statusBitmap.contains(TimeStatusBitmap.MASTER);
+    }
+
+    /**
+     * Returns true if the remote device is a superceding time server
+     *
+     * @return true if the remote device is a superceding time server
+     */
+    public boolean isRemoteSuperceding() {
+        return statusBitmap.contains(TimeStatusBitmap.SUPERSEDING);
+    }
+
+    /**
+     * Returns true if the remote device is synchronised to the time server for DST configuration
+     *
+     * @return true if the remote device is synchronised to the time server for DST configuration
+     */
+    public boolean isRemoteMasterDst() {
+        return statusBitmap.contains(TimeStatusBitmap.MASTER_ZONE_DST);
+    }
+
+    /**
+     * Gets the approximate drift rate of the remote device over a 24 hour period. This is the number of seconds the
+     * time would drift on the remote device if it was not updated.
+     *
+     * @return the 24 hour drift rate, in seconds, of the remote device.
+     */
+    public double getDailyDriftRate() {
+        return dailyDriftRate;
+    }
+
+    /**
+     * Performs a poll on the remote device to get the current time delta.
+     * <p>
+     * Note that this method will block and is intended to be run within a worker thread.
+     *
+     * @return true if the poll was performed successfully
+     */
+    protected boolean doPoll() {
+        logger.debug("{}: Time client: poll start", timeCluster.getZigBeeAddress());
+        ZigBeeUtcTime currentTime = timeCluster.getTime(0);
+        if (currentTime == null) {
+            logger.debug("{}: Time client: poll failed getting time", timeCluster.getZigBeeAddress());
+            return false;
+        }
+        lastRequestedTime = ZigBeeUtcTime.now();
+
+        currentTimeDelta = (int) (lastRequestedTime.getEpochSecond() - currentTime.getEpochSecond());
+
+        // If we have no records in the drift map, then add this as a baseline
+        if (driftMap.isEmpty()) {
+            driftMap.put(lastRequestedTime, currentTime);
+        } else {
+            updateDrift(ZigBeeUtcTime.now(), currentTime);
+        }
+
+        updateStatus();
+
+        logger.debug("{}: Time client: poll complete. Delta {} seconds.", timeCluster.getZigBeeAddress(),
+                currentTimeDelta);
+        return true;
+    }
+
+    /**
+     * Performs a time synchronisation on the remote device.
+     * <p>
+     * Note that this method will block and is intended to be run within a worker thread.
+     *
+     * @return true if the time was set successfully
+     * @throws ExecutionException
+     * @throws InterruptedException
+     */
+    protected boolean doUpdate() throws InterruptedException, ExecutionException {
+        logger.debug("{}: Time client: synchronisation start", timeCluster.getZigBeeAddress());
+
+        ZigBeeUtcTime currentTime = timeCluster.getTime(0);
+        if (currentTime == null) {
+            logger.debug("{}: Time client: synchronisation failed getting time", timeCluster.getZigBeeAddress());
+            return false;
+        }
+        lastRequestedTime = ZigBeeUtcTime.now();
+
+        lastTimeDelta = (int) (lastRequestedTime.getEpochSecond() - currentTime.getEpochSecond());
+
+        CommandResult result = timeCluster.setTime(ZigBeeUtcTime.now()).get();
+        if (!result.isSuccess()) {
+            logger.debug("{}: Time client: synchronisation failed setting time", timeCluster.getZigBeeAddress());
+            return false;
+        }
+        updateDrift(lastRequestedTime, currentTime);
+        lastUpdate = ZigBeeUtcTime.now();
+        driftMap.put(lastUpdate, currentTime);
+
+        // Set the synchronised bit in the remote time status attribute
+        timeCluster.setTimeStatus(TimeStatusBitmap.SYNCHRONIZED.getKey());
+
+        updateStatus();
+
+        // Has DST data been updated since we last set the time?
+        if (!dstUpdated) {
+            timeCluster.setDstStart(dstStart);
+            timeCluster.setDstEnd(dstEnd);
+            timeCluster.setDstShift(dstOffset);
+            dstUpdated = true;
+        }
+        lastSetTime = timeCluster.getLastSetTime(0);
+
+        // Do a poll to update our knowledge
+        // TODO: Some devices don't actually seem to update their clock.
+        // We could check here to see if the delta has changed.
+        currentTime = timeCluster.getTime(0);
+        if (currentTime == null) {
+            logger.debug("{}: Time client: poll failed getting time", timeCluster.getZigBeeAddress());
+            return false;
+        }
+        lastRequestedTime = ZigBeeUtcTime.now();
+        currentTimeDelta = (int) (lastRequestedTime.getEpochSecond() - currentTime.getEpochSecond());
+
+        // TODO: Set the ValidUntilTime attribute based on the calculated drift, plus margin
+
+        logger.debug("{}: Time client: synchronisation complete. Delta {} seconds.", timeCluster.getZigBeeAddress(),
+                currentTimeDelta);
+        return true;
+    }
+
+    private void updateStatus() {
+        lastStatus = timeCluster.getTimeStatus(0);
+        synchronized (statusBitmap) {
+            statusBitmap.clear();
+            for (TimeStatusBitmap bitmap : TimeStatusBitmap.values()) {
+                if ((lastStatus & bitmap.getKey()) != 0) {
+                    statusBitmap.add(bitmap);
+                }
+            }
+        }
+    }
+
+    private void updateDrift(ZigBeeUtcTime lastLocalTime, ZigBeeUtcTime lastRemoteTime) {
+        double duration = 0;
+        double drift = 0;
+        boolean first = true;
+        ZigBeeUtcTime lastSet = null;
+        ZigBeeUtcTime lastTime = null;
+        for (Entry<ZigBeeUtcTime, ZigBeeUtcTime> driftSet : driftMap.entrySet()) {
+            if (first) {
+                lastSet = driftSet.getKey();
+                lastTime = driftSet.getValue();
+                continue;
+            }
+
+            int deltaDuration = (int) (driftSet.getKey().getEpochSecond() - lastSet.getEpochSecond());
+            int deltaDrift = (int) (driftSet.getValue().getEpochSecond() - lastTime.getEpochSecond());
+            if (deltaDuration > MINIMUM_USABLE_DELTA_DURATION || deltaDrift > MINIMUM_USABLE_DELTA_DRIFT) {
+                duration += deltaDuration;
+                drift += deltaDrift;
+            }
+
+            lastSet = driftSet.getKey();
+            lastTime = driftSet.getValue();
+        }
+
+        int deltaDuration = (int) (lastLocalTime.getEpochSecond() - lastSet.getEpochSecond());
+        int deltaDrift = (int) (lastRemoteTime.getEpochSecond() - lastTime.getEpochSecond());
+        if (deltaDuration > MINIMUM_USABLE_DELTA_DURATION || deltaDrift > MINIMUM_USABLE_DELTA_DRIFT) {
+            duration += deltaDuration;
+            drift += deltaDrift;
+        }
+
+        dailyDriftRate = (drift / duration * 86400.0) - 86400.0;
+    }
+}

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/time/ZclTimeServer.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/time/ZclTimeServer.java
@@ -1,0 +1,221 @@
+/**
+ * Copyright (c) 2016-2023 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.app.time;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.zsmartsystems.zigbee.ZigBeeCommand;
+import com.zsmartsystems.zigbee.ZigBeeCommandListener;
+import com.zsmartsystems.zigbee.ZigBeeNetworkManager;
+import com.zsmartsystems.zigbee.zcl.ZclStatus;
+import com.zsmartsystems.zigbee.zcl.clusters.ZclTimeCluster;
+import com.zsmartsystems.zigbee.zcl.clusters.general.ReadAttributesCommand;
+import com.zsmartsystems.zigbee.zcl.clusters.general.ReadAttributesResponse;
+import com.zsmartsystems.zigbee.zcl.clusters.time.TimeStatusBitmap;
+import com.zsmartsystems.zigbee.zcl.field.ReadAttributeStatusRecord;
+import com.zsmartsystems.zigbee.zcl.field.ZigBeeUtcTime;
+import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
+import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
+
+/**
+ * Local time server. This allows any clients on the network to read time as required.
+ *
+ * @author Chris Jackson
+ *
+ */
+public class ZclTimeServer implements ZigBeeCommandListener {
+    /**
+     * The {@link Logger}.
+     */
+    private final Logger logger = LoggerFactory.getLogger(ZclTimeServer.class);
+
+    /**
+     * True if we are a time master server on the network
+     */
+    private boolean master = true;
+
+    /**
+     * True if we are a superceding time server on the network
+     */
+    private boolean superceding = true;
+
+    private ZigBeeUtcTime dstStart;
+    private ZigBeeUtcTime dstEnd;
+    private int dstOffset;
+    private boolean dstSet = false;
+
+    private final ZigBeeNetworkManager networkManager;
+
+    /**
+     * Map holding the last update times for each remote
+     */
+    private final Map<Integer, ZigBeeUtcTime> lastUpdate = new HashMap<>();
+
+    protected ZclTimeServer(ZigBeeNetworkManager networkManager) {
+        this.networkManager = networkManager;
+        networkManager.addCommandListener(this);
+
+        // Report that we support this cluster
+        networkManager.addSupportedClientCluster(ZclTimeCluster.CLUSTER_ID);
+    }
+
+    /**
+     * Shuts down the time server and frees any resources
+     */
+    protected void shutdown() {
+        networkManager.removeCommandListener(this);
+    }
+
+    /**
+     * Gets the time the server last set the time on the requested client
+     *
+     * @param address the address of the remote client
+     * @return the {@link ZigBeeUtcTime} the time was last provided to the client, or null if it has not been set.
+     */
+    public ZigBeeUtcTime getLastUpdateTime(int address) {
+        return lastUpdate.get(address);
+    }
+
+    /**
+     * Enables or disables the master flag. When set, we publish that our server is internally set to a time standard.
+     *
+     * @param master true if this is a master clock source.
+     */
+    protected void setMaster(boolean master) {
+        this.master = master;
+    }
+
+    /**
+     * Returns true if the server is a master clock source.
+     *
+     * @return true if the server is a master clock source.
+     */
+    protected boolean isMaster() {
+        return master;
+    }
+
+    /**
+     * Enables or disables the superceding flag. When set, we publish that our server is superceding other masters.
+     *
+     * @param master true if this is a master clock source.
+     */
+
+    protected void setSuperceding(boolean superceding) {
+        this.superceding = superceding;
+    }
+
+    /**
+     * Returns true of the server is marked as a superceding server.
+     *
+     * @return true of the server is marked as a superceding server.
+     */
+    protected boolean isSuperceding() {
+        return superceding;
+    }
+
+    /**
+     * Set the daylight savings time parameters, including the start and end of daylight saving, and the offset. This
+     * will be passed on to all remote nodes at the next update.
+     *
+     * @param dstStart an {@link ZigBeeUtcTime} defining the time daylight savings time starts
+     * @param dstEnd an {@link ZigBeeUtcTime} defining the time daylight savings time ends
+     * @param dstOffset the number of seconds that daylight savings is adjusted
+     */
+    protected void setDst(ZigBeeUtcTime dstStart, ZigBeeUtcTime dstEnd, int dstOffset) {
+        this.dstStart = dstStart;
+        this.dstEnd = dstEnd;
+        this.dstOffset = dstOffset;
+        dstSet = true;
+    }
+
+    @Override
+    public void commandReceived(ZigBeeCommand command) {
+        if (command.getClusterId() != ZclTimeCluster.CLUSTER_ID) {
+            // TODO: This should check the message is addressed to the local NWK address
+            return;
+        }
+
+        if (command instanceof ReadAttributesCommand) {
+            ReadAttributesCommand readRequest = (ReadAttributesCommand) command;
+            if (readRequest.getCommandDirection() != ZclCommandDirection.CLIENT_TO_SERVER) {
+                return;
+            }
+
+            List<ReadAttributeStatusRecord> records = new ArrayList<>();
+            for (Integer attributeId : readRequest.getIdentifiers()) {
+                ReadAttributeStatusRecord record = new ReadAttributeStatusRecord();
+                record.setAttributeIdentifier(attributeId);
+                switch (attributeId) {
+                    case ZclTimeCluster.ATTR_TIMESTATUS:
+                        int status = TimeStatusBitmap.SYNCHRONIZED.getKey();
+                        status |= master ? TimeStatusBitmap.MASTER.getKey() : 0x0;
+                        status |= superceding ? TimeStatusBitmap.SUPERSEDING.getKey() : 0x0;
+                        status |= dstSet ? TimeStatusBitmap.MASTER_ZONE_DST.getKey() : 0x0;
+                        record.setAttributeDataType(ZclDataType.BITMAP_8_BIT);
+                        record.setAttributeValue(status);
+                        break;
+                    case ZclTimeCluster.ATTR_DSTSTART:
+                        record.setAttributeDataType(ZclDataType.UTCTIME);
+                        record.setAttributeValue(dstStart);
+                        break;
+                    case ZclTimeCluster.ATTR_DSTEND:
+                        record.setAttributeDataType(ZclDataType.UTCTIME);
+                        record.setAttributeValue(dstEnd);
+                        break;
+                    case ZclTimeCluster.ATTR_DSTSHIFT:
+                        record.setAttributeDataType(ZclDataType.SIGNED_32_BIT_INTEGER);
+                        record.setAttributeValue(dstOffset);
+                        break;
+                    case ZclTimeCluster.ATTR_TIME:
+                        record.setAttributeDataType(ZclDataType.UTCTIME);
+                        record.setAttributeValue(ZigBeeUtcTime.now());
+                        lastUpdate.put(command.getSourceAddress().getAddress(), ZigBeeUtcTime.now());
+                        break;
+                    case ZclTimeCluster.ATTR_LASTSETTIME:
+                        record.setAttributeDataType(ZclDataType.UTCTIME);
+                        record.setAttributeValue(ZigBeeUtcTime.now());
+                        break;
+                    case ZclTimeCluster.ATTR_LOCALTIME:
+                    case ZclTimeCluster.ATTR_STANDARDTIME:
+                        record.setAttributeDataType(ZclDataType.UTCTIME);
+                        record.setAttributeValue(ZigBeeUtcTime.now().plus(dstOffset));
+                        lastUpdate.put(command.getSourceAddress().getAddress(), ZigBeeUtcTime.now());
+                        break;
+                    case ZclTimeCluster.ATTR_TIMEZONE:
+                        record.setAttributeDataType(ZclDataType.SIGNED_32_BIT_INTEGER);
+                        record.setAttributeValue(dstOffset);
+                        break;
+                    case ZclTimeCluster.ATTR_VALIDUNTILTIME:
+                        record.setAttributeDataType(ZclDataType.UTCTIME);
+                        record.setAttributeValue(new ZigBeeUtcTime());
+                        break;
+                    default:
+                        record.setStatus(ZclStatus.UNSUPPORTED_ATTRIBUTE);
+                        logger.debug("TIME Server unknown request {} from {}", attributeId, command.getSourceAddress());
+                        break;
+                }
+                records.add(record);
+            }
+
+            ReadAttributesResponse readResponse = new ReadAttributesResponse(records);
+            readResponse.setDestinationAddress(command.getSourceAddress());
+            readResponse.setCommandDirection(ZclCommandDirection.SERVER_TO_CLIENT);
+            readResponse.setClusterId(ZclTimeCluster.CLUSTER_ID);
+            readResponse.setSourceAddress(command.getDestinationAddress());
+            readResponse.setTransactionId(command.getTransactionId());
+
+            networkManager.sendCommand(readResponse);
+        }
+    }
+}

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/time/ZigBeeTimeExtension.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/time/ZigBeeTimeExtension.java
@@ -1,0 +1,421 @@
+/**
+ * Copyright (c) 2016-2023 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.app.time;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ScheduledFuture;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.zsmartsystems.zigbee.ZigBeeEndpoint;
+import com.zsmartsystems.zigbee.ZigBeeEndpointAddress;
+import com.zsmartsystems.zigbee.ZigBeeNetworkManager;
+import com.zsmartsystems.zigbee.ZigBeeNetworkNodeListener;
+import com.zsmartsystems.zigbee.ZigBeeNode;
+import com.zsmartsystems.zigbee.ZigBeeStatus;
+import com.zsmartsystems.zigbee.app.ZigBeeNetworkExtension;
+import com.zsmartsystems.zigbee.zcl.clusters.ZclTimeCluster;
+import com.zsmartsystems.zigbee.zcl.field.ZigBeeUtcTime;
+
+/**
+ * Application to centrally manage the network time. This will keep all times on the network synchronised to the time on
+ * the local computer.
+ * <p>
+ * A single instance of {@link ZclTimeServer} is created to act as a local time server. This server manages requests
+ * from remote clients that may want to update their time.
+ * <p>
+ * An instance of {@link ZclTimeClient} is created for each node on the network that has a time server. The
+ * {@link ZclTimeClient} will periodically poll the time on the remote server, update the time when it is above the
+ * maximum allowed delta. The client will keep track of the time drift seen in a 24 hour period.
+ * <p>
+ * Management of both {@link ZclTimeClient} and {@link ZclTimeServer} are handled through the
+ * {@link ZigBeeTimeExtension}. This class consolidates the client and server requests in the event that a device
+ * supports both, and ensures that time, and time configuration (eg Daylight Saving Time) is managed centrally and
+ * consistently.
+ * <p>
+ * It should be noted that a single thread is used to keep resource usage to a minimum. The updates are therefore
+ * managed directly in the {@link ZigBeeTimeExtension} class.
+ *
+ * @author Chris Jackson
+ *
+ */
+public class ZigBeeTimeExtension implements ZigBeeNetworkExtension, ZigBeeNetworkNodeListener {
+    /**
+     * The {@link Logger}.
+     */
+    private final Logger logger = LoggerFactory.getLogger(ZigBeeTimeExtension.class);
+
+    /**
+     * The default time (in seconds) between each poll of the time on a remote device
+     */
+    private final static int DEFAULT_POLL_PERIOD = 3600;
+
+    private final static long MINIMUM_WORKER_PERIOD = 30;
+
+    private ZigBeeNetworkManager networkManager;
+
+    /**
+     * Our time server that handles any requests from remote clients
+     */
+    private ZclTimeServer timeServer;
+
+    private ZigBeeUtcTime dstStart;
+    private ZigBeeUtcTime dstEnd;
+    private int dstOffset;
+
+    private boolean master = true;
+    private boolean superceding = false;
+
+    /**
+     * The maximum allowed time delta (in seconds) after when the time will be updated by the client.
+     */
+    private int updateDelta = 25;
+
+    /**
+     * The approximate number of seconds between each time request to each remote server. The time is requested
+     * periodically so that the system can ensure it remains within the value set by {@link #setUpdateDelta(int)}.
+     */
+    private int pollPeriod = DEFAULT_POLL_PERIOD;
+
+    /**
+     * The worker thread that is scheduled periodically to check the synchronisation of remote devices
+     */
+    private ScheduledFuture<?> workerJob;
+
+    /**
+     * A map of all the time clients on the network
+     */
+    private final Map<ZigBeeEndpointAddress, ZclTimeClient> timeClients = new ConcurrentHashMap<>();
+
+    @Override
+    public ZigBeeStatus extensionInitialize(ZigBeeNetworkManager networkManager) {
+        this.networkManager = networkManager;
+        networkManager.addSupportedClientCluster(ZclTimeCluster.CLUSTER_ID);
+        networkManager.addNetworkNodeListener(this);
+
+        return ZigBeeStatus.SUCCESS;
+    }
+
+    @Override
+    public ZigBeeStatus extensionStartup() {
+        logger.debug("Time extension: startup");
+
+        timeServer = new ZclTimeServer(networkManager);
+        timeServer.setMaster(master);
+        timeServer.setSuperceding(superceding);
+
+        startWorker();
+        return ZigBeeStatus.SUCCESS;
+    }
+
+    @Override
+    public void extensionShutdown() {
+        networkManager.removeNetworkNodeListener(this);
+
+        if (timeServer != null) {
+            timeServer.shutdown();
+        }
+
+        logger.debug("Time extension: shutdown");
+    }
+
+    /**
+     * Enables or disables the master flag. When set, we publish that our server is internally set to a time standard.
+     *
+     * @param master true if this is a master clock source.
+     */
+    public void setMaster(boolean master) {
+        this.master = master;
+        if (timeServer != null) {
+            timeServer.setMaster(master);
+        }
+    }
+
+    /**
+     * Enables or disables the superceding flag. When set, we publish that our server is superceding other masters.
+     *
+     * @param master true if this is a master clock source.
+     */
+    public void setSuperceding(boolean superceding) {
+        this.superceding = superceding;
+        if (timeServer != null) {
+            timeServer.setSuperceding(superceding);
+        }
+    }
+
+    /**
+     * Returns true if the server is a master clock source.
+     *
+     * @return true if the server is a master clock source.
+     */
+    public boolean isMaster() {
+        return timeServer.isMaster();
+    }
+
+    /**
+     * Returns true of the server is marked as a superceding server.
+     *
+     * @return true of the server is marked as a superceding server.
+     */
+    public boolean isSuperceding() {
+        return timeServer.isSuperceding();
+    }
+
+    /**
+     * Set the daylight savings time parameters, including the start and end of daylight saving, and the offset. This
+     * will be passed on to all remote nodes at the next update.
+     *
+     * @param dstStart an {@link ZigBeeUtcTime} defining the time daylight savings time starts
+     * @param dstEnd an {@link ZigBeeUtcTime} defining the time daylight savings time ends
+     * @param dstOffset the number of seconds that daylight savings is adjusted
+     */
+    public void setDst(ZigBeeUtcTime dstStart, ZigBeeUtcTime dstEnd, int dstOffset) {
+        this.dstStart = dstStart;
+        this.dstEnd = dstEnd;
+        this.dstOffset = dstOffset;
+
+        logger.debug("Time extension: set DST start={}, end={}, offset={}", dstStart, dstEnd, dstOffset);
+
+        timeServer.setDst(dstStart, dstEnd, dstOffset);
+
+        // Update all the clients
+        synchronized (timeClients) {
+            for (ZclTimeClient client : timeClients.values()) {
+                client.setDst(dstStart, dstEnd, dstOffset);
+            }
+        }
+    }
+
+    /**
+     * Gets the last update time by either the client or the server. This may be used in conjunction with
+     * {@link #getLastUpdateMethod(ZigBeeEndpointAddress)}.
+     *
+     * @param address the {@link ZigBeeEndpointAddress} of the remote device.
+     * @return an {@link ZigBeeUtcTime} with the last update time or null if no update has been made to the requested
+     *         address.
+     */
+    public ZigBeeUtcTime getLastUpdateTime(ZigBeeEndpointAddress address) {
+        switch (getLastUpdateMethod(address)) {
+            case CLIENT:
+                return timeClients.get(address).getLastUpdate();
+            case SERVER:
+                return timeServer.getLastUpdateTime(address.getAddress());
+            case NONE:
+            default:
+                return null;
+        }
+    }
+
+    /**
+     * Gets the {@link ZigBeeTimeSetMethod} by which the time was last set on the remote device. This may be used in
+     * conjunction with {@link #getLastUpdateTime(ZigBeeEndpointAddress).
+     *
+     * @param address the {@link ZigBeeEndpointAddress} of the remote device.
+     * @return the {@link ZigBeeTimeSetMethod} by which the time was last set on the remote device.
+     */
+    public ZigBeeTimeSetMethod getLastUpdateMethod(ZigBeeEndpointAddress address) {
+        ZigBeeUtcTime clientTime = null;
+        ZigBeeUtcTime serverTime = timeServer.getLastUpdateTime(address.getAddress());
+
+        ZclTimeClient client = timeClients.get(address);
+        if (client != null) {
+            clientTime = client.getLastUpdate();
+        }
+
+        if (clientTime == null && serverTime == null) {
+            return ZigBeeTimeSetMethod.NONE;
+        } else if (serverTime == null) {
+            return ZigBeeTimeSetMethod.CLIENT;
+        } else {
+            return clientTime.compareTo(serverTime) < 0 ? ZigBeeTimeSetMethod.SERVER : ZigBeeTimeSetMethod.CLIENT;
+        }
+    }
+
+    @Override
+    public void nodeAdded(ZigBeeNode node) {
+        for (ZigBeeEndpoint endpoint : node.getEndpoints()) {
+            ZclTimeCluster timeServer = (ZclTimeCluster) endpoint.getInputCluster(ZclTimeCluster.CLUSTER_ID);
+            if (timeServer != null && !timeClients.containsKey(timeServer.getZigBeeAddress())) {
+                // Create a new local client for the remote server
+                ZclTimeClient timeClient = new ZclTimeClient(timeServer);
+                synchronized (timeClients) {
+                    logger.debug("Time extension: Adding client for {} endpoint {}", node.getIeeeAddress(),
+                            timeServer.getZigBeeAddress());
+                    timeClients.put(timeServer.getZigBeeAddress(), timeClient);
+                }
+            }
+        }
+
+        startWorker();
+    }
+
+    @Override
+    public void nodeUpdated(ZigBeeNode node) {
+        // Not used
+    }
+
+    @Override
+    public void nodeRemoved(ZigBeeNode node) {
+        synchronized (timeClients) {
+            for (ZigBeeEndpoint endpoint : node.getEndpoints()) {
+                if (timeClients.remove(endpoint.getEndpointAddress()) != null) {
+                    logger.debug("Time extension: Removed client for {} endpoint {}", node.getIeeeAddress(),
+                            endpoint.getEndpointAddress());
+                }
+            }
+        }
+    }
+
+    /**
+     * Gets the collection of {@link ZclTimeClient}s known on the network
+     *
+     * @return collection of {@link ZclTimeClient}s known on the network
+     */
+    public Collection<ZclTimeClient> getTimeClients() {
+        return timeClients.values();
+    }
+
+    /**
+     * Gets the {@link ZclTimeClient} for the {@link ZigBeeEndpointAddress}
+     *
+     * @param endpointAddress the {@link ZigBeeEndpointAddress} of the client
+     * @return the {@link ZclTimeClient} for the client, or null if there is no time client set
+     */
+    public ZclTimeClient getTimeClient(ZigBeeEndpointAddress endpointAddress) {
+        return timeClients.get(endpointAddress);
+    }
+
+    /**
+     * @return the dstStart time as {@link ZigBeeUtcTime}
+     */
+    public ZigBeeUtcTime getDstStart() {
+        return dstStart;
+    }
+
+    /**
+     * @return the dstEnd time as {@link ZigBeeUtcTime}
+     */
+    public ZigBeeUtcTime getDstEnd() {
+        return dstEnd;
+    }
+
+    /**
+     * @return the dstOffset in seconds
+     */
+    public int getDstOffset() {
+        return dstOffset;
+    }
+
+    /**
+     * Gets the current allowable clock drift, in seconds, before the client will update the remote server
+     *
+     * @return the current allowable drift in seconds
+     */
+    public int getUpdateDelta() {
+        return updateDelta;
+    }
+
+    /**
+     * Sets the current allowable clock drift, in seconds, before the client will update the remote server.
+     * If a remote time is observed to be more than his number of seconds from the local time, it will be synchronised.
+     *
+     * @param updateDelta the allowable drift in seconds
+     */
+    public void setUpdateDelta(int updateDelta) {
+        this.updateDelta = updateDelta;
+    }
+
+    /**
+     * @return the nominal period between each request of the time on a remote device
+     */
+    public int getPollPeriod() {
+        return pollPeriod;
+    }
+
+    /**
+     * @param pollPeriod the nominal period between each request of the time on a remote device
+     */
+    public void setPollPeriod(int pollPeriod) {
+        this.pollPeriod = pollPeriod;
+    }
+
+    private ZclTimeClient getNextUpdateClient() {
+        ZigBeeUtcTime pollTime = ZigBeeUtcTime.ofEpochSecond(System.currentTimeMillis() / 1000 - pollPeriod);
+
+        synchronized (timeClients) {
+            ZclTimeClient updateClient = null;
+            for (ZclTimeClient client : timeClients.values()) {
+                if (client.getLastRequestedTime() == null || client.getLastRequestedTime().isBefore(pollTime)
+                        && (updateClient == null || updateClient.getLastRequestedTime() == null
+                                || updateClient.getLastRequestedTime().isAfter(client.getLastRequestedTime()))) {
+                    updateClient = client;
+                }
+            }
+            return updateClient;
+        }
+    }
+
+    private void startWorker() {
+        if (workerJob != null) {
+            workerJob.cancel(true);
+            workerJob = null;
+        }
+
+        ZclTimeClient client = getNextUpdateClient();
+        if (client == null) {
+            return;
+        }
+
+        long updateSeconds = (client.getLastRequestedTime() == null) ? MINIMUM_WORKER_PERIOD
+                : Math.max(client.getLastRequestedTime().getEpochSecond() - ZigBeeUtcTime.now().getEpochSecond(),
+                        MINIMUM_WORKER_PERIOD);
+        logger.debug("Time extension: schedule next worker in {} seconds", updateSeconds);
+
+        workerJob = networkManager.scheduleTask(new TimeWorkerThread(), updateSeconds * 1000);
+    }
+
+    /**
+     * Class implementing the {@link Runnable} that will perform the time synchronisation work
+     */
+    private class TimeWorkerThread implements Runnable {
+        @Override
+        public void run() {
+            try {
+                doTimePollAndSet();
+            } catch (InterruptedException | ExecutionException e) {
+                logger.debug("Time extension: worker exception", e);
+            }
+
+            startWorker();
+        }
+
+        private void doTimePollAndSet() throws InterruptedException, ExecutionException {
+            ZclTimeClient client = getNextUpdateClient();
+            if (client == null) {
+                logger.debug("Time extension: worker running - no client found", client);
+                startWorker();
+            }
+
+            logger.debug("Time extension: worker polling {}", client.getZigBeeAddress());
+            if (!client.doPoll()) {
+                // Poll failed
+                startWorker();
+            }
+
+            if (Math.abs(client.getCurrentDelta()) >= updateDelta) {
+                logger.debug("Time extension: worker updating {}, delta is {}", client.getZigBeeAddress(),
+                        client.getCurrentDelta());
+                client.doUpdate();
+            }
+        }
+    }
+}

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/time/ZigBeeTimeSetMethod.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/time/ZigBeeTimeSetMethod.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2016-2023 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.app.time;
+
+/**
+ * Enumeration defining if the time has been synchronised via the client or server
+ *
+ * @author Chris Jackson
+ *
+ */
+public enum ZigBeeTimeSetMethod {
+    NONE,
+
+    CLIENT,
+
+    SERVER;
+}

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/time/package-info.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/app/time/package-info.java
@@ -1,0 +1,18 @@
+/**
+ * The Time extension provides a centralised time management utility. It consists of a {@link ZigBeeTimeClient}
+ * {@link ZigBeeTimeServer} and {@link ZigBeeTimeExtension}.
+ * <p>
+ * The main manager is the {@link ZigBeeTimeExtension} class. This provides a centralised interface for all
+ * time services. It handles the instantiation of the single {@link ZigBeeTimeServer} which in turn is responsible
+ * for responding to requests from remote devices for time information. The {@link ZigBeeTimeServer} acts as a
+ * master time source on the network. In addition, the {@link ZigBeeTimeExtension} instantiates a
+ * {@link ZigBeeTimeClient}s
+ * to interface with each remote client.
+ * <p>
+ * The {@link ZigBeeTimeExtension} will periodically poll the remote clients, checking their current time against
+ * the system master time. If the time is outside of an allowable delta, it will be set. Daylight Saving Time can
+ * also be centrally managed through the {@link ZigBeeTimeExtension}, which will in turn be set consistently for
+ * requests via the {@link ZigBeeTimeClient} or {@link ZigBeeTimeServer}.
+ *
+ */
+package com.zsmartsystems.zigbee.app.time;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/serialization/DefaultDeserializer.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/serialization/DefaultDeserializer.java
@@ -20,6 +20,7 @@ import com.zsmartsystems.zigbee.zcl.field.ByteArray;
 import com.zsmartsystems.zigbee.zcl.field.ExtensionFieldSet;
 import com.zsmartsystems.zigbee.zcl.field.ZclArrayList;
 import com.zsmartsystems.zigbee.zcl.field.ZclDataPair;
+import com.zsmartsystems.zigbee.zcl.field.ZigBeeUtcTime;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 import com.zsmartsystems.zigbee.zdo.ZdoStatus;
 import com.zsmartsystems.zigbee.zdo.field.BindingTable;
@@ -269,6 +270,8 @@ public class DefaultDeserializer implements ZigBeeDeserializer {
                 value[0] = Integer.valueOf((byte) payload[index++] & 0xFF);
                 break;
             case UTCTIME:
+                value[0] = ZigBeeUtcTime.ofZigBeeSecond(payload[index++] + (payload[index++] << 8)
+                        + (payload[index++] << 16) + (payload[index++] << 24));
                 break;
             case ROUTING_TABLE:
                 RoutingTable routingTable = new RoutingTable();

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/serialization/DefaultSerializer.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/serialization/DefaultSerializer.java
@@ -17,6 +17,7 @@ import com.zsmartsystems.zigbee.zcl.ZclStatus;
 import com.zsmartsystems.zigbee.zcl.field.ByteArray;
 import com.zsmartsystems.zigbee.zcl.field.ExtensionFieldSet;
 import com.zsmartsystems.zigbee.zcl.field.ZclArrayList;
+import com.zsmartsystems.zigbee.zcl.field.ZigBeeUtcTime;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 import com.zsmartsystems.zigbee.zdo.ZdoStatus;
 import com.zsmartsystems.zigbee.zdo.field.BindingTable;
@@ -217,6 +218,11 @@ public class DefaultSerializer implements ZigBeeSerializer {
                 buffer[length++] = (int) ((uint48Value >> 40) & 0xFF);
                 break;
             case UTCTIME:
+                final long utcValue = ((ZigBeeUtcTime) data).getZigBeeSecond();
+                buffer[length++] = (int) (utcValue & 0xFF);
+                buffer[length++] = (int) ((utcValue >> 8) & 0xFF);
+                buffer[length++] = (int) ((utcValue >> 16) & 0xFF);
+                buffer[length++] = (int) ((utcValue >> 24) & 0xFF);
                 break;
             case ZDO_STATUS:
                 buffer[length++] = ((ZdoStatus) data).getId();

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclDemandResponseAndLoadControlCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclDemandResponseAndLoadControlCluster.java
@@ -7,7 +7,6 @@
  */
 package com.zsmartsystems.zigbee.zcl.clusters;
 
-import java.util.Calendar;
 import java.util.Map;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.Future;
@@ -26,6 +25,7 @@ import com.zsmartsystems.zigbee.zcl.clusters.demandresponseandloadcontrol.LoadCo
 import com.zsmartsystems.zigbee.zcl.clusters.demandresponseandloadcontrol.ReportEventStatus;
 import com.zsmartsystems.zigbee.zcl.clusters.demandresponseandloadcontrol.ZclDemandResponseAndLoadControlCommand;
 import com.zsmartsystems.zigbee.zcl.field.ByteArray;
+import com.zsmartsystems.zigbee.zcl.field.ZigBeeUtcTime;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
 /**
@@ -46,7 +46,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2022-05-28T21:15:34Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2022-12-09T01:34:23Z")
 public class ZclDemandResponseAndLoadControlCluster extends ZclCluster {
     /**
      * The ZigBee Cluster Library Cluster ID
@@ -184,7 +184,7 @@ public class ZclDemandResponseAndLoadControlCluster extends ZclCluster {
      *
      * @param issuerEventId {@link Integer} Issuer Event ID
      * @param eventStatus {@link Integer} Event Status
-     * @param eventStatusTime {@link Calendar} Event Status Time
+     * @param eventStatusTime {@link ZigBeeUtcTime} Event Status Time
      * @param criticalityLevelApplied {@link Integer} Criticality Level Applied
      * @param coolingTemperatureSetPointApplied {@link Integer} Cooling Temperature Set Point Applied
      * @param heatingTemperatureSetPointApplied {@link Integer} Heating Temperature Set Point Applied
@@ -204,7 +204,7 @@ public class ZclDemandResponseAndLoadControlCluster extends ZclCluster {
      * with <code>cluster.sendCommand(new reportEventStatus(parameters ...))</code>
      */
     @Deprecated
-    public Future<CommandResult> reportEventStatus(Integer issuerEventId, Integer eventStatus, Calendar eventStatusTime, Integer criticalityLevelApplied, Integer coolingTemperatureSetPointApplied, Integer heatingTemperatureSetPointApplied, Integer averageLoadAdjustmentPercentageApplied, Integer dutyCycleApplied, Integer eventControl, Integer signatureType, ByteArray signature) {
+    public Future<CommandResult> reportEventStatus(Integer issuerEventId, Integer eventStatus, ZigBeeUtcTime eventStatusTime, Integer criticalityLevelApplied, Integer coolingTemperatureSetPointApplied, Integer heatingTemperatureSetPointApplied, Integer averageLoadAdjustmentPercentageApplied, Integer dutyCycleApplied, Integer eventControl, Integer signatureType, ByteArray signature) {
         ReportEventStatus command = new ReportEventStatus();
 
         // Set the fields
@@ -231,7 +231,7 @@ public class ZclDemandResponseAndLoadControlCluster extends ZclCluster {
      * the Server, one or more Load Control Event commands will be sent covering both active and
      * scheduled Load Control Events.
      *
-     * @param startTime {@link Calendar} Start Time
+     * @param startTime {@link ZigBeeUtcTime} Start Time
      * @param numberOfEvents {@link Integer} Number Of Events
      * @return the {@link Future<CommandResult>} command result future
      * @deprecated As of release 1.3.0.
@@ -244,7 +244,7 @@ public class ZclDemandResponseAndLoadControlCluster extends ZclCluster {
      * with <code>cluster.sendCommand(new getScheduledEvents(parameters ...))</code>
      */
     @Deprecated
-    public Future<CommandResult> getScheduledEvents(Calendar startTime, Integer numberOfEvents) {
+    public Future<CommandResult> getScheduledEvents(ZigBeeUtcTime startTime, Integer numberOfEvents) {
         GetScheduledEvents command = new GetScheduledEvents();
 
         // Set the fields
@@ -260,7 +260,7 @@ public class ZclDemandResponseAndLoadControlCluster extends ZclCluster {
      * @param issuerEventId {@link Integer} Issuer Event ID
      * @param deviceClass {@link Integer} Device Class
      * @param utilityEnrollmentGroup {@link Integer} Utility Enrollment Group
-     * @param startTime {@link Calendar} Start Time
+     * @param startTime {@link ZigBeeUtcTime} Start Time
      * @param durationInMinutes {@link Integer} Duration In Minutes
      * @param criticalityLevel {@link Integer} Criticality Level
      * @param coolingTemperatureOffset {@link Integer} Cooling Temperature Offset
@@ -281,7 +281,7 @@ public class ZclDemandResponseAndLoadControlCluster extends ZclCluster {
      * with <code>cluster.sendCommand(new loadControlEventCommand(parameters ...))</code>
      */
     @Deprecated
-    public Future<CommandResult> loadControlEventCommand(Integer issuerEventId, Integer deviceClass, Integer utilityEnrollmentGroup, Calendar startTime, Integer durationInMinutes, Integer criticalityLevel, Integer coolingTemperatureOffset, Integer heatingTemperatureOffset, Integer coolingTemperatureSetPoint, Integer heatingTemperatureSetPoint, Integer averageLoadAdjustmentPercentage, Integer dutyCycle, Integer eventControl) {
+    public Future<CommandResult> loadControlEventCommand(Integer issuerEventId, Integer deviceClass, Integer utilityEnrollmentGroup, ZigBeeUtcTime startTime, Integer durationInMinutes, Integer criticalityLevel, Integer coolingTemperatureOffset, Integer heatingTemperatureOffset, Integer coolingTemperatureSetPoint, Integer heatingTemperatureSetPoint, Integer averageLoadAdjustmentPercentage, Integer dutyCycle, Integer eventControl) {
         LoadControlEventCommand command = new LoadControlEventCommand();
 
         // Set the fields
@@ -309,7 +309,7 @@ public class ZclDemandResponseAndLoadControlCluster extends ZclCluster {
      * @param deviceClass {@link Integer} Device Class
      * @param utilityEnrollmentGroup {@link Integer} Utility Enrollment Group
      * @param cancelControl {@link Integer} Cancel Control
-     * @param effectiveTime {@link Calendar} Effective Time
+     * @param effectiveTime {@link ZigBeeUtcTime} Effective Time
      * @return the {@link Future<CommandResult>} command result future
      * @deprecated As of release 1.3.0.
      * Use extended ZclCommand class constructors to instantiate the command
@@ -321,7 +321,7 @@ public class ZclDemandResponseAndLoadControlCluster extends ZclCluster {
      * with <code>cluster.sendCommand(new cancelLoadControlEvent(parameters ...))</code>
      */
     @Deprecated
-    public Future<CommandResult> cancelLoadControlEvent(Integer issuerEventId, Integer deviceClass, Integer utilityEnrollmentGroup, Integer cancelControl, Calendar effectiveTime) {
+    public Future<CommandResult> cancelLoadControlEvent(Integer issuerEventId, Integer deviceClass, Integer utilityEnrollmentGroup, Integer cancelControl, ZigBeeUtcTime effectiveTime) {
         CancelLoadControlEvent command = new CancelLoadControlEvent();
 
         // Set the fields

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclMessagingCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclMessagingCluster.java
@@ -7,7 +7,6 @@
  */
 package com.zsmartsystems.zigbee.zcl.clusters;
 
-import java.util.Calendar;
 import java.util.Map;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.Future;
@@ -29,6 +28,7 @@ import com.zsmartsystems.zigbee.zcl.clusters.messaging.GetMessageCancellation;
 import com.zsmartsystems.zigbee.zcl.clusters.messaging.MessageConfirmation;
 import com.zsmartsystems.zigbee.zcl.clusters.messaging.ZclMessagingCommand;
 import com.zsmartsystems.zigbee.zcl.field.ByteArray;
+import com.zsmartsystems.zigbee.zcl.field.ZigBeeUtcTime;
 
 /**
  * <b>Messaging</b> cluster implementation (<i>Cluster ID 0x0703</i>).
@@ -41,7 +41,7 @@ import com.zsmartsystems.zigbee.zcl.field.ByteArray;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2022-05-28T21:15:34Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2022-12-09T01:34:23Z")
 public class ZclMessagingCluster extends ZclCluster {
     /**
      * The ZigBee Cluster Library Cluster ID
@@ -127,7 +127,7 @@ public class ZclMessagingCluster extends ZclCluster {
      *
      * @param messageId {@link Integer} Message ID
      * @param messageControl {@link Integer} Message Control
-     * @param startTime {@link Calendar} Start Time
+     * @param startTime {@link ZigBeeUtcTime} Start Time
      * @param durationInMinutes {@link Integer} Duration In Minutes
      * @param message {@link String} Message
      * @param extendedMessageControl {@link Integer} Extended Message Control
@@ -142,7 +142,7 @@ public class ZclMessagingCluster extends ZclCluster {
      * with <code>cluster.sendCommand(new displayMessageCommand(parameters ...))</code>
      */
     @Deprecated
-    public Future<CommandResult> displayMessageCommand(Integer messageId, Integer messageControl, Calendar startTime, Integer durationInMinutes, String message, Integer extendedMessageControl) {
+    public Future<CommandResult> displayMessageCommand(Integer messageId, Integer messageControl, ZigBeeUtcTime startTime, Integer durationInMinutes, String message, Integer extendedMessageControl) {
         DisplayMessageCommand command = new DisplayMessageCommand();
 
         // Set the fields
@@ -195,7 +195,7 @@ public class ZclMessagingCluster extends ZclCluster {
      *
      * @param messageId {@link Integer} Message ID
      * @param messageControl {@link Integer} Message Control
-     * @param startTime {@link Calendar} Start Time
+     * @param startTime {@link ZigBeeUtcTime} Start Time
      * @param durationInMinutes {@link Integer} Duration In Minutes
      * @param message {@link String} Message
      * @param extendedMessageControl {@link Integer} Extended Message Control
@@ -210,7 +210,7 @@ public class ZclMessagingCluster extends ZclCluster {
      * with <code>cluster.sendCommand(new displayProtectedMessageCommand(parameters ...))</code>
      */
     @Deprecated
-    public Future<CommandResult> displayProtectedMessageCommand(Integer messageId, Integer messageControl, Calendar startTime, Integer durationInMinutes, String message, Integer extendedMessageControl) {
+    public Future<CommandResult> displayProtectedMessageCommand(Integer messageId, Integer messageControl, ZigBeeUtcTime startTime, Integer durationInMinutes, String message, Integer extendedMessageControl) {
         DisplayProtectedMessageCommand command = new DisplayProtectedMessageCommand();
 
         // Set the fields
@@ -230,7 +230,7 @@ public class ZclMessagingCluster extends ZclCluster {
      * The Cancel All Messages command indicates to a CLIENT | device that it should cancel all
      * display messages currently held by it.
      *
-     * @param implementationTime {@link Calendar} Implementation Time
+     * @param implementationTime {@link ZigBeeUtcTime} Implementation Time
      * @return the {@link Future<CommandResult>} command result future
      * @deprecated As of release 1.3.0.
      * Use extended ZclCommand class constructors to instantiate the command
@@ -242,7 +242,7 @@ public class ZclMessagingCluster extends ZclCluster {
      * with <code>cluster.sendCommand(new cancelAllMessagesCommand(parameters ...))</code>
      */
     @Deprecated
-    public Future<CommandResult> cancelAllMessagesCommand(Calendar implementationTime) {
+    public Future<CommandResult> cancelAllMessagesCommand(ZigBeeUtcTime implementationTime) {
         CancelAllMessagesCommand command = new CancelAllMessagesCommand();
 
         // Set the fields
@@ -260,7 +260,7 @@ public class ZclMessagingCluster extends ZclCluster {
      *
      * @param messageId {@link Integer} Message ID
      * @param messageControl {@link Integer} Message Control
-     * @param startTime {@link Calendar} Start Time
+     * @param startTime {@link ZigBeeUtcTime} Start Time
      * @param durationInMinutes {@link Integer} Duration In Minutes
      * @param message {@link String} Message
      * @param optionalExtendedMessageControl {@link Integer} Optional Extended Message Control
@@ -275,7 +275,7 @@ public class ZclMessagingCluster extends ZclCluster {
      * with <code>cluster.sendCommand(new getLastMessage(parameters ...))</code>
      */
     @Deprecated
-    public Future<CommandResult> getLastMessage(Integer messageId, Integer messageControl, Calendar startTime, Integer durationInMinutes, String message, Integer optionalExtendedMessageControl) {
+    public Future<CommandResult> getLastMessage(Integer messageId, Integer messageControl, ZigBeeUtcTime startTime, Integer durationInMinutes, String message, Integer optionalExtendedMessageControl) {
         GetLastMessage command = new GetLastMessage();
 
         // Set the fields
@@ -298,7 +298,7 @@ public class ZclMessagingCluster extends ZclCluster {
      * confirmation string.
      *
      * @param messageId {@link Integer} Message ID
-     * @param confirmationTime {@link Calendar} Confirmation Time
+     * @param confirmationTime {@link ZigBeeUtcTime} Confirmation Time
      * @param messageConfirmationControl {@link Integer} Message Confirmation Control
      * @param messageConfirmationResponse {@link ByteArray} Message Confirmation Response
      * @return the {@link Future<CommandResult>} command result future
@@ -312,7 +312,7 @@ public class ZclMessagingCluster extends ZclCluster {
      * with <code>cluster.sendCommand(new messageConfirmation(parameters ...))</code>
      */
     @Deprecated
-    public Future<CommandResult> messageConfirmation(Integer messageId, Calendar confirmationTime, Integer messageConfirmationControl, ByteArray messageConfirmationResponse) {
+    public Future<CommandResult> messageConfirmation(Integer messageId, ZigBeeUtcTime confirmationTime, Integer messageConfirmationControl, ByteArray messageConfirmationResponse) {
         MessageConfirmation command = new MessageConfirmation();
 
         // Set the fields
@@ -331,7 +331,7 @@ public class ZclMessagingCluster extends ZclCluster {
      * command held on the associated server, and which has an implementation time equal to or
      * later than the value indicated in the payload.
      *
-     * @param earliestImplementationTime {@link Calendar} Earliest Implementation Time
+     * @param earliestImplementationTime {@link ZigBeeUtcTime} Earliest Implementation Time
      * @return the {@link Future<CommandResult>} command result future
      * @deprecated As of release 1.3.0.
      * Use extended ZclCommand class constructors to instantiate the command
@@ -343,7 +343,7 @@ public class ZclMessagingCluster extends ZclCluster {
      * with <code>cluster.sendCommand(new getMessageCancellation(parameters ...))</code>
      */
     @Deprecated
-    public Future<CommandResult> getMessageCancellation(Calendar earliestImplementationTime) {
+    public Future<CommandResult> getMessageCancellation(ZigBeeUtcTime earliestImplementationTime) {
         GetMessageCancellation command = new GetMessageCancellation();
 
         // Set the fields
@@ -358,7 +358,7 @@ public class ZclMessagingCluster extends ZclCluster {
      * The CancelAllMessages command indicates to a client device that it should cancel all
      * display messages currently held by it.
      *
-     * @param implementationDateTime {@link Calendar} Implementation Date Time
+     * @param implementationDateTime {@link ZigBeeUtcTime} Implementation Date Time
      * @return the {@link Future<CommandResult>} command result future
      * @deprecated As of release 1.3.0.
      * Use extended ZclCommand class constructors to instantiate the command
@@ -370,7 +370,7 @@ public class ZclMessagingCluster extends ZclCluster {
      * with <code>cluster.sendCommand(new cancelAllMessages(parameters ...))</code>
      */
     @Deprecated
-    public Future<CommandResult> cancelAllMessages(Calendar implementationDateTime) {
+    public Future<CommandResult> cancelAllMessages(ZigBeeUtcTime implementationDateTime) {
         CancelAllMessages command = new CancelAllMessages();
 
         // Set the fields

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclMeteringCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclMeteringCluster.java
@@ -7,7 +7,6 @@
  */
 package com.zsmartsystems.zigbee.zcl.clusters;
 
-import java.util.Calendar;
 import java.util.Map;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.Future;
@@ -53,6 +52,7 @@ import com.zsmartsystems.zigbee.zcl.clusters.metering.TakeSnapshot;
 import com.zsmartsystems.zigbee.zcl.clusters.metering.TakeSnapshotResponse;
 import com.zsmartsystems.zigbee.zcl.clusters.metering.ZclMeteringCommand;
 import com.zsmartsystems.zigbee.zcl.field.ByteArray;
+import com.zsmartsystems.zigbee.zcl.field.ZigBeeUtcTime;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
 /**
@@ -67,7 +67,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2022-05-28T21:15:34Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2022-12-09T01:34:23Z")
 public class ZclMeteringCluster extends ZclCluster {
     /**
      * The ZigBee Cluster Library Cluster ID
@@ -4000,7 +4000,7 @@ public class ZclMeteringCluster extends ZclCluster {
      * CurrentMaxDemandDelivered, and CurrentMaxDemandReceived attributes that are
      * supported by the device were updated.
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is MANDATORY
      *
@@ -4027,21 +4027,21 @@ public class ZclMeteringCluster extends ZclCluster {
      * <p>
      * This method will block until the response is received or a timeout occurs unless the current value is returned.
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is MANDATORY
      *
      * @param refreshPeriod the maximum age of the data (in milliseconds) before an update is needed
-     * @return the {@link Calendar} attribute value, or null on error
+     * @return the {@link ZigBeeUtcTime} attribute value, or null on error
      * @deprecated As of release 1.2.0, replaced by {@link #ZclAttribute#readValue(long refreshPeriod)}
      */
     @Deprecated
-    public Calendar getReadingSnapshotTime(final long refreshPeriod) {
+    public ZigBeeUtcTime getReadingSnapshotTime(final long refreshPeriod) {
         if (serverAttributes.get(ATTR_READINGSNAPSHOTTIME).isLastValueCurrent(refreshPeriod)) {
-            return (Calendar) serverAttributes.get(ATTR_READINGSNAPSHOTTIME).getLastValue();
+            return (ZigBeeUtcTime) serverAttributes.get(ATTR_READINGSNAPSHOTTIME).getLastValue();
         }
 
-        return (Calendar) readSync(serverAttributes.get(ATTR_READINGSNAPSHOTTIME));
+        return (ZigBeeUtcTime) readSync(serverAttributes.get(ATTR_READINGSNAPSHOTTIME));
     }
 
     /**
@@ -4052,7 +4052,7 @@ public class ZclMeteringCluster extends ZclCluster {
      * CurrentMaxDemandDelivered, and CurrentMaxDemandReceived attributes that are
      * supported by the device were updated.
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is MANDATORY
      *
@@ -4073,7 +4073,7 @@ public class ZclMeteringCluster extends ZclCluster {
      * The CurrentMaxDemandDeliveredTime attribute represents the time when
      * CurrentMaxDemandDelivered reading was captured.
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is MANDATORY
      *
@@ -4098,21 +4098,21 @@ public class ZclMeteringCluster extends ZclCluster {
      * <p>
      * This method will block until the response is received or a timeout occurs unless the current value is returned.
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is MANDATORY
      *
      * @param refreshPeriod the maximum age of the data (in milliseconds) before an update is needed
-     * @return the {@link Calendar} attribute value, or null on error
+     * @return the {@link ZigBeeUtcTime} attribute value, or null on error
      * @deprecated As of release 1.2.0, replaced by {@link #ZclAttribute#readValue(long refreshPeriod)}
      */
     @Deprecated
-    public Calendar getCurrentMaxDemandDeliveredTime(final long refreshPeriod) {
+    public ZigBeeUtcTime getCurrentMaxDemandDeliveredTime(final long refreshPeriod) {
         if (serverAttributes.get(ATTR_CURRENTMAXDEMANDDELIVEREDTIME).isLastValueCurrent(refreshPeriod)) {
-            return (Calendar) serverAttributes.get(ATTR_CURRENTMAXDEMANDDELIVEREDTIME).getLastValue();
+            return (ZigBeeUtcTime) serverAttributes.get(ATTR_CURRENTMAXDEMANDDELIVEREDTIME).getLastValue();
         }
 
-        return (Calendar) readSync(serverAttributes.get(ATTR_CURRENTMAXDEMANDDELIVEREDTIME));
+        return (ZigBeeUtcTime) readSync(serverAttributes.get(ATTR_CURRENTMAXDEMANDDELIVEREDTIME));
     }
 
     /**
@@ -4121,7 +4121,7 @@ public class ZclMeteringCluster extends ZclCluster {
      * The CurrentMaxDemandDeliveredTime attribute represents the time when
      * CurrentMaxDemandDelivered reading was captured.
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is MANDATORY
      *
@@ -4142,7 +4142,7 @@ public class ZclMeteringCluster extends ZclCluster {
      * The CurrentMaxDemandReceivedTime attribute represents the time when
      * CurrentMaxDemandReceived reading was captured.
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is MANDATORY
      *
@@ -4167,21 +4167,21 @@ public class ZclMeteringCluster extends ZclCluster {
      * <p>
      * This method will block until the response is received or a timeout occurs unless the current value is returned.
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is MANDATORY
      *
      * @param refreshPeriod the maximum age of the data (in milliseconds) before an update is needed
-     * @return the {@link Calendar} attribute value, or null on error
+     * @return the {@link ZigBeeUtcTime} attribute value, or null on error
      * @deprecated As of release 1.2.0, replaced by {@link #ZclAttribute#readValue(long refreshPeriod)}
      */
     @Deprecated
-    public Calendar getCurrentMaxDemandReceivedTime(final long refreshPeriod) {
+    public ZigBeeUtcTime getCurrentMaxDemandReceivedTime(final long refreshPeriod) {
         if (serverAttributes.get(ATTR_CURRENTMAXDEMANDRECEIVEDTIME).isLastValueCurrent(refreshPeriod)) {
-            return (Calendar) serverAttributes.get(ATTR_CURRENTMAXDEMANDRECEIVEDTIME).getLastValue();
+            return (ZigBeeUtcTime) serverAttributes.get(ATTR_CURRENTMAXDEMANDRECEIVEDTIME).getLastValue();
         }
 
-        return (Calendar) readSync(serverAttributes.get(ATTR_CURRENTMAXDEMANDRECEIVEDTIME));
+        return (ZigBeeUtcTime) readSync(serverAttributes.get(ATTR_CURRENTMAXDEMANDRECEIVEDTIME));
     }
 
     /**
@@ -4190,7 +4190,7 @@ public class ZclMeteringCluster extends ZclCluster {
      * The CurrentMaxDemandReceivedTime attribute represents the time when
      * CurrentMaxDemandReceived reading was captured.
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is MANDATORY
      *
@@ -5449,7 +5449,7 @@ public class ZclMeteringCluster extends ZclCluster {
      * value will not change but the LastBlockSwitchTime attribute shall be updated to
      * indicate this change.
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is OPTIONAL
      *
@@ -5484,21 +5484,21 @@ public class ZclMeteringCluster extends ZclCluster {
      * <p>
      * This method will block until the response is received or a timeout occurs unless the current value is returned.
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is OPTIONAL
      *
      * @param refreshPeriod the maximum age of the data (in milliseconds) before an update is needed
-     * @return the {@link Calendar} attribute value, or null on error
+     * @return the {@link ZigBeeUtcTime} attribute value, or null on error
      * @deprecated As of release 1.2.0, replaced by {@link #ZclAttribute#readValue(long refreshPeriod)}
      */
     @Deprecated
-    public Calendar getLastBlockSwitchTime(final long refreshPeriod) {
+    public ZigBeeUtcTime getLastBlockSwitchTime(final long refreshPeriod) {
         if (serverAttributes.get(ATTR_LASTBLOCKSWITCHTIME).isLastValueCurrent(refreshPeriod)) {
-            return (Calendar) serverAttributes.get(ATTR_LASTBLOCKSWITCHTIME).getLastValue();
+            return (ZigBeeUtcTime) serverAttributes.get(ATTR_LASTBLOCKSWITCHTIME).getLastValue();
         }
 
-        return (Calendar) readSync(serverAttributes.get(ATTR_LASTBLOCKSWITCHTIME));
+        return (ZigBeeUtcTime) readSync(serverAttributes.get(ATTR_LASTBLOCKSWITCHTIME));
     }
 
     /**
@@ -8318,7 +8318,7 @@ public class ZclMeteringCluster extends ZclCluster {
      * CurrentPartialProfileIntervalStartTimeDelivered represents the start time of the
      * current Load Profile interval being accumulated for commodity delivered.
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is MANDATORY
      *
@@ -8343,21 +8343,21 @@ public class ZclMeteringCluster extends ZclCluster {
      * <p>
      * This method will block until the response is received or a timeout occurs unless the current value is returned.
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is MANDATORY
      *
      * @param refreshPeriod the maximum age of the data (in milliseconds) before an update is needed
-     * @return the {@link Calendar} attribute value, or null on error
+     * @return the {@link ZigBeeUtcTime} attribute value, or null on error
      * @deprecated As of release 1.2.0, replaced by {@link #ZclAttribute#readValue(long refreshPeriod)}
      */
     @Deprecated
-    public Calendar getCurrentPartialProfileIntervalStartTimeDelivered(final long refreshPeriod) {
+    public ZigBeeUtcTime getCurrentPartialProfileIntervalStartTimeDelivered(final long refreshPeriod) {
         if (serverAttributes.get(ATTR_CURRENTPARTIALPROFILEINTERVALSTARTTIMEDELIVERED).isLastValueCurrent(refreshPeriod)) {
-            return (Calendar) serverAttributes.get(ATTR_CURRENTPARTIALPROFILEINTERVALSTARTTIMEDELIVERED).getLastValue();
+            return (ZigBeeUtcTime) serverAttributes.get(ATTR_CURRENTPARTIALPROFILEINTERVALSTARTTIMEDELIVERED).getLastValue();
         }
 
-        return (Calendar) readSync(serverAttributes.get(ATTR_CURRENTPARTIALPROFILEINTERVALSTARTTIMEDELIVERED));
+        return (ZigBeeUtcTime) readSync(serverAttributes.get(ATTR_CURRENTPARTIALPROFILEINTERVALSTARTTIMEDELIVERED));
     }
 
     /**
@@ -8366,7 +8366,7 @@ public class ZclMeteringCluster extends ZclCluster {
      * CurrentPartialProfileIntervalStartTimeDelivered represents the start time of the
      * current Load Profile interval being accumulated for commodity delivered.
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is MANDATORY
      *
@@ -8387,7 +8387,7 @@ public class ZclMeteringCluster extends ZclCluster {
      * CurrentPartialProfileIntervalStartTimeReceived represents the start time of the
      * current Load Profile interval being accumulated for commodity received.
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is MANDATORY
      *
@@ -8412,21 +8412,21 @@ public class ZclMeteringCluster extends ZclCluster {
      * <p>
      * This method will block until the response is received or a timeout occurs unless the current value is returned.
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is MANDATORY
      *
      * @param refreshPeriod the maximum age of the data (in milliseconds) before an update is needed
-     * @return the {@link Calendar} attribute value, or null on error
+     * @return the {@link ZigBeeUtcTime} attribute value, or null on error
      * @deprecated As of release 1.2.0, replaced by {@link #ZclAttribute#readValue(long refreshPeriod)}
      */
     @Deprecated
-    public Calendar getCurrentPartialProfileIntervalStartTimeReceived(final long refreshPeriod) {
+    public ZigBeeUtcTime getCurrentPartialProfileIntervalStartTimeReceived(final long refreshPeriod) {
         if (serverAttributes.get(ATTR_CURRENTPARTIALPROFILEINTERVALSTARTTIMERECEIVED).isLastValueCurrent(refreshPeriod)) {
-            return (Calendar) serverAttributes.get(ATTR_CURRENTPARTIALPROFILEINTERVALSTARTTIMERECEIVED).getLastValue();
+            return (ZigBeeUtcTime) serverAttributes.get(ATTR_CURRENTPARTIALPROFILEINTERVALSTARTTIMERECEIVED).getLastValue();
         }
 
-        return (Calendar) readSync(serverAttributes.get(ATTR_CURRENTPARTIALPROFILEINTERVALSTARTTIMERECEIVED));
+        return (ZigBeeUtcTime) readSync(serverAttributes.get(ATTR_CURRENTPARTIALPROFILEINTERVALSTARTTIMERECEIVED));
     }
 
     /**
@@ -8435,7 +8435,7 @@ public class ZclMeteringCluster extends ZclCluster {
      * CurrentPartialProfileIntervalStartTimeReceived represents the start time of the
      * current Load Profile interval being accumulated for commodity received.
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is MANDATORY
      *
@@ -13907,7 +13907,7 @@ public class ZclMeteringCluster extends ZclCluster {
      * The UTC timestamp when the associated BillToDateDelivered attribute was last
      * updated.
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is MANDATORY
      *
@@ -13932,21 +13932,21 @@ public class ZclMeteringCluster extends ZclCluster {
      * <p>
      * This method will block until the response is received or a timeout occurs unless the current value is returned.
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is MANDATORY
      *
      * @param refreshPeriod the maximum age of the data (in milliseconds) before an update is needed
-     * @return the {@link Calendar} attribute value, or null on error
+     * @return the {@link ZigBeeUtcTime} attribute value, or null on error
      * @deprecated As of release 1.2.0, replaced by {@link #ZclAttribute#readValue(long refreshPeriod)}
      */
     @Deprecated
-    public Calendar getBillToDateTimeStampDelivered(final long refreshPeriod) {
+    public ZigBeeUtcTime getBillToDateTimeStampDelivered(final long refreshPeriod) {
         if (serverAttributes.get(ATTR_BILLTODATETIMESTAMPDELIVERED).isLastValueCurrent(refreshPeriod)) {
-            return (Calendar) serverAttributes.get(ATTR_BILLTODATETIMESTAMPDELIVERED).getLastValue();
+            return (ZigBeeUtcTime) serverAttributes.get(ATTR_BILLTODATETIMESTAMPDELIVERED).getLastValue();
         }
 
-        return (Calendar) readSync(serverAttributes.get(ATTR_BILLTODATETIMESTAMPDELIVERED));
+        return (ZigBeeUtcTime) readSync(serverAttributes.get(ATTR_BILLTODATETIMESTAMPDELIVERED));
     }
 
     /**
@@ -13955,7 +13955,7 @@ public class ZclMeteringCluster extends ZclCluster {
      * The UTC timestamp when the associated BillToDateDelivered attribute was last
      * updated.
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is MANDATORY
      *
@@ -14051,7 +14051,7 @@ public class ZclMeteringCluster extends ZclCluster {
      * The UTC timestamp when the associated ProjectedBillDelivered attribute was last
      * updated.
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is MANDATORY
      *
@@ -14076,21 +14076,21 @@ public class ZclMeteringCluster extends ZclCluster {
      * <p>
      * This method will block until the response is received or a timeout occurs unless the current value is returned.
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is MANDATORY
      *
      * @param refreshPeriod the maximum age of the data (in milliseconds) before an update is needed
-     * @return the {@link Calendar} attribute value, or null on error
+     * @return the {@link ZigBeeUtcTime} attribute value, or null on error
      * @deprecated As of release 1.2.0, replaced by {@link #ZclAttribute#readValue(long refreshPeriod)}
      */
     @Deprecated
-    public Calendar getProjectedBillTimeStampDelivered(final long refreshPeriod) {
+    public ZigBeeUtcTime getProjectedBillTimeStampDelivered(final long refreshPeriod) {
         if (serverAttributes.get(ATTR_PROJECTEDBILLTIMESTAMPDELIVERED).isLastValueCurrent(refreshPeriod)) {
-            return (Calendar) serverAttributes.get(ATTR_PROJECTEDBILLTIMESTAMPDELIVERED).getLastValue();
+            return (ZigBeeUtcTime) serverAttributes.get(ATTR_PROJECTEDBILLTIMESTAMPDELIVERED).getLastValue();
         }
 
-        return (Calendar) readSync(serverAttributes.get(ATTR_PROJECTEDBILLTIMESTAMPDELIVERED));
+        return (ZigBeeUtcTime) readSync(serverAttributes.get(ATTR_PROJECTEDBILLTIMESTAMPDELIVERED));
     }
 
     /**
@@ -14099,7 +14099,7 @@ public class ZclMeteringCluster extends ZclCluster {
      * The UTC timestamp when the associated ProjectedBillDelivered attribute was last
      * updated.
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is MANDATORY
      *
@@ -14268,7 +14268,7 @@ public class ZclMeteringCluster extends ZclCluster {
      * <p>
      * The UTC timestamp when the associated BillToDateReceived attribute was last updated.
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is MANDATORY
      *
@@ -14292,21 +14292,21 @@ public class ZclMeteringCluster extends ZclCluster {
      * <p>
      * This method will block until the response is received or a timeout occurs unless the current value is returned.
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is MANDATORY
      *
      * @param refreshPeriod the maximum age of the data (in milliseconds) before an update is needed
-     * @return the {@link Calendar} attribute value, or null on error
+     * @return the {@link ZigBeeUtcTime} attribute value, or null on error
      * @deprecated As of release 1.2.0, replaced by {@link #ZclAttribute#readValue(long refreshPeriod)}
      */
     @Deprecated
-    public Calendar getBillToDateTimeStampReceived(final long refreshPeriod) {
+    public ZigBeeUtcTime getBillToDateTimeStampReceived(final long refreshPeriod) {
         if (serverAttributes.get(ATTR_BILLTODATETIMESTAMPRECEIVED).isLastValueCurrent(refreshPeriod)) {
-            return (Calendar) serverAttributes.get(ATTR_BILLTODATETIMESTAMPRECEIVED).getLastValue();
+            return (ZigBeeUtcTime) serverAttributes.get(ATTR_BILLTODATETIMESTAMPRECEIVED).getLastValue();
         }
 
-        return (Calendar) readSync(serverAttributes.get(ATTR_BILLTODATETIMESTAMPRECEIVED));
+        return (ZigBeeUtcTime) readSync(serverAttributes.get(ATTR_BILLTODATETIMESTAMPRECEIVED));
     }
 
     /**
@@ -14314,7 +14314,7 @@ public class ZclMeteringCluster extends ZclCluster {
      * <p>
      * The UTC timestamp when the associated BillToDateReceived attribute was last updated.
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is MANDATORY
      *
@@ -14410,7 +14410,7 @@ public class ZclMeteringCluster extends ZclCluster {
      * The UTC timestamp when the associated ProjectedBillReceived attribute was last
      * updated.
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is MANDATORY
      *
@@ -14435,21 +14435,21 @@ public class ZclMeteringCluster extends ZclCluster {
      * <p>
      * This method will block until the response is received or a timeout occurs unless the current value is returned.
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is MANDATORY
      *
      * @param refreshPeriod the maximum age of the data (in milliseconds) before an update is needed
-     * @return the {@link Calendar} attribute value, or null on error
+     * @return the {@link ZigBeeUtcTime} attribute value, or null on error
      * @deprecated As of release 1.2.0, replaced by {@link #ZclAttribute#readValue(long refreshPeriod)}
      */
     @Deprecated
-    public Calendar getProjectedBillTimeStampReceived(final long refreshPeriod) {
+    public ZigBeeUtcTime getProjectedBillTimeStampReceived(final long refreshPeriod) {
         if (serverAttributes.get(ATTR_PROJECTEDBILLTIMESTAMPRECEIVED).isLastValueCurrent(refreshPeriod)) {
-            return (Calendar) serverAttributes.get(ATTR_PROJECTEDBILLTIMESTAMPRECEIVED).getLastValue();
+            return (ZigBeeUtcTime) serverAttributes.get(ATTR_PROJECTEDBILLTIMESTAMPRECEIVED).getLastValue();
         }
 
-        return (Calendar) readSync(serverAttributes.get(ATTR_PROJECTEDBILLTIMESTAMPRECEIVED));
+        return (ZigBeeUtcTime) readSync(serverAttributes.get(ATTR_PROJECTEDBILLTIMESTAMPRECEIVED));
     }
 
     /**
@@ -14458,7 +14458,7 @@ public class ZclMeteringCluster extends ZclCluster {
      * The UTC timestamp when the associated ProjectedBillReceived attribute was last
      * updated.
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is MANDATORY
      *
@@ -14557,7 +14557,7 @@ public class ZclMeteringCluster extends ZclCluster {
      * proposed change to the supply is to be implemented. If there is no change of supply
      * pending, this attribute will be set to 0xFFFFFFFF.
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is MANDATORY
      *
@@ -14583,21 +14583,21 @@ public class ZclMeteringCluster extends ZclCluster {
      * <p>
      * This method will block until the response is received or a timeout occurs unless the current value is returned.
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is MANDATORY
      *
      * @param refreshPeriod the maximum age of the data (in milliseconds) before an update is needed
-     * @return the {@link Calendar} attribute value, or null on error
+     * @return the {@link ZigBeeUtcTime} attribute value, or null on error
      * @deprecated As of release 1.2.0, replaced by {@link #ZclAttribute#readValue(long refreshPeriod)}
      */
     @Deprecated
-    public Calendar getProposedChangeSupplyImplementationTime(final long refreshPeriod) {
+    public ZigBeeUtcTime getProposedChangeSupplyImplementationTime(final long refreshPeriod) {
         if (serverAttributes.get(ATTR_PROPOSEDCHANGESUPPLYIMPLEMENTATIONTIME).isLastValueCurrent(refreshPeriod)) {
-            return (Calendar) serverAttributes.get(ATTR_PROPOSEDCHANGESUPPLYIMPLEMENTATIONTIME).getLastValue();
+            return (ZigBeeUtcTime) serverAttributes.get(ATTR_PROPOSEDCHANGESUPPLYIMPLEMENTATIONTIME).getLastValue();
         }
 
-        return (Calendar) readSync(serverAttributes.get(ATTR_PROPOSEDCHANGESUPPLYIMPLEMENTATIONTIME));
+        return (ZigBeeUtcTime) readSync(serverAttributes.get(ATTR_PROPOSEDCHANGESUPPLYIMPLEMENTATIONTIME));
     }
 
     /**
@@ -14607,7 +14607,7 @@ public class ZclMeteringCluster extends ZclCluster {
      * proposed change to the supply is to be implemented. If there is no change of supply
      * pending, this attribute will be set to 0xFFFFFFFF.
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is MANDATORY
      *
@@ -15521,7 +15521,7 @@ public class ZclMeteringCluster extends ZclCluster {
      * start time of the current Load Profile interval being accumulated for commodity
      * delivered.
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is MANDATORY
      *
@@ -15547,21 +15547,21 @@ public class ZclMeteringCluster extends ZclCluster {
      * <p>
      * This method will block until the response is received or a timeout occurs unless the current value is returned.
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is MANDATORY
      *
      * @param refreshPeriod the maximum age of the data (in milliseconds) before an update is needed
-     * @return the {@link Calendar} attribute value, or null on error
+     * @return the {@link ZigBeeUtcTime} attribute value, or null on error
      * @deprecated As of release 1.2.0, replaced by {@link #ZclAttribute#readValue(long refreshPeriod)}
      */
     @Deprecated
-    public Calendar getCurrentAlternativePartialProfileIntervalStartTimeDelivered(final long refreshPeriod) {
+    public ZigBeeUtcTime getCurrentAlternativePartialProfileIntervalStartTimeDelivered(final long refreshPeriod) {
         if (serverAttributes.get(ATTR_CURRENTALTERNATIVEPARTIALPROFILEINTERVALSTARTTIMEDELIVERED).isLastValueCurrent(refreshPeriod)) {
-            return (Calendar) serverAttributes.get(ATTR_CURRENTALTERNATIVEPARTIALPROFILEINTERVALSTARTTIMEDELIVERED).getLastValue();
+            return (ZigBeeUtcTime) serverAttributes.get(ATTR_CURRENTALTERNATIVEPARTIALPROFILEINTERVALSTARTTIMEDELIVERED).getLastValue();
         }
 
-        return (Calendar) readSync(serverAttributes.get(ATTR_CURRENTALTERNATIVEPARTIALPROFILEINTERVALSTARTTIMEDELIVERED));
+        return (ZigBeeUtcTime) readSync(serverAttributes.get(ATTR_CURRENTALTERNATIVEPARTIALPROFILEINTERVALSTARTTIMEDELIVERED));
     }
 
     /**
@@ -15571,7 +15571,7 @@ public class ZclMeteringCluster extends ZclCluster {
      * start time of the current Load Profile interval being accumulated for commodity
      * delivered.
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is MANDATORY
      *
@@ -15593,7 +15593,7 @@ public class ZclMeteringCluster extends ZclCluster {
      * start time of the current Load Profile interval being accumulated for commodity
      * received.
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is MANDATORY
      *
@@ -15619,21 +15619,21 @@ public class ZclMeteringCluster extends ZclCluster {
      * <p>
      * This method will block until the response is received or a timeout occurs unless the current value is returned.
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is MANDATORY
      *
      * @param refreshPeriod the maximum age of the data (in milliseconds) before an update is needed
-     * @return the {@link Calendar} attribute value, or null on error
+     * @return the {@link ZigBeeUtcTime} attribute value, or null on error
      * @deprecated As of release 1.2.0, replaced by {@link #ZclAttribute#readValue(long refreshPeriod)}
      */
     @Deprecated
-    public Calendar getCurrentAlternativePartialProfileIntervalStartTimeReceived(final long refreshPeriod) {
+    public ZigBeeUtcTime getCurrentAlternativePartialProfileIntervalStartTimeReceived(final long refreshPeriod) {
         if (serverAttributes.get(ATTR_CURRENTALTERNATIVEPARTIALPROFILEINTERVALSTARTTIMERECEIVED).isLastValueCurrent(refreshPeriod)) {
-            return (Calendar) serverAttributes.get(ATTR_CURRENTALTERNATIVEPARTIALPROFILEINTERVALSTARTTIMERECEIVED).getLastValue();
+            return (ZigBeeUtcTime) serverAttributes.get(ATTR_CURRENTALTERNATIVEPARTIALPROFILEINTERVALSTARTTIMERECEIVED).getLastValue();
         }
 
-        return (Calendar) readSync(serverAttributes.get(ATTR_CURRENTALTERNATIVEPARTIALPROFILEINTERVALSTARTTIMERECEIVED));
+        return (ZigBeeUtcTime) readSync(serverAttributes.get(ATTR_CURRENTALTERNATIVEPARTIALPROFILEINTERVALSTARTTIMERECEIVED));
     }
 
     /**
@@ -15643,7 +15643,7 @@ public class ZclMeteringCluster extends ZclCluster {
      * start time of the current Load Profile interval being accumulated for commodity
      * received.
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is MANDATORY
      *
@@ -17135,7 +17135,7 @@ public class ZclMeteringCluster extends ZclCluster {
      * captured Energy, Gas or water consumption for profiling purposes.
      *
      * @param intervalChannel {@link Integer} Interval Channel
-     * @param endTime {@link Calendar} End Time
+     * @param endTime {@link ZigBeeUtcTime} End Time
      * @param numberOfPeriods {@link Integer} Number Of Periods
      * @return the {@link Future<CommandResult>} command result future
      * @deprecated As of release 1.3.0.
@@ -17148,7 +17148,7 @@ public class ZclMeteringCluster extends ZclCluster {
      * with <code>cluster.sendCommand(new getProfile(parameters ...))</code>
      */
     @Deprecated
-    public Future<CommandResult> getProfile(Integer intervalChannel, Calendar endTime, Integer numberOfPeriods) {
+    public Future<CommandResult> getProfile(Integer intervalChannel, ZigBeeUtcTime endTime, Integer numberOfPeriods) {
         GetProfile command = new GetProfile();
 
         // Set the fields
@@ -17305,8 +17305,8 @@ public class ZclMeteringCluster extends ZclCluster {
      * <p>
      * This command is used to request snapshot data from the cluster server.
      *
-     * @param earliestStartTime {@link Calendar} Earliest Start Time
-     * @param latestEndTime {@link Calendar} Latest End Time
+     * @param earliestStartTime {@link ZigBeeUtcTime} Earliest Start Time
+     * @param latestEndTime {@link ZigBeeUtcTime} Latest End Time
      * @param snapshotOffset {@link Integer} Snapshot Offset
      * @param snapshotCause {@link Integer} Snapshot Cause
      * @return the {@link Future<CommandResult>} command result future
@@ -17320,7 +17320,7 @@ public class ZclMeteringCluster extends ZclCluster {
      * with <code>cluster.sendCommand(new getSnapshot(parameters ...))</code>
      */
     @Deprecated
-    public Future<CommandResult> getSnapshot(Calendar earliestStartTime, Calendar latestEndTime, Integer snapshotOffset, Integer snapshotCause) {
+    public Future<CommandResult> getSnapshot(ZigBeeUtcTime earliestStartTime, ZigBeeUtcTime latestEndTime, Integer snapshotOffset, Integer snapshotCause) {
         GetSnapshot command = new GetSnapshot();
 
         // Set the fields
@@ -17341,7 +17341,7 @@ public class ZclMeteringCluster extends ZclCluster {
      * different sampling rate.
      *
      * @param issuerEventId {@link Integer} Issuer Event ID
-     * @param startSamplingTime {@link Calendar} Start Sampling Time
+     * @param startSamplingTime {@link ZigBeeUtcTime} Start Sampling Time
      * @param sampleType {@link Integer} Sample Type
      * @param sampleRequestInterval {@link Integer} Sample Request Interval
      * @param maxNumberOfSamples {@link Integer} Max Number Of Samples
@@ -17356,7 +17356,7 @@ public class ZclMeteringCluster extends ZclCluster {
      * with <code>cluster.sendCommand(new startSampling(parameters ...))</code>
      */
     @Deprecated
-    public Future<CommandResult> startSampling(Integer issuerEventId, Calendar startSamplingTime, Integer sampleType, Integer sampleRequestInterval, Integer maxNumberOfSamples) {
+    public Future<CommandResult> startSampling(Integer issuerEventId, ZigBeeUtcTime startSamplingTime, Integer sampleType, Integer sampleRequestInterval, Integer maxNumberOfSamples) {
         StartSampling command = new StartSampling();
 
         // Set the fields
@@ -17377,7 +17377,7 @@ public class ZclMeteringCluster extends ZclCluster {
      * held in a single command payload.
      *
      * @param sampleId {@link Integer} Sample ID
-     * @param earliestSampleTime {@link Calendar} Earliest Sample Time
+     * @param earliestSampleTime {@link ZigBeeUtcTime} Earliest Sample Time
      * @param sampleType {@link Integer} Sample Type
      * @param numberOfSamples {@link Integer} Number Of Samples
      * @return the {@link Future<CommandResult>} command result future
@@ -17391,7 +17391,7 @@ public class ZclMeteringCluster extends ZclCluster {
      * with <code>cluster.sendCommand(new getSampledData(parameters ...))</code>
      */
     @Deprecated
-    public Future<CommandResult> getSampledData(Integer sampleId, Calendar earliestSampleTime, Integer sampleType, Integer numberOfSamples) {
+    public Future<CommandResult> getSampledData(Integer sampleId, ZigBeeUtcTime earliestSampleTime, Integer sampleType, Integer numberOfSamples) {
         GetSampledData command = new GetSampledData();
 
         // Set the fields
@@ -17469,8 +17469,8 @@ public class ZclMeteringCluster extends ZclCluster {
      *
      * @param providerId {@link Integer} Provider ID
      * @param issuerEventId {@link Integer} Issuer Event ID
-     * @param requestDateTime {@link Calendar} Request Date Time
-     * @param implementationDateTime {@link Calendar} Implementation Date Time
+     * @param requestDateTime {@link ZigBeeUtcTime} Request Date Time
+     * @param implementationDateTime {@link ZigBeeUtcTime} Implementation Date Time
      * @param proposedSupplyStatus {@link Integer} Proposed Supply Status
      * @param supplyControlBits {@link Integer} Supply Control Bits
      * @return the {@link Future<CommandResult>} command result future
@@ -17484,7 +17484,7 @@ public class ZclMeteringCluster extends ZclCluster {
      * with <code>cluster.sendCommand(new changeSupply(parameters ...))</code>
      */
     @Deprecated
-    public Future<CommandResult> changeSupply(Integer providerId, Integer issuerEventId, Calendar requestDateTime, Calendar implementationDateTime, Integer proposedSupplyStatus, Integer supplyControlBits) {
+    public Future<CommandResult> changeSupply(Integer providerId, Integer issuerEventId, ZigBeeUtcTime requestDateTime, ZigBeeUtcTime implementationDateTime, Integer proposedSupplyStatus, Integer supplyControlBits) {
         ChangeSupply command = new ChangeSupply();
 
         // Set the fields
@@ -17608,7 +17608,7 @@ public class ZclMeteringCluster extends ZclCluster {
      * <p>
      * This command is sent when the Client command GetProfile is received.
      *
-     * @param endTime {@link Calendar} End Time
+     * @param endTime {@link ZigBeeUtcTime} End Time
      * @param status {@link Integer} Status
      * @param profileIntervalPeriod {@link Integer} Profile Interval Period
      * @param numberOfPeriodsDelivered {@link Integer} Number Of Periods Delivered
@@ -17624,7 +17624,7 @@ public class ZclMeteringCluster extends ZclCluster {
      * with <code>cluster.sendCommand(new getProfileResponse(parameters ...))</code>
      */
     @Deprecated
-    public Future<CommandResult> getProfileResponse(Calendar endTime, Integer status, Integer profileIntervalPeriod, Integer numberOfPeriodsDelivered, Integer intervals) {
+    public Future<CommandResult> getProfileResponse(ZigBeeUtcTime endTime, Integer status, Integer profileIntervalPeriod, Integer numberOfPeriodsDelivered, Integer intervals) {
         GetProfileResponse command = new GetProfileResponse();
 
         // Set the fields
@@ -17683,7 +17683,7 @@ public class ZclMeteringCluster extends ZclCluster {
      * This command is generated when the client command Request Fast Poll Mode is received.
      *
      * @param appliedUpdatePeriod {@link Integer} Applied Update Period
-     * @param fastPollModeEndtime {@link Calendar} Fast Poll Mode Endtime
+     * @param fastPollModeEndtime {@link ZigBeeUtcTime} Fast Poll Mode Endtime
      * @return the {@link Future<CommandResult>} command result future
      * @deprecated As of release 1.3.0.
      * Use extended ZclCommand class constructors to instantiate the command
@@ -17695,7 +17695,7 @@ public class ZclMeteringCluster extends ZclCluster {
      * with <code>cluster.sendCommand(new requestFastPollModeResponse(parameters ...))</code>
      */
     @Deprecated
-    public Future<CommandResult> requestFastPollModeResponse(Integer appliedUpdatePeriod, Calendar fastPollModeEndtime) {
+    public Future<CommandResult> requestFastPollModeResponse(Integer appliedUpdatePeriod, ZigBeeUtcTime fastPollModeEndtime) {
         RequestFastPollModeResponse command = new RequestFastPollModeResponse();
 
         // Set the fields
@@ -17770,7 +17770,7 @@ public class ZclMeteringCluster extends ZclCluster {
      * single snapshot to the client.
      *
      * @param snapshotId {@link Integer} Snapshot ID
-     * @param snapshotTime {@link Calendar} Snapshot Time
+     * @param snapshotTime {@link ZigBeeUtcTime} Snapshot Time
      * @param totalSnapshotsFound {@link Integer} Total Snapshots Found
      * @param commandIndex {@link Integer} Command Index
      * @param totalNumberOfCommands {@link Integer} Total Number Of Commands
@@ -17788,7 +17788,7 @@ public class ZclMeteringCluster extends ZclCluster {
      * with <code>cluster.sendCommand(new publishSnapshot(parameters ...))</code>
      */
     @Deprecated
-    public Future<CommandResult> publishSnapshot(Integer snapshotId, Calendar snapshotTime, Integer totalSnapshotsFound, Integer commandIndex, Integer totalNumberOfCommands, Integer snapshotCause, Integer snapshotPayloadType, Integer snapshotPayload) {
+    public Future<CommandResult> publishSnapshot(Integer snapshotId, ZigBeeUtcTime snapshotTime, Integer totalSnapshotsFound, Integer commandIndex, Integer totalNumberOfCommands, Integer snapshotCause, Integer snapshotPayloadType, Integer snapshotPayload) {
         PublishSnapshot command = new PublishSnapshot();
 
         // Set the fields
@@ -17811,7 +17811,7 @@ public class ZclMeteringCluster extends ZclCluster {
      * generated in response to a GetSampledData command.
      *
      * @param sampleId {@link Integer} Sample ID
-     * @param sampleStartTime {@link Calendar} Sample Start Time
+     * @param sampleStartTime {@link ZigBeeUtcTime} Sample Start Time
      * @param sampleType {@link Integer} Sample Type
      * @param sampleRequestInterval {@link Integer} Sample Request Interval
      * @param numberOfSamples {@link Integer} Number Of Samples
@@ -17827,7 +17827,7 @@ public class ZclMeteringCluster extends ZclCluster {
      * with <code>cluster.sendCommand(new getSampledDataResponse(parameters ...))</code>
      */
     @Deprecated
-    public Future<CommandResult> getSampledDataResponse(Integer sampleId, Calendar sampleStartTime, Integer sampleType, Integer sampleRequestInterval, Integer numberOfSamples, Integer samples) {
+    public Future<CommandResult> getSampledDataResponse(Integer sampleId, ZigBeeUtcTime sampleStartTime, Integer sampleType, Integer sampleRequestInterval, Integer numberOfSamples, Integer samples) {
         GetSampledDataResponse command = new GetSampledDataResponse();
 
         // Set the fields
@@ -17979,7 +17979,7 @@ public class ZclMeteringCluster extends ZclCluster {
      *
      * @param providerId {@link Integer} Provider ID
      * @param issuerEventId {@link Integer} Issuer Event ID
-     * @param implementationDateTime {@link Calendar} Implementation Date Time
+     * @param implementationDateTime {@link ZigBeeUtcTime} Implementation Date Time
      * @param supplyStatus {@link Integer} Supply Status
      * @return the {@link Future<CommandResult>} command result future
      * @deprecated As of release 1.3.0.
@@ -17992,7 +17992,7 @@ public class ZclMeteringCluster extends ZclCluster {
      * with <code>cluster.sendCommand(new supplyStatusResponse(parameters ...))</code>
      */
     @Deprecated
-    public Future<CommandResult> supplyStatusResponse(Integer providerId, Integer issuerEventId, Calendar implementationDateTime, Integer supplyStatus) {
+    public Future<CommandResult> supplyStatusResponse(Integer providerId, Integer issuerEventId, ZigBeeUtcTime implementationDateTime, Integer supplyStatus) {
         SupplyStatusResponse command = new SupplyStatusResponse();
 
         // Set the fields

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclPrepaymentCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclPrepaymentCluster.java
@@ -7,7 +7,6 @@
  */
 package com.zsmartsystems.zigbee.zcl.clusters;
 
-import java.util.Calendar;
 import java.util.Map;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.Future;
@@ -40,6 +39,7 @@ import com.zsmartsystems.zigbee.zcl.clusters.prepayment.SetOverallDebtCap;
 import com.zsmartsystems.zigbee.zcl.clusters.prepayment.TopUpPayload;
 import com.zsmartsystems.zigbee.zcl.clusters.prepayment.ZclPrepaymentCommand;
 import com.zsmartsystems.zigbee.zcl.field.ByteArray;
+import com.zsmartsystems.zigbee.zcl.field.ZigBeeUtcTime;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
 /**
@@ -65,7 +65,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2022-05-28T21:15:34Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2022-12-09T01:34:23Z")
 public class ZclPrepaymentCluster extends ZclCluster {
     /**
      * The ZigBee Cluster Library Cluster ID
@@ -1080,7 +1080,7 @@ public class ZclPrepaymentCluster extends ZclCluster {
      * <p>
      * ADDME
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is MANDATORY
      *
@@ -1104,21 +1104,21 @@ public class ZclPrepaymentCluster extends ZclCluster {
      * <p>
      * This method will block until the response is received or a timeout occurs unless the current value is returned.
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is MANDATORY
      *
      * @param refreshPeriod the maximum age of the data (in milliseconds) before an update is needed
-     * @return the {@link Calendar} attribute value, or null on error
+     * @return the {@link ZigBeeUtcTime} attribute value, or null on error
      * @deprecated As of release 1.2.0, replaced by {@link #ZclAttribute#readValue(long refreshPeriod)}
      */
     @Deprecated
-    public Calendar getCreditRemainingTimestamp(final long refreshPeriod) {
+    public ZigBeeUtcTime getCreditRemainingTimestamp(final long refreshPeriod) {
         if (serverAttributes.get(ATTR_CREDITREMAININGTIMESTAMP).isLastValueCurrent(refreshPeriod)) {
-            return (Calendar) serverAttributes.get(ATTR_CREDITREMAININGTIMESTAMP).getLastValue();
+            return (ZigBeeUtcTime) serverAttributes.get(ATTR_CREDITREMAININGTIMESTAMP).getLastValue();
         }
 
-        return (Calendar) readSync(serverAttributes.get(ATTR_CREDITREMAININGTIMESTAMP));
+        return (ZigBeeUtcTime) readSync(serverAttributes.get(ATTR_CREDITREMAININGTIMESTAMP));
     }
 
     /**
@@ -1126,7 +1126,7 @@ public class ZclPrepaymentCluster extends ZclCluster {
      * <p>
      * ADDME
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is MANDATORY
      *
@@ -1936,7 +1936,7 @@ public class ZclPrepaymentCluster extends ZclCluster {
      * <p>
      * ADDME
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is MANDATORY
      *
@@ -1960,21 +1960,21 @@ public class ZclPrepaymentCluster extends ZclCluster {
      * <p>
      * This method will block until the response is received or a timeout occurs unless the current value is returned.
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is MANDATORY
      *
      * @param refreshPeriod the maximum age of the data (in milliseconds) before an update is needed
-     * @return the {@link Calendar} attribute value, or null on error
+     * @return the {@link ZigBeeUtcTime} attribute value, or null on error
      * @deprecated As of release 1.2.0, replaced by {@link #ZclAttribute#readValue(long refreshPeriod)}
      */
     @Deprecated
-    public Calendar getNextFriendlyCreditPeriod(final long refreshPeriod) {
+    public ZigBeeUtcTime getNextFriendlyCreditPeriod(final long refreshPeriod) {
         if (serverAttributes.get(ATTR_NEXTFRIENDLYCREDITPERIOD).isLastValueCurrent(refreshPeriod)) {
-            return (Calendar) serverAttributes.get(ATTR_NEXTFRIENDLYCREDITPERIOD).getLastValue();
+            return (ZigBeeUtcTime) serverAttributes.get(ATTR_NEXTFRIENDLYCREDITPERIOD).getLastValue();
         }
 
-        return (Calendar) readSync(serverAttributes.get(ATTR_NEXTFRIENDLYCREDITPERIOD));
+        return (ZigBeeUtcTime) readSync(serverAttributes.get(ATTR_NEXTFRIENDLYCREDITPERIOD));
     }
 
     /**
@@ -1982,7 +1982,7 @@ public class ZclPrepaymentCluster extends ZclCluster {
      * <p>
      * ADDME
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is MANDATORY
      *
@@ -2132,7 +2132,7 @@ public class ZclPrepaymentCluster extends ZclCluster {
      * <p>
      * ADDME
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is MANDATORY
      *
@@ -2156,21 +2156,21 @@ public class ZclPrepaymentCluster extends ZclCluster {
      * <p>
      * This method will block until the response is received or a timeout occurs unless the current value is returned.
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is MANDATORY
      *
      * @param refreshPeriod the maximum age of the data (in milliseconds) before an update is needed
-     * @return the {@link Calendar} attribute value, or null on error
+     * @return the {@link ZigBeeUtcTime} attribute value, or null on error
      * @deprecated As of release 1.2.0, replaced by {@link #ZclAttribute#readValue(long refreshPeriod)}
      */
     @Deprecated
-    public Calendar getTopUpDateTime1(final long refreshPeriod) {
+    public ZigBeeUtcTime getTopUpDateTime1(final long refreshPeriod) {
         if (serverAttributes.get(ATTR_TOPUPDATETIME1).isLastValueCurrent(refreshPeriod)) {
-            return (Calendar) serverAttributes.get(ATTR_TOPUPDATETIME1).getLastValue();
+            return (ZigBeeUtcTime) serverAttributes.get(ATTR_TOPUPDATETIME1).getLastValue();
         }
 
-        return (Calendar) readSync(serverAttributes.get(ATTR_TOPUPDATETIME1));
+        return (ZigBeeUtcTime) readSync(serverAttributes.get(ATTR_TOPUPDATETIME1));
     }
 
     /**
@@ -2178,7 +2178,7 @@ public class ZclPrepaymentCluster extends ZclCluster {
      * <p>
      * ADDME
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is MANDATORY
      *
@@ -2394,7 +2394,7 @@ public class ZclPrepaymentCluster extends ZclCluster {
      * <p>
      * ADDME
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is MANDATORY
      *
@@ -2418,21 +2418,21 @@ public class ZclPrepaymentCluster extends ZclCluster {
      * <p>
      * This method will block until the response is received or a timeout occurs unless the current value is returned.
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is MANDATORY
      *
      * @param refreshPeriod the maximum age of the data (in milliseconds) before an update is needed
-     * @return the {@link Calendar} attribute value, or null on error
+     * @return the {@link ZigBeeUtcTime} attribute value, or null on error
      * @deprecated As of release 1.2.0, replaced by {@link #ZclAttribute#readValue(long refreshPeriod)}
      */
     @Deprecated
-    public Calendar getTopUpDateTime2(final long refreshPeriod) {
+    public ZigBeeUtcTime getTopUpDateTime2(final long refreshPeriod) {
         if (serverAttributes.get(ATTR_TOPUPDATETIME2).isLastValueCurrent(refreshPeriod)) {
-            return (Calendar) serverAttributes.get(ATTR_TOPUPDATETIME2).getLastValue();
+            return (ZigBeeUtcTime) serverAttributes.get(ATTR_TOPUPDATETIME2).getLastValue();
         }
 
-        return (Calendar) readSync(serverAttributes.get(ATTR_TOPUPDATETIME2));
+        return (ZigBeeUtcTime) readSync(serverAttributes.get(ATTR_TOPUPDATETIME2));
     }
 
     /**
@@ -2440,7 +2440,7 @@ public class ZclPrepaymentCluster extends ZclCluster {
      * <p>
      * ADDME
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is MANDATORY
      *
@@ -2656,7 +2656,7 @@ public class ZclPrepaymentCluster extends ZclCluster {
      * <p>
      * ADDME
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is MANDATORY
      *
@@ -2680,21 +2680,21 @@ public class ZclPrepaymentCluster extends ZclCluster {
      * <p>
      * This method will block until the response is received or a timeout occurs unless the current value is returned.
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is MANDATORY
      *
      * @param refreshPeriod the maximum age of the data (in milliseconds) before an update is needed
-     * @return the {@link Calendar} attribute value, or null on error
+     * @return the {@link ZigBeeUtcTime} attribute value, or null on error
      * @deprecated As of release 1.2.0, replaced by {@link #ZclAttribute#readValue(long refreshPeriod)}
      */
     @Deprecated
-    public Calendar getTopUpDateTime3(final long refreshPeriod) {
+    public ZigBeeUtcTime getTopUpDateTime3(final long refreshPeriod) {
         if (serverAttributes.get(ATTR_TOPUPDATETIME3).isLastValueCurrent(refreshPeriod)) {
-            return (Calendar) serverAttributes.get(ATTR_TOPUPDATETIME3).getLastValue();
+            return (ZigBeeUtcTime) serverAttributes.get(ATTR_TOPUPDATETIME3).getLastValue();
         }
 
-        return (Calendar) readSync(serverAttributes.get(ATTR_TOPUPDATETIME3));
+        return (ZigBeeUtcTime) readSync(serverAttributes.get(ATTR_TOPUPDATETIME3));
     }
 
     /**
@@ -2702,7 +2702,7 @@ public class ZclPrepaymentCluster extends ZclCluster {
      * <p>
      * ADDME
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is MANDATORY
      *
@@ -2918,7 +2918,7 @@ public class ZclPrepaymentCluster extends ZclCluster {
      * <p>
      * ADDME
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is MANDATORY
      *
@@ -2942,21 +2942,21 @@ public class ZclPrepaymentCluster extends ZclCluster {
      * <p>
      * This method will block until the response is received or a timeout occurs unless the current value is returned.
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is MANDATORY
      *
      * @param refreshPeriod the maximum age of the data (in milliseconds) before an update is needed
-     * @return the {@link Calendar} attribute value, or null on error
+     * @return the {@link ZigBeeUtcTime} attribute value, or null on error
      * @deprecated As of release 1.2.0, replaced by {@link #ZclAttribute#readValue(long refreshPeriod)}
      */
     @Deprecated
-    public Calendar getTopUpDateTime4(final long refreshPeriod) {
+    public ZigBeeUtcTime getTopUpDateTime4(final long refreshPeriod) {
         if (serverAttributes.get(ATTR_TOPUPDATETIME4).isLastValueCurrent(refreshPeriod)) {
-            return (Calendar) serverAttributes.get(ATTR_TOPUPDATETIME4).getLastValue();
+            return (ZigBeeUtcTime) serverAttributes.get(ATTR_TOPUPDATETIME4).getLastValue();
         }
 
-        return (Calendar) readSync(serverAttributes.get(ATTR_TOPUPDATETIME4));
+        return (ZigBeeUtcTime) readSync(serverAttributes.get(ATTR_TOPUPDATETIME4));
     }
 
     /**
@@ -2964,7 +2964,7 @@ public class ZclPrepaymentCluster extends ZclCluster {
      * <p>
      * ADDME
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is MANDATORY
      *
@@ -3180,7 +3180,7 @@ public class ZclPrepaymentCluster extends ZclCluster {
      * <p>
      * ADDME
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is MANDATORY
      *
@@ -3204,21 +3204,21 @@ public class ZclPrepaymentCluster extends ZclCluster {
      * <p>
      * This method will block until the response is received or a timeout occurs unless the current value is returned.
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is MANDATORY
      *
      * @param refreshPeriod the maximum age of the data (in milliseconds) before an update is needed
-     * @return the {@link Calendar} attribute value, or null on error
+     * @return the {@link ZigBeeUtcTime} attribute value, or null on error
      * @deprecated As of release 1.2.0, replaced by {@link #ZclAttribute#readValue(long refreshPeriod)}
      */
     @Deprecated
-    public Calendar getTopUpDateTime5(final long refreshPeriod) {
+    public ZigBeeUtcTime getTopUpDateTime5(final long refreshPeriod) {
         if (serverAttributes.get(ATTR_TOPUPDATETIME5).isLastValueCurrent(refreshPeriod)) {
-            return (Calendar) serverAttributes.get(ATTR_TOPUPDATETIME5).getLastValue();
+            return (ZigBeeUtcTime) serverAttributes.get(ATTR_TOPUPDATETIME5).getLastValue();
         }
 
-        return (Calendar) readSync(serverAttributes.get(ATTR_TOPUPDATETIME5));
+        return (ZigBeeUtcTime) readSync(serverAttributes.get(ATTR_TOPUPDATETIME5));
     }
 
     /**
@@ -3226,7 +3226,7 @@ public class ZclPrepaymentCluster extends ZclCluster {
      * <p>
      * ADDME
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is MANDATORY
      *
@@ -3638,7 +3638,7 @@ public class ZclPrepaymentCluster extends ZclCluster {
      * <p>
      * ADDME
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is MANDATORY
      *
@@ -3662,21 +3662,21 @@ public class ZclPrepaymentCluster extends ZclCluster {
      * <p>
      * This method will block until the response is received or a timeout occurs unless the current value is returned.
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is MANDATORY
      *
      * @param refreshPeriod the maximum age of the data (in milliseconds) before an update is needed
-     * @return the {@link Calendar} attribute value, or null on error
+     * @return the {@link ZigBeeUtcTime} attribute value, or null on error
      * @deprecated As of release 1.2.0, replaced by {@link #ZclAttribute#readValue(long refreshPeriod)}
      */
     @Deprecated
-    public Calendar getDebtRecoveryStartTime1(final long refreshPeriod) {
+    public ZigBeeUtcTime getDebtRecoveryStartTime1(final long refreshPeriod) {
         if (serverAttributes.get(ATTR_DEBTRECOVERYSTARTTIME1).isLastValueCurrent(refreshPeriod)) {
-            return (Calendar) serverAttributes.get(ATTR_DEBTRECOVERYSTARTTIME1).getLastValue();
+            return (ZigBeeUtcTime) serverAttributes.get(ATTR_DEBTRECOVERYSTARTTIME1).getLastValue();
         }
 
-        return (Calendar) readSync(serverAttributes.get(ATTR_DEBTRECOVERYSTARTTIME1));
+        return (ZigBeeUtcTime) readSync(serverAttributes.get(ATTR_DEBTRECOVERYSTARTTIME1));
     }
 
     /**
@@ -3684,7 +3684,7 @@ public class ZclPrepaymentCluster extends ZclCluster {
      * <p>
      * ADDME
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is MANDATORY
      *
@@ -4163,7 +4163,7 @@ public class ZclPrepaymentCluster extends ZclCluster {
      * <p>
      * ADDME
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is MANDATORY
      *
@@ -4187,21 +4187,21 @@ public class ZclPrepaymentCluster extends ZclCluster {
      * <p>
      * This method will block until the response is received or a timeout occurs unless the current value is returned.
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is MANDATORY
      *
      * @param refreshPeriod the maximum age of the data (in milliseconds) before an update is needed
-     * @return the {@link Calendar} attribute value, or null on error
+     * @return the {@link ZigBeeUtcTime} attribute value, or null on error
      * @deprecated As of release 1.2.0, replaced by {@link #ZclAttribute#readValue(long refreshPeriod)}
      */
     @Deprecated
-    public Calendar getDebtRecoveryStartTime2(final long refreshPeriod) {
+    public ZigBeeUtcTime getDebtRecoveryStartTime2(final long refreshPeriod) {
         if (serverAttributes.get(ATTR_DEBTRECOVERYSTARTTIME2).isLastValueCurrent(refreshPeriod)) {
-            return (Calendar) serverAttributes.get(ATTR_DEBTRECOVERYSTARTTIME2).getLastValue();
+            return (ZigBeeUtcTime) serverAttributes.get(ATTR_DEBTRECOVERYSTARTTIME2).getLastValue();
         }
 
-        return (Calendar) readSync(serverAttributes.get(ATTR_DEBTRECOVERYSTARTTIME2));
+        return (ZigBeeUtcTime) readSync(serverAttributes.get(ATTR_DEBTRECOVERYSTARTTIME2));
     }
 
     /**
@@ -4209,7 +4209,7 @@ public class ZclPrepaymentCluster extends ZclCluster {
      * <p>
      * ADDME
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is MANDATORY
      *
@@ -4688,7 +4688,7 @@ public class ZclPrepaymentCluster extends ZclCluster {
      * <p>
      * ADDME
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is MANDATORY
      *
@@ -4712,21 +4712,21 @@ public class ZclPrepaymentCluster extends ZclCluster {
      * <p>
      * This method will block until the response is received or a timeout occurs unless the current value is returned.
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is MANDATORY
      *
      * @param refreshPeriod the maximum age of the data (in milliseconds) before an update is needed
-     * @return the {@link Calendar} attribute value, or null on error
+     * @return the {@link ZigBeeUtcTime} attribute value, or null on error
      * @deprecated As of release 1.2.0, replaced by {@link #ZclAttribute#readValue(long refreshPeriod)}
      */
     @Deprecated
-    public Calendar getDebtRecoveryStartTime3(final long refreshPeriod) {
+    public ZigBeeUtcTime getDebtRecoveryStartTime3(final long refreshPeriod) {
         if (serverAttributes.get(ATTR_DEBTRECOVERYSTARTTIME3).isLastValueCurrent(refreshPeriod)) {
-            return (Calendar) serverAttributes.get(ATTR_DEBTRECOVERYSTARTTIME3).getLastValue();
+            return (ZigBeeUtcTime) serverAttributes.get(ATTR_DEBTRECOVERYSTARTTIME3).getLastValue();
         }
 
-        return (Calendar) readSync(serverAttributes.get(ATTR_DEBTRECOVERYSTARTTIME3));
+        return (ZigBeeUtcTime) readSync(serverAttributes.get(ATTR_DEBTRECOVERYSTARTTIME3));
     }
 
     /**
@@ -4734,7 +4734,7 @@ public class ZclPrepaymentCluster extends ZclCluster {
      * <p>
      * ADDME
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is MANDATORY
      *
@@ -9429,7 +9429,7 @@ public class ZclPrepaymentCluster extends ZclCluster {
      * FIXME: This command is sent to the Metering Device to activate the use of any Emergency
      * Credit available on the Metering Device.
      *
-     * @param commandIssueDateTime {@link Calendar} Command Issue Date Time
+     * @param commandIssueDateTime {@link ZigBeeUtcTime} Command Issue Date Time
      * @param originatingDevice {@link Integer} Originating Device
      * @param siteId {@link ByteArray} Site ID
      * @param meterSerialNumber {@link ByteArray} Meter Serial Number
@@ -9444,7 +9444,7 @@ public class ZclPrepaymentCluster extends ZclCluster {
      * with <code>cluster.sendCommand(new selectAvailableEmergencyCredit(parameters ...))</code>
      */
     @Deprecated
-    public Future<CommandResult> selectAvailableEmergencyCredit(Calendar commandIssueDateTime, Integer originatingDevice, ByteArray siteId, ByteArray meterSerialNumber) {
+    public Future<CommandResult> selectAvailableEmergencyCredit(ZigBeeUtcTime commandIssueDateTime, Integer originatingDevice, ByteArray siteId, ByteArray meterSerialNumber) {
         SelectAvailableEmergencyCredit command = new SelectAvailableEmergencyCredit();
 
         // Set the fields
@@ -9467,7 +9467,7 @@ public class ZclPrepaymentCluster extends ZclCluster {
      * @param debtAmount {@link Integer} Debt Amount
      * @param debtRecoveryMethod {@link Integer} Debt Recovery Method
      * @param debtAmountType {@link Integer} Debt Amount Type
-     * @param debtRecoveryStartTime {@link Calendar} Debt Recovery Start Time
+     * @param debtRecoveryStartTime {@link ZigBeeUtcTime} Debt Recovery Start Time
      * @param debtRecoveryCollectionTime {@link Integer} Debt Recovery Collection Time
      * @param debtRecoveryFrequency {@link Integer} Debt Recovery Frequency
      * @param debtRecoveryAmount {@link Integer} Debt Recovery Amount
@@ -9483,7 +9483,7 @@ public class ZclPrepaymentCluster extends ZclCluster {
      * with <code>cluster.sendCommand(new changeDebt(parameters ...))</code>
      */
     @Deprecated
-    public Future<CommandResult> changeDebt(Integer issuerEventId, ByteArray debtLabel, Integer debtAmount, Integer debtRecoveryMethod, Integer debtAmountType, Calendar debtRecoveryStartTime, Integer debtRecoveryCollectionTime, Integer debtRecoveryFrequency, Integer debtRecoveryAmount, Integer debtRecoveryBalancePercentage) {
+    public Future<CommandResult> changeDebt(Integer issuerEventId, ByteArray debtLabel, Integer debtAmount, Integer debtRecoveryMethod, Integer debtAmountType, ZigBeeUtcTime debtRecoveryStartTime, Integer debtRecoveryCollectionTime, Integer debtRecoveryFrequency, Integer debtRecoveryAmount, Integer debtRecoveryBalancePercentage) {
         ChangeDebt command = new ChangeDebt();
 
         // Set the fields
@@ -9507,7 +9507,7 @@ public class ZclPrepaymentCluster extends ZclCluster {
      * FIXME: This command is a method to set up the parameters for the emergency credit.
      *
      * @param issuerEventId {@link Integer} Issuer Event ID
-     * @param startTime {@link Calendar} Start Time
+     * @param startTime {@link ZigBeeUtcTime} Start Time
      * @param emergencyCreditLimit {@link Integer} Emergency Credit Limit
      * @param emergencyCreditThreshold {@link Integer} Emergency Credit Threshold
      * @return the {@link Future<CommandResult>} command result future
@@ -9521,7 +9521,7 @@ public class ZclPrepaymentCluster extends ZclCluster {
      * with <code>cluster.sendCommand(new emergencyCreditSetup(parameters ...))</code>
      */
     @Deprecated
-    public Future<CommandResult> emergencyCreditSetup(Integer issuerEventId, Calendar startTime, Integer emergencyCreditLimit, Integer emergencyCreditThreshold) {
+    public Future<CommandResult> emergencyCreditSetup(Integer issuerEventId, ZigBeeUtcTime startTime, Integer emergencyCreditLimit, Integer emergencyCreditThreshold) {
         EmergencyCreditSetup command = new EmergencyCreditSetup();
 
         // Set the fields
@@ -9569,7 +9569,7 @@ public class ZclPrepaymentCluster extends ZclCluster {
      * Prepayment meter.
      *
      * @param issuerEventId {@link Integer} Issuer Event ID
-     * @param startTime {@link Calendar} Start Time
+     * @param startTime {@link ZigBeeUtcTime} Start Time
      * @param creditAdjustmentType {@link Integer} Credit Adjustment Type
      * @param creditAdjustmentValue {@link Integer} Credit Adjustment Value
      * @return the {@link Future<CommandResult>} command result future
@@ -9583,7 +9583,7 @@ public class ZclPrepaymentCluster extends ZclCluster {
      * with <code>cluster.sendCommand(new creditAdjustment(parameters ...))</code>
      */
     @Deprecated
-    public Future<CommandResult> creditAdjustment(Integer issuerEventId, Calendar startTime, Integer creditAdjustmentType, Integer creditAdjustmentValue) {
+    public Future<CommandResult> creditAdjustment(Integer issuerEventId, ZigBeeUtcTime startTime, Integer creditAdjustmentType, Integer creditAdjustmentValue) {
         CreditAdjustment command = new CreditAdjustment();
 
         // Set the fields
@@ -9603,7 +9603,7 @@ public class ZclPrepaymentCluster extends ZclCluster {
      *
      * @param providerId {@link Integer} Provider ID
      * @param issuerEventId {@link Integer} Issuer Event ID
-     * @param implementationDateTime {@link Calendar} Implementation Date Time
+     * @param implementationDateTime {@link ZigBeeUtcTime} Implementation Date Time
      * @param proposedPaymentControlConfiguration {@link Integer} Proposed Payment Control Configuration
      * @param cutOffValue {@link Integer} Cut Off Value
      * @return the {@link Future<CommandResult>} command result future
@@ -9617,7 +9617,7 @@ public class ZclPrepaymentCluster extends ZclCluster {
      * with <code>cluster.sendCommand(new changePaymentMode(parameters ...))</code>
      */
     @Deprecated
-    public Future<CommandResult> changePaymentMode(Integer providerId, Integer issuerEventId, Calendar implementationDateTime, Integer proposedPaymentControlConfiguration, Integer cutOffValue) {
+    public Future<CommandResult> changePaymentMode(Integer providerId, Integer issuerEventId, ZigBeeUtcTime implementationDateTime, Integer proposedPaymentControlConfiguration, Integer cutOffValue) {
         ChangePaymentMode command = new ChangePaymentMode();
 
         // Set the fields
@@ -9635,8 +9635,8 @@ public class ZclPrepaymentCluster extends ZclCluster {
      * <p>
      * FIXME: This command is used to request the cluster server for snapshot data.
      *
-     * @param earliestStartTime {@link Calendar} Earliest Start Time
-     * @param latestEndTime {@link Calendar} Latest End Time
+     * @param earliestStartTime {@link ZigBeeUtcTime} Earliest Start Time
+     * @param latestEndTime {@link ZigBeeUtcTime} Latest End Time
      * @param snapshotOffset {@link Integer} Snapshot Offset
      * @param snapshotCause {@link Integer} Snapshot Cause
      * @return the {@link Future<CommandResult>} command result future
@@ -9650,7 +9650,7 @@ public class ZclPrepaymentCluster extends ZclCluster {
      * with <code>cluster.sendCommand(new getPrepaySnapshot(parameters ...))</code>
      */
     @Deprecated
-    public Future<CommandResult> getPrepaySnapshot(Calendar earliestStartTime, Calendar latestEndTime, Integer snapshotOffset, Integer snapshotCause) {
+    public Future<CommandResult> getPrepaySnapshot(ZigBeeUtcTime earliestStartTime, ZigBeeUtcTime latestEndTime, Integer snapshotOffset, Integer snapshotCause) {
         GetPrepaySnapshot command = new GetPrepaySnapshot();
 
         // Set the fields
@@ -9668,7 +9668,7 @@ public class ZclPrepaymentCluster extends ZclCluster {
      * FIXME: This command is sent to the Metering Device to retrieve the log of Top Up codes
      * received by the meter.
      *
-     * @param latestEndTime {@link Calendar} Latest End Time
+     * @param latestEndTime {@link ZigBeeUtcTime} Latest End Time
      * @param numberOfRecords {@link Integer} Number Of Records
      * @return the {@link Future<CommandResult>} command result future
      * @deprecated As of release 1.3.0.
@@ -9681,7 +9681,7 @@ public class ZclPrepaymentCluster extends ZclCluster {
      * with <code>cluster.sendCommand(new getTopUpLog(parameters ...))</code>
      */
     @Deprecated
-    public Future<CommandResult> getTopUpLog(Calendar latestEndTime, Integer numberOfRecords) {
+    public Future<CommandResult> getTopUpLog(ZigBeeUtcTime latestEndTime, Integer numberOfRecords) {
         GetTopUpLog command = new GetTopUpLog();
 
         // Set the fields
@@ -9723,7 +9723,7 @@ public class ZclPrepaymentCluster extends ZclCluster {
      * <p>
      * FIXME: This command is used to request the contents of the repayment log.
      *
-     * @param latestEndTime {@link Calendar} Latest End Time
+     * @param latestEndTime {@link ZigBeeUtcTime} Latest End Time
      * @param numberOfDebts {@link Integer} Number Of Debts
      * @param debtType {@link Integer} Debt Type
      * @return the {@link Future<CommandResult>} command result future
@@ -9737,7 +9737,7 @@ public class ZclPrepaymentCluster extends ZclCluster {
      * with <code>cluster.sendCommand(new getDebtRepaymentLog(parameters ...))</code>
      */
     @Deprecated
-    public Future<CommandResult> getDebtRepaymentLog(Calendar latestEndTime, Integer numberOfDebts, Integer debtType) {
+    public Future<CommandResult> getDebtRepaymentLog(ZigBeeUtcTime latestEndTime, Integer numberOfDebts, Integer debtType) {
         GetDebtRepaymentLog command = new GetDebtRepaymentLog();
 
         // Set the fields
@@ -9756,7 +9756,7 @@ public class ZclPrepaymentCluster extends ZclCluster {
      *
      * @param providerId {@link Integer} Provider ID
      * @param issuerEventId {@link Integer} Issuer Event ID
-     * @param implementationDateTime {@link Calendar} Implementation Date Time
+     * @param implementationDateTime {@link ZigBeeUtcTime} Implementation Date Time
      * @param maximumCreditLevel {@link Integer} Maximum Credit Level
      * @param maximumCreditPerTopUp {@link Integer} Maximum Credit Per Top Up
      * @return the {@link Future<CommandResult>} command result future
@@ -9770,7 +9770,7 @@ public class ZclPrepaymentCluster extends ZclCluster {
      * with <code>cluster.sendCommand(new setMaximumCreditLimit(parameters ...))</code>
      */
     @Deprecated
-    public Future<CommandResult> setMaximumCreditLimit(Integer providerId, Integer issuerEventId, Calendar implementationDateTime, Integer maximumCreditLevel, Integer maximumCreditPerTopUp) {
+    public Future<CommandResult> setMaximumCreditLimit(Integer providerId, Integer issuerEventId, ZigBeeUtcTime implementationDateTime, Integer maximumCreditLevel, Integer maximumCreditPerTopUp) {
         SetMaximumCreditLimit command = new SetMaximumCreditLimit();
 
         // Set the fields
@@ -9791,7 +9791,7 @@ public class ZclPrepaymentCluster extends ZclCluster {
      *
      * @param providerId {@link Integer} Provider ID
      * @param issuerEventId {@link Integer} Issuer Event ID
-     * @param implementationDateTime {@link Calendar} Implementation Date Time
+     * @param implementationDateTime {@link ZigBeeUtcTime} Implementation Date Time
      * @param overallDebtCap {@link Integer} Overall Debt Cap
      * @return the {@link Future<CommandResult>} command result future
      * @deprecated As of release 1.3.0.
@@ -9804,7 +9804,7 @@ public class ZclPrepaymentCluster extends ZclCluster {
      * with <code>cluster.sendCommand(new setOverallDebtCap(parameters ...))</code>
      */
     @Deprecated
-    public Future<CommandResult> setOverallDebtCap(Integer providerId, Integer issuerEventId, Calendar implementationDateTime, Integer overallDebtCap) {
+    public Future<CommandResult> setOverallDebtCap(Integer providerId, Integer issuerEventId, ZigBeeUtcTime implementationDateTime, Integer overallDebtCap) {
         SetOverallDebtCap command = new SetOverallDebtCap();
 
         // Set the fields
@@ -9823,7 +9823,7 @@ public class ZclPrepaymentCluster extends ZclCluster {
      * to return a single snapshot to the client.
      *
      * @param snapshotId {@link Integer} Snapshot ID
-     * @param snapshotTime {@link Calendar} Snapshot Time
+     * @param snapshotTime {@link ZigBeeUtcTime} Snapshot Time
      * @param totalSnapshotsFound {@link Integer} Total Snapshots Found
      * @param commandIndex {@link Integer} Command Index
      * @param totalNumberOfCommands {@link Integer} Total Number Of Commands
@@ -9841,7 +9841,7 @@ public class ZclPrepaymentCluster extends ZclCluster {
      * with <code>cluster.sendCommand(new publishPrepaySnapshot(parameters ...))</code>
      */
     @Deprecated
-    public Future<CommandResult> publishPrepaySnapshot(Integer snapshotId, Calendar snapshotTime, Integer totalSnapshotsFound, Integer commandIndex, Integer totalNumberOfCommands, Integer snapshotCause, Integer snapshotPayloadType, Integer snapshotPayload) {
+    public Future<CommandResult> publishPrepaySnapshot(Integer snapshotId, ZigBeeUtcTime snapshotTime, Integer totalSnapshotsFound, Integer commandIndex, Integer totalNumberOfCommands, Integer snapshotCause, Integer snapshotPayloadType, Integer snapshotPayload) {
         PublishPrepaySnapshot command = new PublishPrepaySnapshot();
 
         // Set the fields

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclPriceCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclPriceCluster.java
@@ -7,7 +7,6 @@
  */
 package com.zsmartsystems.zigbee.zcl.clusters;
 
-import java.util.Calendar;
 import java.util.Map;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.Future;
@@ -55,6 +54,7 @@ import com.zsmartsystems.zigbee.zcl.clusters.price.PublishTariffInformationComma
 import com.zsmartsystems.zigbee.zcl.clusters.price.PublishTierLabelsCommand;
 import com.zsmartsystems.zigbee.zcl.clusters.price.ZclPriceCommand;
 import com.zsmartsystems.zigbee.zcl.field.ByteArray;
+import com.zsmartsystems.zigbee.zcl.field.ZigBeeUtcTime;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
 /**
@@ -72,7 +72,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2022-05-28T21:15:34Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2022-12-09T01:34:23Z")
 public class ZclPriceCluster extends ZclCluster {
     /**
      * The ZigBee Cluster Library Cluster ID
@@ -6730,7 +6730,7 @@ public class ZclPriceCluster extends ZclCluster {
      * The StartofBlockPeriod attribute represents the start time of the current block
      * tariff period. A change indicates that a new Block Period is in effect.
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is OPTIONAL
      *
@@ -6755,21 +6755,21 @@ public class ZclPriceCluster extends ZclCluster {
      * <p>
      * This method will block until the response is received or a timeout occurs unless the current value is returned.
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is OPTIONAL
      *
      * @param refreshPeriod the maximum age of the data (in milliseconds) before an update is needed
-     * @return the {@link Calendar} attribute value, or null on error
+     * @return the {@link ZigBeeUtcTime} attribute value, or null on error
      * @deprecated As of release 1.2.0, replaced by {@link #ZclAttribute#readValue(long refreshPeriod)}
      */
     @Deprecated
-    public Calendar getStartOfBlockPeriod(final long refreshPeriod) {
+    public ZigBeeUtcTime getStartOfBlockPeriod(final long refreshPeriod) {
         if (serverAttributes.get(ATTR_STARTOFBLOCKPERIOD).isLastValueCurrent(refreshPeriod)) {
-            return (Calendar) serverAttributes.get(ATTR_STARTOFBLOCKPERIOD).getLastValue();
+            return (ZigBeeUtcTime) serverAttributes.get(ATTR_STARTOFBLOCKPERIOD).getLastValue();
         }
 
-        return (Calendar) readSync(serverAttributes.get(ATTR_STARTOFBLOCKPERIOD));
+        return (ZigBeeUtcTime) readSync(serverAttributes.get(ATTR_STARTOFBLOCKPERIOD));
     }
 
     /**
@@ -8710,7 +8710,7 @@ public class ZclPriceCluster extends ZclCluster {
      * The CurrentBillingPeriodStart attribute represents the start time of the current
      * billing period.
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is OPTIONAL
      *
@@ -8735,21 +8735,21 @@ public class ZclPriceCluster extends ZclCluster {
      * <p>
      * This method will block until the response is received or a timeout occurs unless the current value is returned.
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is OPTIONAL
      *
      * @param refreshPeriod the maximum age of the data (in milliseconds) before an update is needed
-     * @return the {@link Calendar} attribute value, or null on error
+     * @return the {@link ZigBeeUtcTime} attribute value, or null on error
      * @deprecated As of release 1.2.0, replaced by {@link #ZclAttribute#readValue(long refreshPeriod)}
      */
     @Deprecated
-    public Calendar getCurrentBillingPeriodStart(final long refreshPeriod) {
+    public ZigBeeUtcTime getCurrentBillingPeriodStart(final long refreshPeriod) {
         if (serverAttributes.get(ATTR_CURRENTBILLINGPERIODSTART).isLastValueCurrent(refreshPeriod)) {
-            return (Calendar) serverAttributes.get(ATTR_CURRENTBILLINGPERIODSTART).getLastValue();
+            return (ZigBeeUtcTime) serverAttributes.get(ATTR_CURRENTBILLINGPERIODSTART).getLastValue();
         }
 
-        return (Calendar) readSync(serverAttributes.get(ATTR_CURRENTBILLINGPERIODSTART));
+        return (ZigBeeUtcTime) readSync(serverAttributes.get(ATTR_CURRENTBILLINGPERIODSTART));
     }
 
     /**
@@ -8806,7 +8806,7 @@ public class ZclPriceCluster extends ZclCluster {
      * The LastBillingPeriodStart attribute represents the start time of the last billing
      * period.
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is OPTIONAL
      *
@@ -8831,21 +8831,21 @@ public class ZclPriceCluster extends ZclCluster {
      * <p>
      * This method will block until the response is received or a timeout occurs unless the current value is returned.
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is OPTIONAL
      *
      * @param refreshPeriod the maximum age of the data (in milliseconds) before an update is needed
-     * @return the {@link Calendar} attribute value, or null on error
+     * @return the {@link ZigBeeUtcTime} attribute value, or null on error
      * @deprecated As of release 1.2.0, replaced by {@link #ZclAttribute#readValue(long refreshPeriod)}
      */
     @Deprecated
-    public Calendar getLastBillingPeriodStart(final long refreshPeriod) {
+    public ZigBeeUtcTime getLastBillingPeriodStart(final long refreshPeriod) {
         if (serverAttributes.get(ATTR_LASTBILLINGPERIODSTART).isLastValueCurrent(refreshPeriod)) {
-            return (Calendar) serverAttributes.get(ATTR_LASTBILLINGPERIODSTART).getLastValue();
+            return (ZigBeeUtcTime) serverAttributes.get(ATTR_LASTBILLINGPERIODSTART).getLastValue();
         }
 
-        return (Calendar) readSync(serverAttributes.get(ATTR_LASTBILLINGPERIODSTART));
+        return (ZigBeeUtcTime) readSync(serverAttributes.get(ATTR_LASTBILLINGPERIODSTART));
     }
 
     /**
@@ -8956,7 +8956,7 @@ public class ZclPriceCluster extends ZclCluster {
      * The CreditPaymentDueDate attribute indicates the date and time when the next credit
      * payment is due to be paid by the consumer to the supplier.
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is OPTIONAL
      *
@@ -8981,21 +8981,21 @@ public class ZclPriceCluster extends ZclCluster {
      * <p>
      * This method will block until the response is received or a timeout occurs unless the current value is returned.
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is OPTIONAL
      *
      * @param refreshPeriod the maximum age of the data (in milliseconds) before an update is needed
-     * @return the {@link Calendar} attribute value, or null on error
+     * @return the {@link ZigBeeUtcTime} attribute value, or null on error
      * @deprecated As of release 1.2.0, replaced by {@link #ZclAttribute#readValue(long refreshPeriod)}
      */
     @Deprecated
-    public Calendar getCreditPaymentDueDate(final long refreshPeriod) {
+    public ZigBeeUtcTime getCreditPaymentDueDate(final long refreshPeriod) {
         if (serverAttributes.get(ATTR_CREDITPAYMENTDUEDATE).isLastValueCurrent(refreshPeriod)) {
-            return (Calendar) serverAttributes.get(ATTR_CREDITPAYMENTDUEDATE).getLastValue();
+            return (ZigBeeUtcTime) serverAttributes.get(ATTR_CREDITPAYMENTDUEDATE).getLastValue();
         }
 
-        return (Calendar) readSync(serverAttributes.get(ATTR_CREDITPAYMENTDUEDATE));
+        return (ZigBeeUtcTime) readSync(serverAttributes.get(ATTR_CREDITPAYMENTDUEDATE));
     }
 
     /**
@@ -9231,7 +9231,7 @@ public class ZclPriceCluster extends ZclCluster {
     /**
      * Get the <i>Credit Card Payment Date 1</i> attribute [attribute ID <b>0x0811</b>].
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is OPTIONAL
      *
@@ -9253,21 +9253,21 @@ public class ZclPriceCluster extends ZclCluster {
      * <p>
      * This method will block until the response is received or a timeout occurs unless the current value is returned.
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is OPTIONAL
      *
      * @param refreshPeriod the maximum age of the data (in milliseconds) before an update is needed
-     * @return the {@link Calendar} attribute value, or null on error
+     * @return the {@link ZigBeeUtcTime} attribute value, or null on error
      * @deprecated As of release 1.2.0, replaced by {@link #ZclAttribute#readValue(long refreshPeriod)}
      */
     @Deprecated
-    public Calendar getCreditCardPaymentDate1(final long refreshPeriod) {
+    public ZigBeeUtcTime getCreditCardPaymentDate1(final long refreshPeriod) {
         if (serverAttributes.get(ATTR_CREDITCARDPAYMENTDATE1).isLastValueCurrent(refreshPeriod)) {
-            return (Calendar) serverAttributes.get(ATTR_CREDITCARDPAYMENTDATE1).getLastValue();
+            return (ZigBeeUtcTime) serverAttributes.get(ATTR_CREDITCARDPAYMENTDATE1).getLastValue();
         }
 
-        return (Calendar) readSync(serverAttributes.get(ATTR_CREDITCARDPAYMENTDATE1));
+        return (ZigBeeUtcTime) readSync(serverAttributes.get(ATTR_CREDITCARDPAYMENTDATE1));
     }
 
     /**
@@ -9357,7 +9357,7 @@ public class ZclPriceCluster extends ZclCluster {
     /**
      * Get the <i>Credit Card Payment Date 2</i> attribute [attribute ID <b>0x0821</b>].
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is OPTIONAL
      *
@@ -9379,21 +9379,21 @@ public class ZclPriceCluster extends ZclCluster {
      * <p>
      * This method will block until the response is received or a timeout occurs unless the current value is returned.
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is OPTIONAL
      *
      * @param refreshPeriod the maximum age of the data (in milliseconds) before an update is needed
-     * @return the {@link Calendar} attribute value, or null on error
+     * @return the {@link ZigBeeUtcTime} attribute value, or null on error
      * @deprecated As of release 1.2.0, replaced by {@link #ZclAttribute#readValue(long refreshPeriod)}
      */
     @Deprecated
-    public Calendar getCreditCardPaymentDate2(final long refreshPeriod) {
+    public ZigBeeUtcTime getCreditCardPaymentDate2(final long refreshPeriod) {
         if (serverAttributes.get(ATTR_CREDITCARDPAYMENTDATE2).isLastValueCurrent(refreshPeriod)) {
-            return (Calendar) serverAttributes.get(ATTR_CREDITCARDPAYMENTDATE2).getLastValue();
+            return (ZigBeeUtcTime) serverAttributes.get(ATTR_CREDITCARDPAYMENTDATE2).getLastValue();
         }
 
-        return (Calendar) readSync(serverAttributes.get(ATTR_CREDITCARDPAYMENTDATE2));
+        return (ZigBeeUtcTime) readSync(serverAttributes.get(ATTR_CREDITCARDPAYMENTDATE2));
     }
 
     /**
@@ -9483,7 +9483,7 @@ public class ZclPriceCluster extends ZclCluster {
     /**
      * Get the <i>Credit Card Payment Date 3</i> attribute [attribute ID <b>0x0831</b>].
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is OPTIONAL
      *
@@ -9505,21 +9505,21 @@ public class ZclPriceCluster extends ZclCluster {
      * <p>
      * This method will block until the response is received or a timeout occurs unless the current value is returned.
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is OPTIONAL
      *
      * @param refreshPeriod the maximum age of the data (in milliseconds) before an update is needed
-     * @return the {@link Calendar} attribute value, or null on error
+     * @return the {@link ZigBeeUtcTime} attribute value, or null on error
      * @deprecated As of release 1.2.0, replaced by {@link #ZclAttribute#readValue(long refreshPeriod)}
      */
     @Deprecated
-    public Calendar getCreditCardPaymentDate3(final long refreshPeriod) {
+    public ZigBeeUtcTime getCreditCardPaymentDate3(final long refreshPeriod) {
         if (serverAttributes.get(ATTR_CREDITCARDPAYMENTDATE3).isLastValueCurrent(refreshPeriod)) {
-            return (Calendar) serverAttributes.get(ATTR_CREDITCARDPAYMENTDATE3).getLastValue();
+            return (ZigBeeUtcTime) serverAttributes.get(ATTR_CREDITCARDPAYMENTDATE3).getLastValue();
         }
 
-        return (Calendar) readSync(serverAttributes.get(ATTR_CREDITCARDPAYMENTDATE3));
+        return (ZigBeeUtcTime) readSync(serverAttributes.get(ATTR_CREDITCARDPAYMENTDATE3));
     }
 
     /**
@@ -9609,7 +9609,7 @@ public class ZclPriceCluster extends ZclCluster {
     /**
      * Get the <i>Credit Card Payment Date 4</i> attribute [attribute ID <b>0x0841</b>].
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is OPTIONAL
      *
@@ -9631,21 +9631,21 @@ public class ZclPriceCluster extends ZclCluster {
      * <p>
      * This method will block until the response is received or a timeout occurs unless the current value is returned.
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is OPTIONAL
      *
      * @param refreshPeriod the maximum age of the data (in milliseconds) before an update is needed
-     * @return the {@link Calendar} attribute value, or null on error
+     * @return the {@link ZigBeeUtcTime} attribute value, or null on error
      * @deprecated As of release 1.2.0, replaced by {@link #ZclAttribute#readValue(long refreshPeriod)}
      */
     @Deprecated
-    public Calendar getCreditCardPaymentDate4(final long refreshPeriod) {
+    public ZigBeeUtcTime getCreditCardPaymentDate4(final long refreshPeriod) {
         if (serverAttributes.get(ATTR_CREDITCARDPAYMENTDATE4).isLastValueCurrent(refreshPeriod)) {
-            return (Calendar) serverAttributes.get(ATTR_CREDITCARDPAYMENTDATE4).getLastValue();
+            return (ZigBeeUtcTime) serverAttributes.get(ATTR_CREDITCARDPAYMENTDATE4).getLastValue();
         }
 
-        return (Calendar) readSync(serverAttributes.get(ATTR_CREDITCARDPAYMENTDATE4));
+        return (ZigBeeUtcTime) readSync(serverAttributes.get(ATTR_CREDITCARDPAYMENTDATE4));
     }
 
     /**
@@ -9735,7 +9735,7 @@ public class ZclPriceCluster extends ZclCluster {
     /**
      * Get the <i>Credit Card Payment Date 5</i> attribute [attribute ID <b>0x0851</b>].
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is OPTIONAL
      *
@@ -9757,21 +9757,21 @@ public class ZclPriceCluster extends ZclCluster {
      * <p>
      * This method will block until the response is received or a timeout occurs unless the current value is returned.
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is OPTIONAL
      *
      * @param refreshPeriod the maximum age of the data (in milliseconds) before an update is needed
-     * @return the {@link Calendar} attribute value, or null on error
+     * @return the {@link ZigBeeUtcTime} attribute value, or null on error
      * @deprecated As of release 1.2.0, replaced by {@link #ZclAttribute#readValue(long refreshPeriod)}
      */
     @Deprecated
-    public Calendar getCreditCardPaymentDate5(final long refreshPeriod) {
+    public ZigBeeUtcTime getCreditCardPaymentDate5(final long refreshPeriod) {
         if (serverAttributes.get(ATTR_CREDITCARDPAYMENTDATE5).isLastValueCurrent(refreshPeriod)) {
-            return (Calendar) serverAttributes.get(ATTR_CREDITCARDPAYMENTDATE5).getLastValue();
+            return (ZigBeeUtcTime) serverAttributes.get(ATTR_CREDITCARDPAYMENTDATE5).getLastValue();
         }
 
-        return (Calendar) readSync(serverAttributes.get(ATTR_CREDITCARDPAYMENTDATE5));
+        return (ZigBeeUtcTime) readSync(serverAttributes.get(ATTR_CREDITCARDPAYMENTDATE5));
     }
 
     /**
@@ -9932,7 +9932,7 @@ public class ZclPriceCluster extends ZclCluster {
     /**
      * Get the <i>Received Start Of Block Period</i> attribute [attribute ID <b>0x8200</b>].
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is OPTIONAL
      *
@@ -9954,21 +9954,21 @@ public class ZclPriceCluster extends ZclCluster {
      * <p>
      * This method will block until the response is received or a timeout occurs unless the current value is returned.
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is OPTIONAL
      *
      * @param refreshPeriod the maximum age of the data (in milliseconds) before an update is needed
-     * @return the {@link Calendar} attribute value, or null on error
+     * @return the {@link ZigBeeUtcTime} attribute value, or null on error
      * @deprecated As of release 1.2.0, replaced by {@link #ZclAttribute#readValue(long refreshPeriod)}
      */
     @Deprecated
-    public Calendar getReceivedStartOfBlockPeriod(final long refreshPeriod) {
+    public ZigBeeUtcTime getReceivedStartOfBlockPeriod(final long refreshPeriod) {
         if (serverAttributes.get(ATTR_RECEIVEDSTARTOFBLOCKPERIOD).isLastValueCurrent(refreshPeriod)) {
-            return (Calendar) serverAttributes.get(ATTR_RECEIVEDSTARTOFBLOCKPERIOD).getLastValue();
+            return (ZigBeeUtcTime) serverAttributes.get(ATTR_RECEIVEDSTARTOFBLOCKPERIOD).getLastValue();
         }
 
-        return (Calendar) readSync(serverAttributes.get(ATTR_RECEIVEDSTARTOFBLOCKPERIOD));
+        return (ZigBeeUtcTime) readSync(serverAttributes.get(ATTR_RECEIVEDSTARTOFBLOCKPERIOD));
     }
 
     /**
@@ -11210,7 +11210,7 @@ public class ZclPriceCluster extends ZclCluster {
     /**
      * Get the <i>Received Current Billing Period Start</i> attribute [attribute ID <b>0x8700</b>].
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is OPTIONAL
      *
@@ -11232,21 +11232,21 @@ public class ZclPriceCluster extends ZclCluster {
      * <p>
      * This method will block until the response is received or a timeout occurs unless the current value is returned.
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is OPTIONAL
      *
      * @param refreshPeriod the maximum age of the data (in milliseconds) before an update is needed
-     * @return the {@link Calendar} attribute value, or null on error
+     * @return the {@link ZigBeeUtcTime} attribute value, or null on error
      * @deprecated As of release 1.2.0, replaced by {@link #ZclAttribute#readValue(long refreshPeriod)}
      */
     @Deprecated
-    public Calendar getReceivedCurrentBillingPeriodStart(final long refreshPeriod) {
+    public ZigBeeUtcTime getReceivedCurrentBillingPeriodStart(final long refreshPeriod) {
         if (serverAttributes.get(ATTR_RECEIVEDCURRENTBILLINGPERIODSTART).isLastValueCurrent(refreshPeriod)) {
-            return (Calendar) serverAttributes.get(ATTR_RECEIVEDCURRENTBILLINGPERIODSTART).getLastValue();
+            return (ZigBeeUtcTime) serverAttributes.get(ATTR_RECEIVEDCURRENTBILLINGPERIODSTART).getLastValue();
         }
 
-        return (Calendar) readSync(serverAttributes.get(ATTR_RECEIVEDCURRENTBILLINGPERIODSTART));
+        return (ZigBeeUtcTime) readSync(serverAttributes.get(ATTR_RECEIVEDCURRENTBILLINGPERIODSTART));
     }
 
     /**
@@ -11294,7 +11294,7 @@ public class ZclPriceCluster extends ZclCluster {
     /**
      * Get the <i>Received Last Billing Period Start</i> attribute [attribute ID <b>0x8702</b>].
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is OPTIONAL
      *
@@ -11316,21 +11316,21 @@ public class ZclPriceCluster extends ZclCluster {
      * <p>
      * This method will block until the response is received or a timeout occurs unless the current value is returned.
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is OPTIONAL
      *
      * @param refreshPeriod the maximum age of the data (in milliseconds) before an update is needed
-     * @return the {@link Calendar} attribute value, or null on error
+     * @return the {@link ZigBeeUtcTime} attribute value, or null on error
      * @deprecated As of release 1.2.0, replaced by {@link #ZclAttribute#readValue(long refreshPeriod)}
      */
     @Deprecated
-    public Calendar getReceivedLastBillingPeriodStart(final long refreshPeriod) {
+    public ZigBeeUtcTime getReceivedLastBillingPeriodStart(final long refreshPeriod) {
         if (serverAttributes.get(ATTR_RECEIVEDLASTBILLINGPERIODSTART).isLastValueCurrent(refreshPeriod)) {
-            return (Calendar) serverAttributes.get(ATTR_RECEIVEDLASTBILLINGPERIODSTART).getLastValue();
+            return (ZigBeeUtcTime) serverAttributes.get(ATTR_RECEIVEDLASTBILLINGPERIODSTART).getLastValue();
         }
 
-        return (Calendar) readSync(serverAttributes.get(ATTR_RECEIVEDLASTBILLINGPERIODSTART));
+        return (ZigBeeUtcTime) readSync(serverAttributes.get(ATTR_RECEIVEDLASTBILLINGPERIODSTART));
     }
 
     /**
@@ -11453,7 +11453,7 @@ public class ZclPriceCluster extends ZclCluster {
      * command, the device shall send a PublishPrice command for the currently scheduled
      * time.
      *
-     * @param startTime {@link Calendar} Start Time
+     * @param startTime {@link ZigBeeUtcTime} Start Time
      * @param numberOfEvents {@link Integer} Number Of Events
      * @return the {@link Future<CommandResult>} command result future
      * @deprecated As of release 1.3.0.
@@ -11466,7 +11466,7 @@ public class ZclPriceCluster extends ZclCluster {
      * with <code>cluster.sendCommand(new getScheduledPricesCommand(parameters ...))</code>
      */
     @Deprecated
-    public Future<CommandResult> getScheduledPricesCommand(Calendar startTime, Integer numberOfEvents) {
+    public Future<CommandResult> getScheduledPricesCommand(ZigBeeUtcTime startTime, Integer numberOfEvents) {
         GetScheduledPricesCommand command = new GetScheduledPricesCommand();
 
         // Set the fields
@@ -11485,7 +11485,7 @@ public class ZclPriceCluster extends ZclCluster {
      *
      * @param providerId {@link Integer} Provider ID
      * @param issuerEventId {@link Integer} Issuer Event ID
-     * @param priceAckTime {@link Calendar} Price Ack Time
+     * @param priceAckTime {@link ZigBeeUtcTime} Price Ack Time
      * @param control {@link Integer} Control
      * @return the {@link Future<CommandResult>} command result future
      * @deprecated As of release 1.3.0.
@@ -11498,7 +11498,7 @@ public class ZclPriceCluster extends ZclCluster {
      * with <code>cluster.sendCommand(new priceAcknowledgementCommand(parameters ...))</code>
      */
     @Deprecated
-    public Future<CommandResult> priceAcknowledgementCommand(Integer providerId, Integer issuerEventId, Calendar priceAckTime, Integer control) {
+    public Future<CommandResult> priceAcknowledgementCommand(Integer providerId, Integer issuerEventId, ZigBeeUtcTime priceAckTime, Integer control) {
         PriceAcknowledgementCommand command = new PriceAcknowledgementCommand();
 
         // Set the fields
@@ -11518,7 +11518,7 @@ public class ZclPriceCluster extends ZclCluster {
      * current period and a period to be activated in the near future. <br> A ZCL Default
      * response with status NOT_FOUND shall be returned if there are no events available.
      *
-     * @param startTime {@link Calendar} Start Time
+     * @param startTime {@link ZigBeeUtcTime} Start Time
      * @param numberOfEvents {@link Integer} Number Of Events
      * @param tariffType {@link Integer} Tariff Type
      * @return the {@link Future<CommandResult>} command result future
@@ -11532,7 +11532,7 @@ public class ZclPriceCluster extends ZclCluster {
      * with <code>cluster.sendCommand(new getBlockPeriodCommand(parameters ...))</code>
      */
     @Deprecated
-    public Future<CommandResult> getBlockPeriodCommand(Calendar startTime, Integer numberOfEvents, Integer tariffType) {
+    public Future<CommandResult> getBlockPeriodCommand(ZigBeeUtcTime startTime, Integer numberOfEvents, Integer tariffType) {
         GetBlockPeriodCommand command = new GetBlockPeriodCommand();
 
         // Set the fields
@@ -11552,7 +11552,7 @@ public class ZclPriceCluster extends ZclCluster {
      * <br> A ZCL Default response with status NOT_FOUND shall be returned if there are no
      * conversion factor updates available
      *
-     * @param earliestStartTime {@link Calendar} Earliest Start Time
+     * @param earliestStartTime {@link ZigBeeUtcTime} Earliest Start Time
      * @param minIssuerEventId {@link Integer} Min . Issuer Event ID
      * @param numberOfCommands {@link Integer} Number Of Commands
      * @return the {@link Future<CommandResult>} command result future
@@ -11566,7 +11566,7 @@ public class ZclPriceCluster extends ZclCluster {
      * with <code>cluster.sendCommand(new getConversionFactorCommand(parameters ...))</code>
      */
     @Deprecated
-    public Future<CommandResult> getConversionFactorCommand(Calendar earliestStartTime, Integer minIssuerEventId, Integer numberOfCommands) {
+    public Future<CommandResult> getConversionFactorCommand(ZigBeeUtcTime earliestStartTime, Integer minIssuerEventId, Integer numberOfCommands) {
         GetConversionFactorCommand command = new GetConversionFactorCommand();
 
         // Set the fields
@@ -11586,7 +11586,7 @@ public class ZclPriceCluster extends ZclCluster {
      * Default response with status NOT_FOUND shall be returned if there are no conversion
      * factor updates available
      *
-     * @param earliestStartTime {@link Calendar} Earliest Start Time
+     * @param earliestStartTime {@link ZigBeeUtcTime} Earliest Start Time
      * @param minIssuerEventId {@link Integer} Min . Issuer Event ID
      * @param numberOfCommands {@link Integer} Number Of Commands
      * @return the {@link Future<CommandResult>} command result future
@@ -11600,7 +11600,7 @@ public class ZclPriceCluster extends ZclCluster {
      * with <code>cluster.sendCommand(new getCalorificValueCommand(parameters ...))</code>
      */
     @Deprecated
-    public Future<CommandResult> getCalorificValueCommand(Calendar earliestStartTime, Integer minIssuerEventId, Integer numberOfCommands) {
+    public Future<CommandResult> getCalorificValueCommand(ZigBeeUtcTime earliestStartTime, Integer minIssuerEventId, Integer numberOfCommands) {
         GetCalorificValueCommand command = new GetCalorificValueCommand();
 
         // Set the fields
@@ -11622,7 +11622,7 @@ public class ZclPriceCluster extends ZclCluster {
      * must be sent using the start time and IssuerTariffID obtained from the appropriate
      * PublishTariffInformation command.
      *
-     * @param earliestStartTime {@link Calendar} Earliest Start Time
+     * @param earliestStartTime {@link ZigBeeUtcTime} Earliest Start Time
      * @param minIssuerEventId {@link Integer} Min . Issuer Event ID
      * @param numberOfCommands {@link Integer} Number Of Commands
      * @param tariffType {@link Integer} Tariff Type
@@ -11637,7 +11637,7 @@ public class ZclPriceCluster extends ZclCluster {
      * with <code>cluster.sendCommand(new getTariffInformationCommand(parameters ...))</code>
      */
     @Deprecated
-    public Future<CommandResult> getTariffInformationCommand(Calendar earliestStartTime, Integer minIssuerEventId, Integer numberOfCommands, Integer tariffType) {
+    public Future<CommandResult> getTariffInformationCommand(ZigBeeUtcTime earliestStartTime, Integer minIssuerEventId, Integer numberOfCommands, Integer tariffType) {
         GetTariffInformationCommand command = new GetTariffInformationCommand();
 
         // Set the fields
@@ -11714,7 +11714,7 @@ public class ZclPriceCluster extends ZclCluster {
      * factor updates. A server device shall be capable of storing at least two instances,
      * current and (if available) next instance to be activated in the future.
      *
-     * @param earliestStartTime {@link Calendar} Earliest Start Time
+     * @param earliestStartTime {@link ZigBeeUtcTime} Earliest Start Time
      * @param minIssuerEventId {@link Integer} Min . Issuer Event ID
      * @param numberOfCommands {@link Integer} Number Of Commands
      * @param tariffType {@link Integer} Tariff Type
@@ -11729,7 +11729,7 @@ public class ZclPriceCluster extends ZclCluster {
      * with <code>cluster.sendCommand(new getCo2ValueCommand(parameters ...))</code>
      */
     @Deprecated
-    public Future<CommandResult> getCo2ValueCommand(Calendar earliestStartTime, Integer minIssuerEventId, Integer numberOfCommands, Integer tariffType) {
+    public Future<CommandResult> getCo2ValueCommand(ZigBeeUtcTime earliestStartTime, Integer minIssuerEventId, Integer numberOfCommands, Integer tariffType) {
         GetCo2ValueCommand command = new GetCo2ValueCommand();
 
         // Set the fields
@@ -11774,7 +11774,7 @@ public class ZclPriceCluster extends ZclCluster {
      * This command initiates one or more PublishBillingPeriod commands for currently
      * scheduled billing periods.
      *
-     * @param earliestStartTime {@link Calendar} Earliest Start Time
+     * @param earliestStartTime {@link ZigBeeUtcTime} Earliest Start Time
      * @param minIssuerEventId {@link Integer} Min . Issuer Event ID
      * @param numberOfCommands {@link Integer} Number Of Commands
      * @param tariffType {@link Integer} Tariff Type
@@ -11789,7 +11789,7 @@ public class ZclPriceCluster extends ZclCluster {
      * with <code>cluster.sendCommand(new getBillingPeriodCommand(parameters ...))</code>
      */
     @Deprecated
-    public Future<CommandResult> getBillingPeriodCommand(Calendar earliestStartTime, Integer minIssuerEventId, Integer numberOfCommands, Integer tariffType) {
+    public Future<CommandResult> getBillingPeriodCommand(ZigBeeUtcTime earliestStartTime, Integer minIssuerEventId, Integer numberOfCommands, Integer tariffType) {
         GetBillingPeriodCommand command = new GetBillingPeriodCommand();
 
         // Set the fields
@@ -11807,7 +11807,7 @@ public class ZclPriceCluster extends ZclCluster {
      * This command initiates one or more PublishConsolidatedBill commands with the
      * requested billing information.
      *
-     * @param earliestStartTime {@link Calendar} Earliest Start Time
+     * @param earliestStartTime {@link ZigBeeUtcTime} Earliest Start Time
      * @param minIssuerEventId {@link Integer} Min . Issuer Event ID
      * @param numberOfCommands {@link Integer} Number Of Commands
      * @param tariffType {@link Integer} Tariff Type
@@ -11822,7 +11822,7 @@ public class ZclPriceCluster extends ZclCluster {
      * with <code>cluster.sendCommand(new getConsolidatedBillCommand(parameters ...))</code>
      */
     @Deprecated
-    public Future<CommandResult> getConsolidatedBillCommand(Calendar earliestStartTime, Integer minIssuerEventId, Integer numberOfCommands, Integer tariffType) {
+    public Future<CommandResult> getConsolidatedBillCommand(ZigBeeUtcTime earliestStartTime, Integer minIssuerEventId, Integer numberOfCommands, Integer tariffType) {
         GetConsolidatedBillCommand command = new GetConsolidatedBillCommand();
 
         // Set the fields
@@ -11869,7 +11869,7 @@ public class ZclPriceCluster extends ZclCluster {
      * This command initiates PublishCreditPayment commands for the requested credit
      * payment information.
      *
-     * @param latestEndTime {@link Calendar} Latest End Time
+     * @param latestEndTime {@link ZigBeeUtcTime} Latest End Time
      * @param numberOfRecords {@link Integer} Number Of Records
      * @return the {@link Future<CommandResult>} command result future
      * @deprecated As of release 1.3.0.
@@ -11882,7 +11882,7 @@ public class ZclPriceCluster extends ZclCluster {
      * with <code>cluster.sendCommand(new getCreditPaymentCommand(parameters ...))</code>
      */
     @Deprecated
-    public Future<CommandResult> getCreditPaymentCommand(Calendar latestEndTime, Integer numberOfRecords) {
+    public Future<CommandResult> getCreditPaymentCommand(ZigBeeUtcTime latestEndTime, Integer numberOfRecords) {
         GetCreditPaymentCommand command = new GetCreditPaymentCommand();
 
         // Set the fields
@@ -11966,12 +11966,12 @@ public class ZclPriceCluster extends ZclCluster {
      * @param providerId {@link Integer} Provider ID
      * @param rateLabel {@link ByteArray} Rate Label
      * @param issuerEventId {@link Integer} Issuer Event ID
-     * @param currentTime {@link Calendar} Current Time
+     * @param currentTime {@link ZigBeeUtcTime} Current Time
      * @param unitOfMeasure {@link Integer} Unit Of Measure
      * @param currency {@link Integer} Currency
      * @param priceTrailingDigitAndTier {@link Integer} Price Trailing Digit And Tier
      * @param numberOfPriceTiers {@link Integer} Number Of Price Tiers
-     * @param startTime {@link Calendar} Start Time
+     * @param startTime {@link ZigBeeUtcTime} Start Time
      * @param duration {@link Integer} Duration
      * @param price {@link Integer} Price
      * @param priceRatio {@link Integer} Price Ratio
@@ -11998,7 +11998,7 @@ public class ZclPriceCluster extends ZclCluster {
      * with <code>cluster.sendCommand(new publishPriceCommand(parameters ...))</code>
      */
     @Deprecated
-    public Future<CommandResult> publishPriceCommand(Integer providerId, ByteArray rateLabel, Integer issuerEventId, Calendar currentTime, Integer unitOfMeasure, Integer currency, Integer priceTrailingDigitAndTier, Integer numberOfPriceTiers, Calendar startTime, Integer duration, Integer price, Integer priceRatio, Integer generationPrice, Integer generationPriceRatio, Integer alternateCostDelivered, Integer alternateCostUnit, Integer alternateCostTrailingDigit, Integer numberOfBlockThresholds, Integer priceControl, Integer numberOfGenerationTiers, Integer generationTier, Integer extendedNumberOfPriceTiers, Integer extendedPriceTier, Integer extendedRegisterTier) {
+    public Future<CommandResult> publishPriceCommand(Integer providerId, ByteArray rateLabel, Integer issuerEventId, ZigBeeUtcTime currentTime, Integer unitOfMeasure, Integer currency, Integer priceTrailingDigitAndTier, Integer numberOfPriceTiers, ZigBeeUtcTime startTime, Integer duration, Integer price, Integer priceRatio, Integer generationPrice, Integer generationPriceRatio, Integer alternateCostDelivered, Integer alternateCostUnit, Integer alternateCostTrailingDigit, Integer numberOfBlockThresholds, Integer priceControl, Integer numberOfGenerationTiers, Integer generationTier, Integer extendedNumberOfPriceTiers, Integer extendedPriceTier, Integer extendedRegisterTier) {
         PublishPriceCommand command = new PublishPriceCommand();
 
         // Set the fields
@@ -12048,7 +12048,7 @@ public class ZclPriceCluster extends ZclCluster {
      *
      * @param providerId {@link Integer} Provider ID
      * @param issuerEventId {@link Integer} Issuer Event ID
-     * @param blockPeriodStartTime {@link Calendar} Block Period Start Time
+     * @param blockPeriodStartTime {@link ZigBeeUtcTime} Block Period Start Time
      * @param blockPeriodDuration {@link Integer} Block Period Duration
      * @param blockPeriodControl {@link Integer} Block Period Control
      * @param blockPeriodDurationType {@link Integer} Block Period Duration Type
@@ -12065,7 +12065,7 @@ public class ZclPriceCluster extends ZclCluster {
      * with <code>cluster.sendCommand(new publishBlockPeriodCommand(parameters ...))</code>
      */
     @Deprecated
-    public Future<CommandResult> publishBlockPeriodCommand(Integer providerId, Integer issuerEventId, Calendar blockPeriodStartTime, Integer blockPeriodDuration, Integer blockPeriodControl, Integer blockPeriodDurationType, Integer tariffType, Integer tariffResolutionPeriod) {
+    public Future<CommandResult> publishBlockPeriodCommand(Integer providerId, Integer issuerEventId, ZigBeeUtcTime blockPeriodStartTime, Integer blockPeriodDuration, Integer blockPeriodControl, Integer blockPeriodDurationType, Integer tariffType, Integer tariffResolutionPeriod) {
         PublishBlockPeriodCommand command = new PublishBlockPeriodCommand();
 
         // Set the fields
@@ -12090,7 +12090,7 @@ public class ZclPriceCluster extends ZclCluster {
      * one.
      *
      * @param issuerEventId {@link Integer} Issuer Event ID
-     * @param startTime {@link Calendar} Start Time
+     * @param startTime {@link ZigBeeUtcTime} Start Time
      * @param conversionFactor {@link Integer} Conversion Factor
      * @param conversionFactorTrailingDigit {@link Integer} Conversion Factor Trailing Digit
      * @return the {@link Future<CommandResult>} command result future
@@ -12104,7 +12104,7 @@ public class ZclPriceCluster extends ZclCluster {
      * with <code>cluster.sendCommand(new publishConversionFactorCommand(parameters ...))</code>
      */
     @Deprecated
-    public Future<CommandResult> publishConversionFactorCommand(Integer issuerEventId, Calendar startTime, Integer conversionFactor, Integer conversionFactorTrailingDigit) {
+    public Future<CommandResult> publishConversionFactorCommand(Integer issuerEventId, ZigBeeUtcTime startTime, Integer conversionFactor, Integer conversionFactorTrailingDigit) {
         PublishConversionFactorCommand command = new PublishConversionFactorCommand();
 
         // Set the fields
@@ -12124,7 +12124,7 @@ public class ZclPriceCluster extends ZclCluster {
      * instances of the Calorific Value, the currently active one and the next one.
      *
      * @param issuerEventId {@link Integer} Issuer Event ID
-     * @param startTime {@link Calendar} Start Time
+     * @param startTime {@link ZigBeeUtcTime} Start Time
      * @param calorificValue {@link Integer} Calorific Value
      * @param calorificValueUnit {@link Integer} Calorific Value Unit
      * @param calorificValueTrailingDigit {@link Integer} Calorific Value Trailing Digit
@@ -12139,7 +12139,7 @@ public class ZclPriceCluster extends ZclCluster {
      * with <code>cluster.sendCommand(new publishCalorificValueCommand(parameters ...))</code>
      */
     @Deprecated
-    public Future<CommandResult> publishCalorificValueCommand(Integer issuerEventId, Calendar startTime, Integer calorificValue, Integer calorificValueUnit, Integer calorificValueTrailingDigit) {
+    public Future<CommandResult> publishCalorificValueCommand(Integer issuerEventId, ZigBeeUtcTime startTime, Integer calorificValue, Integer calorificValueUnit, Integer calorificValueTrailingDigit) {
         PublishCalorificValueCommand command = new PublishCalorificValueCommand();
 
         // Set the fields
@@ -12168,7 +12168,7 @@ public class ZclPriceCluster extends ZclCluster {
      * @param providerId {@link Integer} Provider ID
      * @param issuerEventId {@link Integer} Issuer Event ID
      * @param issuerTariffId {@link Integer} Issuer Tariff ID
-     * @param startTime {@link Calendar} Start Time
+     * @param startTime {@link ZigBeeUtcTime} Start Time
      * @param tariffType {@link Integer} Tariff Type
      * @param tariffLabel {@link ByteArray} Tariff Label
      * @param numberOfPriceTiers {@link Integer} Number Of Price Tiers
@@ -12191,7 +12191,7 @@ public class ZclPriceCluster extends ZclCluster {
      * with <code>cluster.sendCommand(new publishTariffInformationCommand(parameters ...))</code>
      */
     @Deprecated
-    public Future<CommandResult> publishTariffInformationCommand(Integer providerId, Integer issuerEventId, Integer issuerTariffId, Calendar startTime, Integer tariffType, ByteArray tariffLabel, Integer numberOfPriceTiers, Integer numberOfBlockThresholds, Integer unitOfMeasure, Integer currency, Integer priceTrailingDigit, Integer standingCharge, Integer tierBlockMode, Integer blockThresholdMultiplier, Integer blockThresholdDivisor) {
+    public Future<CommandResult> publishTariffInformationCommand(Integer providerId, Integer issuerEventId, Integer issuerTariffId, ZigBeeUtcTime startTime, Integer tariffType, ByteArray tariffLabel, Integer numberOfPriceTiers, Integer numberOfBlockThresholds, Integer unitOfMeasure, Integer currency, Integer priceTrailingDigit, Integer standingCharge, Integer tierBlockMode, Integer blockThresholdMultiplier, Integer blockThresholdDivisor) {
         PublishTariffInformationCommand command = new PublishTariffInformationCommand();
 
         // Set the fields
@@ -12235,7 +12235,7 @@ public class ZclPriceCluster extends ZclCluster {
      *
      * @param providerId {@link Integer} Provider ID
      * @param issuerEventId {@link Integer} Issuer Event ID
-     * @param startTime {@link Calendar} Start Time
+     * @param startTime {@link ZigBeeUtcTime} Start Time
      * @param issuerTariffId {@link Integer} Issuer Tariff ID
      * @param commandIndex {@link Integer} Command Index
      * @param totalNumberOfCommands {@link Integer} Total Number Of Commands
@@ -12252,7 +12252,7 @@ public class ZclPriceCluster extends ZclCluster {
      * with <code>cluster.sendCommand(new publishPriceMatrixCommand(parameters ...))</code>
      */
     @Deprecated
-    public Future<CommandResult> publishPriceMatrixCommand(Integer providerId, Integer issuerEventId, Calendar startTime, Integer issuerTariffId, Integer commandIndex, Integer totalNumberOfCommands, Integer subPayloadControl, PriceMatrixSubPayload priceMatrixSubPayload) {
+    public Future<CommandResult> publishPriceMatrixCommand(Integer providerId, Integer issuerEventId, ZigBeeUtcTime startTime, Integer issuerTariffId, Integer commandIndex, Integer totalNumberOfCommands, Integer subPayloadControl, PriceMatrixSubPayload priceMatrixSubPayload) {
         PublishPriceMatrixCommand command = new PublishPriceMatrixCommand();
 
         // Set the fields
@@ -12287,7 +12287,7 @@ public class ZclPriceCluster extends ZclCluster {
      *
      * @param providerId {@link Integer} Provider ID
      * @param issuerEventId {@link Integer} Issuer Event ID
-     * @param startTime {@link Calendar} Start Time
+     * @param startTime {@link ZigBeeUtcTime} Start Time
      * @param issuerTariffId {@link Integer} Issuer Tariff ID
      * @param commandIndex {@link Integer} Command Index
      * @param totalNumberOfCommands {@link Integer} Total Number Of Commands
@@ -12304,7 +12304,7 @@ public class ZclPriceCluster extends ZclCluster {
      * with <code>cluster.sendCommand(new publishBlockThresholdsCommand(parameters ...))</code>
      */
     @Deprecated
-    public Future<CommandResult> publishBlockThresholdsCommand(Integer providerId, Integer issuerEventId, Calendar startTime, Integer issuerTariffId, Integer commandIndex, Integer totalNumberOfCommands, Integer subPayloadControl, BlockThresholdSubPayload blockThresholdSubPayload) {
+    public Future<CommandResult> publishBlockThresholdsCommand(Integer providerId, Integer issuerEventId, ZigBeeUtcTime startTime, Integer issuerTariffId, Integer commandIndex, Integer totalNumberOfCommands, Integer subPayloadControl, BlockThresholdSubPayload blockThresholdSubPayload) {
         PublishBlockThresholdsCommand command = new PublishBlockThresholdsCommand();
 
         // Set the fields
@@ -12329,7 +12329,7 @@ public class ZclPriceCluster extends ZclCluster {
      *
      * @param providerId {@link Integer} Provider ID
      * @param issuerEventId {@link Integer} Issuer Event ID
-     * @param startTime {@link Calendar} Start Time
+     * @param startTime {@link ZigBeeUtcTime} Start Time
      * @param tariffType {@link Integer} Tariff Type
      * @param co2Value {@link Integer} CO2 Value
      * @param co2ValueUnit {@link Integer} CO2 Value Unit
@@ -12345,7 +12345,7 @@ public class ZclPriceCluster extends ZclCluster {
      * with <code>cluster.sendCommand(new publishCo2ValueCommand(parameters ...))</code>
      */
     @Deprecated
-    public Future<CommandResult> publishCo2ValueCommand(Integer providerId, Integer issuerEventId, Calendar startTime, Integer tariffType, Integer co2Value, Integer co2ValueUnit, Integer co2ValueTrailingDigit) {
+    public Future<CommandResult> publishCo2ValueCommand(Integer providerId, Integer issuerEventId, ZigBeeUtcTime startTime, Integer tariffType, Integer co2Value, Integer co2ValueUnit, Integer co2ValueTrailingDigit) {
         PublishCo2ValueCommand command = new PublishCo2ValueCommand();
 
         // Set the fields
@@ -12414,7 +12414,7 @@ public class ZclPriceCluster extends ZclCluster {
      *
      * @param providerId {@link Integer} Provider ID
      * @param issuerEventId {@link Integer} Issuer Event ID
-     * @param billingPeriodStartTime {@link Calendar} Billing Period Start Time
+     * @param billingPeriodStartTime {@link ZigBeeUtcTime} Billing Period Start Time
      * @param billingPeriodDuration {@link Integer} Billing Period Duration
      * @param billingPeriodDurationType {@link Integer} Billing Period Duration Type
      * @param tariffType {@link Integer} Tariff Type
@@ -12429,7 +12429,7 @@ public class ZclPriceCluster extends ZclCluster {
      * with <code>cluster.sendCommand(new publishBillingPeriodCommand(parameters ...))</code>
      */
     @Deprecated
-    public Future<CommandResult> publishBillingPeriodCommand(Integer providerId, Integer issuerEventId, Calendar billingPeriodStartTime, Integer billingPeriodDuration, Integer billingPeriodDurationType, Integer tariffType) {
+    public Future<CommandResult> publishBillingPeriodCommand(Integer providerId, Integer issuerEventId, ZigBeeUtcTime billingPeriodStartTime, Integer billingPeriodDuration, Integer billingPeriodDurationType, Integer tariffType) {
         PublishBillingPeriodCommand command = new PublishBillingPeriodCommand();
 
         // Set the fields
@@ -12457,7 +12457,7 @@ public class ZclPriceCluster extends ZclCluster {
      *
      * @param providerId {@link Integer} Provider ID
      * @param issuerEventId {@link Integer} Issuer Event ID
-     * @param billingPeriodStartTime {@link Calendar} Billing Period Start Time
+     * @param billingPeriodStartTime {@link ZigBeeUtcTime} Billing Period Start Time
      * @param billingPeriodDuration {@link Integer} Billing Period Duration
      * @param billingPeriodDurationType {@link Integer} Billing Period Duration Type
      * @param tariffType {@link Integer} Tariff Type
@@ -12475,7 +12475,7 @@ public class ZclPriceCluster extends ZclCluster {
      * with <code>cluster.sendCommand(new publishConsolidatedBillCommand(parameters ...))</code>
      */
     @Deprecated
-    public Future<CommandResult> publishConsolidatedBillCommand(Integer providerId, Integer issuerEventId, Calendar billingPeriodStartTime, Integer billingPeriodDuration, Integer billingPeriodDurationType, Integer tariffType, Integer consolidatedBill, Integer currency, Integer billTrailingDigit) {
+    public Future<CommandResult> publishConsolidatedBillCommand(Integer providerId, Integer issuerEventId, ZigBeeUtcTime billingPeriodStartTime, Integer billingPeriodDuration, Integer billingPeriodDurationType, Integer tariffType, Integer consolidatedBill, Integer currency, Integer billTrailingDigit) {
         PublishConsolidatedBillCommand command = new PublishConsolidatedBillCommand();
 
         // Set the fields
@@ -12506,7 +12506,7 @@ public class ZclPriceCluster extends ZclCluster {
      *
      * @param providerId {@link Integer} Provider ID
      * @param issuerEventId {@link Integer} Issuer Event ID
-     * @param startTime {@link Calendar} Start Time
+     * @param startTime {@link ZigBeeUtcTime} Start Time
      * @param durationInMinutes {@link Integer} Duration In Minutes
      * @param tariffType {@link Integer} Tariff Type
      * @param cppPriceTier {@link Integer} Cpp Price Tier
@@ -12522,7 +12522,7 @@ public class ZclPriceCluster extends ZclCluster {
      * with <code>cluster.sendCommand(new publishCppEventCommand(parameters ...))</code>
      */
     @Deprecated
-    public Future<CommandResult> publishCppEventCommand(Integer providerId, Integer issuerEventId, Calendar startTime, Integer durationInMinutes, Integer tariffType, Integer cppPriceTier, Integer cppAuth) {
+    public Future<CommandResult> publishCppEventCommand(Integer providerId, Integer issuerEventId, ZigBeeUtcTime startTime, Integer durationInMinutes, Integer tariffType, Integer cppPriceTier, Integer cppAuth) {
         PublishCppEventCommand command = new PublishCppEventCommand();
 
         // Set the fields
@@ -12548,11 +12548,11 @@ public class ZclPriceCluster extends ZclCluster {
      *
      * @param providerId {@link Integer} Provider ID
      * @param issuerEventId {@link Integer} Issuer Event ID
-     * @param creditPaymentDueDate {@link Calendar} Credit Payment Due Date
+     * @param creditPaymentDueDate {@link ZigBeeUtcTime} Credit Payment Due Date
      * @param creditPaymentOverdueAmount {@link Integer} Credit Payment Overdue Amount
      * @param creditPaymentStatus {@link Integer} Credit Payment Status
      * @param creditPayment {@link Integer} Credit Payment
-     * @param creditPaymentDate {@link Calendar} Credit Payment Date
+     * @param creditPaymentDate {@link ZigBeeUtcTime} Credit Payment Date
      * @param creditPaymentRef {@link ByteArray} Credit Payment Ref
      * @return the {@link Future<CommandResult>} command result future
      * @deprecated As of release 1.3.0.
@@ -12565,7 +12565,7 @@ public class ZclPriceCluster extends ZclCluster {
      * with <code>cluster.sendCommand(new publishCreditPaymentCommand(parameters ...))</code>
      */
     @Deprecated
-    public Future<CommandResult> publishCreditPaymentCommand(Integer providerId, Integer issuerEventId, Calendar creditPaymentDueDate, Integer creditPaymentOverdueAmount, Integer creditPaymentStatus, Integer creditPayment, Calendar creditPaymentDate, ByteArray creditPaymentRef) {
+    public Future<CommandResult> publishCreditPaymentCommand(Integer providerId, Integer issuerEventId, ZigBeeUtcTime creditPaymentDueDate, Integer creditPaymentOverdueAmount, Integer creditPaymentStatus, Integer creditPayment, ZigBeeUtcTime creditPaymentDate, ByteArray creditPaymentRef) {
         PublishCreditPaymentCommand command = new PublishCreditPaymentCommand();
 
         // Set the fields
@@ -12589,7 +12589,7 @@ public class ZclPriceCluster extends ZclCluster {
      *
      * @param providerId {@link Integer} Provider ID
      * @param issuerEventId {@link Integer} Issuer Event ID
-     * @param startTime {@link Calendar} Start Time
+     * @param startTime {@link ZigBeeUtcTime} Start Time
      * @param oldCurrency {@link Integer} Old Currency
      * @param newCurrency {@link Integer} New Currency
      * @param conversionFactor {@link Integer} Conversion Factor
@@ -12606,7 +12606,7 @@ public class ZclPriceCluster extends ZclCluster {
      * with <code>cluster.sendCommand(new publishCurrencyConversionCommand(parameters ...))</code>
      */
     @Deprecated
-    public Future<CommandResult> publishCurrencyConversionCommand(Integer providerId, Integer issuerEventId, Calendar startTime, Integer oldCurrency, Integer newCurrency, Integer conversionFactor, Integer conversionFactorTrailingDigit, Integer currencyChangeControlFlags) {
+    public Future<CommandResult> publishCurrencyConversionCommand(Integer providerId, Integer issuerEventId, ZigBeeUtcTime startTime, Integer oldCurrency, Integer newCurrency, Integer conversionFactor, Integer conversionFactorTrailingDigit, Integer currencyChangeControlFlags) {
         PublishCurrencyConversionCommand command = new PublishCurrencyConversionCommand();
 
         // Set the fields

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclThermostatCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclThermostatCluster.java
@@ -7,7 +7,6 @@
  */
 package com.zsmartsystems.zigbee.zcl.clusters;
 
-import java.util.Calendar;
 import java.util.Map;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.Future;
@@ -27,6 +26,7 @@ import com.zsmartsystems.zigbee.zcl.clusters.thermostat.GetWeeklyScheduleRespons
 import com.zsmartsystems.zigbee.zcl.clusters.thermostat.SetWeeklySchedule;
 import com.zsmartsystems.zigbee.zcl.clusters.thermostat.SetpointRaiseLowerCommand;
 import com.zsmartsystems.zigbee.zcl.clusters.thermostat.ZclThermostatCommand;
+import com.zsmartsystems.zigbee.zcl.field.ZigBeeUtcTime;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
 /**
@@ -36,7 +36,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2022-05-28T21:15:34Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2022-12-09T01:34:23Z")
 public class ZclThermostatCluster extends ZclCluster {
     /**
      * The ZigBee Cluster Library Cluster ID
@@ -2106,7 +2106,7 @@ public class ZclThermostatCluster extends ZclCluster {
     /**
      * Get the <i>Setpoint Change Source Timestamp</i> attribute [attribute ID <b>0x0032</b>].
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is OPTIONAL
      *
@@ -2128,21 +2128,21 @@ public class ZclThermostatCluster extends ZclCluster {
      * <p>
      * This method will block until the response is received or a timeout occurs unless the current value is returned.
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is OPTIONAL
      *
      * @param refreshPeriod the maximum age of the data (in milliseconds) before an update is needed
-     * @return the {@link Calendar} attribute value, or null on error
+     * @return the {@link ZigBeeUtcTime} attribute value, or null on error
      * @deprecated As of release 1.2.0, replaced by {@link #ZclAttribute#readValue(long refreshPeriod)}
      */
     @Deprecated
-    public Calendar getSetpointChangeSourceTimestamp(final long refreshPeriod) {
+    public ZigBeeUtcTime getSetpointChangeSourceTimestamp(final long refreshPeriod) {
         if (serverAttributes.get(ATTR_SETPOINTCHANGESOURCETIMESTAMP).isLastValueCurrent(refreshPeriod)) {
-            return (Calendar) serverAttributes.get(ATTR_SETPOINTCHANGESOURCETIMESTAMP).getLastValue();
+            return (ZigBeeUtcTime) serverAttributes.get(ATTR_SETPOINTCHANGESOURCETIMESTAMP).getLastValue();
         }
 
-        return (Calendar) readSync(serverAttributes.get(ATTR_SETPOINTCHANGESOURCETIMESTAMP));
+        return (ZigBeeUtcTime) readSync(serverAttributes.get(ATTR_SETPOINTCHANGESOURCETIMESTAMP));
     }
 
     /**

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclTimeCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclTimeCluster.java
@@ -7,7 +7,6 @@
  */
 package com.zsmartsystems.zigbee.zcl.clusters;
 
-import java.util.Calendar;
 import java.util.Map;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.Future;
@@ -18,6 +17,7 @@ import com.zsmartsystems.zigbee.CommandResult;
 import com.zsmartsystems.zigbee.ZigBeeEndpoint;
 import com.zsmartsystems.zigbee.zcl.ZclAttribute;
 import com.zsmartsystems.zigbee.zcl.ZclCluster;
+import com.zsmartsystems.zigbee.zcl.field.ZigBeeUtcTime;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
 /**
@@ -30,7 +30,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2022-05-28T21:15:34Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2022-12-09T01:34:23Z")
 public class ZclTimeCluster extends ZclCluster {
     /**
      * The ZigBee Cluster Library Cluster ID
@@ -78,9 +78,6 @@ public class ZclTimeCluster extends ZclCluster {
      * Note that this attribute should be set to a new value once every year, and should be
      * written synchronously with the DstStart attribute. The DstEnd attribute indicates
      * the DST end time in seconds. The value 0xffffffff indicates an invalid DST end time.
-     * <p>
-     * Note that this attribute should be set to a new value once every year, and should be
-     * written synchronously with the DstStart attribute
      */
     public static final int ATTR_DSTEND = 0x0004;
     /**
@@ -168,16 +165,16 @@ public class ZclTimeCluster extends ZclCluster {
      * shall set the real time clock to the written value, otherwise it cannot be written. The
      * value 0xffffffff indicates an invalid time.
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is MANDATORY
      *
-     * @param time the {@link Calendar} attribute value to be set
+     * @param time the {@link ZigBeeUtcTime} attribute value to be set
      * @return the {@link Future<CommandResult>} command result future
      * @deprecated As of release 1.2.0, replaced by {@link #writeAttribute(int attributeId, Object value)}
      */
     @Deprecated
-    public Future<CommandResult> setTime(final Calendar value) {
+    public Future<CommandResult> setTime(final ZigBeeUtcTime value) {
         return write(serverAttributes.get(ATTR_TIME), value);
     }
 
@@ -192,7 +189,7 @@ public class ZclTimeCluster extends ZclCluster {
      * shall set the real time clock to the written value, otherwise it cannot be written. The
      * value 0xffffffff indicates an invalid time.
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is MANDATORY
      *
@@ -222,21 +219,21 @@ public class ZclTimeCluster extends ZclCluster {
      * <p>
      * This method will block until the response is received or a timeout occurs unless the current value is returned.
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is MANDATORY
      *
      * @param refreshPeriod the maximum age of the data (in milliseconds) before an update is needed
-     * @return the {@link Calendar} attribute value, or null on error
+     * @return the {@link ZigBeeUtcTime} attribute value, or null on error
      * @deprecated As of release 1.2.0, replaced by {@link #ZclAttribute#readValue(long refreshPeriod)}
      */
     @Deprecated
-    public Calendar getTime(final long refreshPeriod) {
+    public ZigBeeUtcTime getTime(final long refreshPeriod) {
         if (serverAttributes.get(ATTR_TIME).isLastValueCurrent(refreshPeriod)) {
-            return (Calendar) serverAttributes.get(ATTR_TIME).getLastValue();
+            return (ZigBeeUtcTime) serverAttributes.get(ATTR_TIME).getLastValue();
         }
 
-        return (Calendar) readSync(serverAttributes.get(ATTR_TIME));
+        return (ZigBeeUtcTime) readSync(serverAttributes.get(ATTR_TIME));
     }
 
     /**
@@ -250,7 +247,7 @@ public class ZclTimeCluster extends ZclCluster {
      * shall set the real time clock to the written value, otherwise it cannot be written. The
      * value 0xffffffff indicates an invalid time.
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is MANDATORY
      *
@@ -402,16 +399,16 @@ public class ZclTimeCluster extends ZclCluster {
      * The DstStart attribute indicates the DST start time in seconds. The value 0xffffffff
      * indicates an invalid DST start time.
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is OPTIONAL
      *
-     * @param dstStart the {@link Calendar} attribute value to be set
+     * @param dstStart the {@link ZigBeeUtcTime} attribute value to be set
      * @return the {@link Future<CommandResult>} command result future
      * @deprecated As of release 1.2.0, replaced by {@link #writeAttribute(int attributeId, Object value)}
      */
     @Deprecated
-    public Future<CommandResult> setDstStart(final Calendar value) {
+    public Future<CommandResult> setDstStart(final ZigBeeUtcTime value) {
         return write(serverAttributes.get(ATTR_DSTSTART), value);
     }
 
@@ -421,7 +418,7 @@ public class ZclTimeCluster extends ZclCluster {
      * The DstStart attribute indicates the DST start time in seconds. The value 0xffffffff
      * indicates an invalid DST start time.
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is OPTIONAL
      *
@@ -446,21 +443,21 @@ public class ZclTimeCluster extends ZclCluster {
      * <p>
      * This method will block until the response is received or a timeout occurs unless the current value is returned.
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is OPTIONAL
      *
      * @param refreshPeriod the maximum age of the data (in milliseconds) before an update is needed
-     * @return the {@link Calendar} attribute value, or null on error
+     * @return the {@link ZigBeeUtcTime} attribute value, or null on error
      * @deprecated As of release 1.2.0, replaced by {@link #ZclAttribute#readValue(long refreshPeriod)}
      */
     @Deprecated
-    public Calendar getDstStart(final long refreshPeriod) {
+    public ZigBeeUtcTime getDstStart(final long refreshPeriod) {
         if (serverAttributes.get(ATTR_DSTSTART).isLastValueCurrent(refreshPeriod)) {
-            return (Calendar) serverAttributes.get(ATTR_DSTSTART).getLastValue();
+            return (ZigBeeUtcTime) serverAttributes.get(ATTR_DSTSTART).getLastValue();
         }
 
-        return (Calendar) readSync(serverAttributes.get(ATTR_DSTSTART));
+        return (ZigBeeUtcTime) readSync(serverAttributes.get(ATTR_DSTSTART));
     }
 
     /**
@@ -477,19 +474,16 @@ public class ZclTimeCluster extends ZclCluster {
      * written synchronously with the DstStart attribute. The DstEnd attribute indicates
      * the DST end time in seconds. The value 0xffffffff indicates an invalid DST end time.
      * <p>
-     * Note that this attribute should be set to a new value once every year, and should be
-     * written synchronously with the DstStart attribute
-     * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is OPTIONAL
      *
-     * @param dstEnd the {@link Calendar} attribute value to be set
+     * @param dstEnd the {@link ZigBeeUtcTime} attribute value to be set
      * @return the {@link Future<CommandResult>} command result future
      * @deprecated As of release 1.2.0, replaced by {@link #writeAttribute(int attributeId, Object value)}
      */
     @Deprecated
-    public Future<CommandResult> setDstEnd(final Calendar value) {
+    public Future<CommandResult> setDstEnd(final ZigBeeUtcTime value) {
         return write(serverAttributes.get(ATTR_DSTEND), value);
     }
 
@@ -507,10 +501,7 @@ public class ZclTimeCluster extends ZclCluster {
      * written synchronously with the DstStart attribute. The DstEnd attribute indicates
      * the DST end time in seconds. The value 0xffffffff indicates an invalid DST end time.
      * <p>
-     * Note that this attribute should be set to a new value once every year, and should be
-     * written synchronously with the DstStart attribute
-     * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is OPTIONAL
      *
@@ -536,9 +527,6 @@ public class ZclTimeCluster extends ZclCluster {
      * written synchronously with the DstStart attribute. The DstEnd attribute indicates
      * the DST end time in seconds. The value 0xffffffff indicates an invalid DST end time.
      * <p>
-     * Note that this attribute should be set to a new value once every year, and should be
-     * written synchronously with the DstStart attribute
-     * <p>
      * This method can return cached data if the attribute has already been received.
      * The parameter <i>refreshPeriod</i> is used to control this. If the attribute has been received
      * within <i>refreshPeriod</i> milliseconds, then the method will immediately return the last value
@@ -546,21 +534,21 @@ public class ZclTimeCluster extends ZclCluster {
      * <p>
      * This method will block until the response is received or a timeout occurs unless the current value is returned.
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is OPTIONAL
      *
      * @param refreshPeriod the maximum age of the data (in milliseconds) before an update is needed
-     * @return the {@link Calendar} attribute value, or null on error
+     * @return the {@link ZigBeeUtcTime} attribute value, or null on error
      * @deprecated As of release 1.2.0, replaced by {@link #ZclAttribute#readValue(long refreshPeriod)}
      */
     @Deprecated
-    public Calendar getDstEnd(final long refreshPeriod) {
+    public ZigBeeUtcTime getDstEnd(final long refreshPeriod) {
         if (serverAttributes.get(ATTR_DSTEND).isLastValueCurrent(refreshPeriod)) {
-            return (Calendar) serverAttributes.get(ATTR_DSTEND).getLastValue();
+            return (ZigBeeUtcTime) serverAttributes.get(ATTR_DSTEND).getLastValue();
         }
 
-        return (Calendar) readSync(serverAttributes.get(ATTR_DSTEND));
+        return (ZigBeeUtcTime) readSync(serverAttributes.get(ATTR_DSTEND));
     }
 
     /**
@@ -652,7 +640,7 @@ public class ZclTimeCluster extends ZclCluster {
      * together. If implemented however, the optional StandardTime attribute indicates
      * this time directly. The value 0xffffffff indicates an invalid Standard Time.
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is OPTIONAL
      *
@@ -678,21 +666,21 @@ public class ZclTimeCluster extends ZclCluster {
      * <p>
      * This method will block until the response is received or a timeout occurs unless the current value is returned.
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is OPTIONAL
      *
      * @param refreshPeriod the maximum age of the data (in milliseconds) before an update is needed
-     * @return the {@link Calendar} attribute value, or null on error
+     * @return the {@link ZigBeeUtcTime} attribute value, or null on error
      * @deprecated As of release 1.2.0, replaced by {@link #ZclAttribute#readValue(long refreshPeriod)}
      */
     @Deprecated
-    public Calendar getStandardTime(final long refreshPeriod) {
+    public ZigBeeUtcTime getStandardTime(final long refreshPeriod) {
         if (serverAttributes.get(ATTR_STANDARDTIME).isLastValueCurrent(refreshPeriod)) {
-            return (Calendar) serverAttributes.get(ATTR_STANDARDTIME).getLastValue();
+            return (ZigBeeUtcTime) serverAttributes.get(ATTR_STANDARDTIME).getLastValue();
         }
 
-        return (Calendar) readSync(serverAttributes.get(ATTR_STANDARDTIME));
+        return (ZigBeeUtcTime) readSync(serverAttributes.get(ATTR_STANDARDTIME));
     }
 
     /**
@@ -703,7 +691,7 @@ public class ZclTimeCluster extends ZclCluster {
      * optional LocalTime attribute indicates this time directly. The value 0xffffffff
      * indicates an invalid Local Time.
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is OPTIONAL
      *
@@ -730,21 +718,21 @@ public class ZclTimeCluster extends ZclCluster {
      * <p>
      * This method will block until the response is received or a timeout occurs unless the current value is returned.
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is OPTIONAL
      *
      * @param refreshPeriod the maximum age of the data (in milliseconds) before an update is needed
-     * @return the {@link Calendar} attribute value, or null on error
+     * @return the {@link ZigBeeUtcTime} attribute value, or null on error
      * @deprecated As of release 1.2.0, replaced by {@link #ZclAttribute#readValue(long refreshPeriod)}
      */
     @Deprecated
-    public Calendar getLocalTime(final long refreshPeriod) {
+    public ZigBeeUtcTime getLocalTime(final long refreshPeriod) {
         if (serverAttributes.get(ATTR_LOCALTIME).isLastValueCurrent(refreshPeriod)) {
-            return (Calendar) serverAttributes.get(ATTR_LOCALTIME).getLastValue();
+            return (ZigBeeUtcTime) serverAttributes.get(ATTR_LOCALTIME).getLastValue();
         }
 
-        return (Calendar) readSync(serverAttributes.get(ATTR_LOCALTIME));
+        return (ZigBeeUtcTime) readSync(serverAttributes.get(ATTR_LOCALTIME));
     }
 
     /**
@@ -755,7 +743,7 @@ public class ZclTimeCluster extends ZclCluster {
      * that Time was set to). This attribute is set automatically, so is Read Only. The value
      * 0xffffffff indicates an invalid LastSetTime.
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is OPTIONAL
      *
@@ -782,21 +770,21 @@ public class ZclTimeCluster extends ZclCluster {
      * <p>
      * This method will block until the response is received or a timeout occurs unless the current value is returned.
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is OPTIONAL
      *
      * @param refreshPeriod the maximum age of the data (in milliseconds) before an update is needed
-     * @return the {@link Calendar} attribute value, or null on error
+     * @return the {@link ZigBeeUtcTime} attribute value, or null on error
      * @deprecated As of release 1.2.0, replaced by {@link #ZclAttribute#readValue(long refreshPeriod)}
      */
     @Deprecated
-    public Calendar getLastSetTime(final long refreshPeriod) {
+    public ZigBeeUtcTime getLastSetTime(final long refreshPeriod) {
         if (serverAttributes.get(ATTR_LASTSETTIME).isLastValueCurrent(refreshPeriod)) {
-            return (Calendar) serverAttributes.get(ATTR_LASTSETTIME).getLastValue();
+            return (ZigBeeUtcTime) serverAttributes.get(ATTR_LASTSETTIME).getLastValue();
         }
 
-        return (Calendar) readSync(serverAttributes.get(ATTR_LASTSETTIME));
+        return (ZigBeeUtcTime) readSync(serverAttributes.get(ATTR_LASTSETTIME));
     }
 
     /**
@@ -808,16 +796,16 @@ public class ZclTimeCluster extends ZclCluster {
      * not defined by this cluster specification, but may be defined by the application
      * profile in which devices that use this cluster are specified.
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is OPTIONAL
      *
-     * @param validUntilTime the {@link Calendar} attribute value to be set
+     * @param validUntilTime the {@link ZigBeeUtcTime} attribute value to be set
      * @return the {@link Future<CommandResult>} command result future
      * @deprecated As of release 1.2.0, replaced by {@link #writeAttribute(int attributeId, Object value)}
      */
     @Deprecated
-    public Future<CommandResult> setValidUntilTime(final Calendar value) {
+    public Future<CommandResult> setValidUntilTime(final ZigBeeUtcTime value) {
         return write(serverAttributes.get(ATTR_VALIDUNTILTIME), value);
     }
 
@@ -830,7 +818,7 @@ public class ZclTimeCluster extends ZclCluster {
      * not defined by this cluster specification, but may be defined by the application
      * profile in which devices that use this cluster are specified.
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is OPTIONAL
      *
@@ -858,20 +846,20 @@ public class ZclTimeCluster extends ZclCluster {
      * <p>
      * This method will block until the response is received or a timeout occurs unless the current value is returned.
      * <p>
-     * The attribute is of type {@link Calendar}.
+     * The attribute is of type {@link ZigBeeUtcTime}.
      * <p>
      * The implementation of this attribute by a device is OPTIONAL
      *
      * @param refreshPeriod the maximum age of the data (in milliseconds) before an update is needed
-     * @return the {@link Calendar} attribute value, or null on error
+     * @return the {@link ZigBeeUtcTime} attribute value, or null on error
      * @deprecated As of release 1.2.0, replaced by {@link #ZclAttribute#readValue(long refreshPeriod)}
      */
     @Deprecated
-    public Calendar getValidUntilTime(final long refreshPeriod) {
+    public ZigBeeUtcTime getValidUntilTime(final long refreshPeriod) {
         if (serverAttributes.get(ATTR_VALIDUNTILTIME).isLastValueCurrent(refreshPeriod)) {
-            return (Calendar) serverAttributes.get(ATTR_VALIDUNTILTIME).getLastValue();
+            return (ZigBeeUtcTime) serverAttributes.get(ATTR_VALIDUNTILTIME).getLastValue();
         }
 
-        return (Calendar) readSync(serverAttributes.get(ATTR_VALIDUNTILTIME));
+        return (ZigBeeUtcTime) readSync(serverAttributes.get(ATTR_VALIDUNTILTIME));
     }
 }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/demandresponseandloadcontrol/CancelLoadControlEvent.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/demandresponseandloadcontrol/CancelLoadControlEvent.java
@@ -7,12 +7,11 @@
  */
 package com.zsmartsystems.zigbee.zcl.clusters.demandresponseandloadcontrol;
 
-import java.util.Calendar;
-
 import javax.annotation.Generated;
 
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
+import com.zsmartsystems.zigbee.zcl.field.ZigBeeUtcTime;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
@@ -24,7 +23,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-12-25T10:11:19Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2022-12-09T01:34:23Z")
 public class CancelLoadControlEvent extends ZclDemandResponseAndLoadControlCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -92,7 +91,7 @@ public class CancelLoadControlEvent extends ZclDemandResponseAndLoadControlComma
      * an event with an Effective Time of now, adjust the Duration In Minutes field to
      * correspond to the remainder of the event.
      */
-    private Calendar effectiveTime;
+    private ZigBeeUtcTime effectiveTime;
 
     /**
      * Default constructor.
@@ -114,14 +113,14 @@ public class CancelLoadControlEvent extends ZclDemandResponseAndLoadControlComma
      * @param deviceClass {@link Integer} Device Class
      * @param utilityEnrollmentGroup {@link Integer} Utility Enrollment Group
      * @param cancelControl {@link Integer} Cancel Control
-     * @param effectiveTime {@link Calendar} Effective Time
+     * @param effectiveTime {@link ZigBeeUtcTime} Effective Time
      */
     public CancelLoadControlEvent(
             Integer issuerEventId,
             Integer deviceClass,
             Integer utilityEnrollmentGroup,
             Integer cancelControl,
-            Calendar effectiveTime) {
+            ZigBeeUtcTime effectiveTime) {
 
         clusterId = CLUSTER_ID;
         commandId = COMMAND_ID;
@@ -276,7 +275,7 @@ public class CancelLoadControlEvent extends ZclDemandResponseAndLoadControlComma
      *
      * @return the Effective Time
      */
-    public Calendar getEffectiveTime() {
+    public ZigBeeUtcTime getEffectiveTime() {
         return effectiveTime;
     }
 
@@ -297,7 +296,7 @@ public class CancelLoadControlEvent extends ZclDemandResponseAndLoadControlComma
      * @deprecated as of 1.3.0. Use the parameterised constructor instead to ensure that all mandatory fields are provided.
      */
     @Deprecated
-    public void setEffectiveTime(final Calendar effectiveTime) {
+    public void setEffectiveTime(final ZigBeeUtcTime effectiveTime) {
         this.effectiveTime = effectiveTime;
     }
 
@@ -316,7 +315,7 @@ public class CancelLoadControlEvent extends ZclDemandResponseAndLoadControlComma
         deviceClass = (Integer) deserializer.deserialize(ZclDataType.BITMAP_16_BIT);
         utilityEnrollmentGroup = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
         cancelControl = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
-        effectiveTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
+        effectiveTime = (ZigBeeUtcTime) deserializer.deserialize(ZclDataType.UTCTIME);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/demandresponseandloadcontrol/GetScheduledEvents.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/demandresponseandloadcontrol/GetScheduledEvents.java
@@ -7,12 +7,11 @@
  */
 package com.zsmartsystems.zigbee.zcl.clusters.demandresponseandloadcontrol;
 
-import java.util.Calendar;
-
 import javax.annotation.Generated;
 
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
+import com.zsmartsystems.zigbee.zcl.field.ZigBeeUtcTime;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
@@ -29,7 +28,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-12-25T10:11:19Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2022-12-09T01:34:23Z")
 public class GetScheduledEvents extends ZclDemandResponseAndLoadControlCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -48,7 +47,7 @@ public class GetScheduledEvents extends ZclDemandResponseAndLoadControlCommand {
      * active events to be resent. If either command has a Start Time of 0x00000000, replace
      * that Start Time with the current time stamp.
      */
-    private Calendar startTime;
+    private ZigBeeUtcTime startTime;
 
     /**
      * Number Of Events command message field.
@@ -77,11 +76,11 @@ public class GetScheduledEvents extends ZclDemandResponseAndLoadControlCommand {
     /**
      * Constructor providing all required parameters.
      *
-     * @param startTime {@link Calendar} Start Time
+     * @param startTime {@link ZigBeeUtcTime} Start Time
      * @param numberOfEvents {@link Integer} Number Of Events
      */
     public GetScheduledEvents(
-            Calendar startTime,
+            ZigBeeUtcTime startTime,
             Integer numberOfEvents) {
 
         clusterId = CLUSTER_ID;
@@ -102,7 +101,7 @@ public class GetScheduledEvents extends ZclDemandResponseAndLoadControlCommand {
      *
      * @return the Start Time
      */
-    public Calendar getStartTime() {
+    public ZigBeeUtcTime getStartTime() {
         return startTime;
     }
 
@@ -117,7 +116,7 @@ public class GetScheduledEvents extends ZclDemandResponseAndLoadControlCommand {
      * @deprecated as of 1.3.0. Use the parameterised constructor instead to ensure that all mandatory fields are provided.
      */
     @Deprecated
-    public void setStartTime(final Calendar startTime) {
+    public void setStartTime(final ZigBeeUtcTime startTime) {
         this.startTime = startTime;
     }
 
@@ -161,7 +160,7 @@ public class GetScheduledEvents extends ZclDemandResponseAndLoadControlCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        startTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
+        startTime = (ZigBeeUtcTime) deserializer.deserialize(ZclDataType.UTCTIME);
         numberOfEvents = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
     }
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/demandresponseandloadcontrol/LoadControlEventCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/demandresponseandloadcontrol/LoadControlEventCommand.java
@@ -7,12 +7,11 @@
  */
 package com.zsmartsystems.zigbee.zcl.clusters.demandresponseandloadcontrol;
 
-import java.util.Calendar;
-
 import javax.annotation.Generated;
 
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
+import com.zsmartsystems.zigbee.zcl.field.ZigBeeUtcTime;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
@@ -24,7 +23,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-12-25T10:11:19Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2022-12-09T01:34:23Z")
 public class LoadControlEventCommand extends ZclDemandResponseAndLoadControlCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -86,7 +85,7 @@ public class LoadControlEventCommand extends ZclDemandResponseAndLoadControlComm
      * Start Time of now, adjust the Duration In Minutes field to correspond to the remainder of
      * the event.
      */
-    private Calendar startTime;
+    private ZigBeeUtcTime startTime;
 
     /**
      * Duration In Minutes command message field.
@@ -201,7 +200,7 @@ public class LoadControlEventCommand extends ZclDemandResponseAndLoadControlComm
      * @param issuerEventId {@link Integer} Issuer Event ID
      * @param deviceClass {@link Integer} Device Class
      * @param utilityEnrollmentGroup {@link Integer} Utility Enrollment Group
-     * @param startTime {@link Calendar} Start Time
+     * @param startTime {@link ZigBeeUtcTime} Start Time
      * @param durationInMinutes {@link Integer} Duration In Minutes
      * @param criticalityLevel {@link Integer} Criticality Level
      * @param coolingTemperatureOffset {@link Integer} Cooling Temperature Offset
@@ -216,7 +215,7 @@ public class LoadControlEventCommand extends ZclDemandResponseAndLoadControlComm
             Integer issuerEventId,
             Integer deviceClass,
             Integer utilityEnrollmentGroup,
-            Calendar startTime,
+            ZigBeeUtcTime startTime,
             Integer durationInMinutes,
             Integer criticalityLevel,
             Integer coolingTemperatureOffset,
@@ -371,7 +370,7 @@ public class LoadControlEventCommand extends ZclDemandResponseAndLoadControlComm
      *
      * @return the Start Time
      */
-    public Calendar getStartTime() {
+    public ZigBeeUtcTime getStartTime() {
         return startTime;
     }
 
@@ -387,7 +386,7 @@ public class LoadControlEventCommand extends ZclDemandResponseAndLoadControlComm
      * @deprecated as of 1.3.0. Use the parameterised constructor instead to ensure that all mandatory fields are provided.
      */
     @Deprecated
-    public void setStartTime(final Calendar startTime) {
+    public void setStartTime(final ZigBeeUtcTime startTime) {
         this.startTime = startTime;
     }
 
@@ -691,7 +690,7 @@ public class LoadControlEventCommand extends ZclDemandResponseAndLoadControlComm
         issuerEventId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
         deviceClass = (Integer) deserializer.deserialize(ZclDataType.BITMAP_16_BIT);
         utilityEnrollmentGroup = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        startTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
+        startTime = (ZigBeeUtcTime) deserializer.deserialize(ZclDataType.UTCTIME);
         durationInMinutes = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
         criticalityLevel = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
         coolingTemperatureOffset = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/demandresponseandloadcontrol/ReportEventStatus.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/demandresponseandloadcontrol/ReportEventStatus.java
@@ -7,13 +7,12 @@
  */
 package com.zsmartsystems.zigbee.zcl.clusters.demandresponseandloadcontrol;
 
-import java.util.Calendar;
-
 import javax.annotation.Generated;
 
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.field.ByteArray;
+import com.zsmartsystems.zigbee.zcl.field.ZigBeeUtcTime;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
@@ -25,7 +24,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-12-25T10:11:19Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2022-12-09T01:34:23Z")
 public class ReportEventStatus extends ZclDemandResponseAndLoadControlCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -61,7 +60,7 @@ public class ReportEventStatus extends ZclDemandResponseAndLoadControlCommand {
      * UTC Timestamp representing when the event status occurred. This field shall not use the
      * value of 0x00000000.
      */
-    private Calendar eventStatusTime;
+    private ZigBeeUtcTime eventStatusTime;
 
     /**
      * Criticality Level Applied command message field.
@@ -147,7 +146,7 @@ public class ReportEventStatus extends ZclDemandResponseAndLoadControlCommand {
      *
      * @param issuerEventId {@link Integer} Issuer Event ID
      * @param eventStatus {@link Integer} Event Status
-     * @param eventStatusTime {@link Calendar} Event Status Time
+     * @param eventStatusTime {@link ZigBeeUtcTime} Event Status Time
      * @param criticalityLevelApplied {@link Integer} Criticality Level Applied
      * @param coolingTemperatureSetPointApplied {@link Integer} Cooling Temperature Set Point Applied
      * @param heatingTemperatureSetPointApplied {@link Integer} Heating Temperature Set Point Applied
@@ -160,7 +159,7 @@ public class ReportEventStatus extends ZclDemandResponseAndLoadControlCommand {
     public ReportEventStatus(
             Integer issuerEventId,
             Integer eventStatus,
-            Calendar eventStatusTime,
+            ZigBeeUtcTime eventStatusTime,
             Integer criticalityLevelApplied,
             Integer coolingTemperatureSetPointApplied,
             Integer heatingTemperatureSetPointApplied,
@@ -252,7 +251,7 @@ public class ReportEventStatus extends ZclDemandResponseAndLoadControlCommand {
      *
      * @return the Event Status Time
      */
-    public Calendar getEventStatusTime() {
+    public ZigBeeUtcTime getEventStatusTime() {
         return eventStatusTime;
     }
 
@@ -266,7 +265,7 @@ public class ReportEventStatus extends ZclDemandResponseAndLoadControlCommand {
      * @deprecated as of 1.3.0. Use the parameterised constructor instead to ensure that all mandatory fields are provided.
      */
     @Deprecated
-    public void setEventStatusTime(final Calendar eventStatusTime) {
+    public void setEventStatusTime(final ZigBeeUtcTime eventStatusTime) {
         this.eventStatusTime = eventStatusTime;
     }
 
@@ -501,7 +500,7 @@ public class ReportEventStatus extends ZclDemandResponseAndLoadControlCommand {
     public void deserialize(final ZclFieldDeserializer deserializer) {
         issuerEventId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
         eventStatus = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        eventStatusTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
+        eventStatusTime = (ZigBeeUtcTime) deserializer.deserialize(ZclDataType.UTCTIME);
         criticalityLevelApplied = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
         coolingTemperatureSetPointApplied = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
         heatingTemperatureSetPointApplied = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/messaging/CancelAllMessages.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/messaging/CancelAllMessages.java
@@ -7,12 +7,11 @@
  */
 package com.zsmartsystems.zigbee.zcl.clusters.messaging;
 
-import java.util.Calendar;
-
 import javax.annotation.Generated;
 
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
+import com.zsmartsystems.zigbee.zcl.field.ZigBeeUtcTime;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
@@ -27,7 +26,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-12-25T10:11:19Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2022-12-09T01:34:23Z")
 public class CancelAllMessages extends ZclMessagingCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -45,7 +44,7 @@ public class CancelAllMessages extends ZclMessagingCommand {
      * A UTC Time field to indicate the date/time at which all existing display messages should
      * be cleared.
      */
-    private Calendar implementationDateTime;
+    private ZigBeeUtcTime implementationDateTime;
 
     /**
      * Default constructor.
@@ -63,10 +62,10 @@ public class CancelAllMessages extends ZclMessagingCommand {
     /**
      * Constructor providing all required parameters.
      *
-     * @param implementationDateTime {@link Calendar} Implementation Date Time
+     * @param implementationDateTime {@link ZigBeeUtcTime} Implementation Date Time
      */
     public CancelAllMessages(
-            Calendar implementationDateTime) {
+            ZigBeeUtcTime implementationDateTime) {
 
         clusterId = CLUSTER_ID;
         commandId = COMMAND_ID;
@@ -84,7 +83,7 @@ public class CancelAllMessages extends ZclMessagingCommand {
      *
      * @return the Implementation Date Time
      */
-    public Calendar getImplementationDateTime() {
+    public ZigBeeUtcTime getImplementationDateTime() {
         return implementationDateTime;
     }
 
@@ -98,7 +97,7 @@ public class CancelAllMessages extends ZclMessagingCommand {
      * @deprecated as of 1.3.0. Use the parameterised constructor instead to ensure that all mandatory fields are provided.
      */
     @Deprecated
-    public void setImplementationDateTime(final Calendar implementationDateTime) {
+    public void setImplementationDateTime(final ZigBeeUtcTime implementationDateTime) {
         this.implementationDateTime = implementationDateTime;
     }
 
@@ -109,7 +108,7 @@ public class CancelAllMessages extends ZclMessagingCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        implementationDateTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
+        implementationDateTime = (ZigBeeUtcTime) deserializer.deserialize(ZclDataType.UTCTIME);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/messaging/CancelAllMessagesCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/messaging/CancelAllMessagesCommand.java
@@ -7,12 +7,11 @@
  */
 package com.zsmartsystems.zigbee.zcl.clusters.messaging;
 
-import java.util.Calendar;
-
 import javax.annotation.Generated;
 
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
+import com.zsmartsystems.zigbee.zcl.field.ZigBeeUtcTime;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
@@ -27,7 +26,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-12-25T10:11:19Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2022-12-09T01:34:23Z")
 public class CancelAllMessagesCommand extends ZclMessagingCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -42,7 +41,7 @@ public class CancelAllMessagesCommand extends ZclMessagingCommand {
     /**
      * Implementation Time command message field.
      */
-    private Calendar implementationTime;
+    private ZigBeeUtcTime implementationTime;
 
     /**
      * Default constructor.
@@ -60,10 +59,10 @@ public class CancelAllMessagesCommand extends ZclMessagingCommand {
     /**
      * Constructor providing all required parameters.
      *
-     * @param implementationTime {@link Calendar} Implementation Time
+     * @param implementationTime {@link ZigBeeUtcTime} Implementation Time
      */
     public CancelAllMessagesCommand(
-            Calendar implementationTime) {
+            ZigBeeUtcTime implementationTime) {
 
         clusterId = CLUSTER_ID;
         commandId = COMMAND_ID;
@@ -78,7 +77,7 @@ public class CancelAllMessagesCommand extends ZclMessagingCommand {
      *
      * @return the Implementation Time
      */
-    public Calendar getImplementationTime() {
+    public ZigBeeUtcTime getImplementationTime() {
         return implementationTime;
     }
 
@@ -89,7 +88,7 @@ public class CancelAllMessagesCommand extends ZclMessagingCommand {
      * @deprecated as of 1.3.0. Use the parameterised constructor instead to ensure that all mandatory fields are provided.
      */
     @Deprecated
-    public void setImplementationTime(final Calendar implementationTime) {
+    public void setImplementationTime(final ZigBeeUtcTime implementationTime) {
         this.implementationTime = implementationTime;
     }
 
@@ -100,7 +99,7 @@ public class CancelAllMessagesCommand extends ZclMessagingCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        implementationTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
+        implementationTime = (ZigBeeUtcTime) deserializer.deserialize(ZclDataType.UTCTIME);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/messaging/DisplayMessageCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/messaging/DisplayMessageCommand.java
@@ -7,12 +7,11 @@
  */
 package com.zsmartsystems.zigbee.zcl.clusters.messaging;
 
-import java.util.Calendar;
-
 import javax.annotation.Generated;
 
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
+import com.zsmartsystems.zigbee.zcl.field.ZigBeeUtcTime;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
@@ -24,7 +23,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-12-25T10:11:19Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2022-12-09T01:34:23Z")
 public class DisplayMessageCommand extends ZclMessagingCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -60,7 +59,7 @@ public class DisplayMessageCommand extends ZclMessagingCommand {
      * Start Time of now, adjust the Duration In Minutes field to correspond to the remainder of
      * the event.
      */
-    private Calendar startTime;
+    private ZigBeeUtcTime startTime;
 
     /**
      * Duration In Minutes command message field.
@@ -112,7 +111,7 @@ public class DisplayMessageCommand extends ZclMessagingCommand {
      *
      * @param messageId {@link Integer} Message ID
      * @param messageControl {@link Integer} Message Control
-     * @param startTime {@link Calendar} Start Time
+     * @param startTime {@link ZigBeeUtcTime} Start Time
      * @param durationInMinutes {@link Integer} Duration In Minutes
      * @param message {@link String} Message
      * @param extendedMessageControl {@link Integer} Extended Message Control
@@ -120,7 +119,7 @@ public class DisplayMessageCommand extends ZclMessagingCommand {
     public DisplayMessageCommand(
             Integer messageId,
             Integer messageControl,
-            Calendar startTime,
+            ZigBeeUtcTime startTime,
             Integer durationInMinutes,
             String message,
             Integer extendedMessageControl) {
@@ -200,7 +199,7 @@ public class DisplayMessageCommand extends ZclMessagingCommand {
      *
      * @return the Start Time
      */
-    public Calendar getStartTime() {
+    public ZigBeeUtcTime getStartTime() {
         return startTime;
     }
 
@@ -216,7 +215,7 @@ public class DisplayMessageCommand extends ZclMessagingCommand {
      * @deprecated as of 1.3.0. Use the parameterised constructor instead to ensure that all mandatory fields are provided.
      */
     @Deprecated
-    public void setStartTime(final Calendar startTime) {
+    public void setStartTime(final ZigBeeUtcTime startTime) {
         this.startTime = startTime;
     }
 
@@ -328,7 +327,7 @@ public class DisplayMessageCommand extends ZclMessagingCommand {
     public void deserialize(final ZclFieldDeserializer deserializer) {
         messageId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
         messageControl = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
-        startTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
+        startTime = (ZigBeeUtcTime) deserializer.deserialize(ZclDataType.UTCTIME);
         durationInMinutes = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
         message = (String) deserializer.deserialize(ZclDataType.CHARACTER_STRING);
         extendedMessageControl = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/messaging/DisplayProtectedMessageCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/messaging/DisplayProtectedMessageCommand.java
@@ -7,12 +7,11 @@
  */
 package com.zsmartsystems.zigbee.zcl.clusters.messaging;
 
-import java.util.Calendar;
-
 import javax.annotation.Generated;
 
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
+import com.zsmartsystems.zigbee.zcl.field.ZigBeeUtcTime;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
@@ -27,7 +26,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-12-25T10:11:19Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2022-12-09T01:34:23Z")
 public class DisplayProtectedMessageCommand extends ZclMessagingCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -63,7 +62,7 @@ public class DisplayProtectedMessageCommand extends ZclMessagingCommand {
      * Start Time of now, adjust the Duration In Minutes field to correspond to the remainder of
      * the event.
      */
-    private Calendar startTime;
+    private ZigBeeUtcTime startTime;
 
     /**
      * Duration In Minutes command message field.
@@ -116,7 +115,7 @@ public class DisplayProtectedMessageCommand extends ZclMessagingCommand {
      *
      * @param messageId {@link Integer} Message ID
      * @param messageControl {@link Integer} Message Control
-     * @param startTime {@link Calendar} Start Time
+     * @param startTime {@link ZigBeeUtcTime} Start Time
      * @param durationInMinutes {@link Integer} Duration In Minutes
      * @param message {@link String} Message
      * @param extendedMessageControl {@link Integer} Extended Message Control
@@ -124,7 +123,7 @@ public class DisplayProtectedMessageCommand extends ZclMessagingCommand {
     public DisplayProtectedMessageCommand(
             Integer messageId,
             Integer messageControl,
-            Calendar startTime,
+            ZigBeeUtcTime startTime,
             Integer durationInMinutes,
             String message,
             Integer extendedMessageControl) {
@@ -204,7 +203,7 @@ public class DisplayProtectedMessageCommand extends ZclMessagingCommand {
      *
      * @return the Start Time
      */
-    public Calendar getStartTime() {
+    public ZigBeeUtcTime getStartTime() {
         return startTime;
     }
 
@@ -220,7 +219,7 @@ public class DisplayProtectedMessageCommand extends ZclMessagingCommand {
      * @deprecated as of 1.3.0. Use the parameterised constructor instead to ensure that all mandatory fields are provided.
      */
     @Deprecated
-    public void setStartTime(final Calendar startTime) {
+    public void setStartTime(final ZigBeeUtcTime startTime) {
         this.startTime = startTime;
     }
 
@@ -334,7 +333,7 @@ public class DisplayProtectedMessageCommand extends ZclMessagingCommand {
     public void deserialize(final ZclFieldDeserializer deserializer) {
         messageId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
         messageControl = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
-        startTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
+        startTime = (ZigBeeUtcTime) deserializer.deserialize(ZclDataType.UTCTIME);
         durationInMinutes = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
         message = (String) deserializer.deserialize(ZclDataType.CHARACTER_STRING);
         extendedMessageControl = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/messaging/GetLastMessage.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/messaging/GetLastMessage.java
@@ -7,12 +7,11 @@
  */
 package com.zsmartsystems.zigbee.zcl.clusters.messaging;
 
-import java.util.Calendar;
-
 import javax.annotation.Generated;
 
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
+import com.zsmartsystems.zigbee.zcl.field.ZigBeeUtcTime;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
@@ -28,7 +27,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-12-25T10:11:19Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2022-12-09T01:34:23Z")
 public class GetLastMessage extends ZclMessagingCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -53,7 +52,7 @@ public class GetLastMessage extends ZclMessagingCommand {
     /**
      * Start Time command message field.
      */
-    private Calendar startTime;
+    private ZigBeeUtcTime startTime;
 
     /**
      * Duration In Minutes command message field.
@@ -88,7 +87,7 @@ public class GetLastMessage extends ZclMessagingCommand {
      *
      * @param messageId {@link Integer} Message ID
      * @param messageControl {@link Integer} Message Control
-     * @param startTime {@link Calendar} Start Time
+     * @param startTime {@link ZigBeeUtcTime} Start Time
      * @param durationInMinutes {@link Integer} Duration In Minutes
      * @param message {@link String} Message
      * @param optionalExtendedMessageControl {@link Integer} Optional Extended Message Control
@@ -96,7 +95,7 @@ public class GetLastMessage extends ZclMessagingCommand {
     public GetLastMessage(
             Integer messageId,
             Integer messageControl,
-            Calendar startTime,
+            ZigBeeUtcTime startTime,
             Integer durationInMinutes,
             String message,
             Integer optionalExtendedMessageControl) {
@@ -159,7 +158,7 @@ public class GetLastMessage extends ZclMessagingCommand {
      *
      * @return the Start Time
      */
-    public Calendar getStartTime() {
+    public ZigBeeUtcTime getStartTime() {
         return startTime;
     }
 
@@ -170,7 +169,7 @@ public class GetLastMessage extends ZclMessagingCommand {
      * @deprecated as of 1.3.0. Use the parameterised constructor instead to ensure that all mandatory fields are provided.
      */
     @Deprecated
-    public void setStartTime(final Calendar startTime) {
+    public void setStartTime(final ZigBeeUtcTime startTime) {
         this.startTime = startTime;
     }
 
@@ -248,7 +247,7 @@ public class GetLastMessage extends ZclMessagingCommand {
     public void deserialize(final ZclFieldDeserializer deserializer) {
         messageId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
         messageControl = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
-        startTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
+        startTime = (ZigBeeUtcTime) deserializer.deserialize(ZclDataType.UTCTIME);
         durationInMinutes = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
         message = (String) deserializer.deserialize(ZclDataType.CHARACTER_STRING);
         optionalExtendedMessageControl = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/messaging/GetMessageCancellation.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/messaging/GetMessageCancellation.java
@@ -7,12 +7,11 @@
  */
 package com.zsmartsystems.zigbee.zcl.clusters.messaging;
 
-import java.util.Calendar;
-
 import javax.annotation.Generated;
 
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
+import com.zsmartsystems.zigbee.zcl.field.ZigBeeUtcTime;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
@@ -28,7 +27,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-12-25T10:11:19Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2022-12-09T01:34:23Z")
 public class GetMessageCancellation extends ZclMessagingCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -46,7 +45,7 @@ public class GetMessageCancellation extends ZclMessagingCommand {
      * UTC Timestamp indicating the earliest implementation time of a Cancel All Messages
      * command to be returned.
      */
-    private Calendar earliestImplementationTime;
+    private ZigBeeUtcTime earliestImplementationTime;
 
     /**
      * Default constructor.
@@ -64,10 +63,10 @@ public class GetMessageCancellation extends ZclMessagingCommand {
     /**
      * Constructor providing all required parameters.
      *
-     * @param earliestImplementationTime {@link Calendar} Earliest Implementation Time
+     * @param earliestImplementationTime {@link ZigBeeUtcTime} Earliest Implementation Time
      */
     public GetMessageCancellation(
-            Calendar earliestImplementationTime) {
+            ZigBeeUtcTime earliestImplementationTime) {
 
         clusterId = CLUSTER_ID;
         commandId = COMMAND_ID;
@@ -85,7 +84,7 @@ public class GetMessageCancellation extends ZclMessagingCommand {
      *
      * @return the Earliest Implementation Time
      */
-    public Calendar getEarliestImplementationTime() {
+    public ZigBeeUtcTime getEarliestImplementationTime() {
         return earliestImplementationTime;
     }
 
@@ -99,7 +98,7 @@ public class GetMessageCancellation extends ZclMessagingCommand {
      * @deprecated as of 1.3.0. Use the parameterised constructor instead to ensure that all mandatory fields are provided.
      */
     @Deprecated
-    public void setEarliestImplementationTime(final Calendar earliestImplementationTime) {
+    public void setEarliestImplementationTime(final ZigBeeUtcTime earliestImplementationTime) {
         this.earliestImplementationTime = earliestImplementationTime;
     }
 
@@ -110,7 +109,7 @@ public class GetMessageCancellation extends ZclMessagingCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        earliestImplementationTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
+        earliestImplementationTime = (ZigBeeUtcTime) deserializer.deserialize(ZclDataType.UTCTIME);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/messaging/MessageConfirmation.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/messaging/MessageConfirmation.java
@@ -7,13 +7,12 @@
  */
 package com.zsmartsystems.zigbee.zcl.clusters.messaging;
 
-import java.util.Calendar;
-
 import javax.annotation.Generated;
 
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.field.ByteArray;
+import com.zsmartsystems.zigbee.zcl.field.ZigBeeUtcTime;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
@@ -30,7 +29,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-12-25T10:11:19Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2022-12-09T01:34:23Z")
 public class MessageConfirmation extends ZclMessagingCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -54,7 +53,7 @@ public class MessageConfirmation extends ZclMessagingCommand {
      * <p>
      * UTCTime of user confirmation of message.
      */
-    private Calendar confirmationTime;
+    private ZigBeeUtcTime confirmationTime;
 
     /**
      * Message Confirmation Control command message field.
@@ -90,13 +89,13 @@ public class MessageConfirmation extends ZclMessagingCommand {
      * Constructor providing all required parameters.
      *
      * @param messageId {@link Integer} Message ID
-     * @param confirmationTime {@link Calendar} Confirmation Time
+     * @param confirmationTime {@link ZigBeeUtcTime} Confirmation Time
      * @param messageConfirmationControl {@link Integer} Message Confirmation Control
      * @param messageConfirmationResponse {@link ByteArray} Message Confirmation Response
      */
     public MessageConfirmation(
             Integer messageId,
-            Calendar confirmationTime,
+            ZigBeeUtcTime confirmationTime,
             Integer messageConfirmationControl,
             ByteArray messageConfirmationResponse) {
 
@@ -142,7 +141,7 @@ public class MessageConfirmation extends ZclMessagingCommand {
      *
      * @return the Confirmation Time
      */
-    public Calendar getConfirmationTime() {
+    public ZigBeeUtcTime getConfirmationTime() {
         return confirmationTime;
     }
 
@@ -155,7 +154,7 @@ public class MessageConfirmation extends ZclMessagingCommand {
      * @deprecated as of 1.3.0. Use the parameterised constructor instead to ensure that all mandatory fields are provided.
      */
     @Deprecated
-    public void setConfirmationTime(final Calendar confirmationTime) {
+    public void setConfirmationTime(final ZigBeeUtcTime confirmationTime) {
         this.confirmationTime = confirmationTime;
     }
 
@@ -224,7 +223,7 @@ public class MessageConfirmation extends ZclMessagingCommand {
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
         messageId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        confirmationTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
+        confirmationTime = (ZigBeeUtcTime) deserializer.deserialize(ZclDataType.UTCTIME);
         messageConfirmationControl = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
         messageConfirmationResponse = (ByteArray) deserializer.deserialize(ZclDataType.OCTET_STRING);
     }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/ChangeSupply.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/ChangeSupply.java
@@ -7,12 +7,11 @@
  */
 package com.zsmartsystems.zigbee.zcl.clusters.metering;
 
-import java.util.Calendar;
-
 import javax.annotation.Generated;
 
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
+import com.zsmartsystems.zigbee.zcl.field.ZigBeeUtcTime;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
@@ -27,7 +26,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-12-25T10:11:19Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2022-12-09T01:34:23Z")
 public class ChangeSupply extends ZclMeteringCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -64,7 +63,7 @@ public class ChangeSupply extends ZclMeteringCommand {
      * <p>
      * A UTC Time field to indicate the date and time at which the supply change was requested.
      */
-    private Calendar requestDateTime;
+    private ZigBeeUtcTime requestDateTime;
 
     /**
      * Implementation Date Time command message field.
@@ -76,7 +75,7 @@ public class ChangeSupply extends ZclMeteringCommand {
      * to be cancelled (the status of the supply will not change but the Proposed Change Supply
      * Implementation Time attribute shall be reset to zero).
      */
-    private Calendar implementationDateTime;
+    private ZigBeeUtcTime implementationDateTime;
 
     /**
      * Proposed Supply Status command message field.
@@ -111,16 +110,16 @@ public class ChangeSupply extends ZclMeteringCommand {
      *
      * @param providerId {@link Integer} Provider ID
      * @param issuerEventId {@link Integer} Issuer Event ID
-     * @param requestDateTime {@link Calendar} Request Date Time
-     * @param implementationDateTime {@link Calendar} Implementation Date Time
+     * @param requestDateTime {@link ZigBeeUtcTime} Request Date Time
+     * @param implementationDateTime {@link ZigBeeUtcTime} Implementation Date Time
      * @param proposedSupplyStatus {@link Integer} Proposed Supply Status
      * @param supplyControlBits {@link Integer} Supply Control Bits
      */
     public ChangeSupply(
             Integer providerId,
             Integer issuerEventId,
-            Calendar requestDateTime,
-            Calendar implementationDateTime,
+            ZigBeeUtcTime requestDateTime,
+            ZigBeeUtcTime implementationDateTime,
             Integer proposedSupplyStatus,
             Integer supplyControlBits) {
 
@@ -204,7 +203,7 @@ public class ChangeSupply extends ZclMeteringCommand {
      *
      * @return the Request Date Time
      */
-    public Calendar getRequestDateTime() {
+    public ZigBeeUtcTime getRequestDateTime() {
         return requestDateTime;
     }
 
@@ -217,7 +216,7 @@ public class ChangeSupply extends ZclMeteringCommand {
      * @deprecated as of 1.3.0. Use the parameterised constructor instead to ensure that all mandatory fields are provided.
      */
     @Deprecated
-    public void setRequestDateTime(final Calendar requestDateTime) {
+    public void setRequestDateTime(final ZigBeeUtcTime requestDateTime) {
         this.requestDateTime = requestDateTime;
     }
 
@@ -233,7 +232,7 @@ public class ChangeSupply extends ZclMeteringCommand {
      *
      * @return the Implementation Date Time
      */
-    public Calendar getImplementationDateTime() {
+    public ZigBeeUtcTime getImplementationDateTime() {
         return implementationDateTime;
     }
 
@@ -251,7 +250,7 @@ public class ChangeSupply extends ZclMeteringCommand {
      * @deprecated as of 1.3.0. Use the parameterised constructor instead to ensure that all mandatory fields are provided.
      */
     @Deprecated
-    public void setImplementationDateTime(final Calendar implementationDateTime) {
+    public void setImplementationDateTime(final ZigBeeUtcTime implementationDateTime) {
         this.implementationDateTime = implementationDateTime;
     }
 
@@ -319,8 +318,8 @@ public class ChangeSupply extends ZclMeteringCommand {
     public void deserialize(final ZclFieldDeserializer deserializer) {
         providerId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
         issuerEventId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        requestDateTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
-        implementationDateTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
+        requestDateTime = (ZigBeeUtcTime) deserializer.deserialize(ZclDataType.UTCTIME);
+        implementationDateTime = (ZigBeeUtcTime) deserializer.deserialize(ZclDataType.UTCTIME);
         proposedSupplyStatus = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
         supplyControlBits = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
     }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/GetProfile.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/GetProfile.java
@@ -7,12 +7,11 @@
  */
 package com.zsmartsystems.zigbee.zcl.clusters.metering;
 
-import java.util.Calendar;
-
 import javax.annotation.Generated;
 
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
+import com.zsmartsystems.zigbee.zcl.field.ZigBeeUtcTime;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
@@ -27,7 +26,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-12-25T10:11:19Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2022-12-09T01:34:23Z")
 public class GetProfile extends ZclMeteringCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -57,7 +56,7 @@ public class GetProfile extends ZclMeteringCommand {
      * End time set to the EndTime of the previous block - (number of intervals of the previous
      * block * ProfileIntervalPeriod).
      */
-    private Calendar endTime;
+    private ZigBeeUtcTime endTime;
 
     /**
      * Number Of Periods command message field.
@@ -87,12 +86,12 @@ public class GetProfile extends ZclMeteringCommand {
      * Constructor providing all required parameters.
      *
      * @param intervalChannel {@link Integer} Interval Channel
-     * @param endTime {@link Calendar} End Time
+     * @param endTime {@link ZigBeeUtcTime} End Time
      * @param numberOfPeriods {@link Integer} Number Of Periods
      */
     public GetProfile(
             Integer intervalChannel,
-            Calendar endTime,
+            ZigBeeUtcTime endTime,
             Integer numberOfPeriods) {
 
         clusterId = CLUSTER_ID;
@@ -143,7 +142,7 @@ public class GetProfile extends ZclMeteringCommand {
      *
      * @return the End Time
      */
-    public Calendar getEndTime() {
+    public ZigBeeUtcTime getEndTime() {
         return endTime;
     }
 
@@ -161,7 +160,7 @@ public class GetProfile extends ZclMeteringCommand {
      * @deprecated as of 1.3.0. Use the parameterised constructor instead to ensure that all mandatory fields are provided.
      */
     @Deprecated
-    public void setEndTime(final Calendar endTime) {
+    public void setEndTime(final ZigBeeUtcTime endTime) {
         this.endTime = endTime;
     }
 
@@ -207,7 +206,7 @@ public class GetProfile extends ZclMeteringCommand {
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
         intervalChannel = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        endTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
+        endTime = (ZigBeeUtcTime) deserializer.deserialize(ZclDataType.UTCTIME);
         numberOfPeriods = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
     }
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/GetProfileResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/GetProfileResponse.java
@@ -7,12 +7,11 @@
  */
 package com.zsmartsystems.zigbee.zcl.clusters.metering;
 
-import java.util.Calendar;
-
 import javax.annotation.Generated;
 
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
+import com.zsmartsystems.zigbee.zcl.field.ZigBeeUtcTime;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
@@ -26,7 +25,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-12-25T10:11:19Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2022-12-09T01:34:23Z")
 public class GetProfileResponse extends ZclMeteringCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -47,7 +46,7 @@ public class GetProfileResponse extends ZclMeteringCommand {
      * interval accumulating is not included in most recent block but can be retrieved using
      * the CurrentPartialProfileIntervalValue attribute.
      */
-    private Calendar endTime;
+    private ZigBeeUtcTime endTime;
 
     /**
      * Status command message field.
@@ -101,14 +100,14 @@ public class GetProfileResponse extends ZclMeteringCommand {
     /**
      * Constructor providing all required parameters.
      *
-     * @param endTime {@link Calendar} End Time
+     * @param endTime {@link ZigBeeUtcTime} End Time
      * @param status {@link Integer} Status
      * @param profileIntervalPeriod {@link Integer} Profile Interval Period
      * @param numberOfPeriodsDelivered {@link Integer} Number Of Periods Delivered
      * @param intervals {@link Integer} Intervals
      */
     public GetProfileResponse(
-            Calendar endTime,
+            ZigBeeUtcTime endTime,
             Integer status,
             Integer profileIntervalPeriod,
             Integer numberOfPeriodsDelivered,
@@ -137,7 +136,7 @@ public class GetProfileResponse extends ZclMeteringCommand {
      *
      * @return the End Time
      */
-    public Calendar getEndTime() {
+    public ZigBeeUtcTime getEndTime() {
         return endTime;
     }
 
@@ -154,7 +153,7 @@ public class GetProfileResponse extends ZclMeteringCommand {
      * @deprecated as of 1.3.0. Use the parameterised constructor instead to ensure that all mandatory fields are provided.
      */
     @Deprecated
-    public void setEndTime(final Calendar endTime) {
+    public void setEndTime(final ZigBeeUtcTime endTime) {
         this.endTime = endTime;
     }
 
@@ -281,7 +280,7 @@ public class GetProfileResponse extends ZclMeteringCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        endTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
+        endTime = (ZigBeeUtcTime) deserializer.deserialize(ZclDataType.UTCTIME);
         status = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
         profileIntervalPeriod = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
         numberOfPeriodsDelivered = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/GetSampledData.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/GetSampledData.java
@@ -7,12 +7,11 @@
  */
 package com.zsmartsystems.zigbee.zcl.clusters.metering;
 
-import java.util.Calendar;
-
 import javax.annotation.Generated;
 
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
+import com.zsmartsystems.zigbee.zcl.field.ZigBeeUtcTime;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
@@ -28,7 +27,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-12-25T10:11:19Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2022-12-09T01:34:23Z")
 public class GetSampledData extends ZclMeteringCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -55,7 +54,7 @@ public class GetSampledData extends ZclMeteringCommand {
      * timestamp equal to or greater than the specified EarliestSampleTime shall be
      * returned.
      */
-    private Calendar earliestSampleTime;
+    private ZigBeeUtcTime earliestSampleTime;
 
     /**
      * Sample Type command message field.
@@ -92,13 +91,13 @@ public class GetSampledData extends ZclMeteringCommand {
      * Constructor providing all required parameters.
      *
      * @param sampleId {@link Integer} Sample ID
-     * @param earliestSampleTime {@link Calendar} Earliest Sample Time
+     * @param earliestSampleTime {@link ZigBeeUtcTime} Earliest Sample Time
      * @param sampleType {@link Integer} Sample Type
      * @param numberOfSamples {@link Integer} Number Of Samples
      */
     public GetSampledData(
             Integer sampleId,
-            Calendar earliestSampleTime,
+            ZigBeeUtcTime earliestSampleTime,
             Integer sampleType,
             Integer numberOfSamples) {
 
@@ -148,7 +147,7 @@ public class GetSampledData extends ZclMeteringCommand {
      *
      * @return the Earliest Sample Time
      */
-    public Calendar getEarliestSampleTime() {
+    public ZigBeeUtcTime getEarliestSampleTime() {
         return earliestSampleTime;
     }
 
@@ -163,7 +162,7 @@ public class GetSampledData extends ZclMeteringCommand {
      * @deprecated as of 1.3.0. Use the parameterised constructor instead to ensure that all mandatory fields are provided.
      */
     @Deprecated
-    public void setEarliestSampleTime(final Calendar earliestSampleTime) {
+    public void setEarliestSampleTime(final ZigBeeUtcTime earliestSampleTime) {
         this.earliestSampleTime = earliestSampleTime;
     }
 
@@ -234,7 +233,7 @@ public class GetSampledData extends ZclMeteringCommand {
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
         sampleId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        earliestSampleTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
+        earliestSampleTime = (ZigBeeUtcTime) deserializer.deserialize(ZclDataType.UTCTIME);
         sampleType = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
         numberOfSamples = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
     }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/GetSampledDataResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/GetSampledDataResponse.java
@@ -7,12 +7,11 @@
  */
 package com.zsmartsystems.zigbee.zcl.clusters.metering;
 
-import java.util.Calendar;
-
 import javax.annotation.Generated;
 
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
+import com.zsmartsystems.zigbee.zcl.field.ZigBeeUtcTime;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
@@ -27,7 +26,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-12-25T10:11:19Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2022-12-09T01:34:23Z")
 public class GetSampledDataResponse extends ZclMeteringCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -52,7 +51,7 @@ public class GetSampledDataResponse extends ZclMeteringCommand {
      * <p>
      * A UTC Time field to denote the time of the first sample returned in this response.
      */
-    private Calendar sampleStartTime;
+    private ZigBeeUtcTime sampleStartTime;
 
     /**
      * Sample Type command message field.
@@ -107,7 +106,7 @@ public class GetSampledDataResponse extends ZclMeteringCommand {
      * Constructor providing all required parameters.
      *
      * @param sampleId {@link Integer} Sample ID
-     * @param sampleStartTime {@link Calendar} Sample Start Time
+     * @param sampleStartTime {@link ZigBeeUtcTime} Sample Start Time
      * @param sampleType {@link Integer} Sample Type
      * @param sampleRequestInterval {@link Integer} Sample Request Interval
      * @param numberOfSamples {@link Integer} Number Of Samples
@@ -115,7 +114,7 @@ public class GetSampledDataResponse extends ZclMeteringCommand {
      */
     public GetSampledDataResponse(
             Integer sampleId,
-            Calendar sampleStartTime,
+            ZigBeeUtcTime sampleStartTime,
             Integer sampleType,
             Integer sampleRequestInterval,
             Integer numberOfSamples,
@@ -167,7 +166,7 @@ public class GetSampledDataResponse extends ZclMeteringCommand {
      *
      * @return the Sample Start Time
      */
-    public Calendar getSampleStartTime() {
+    public ZigBeeUtcTime getSampleStartTime() {
         return sampleStartTime;
     }
 
@@ -180,7 +179,7 @@ public class GetSampledDataResponse extends ZclMeteringCommand {
      * @deprecated as of 1.3.0. Use the parameterised constructor instead to ensure that all mandatory fields are provided.
      */
     @Deprecated
-    public void setSampleStartTime(final Calendar sampleStartTime) {
+    public void setSampleStartTime(final ZigBeeUtcTime sampleStartTime) {
         this.sampleStartTime = sampleStartTime;
     }
 
@@ -309,7 +308,7 @@ public class GetSampledDataResponse extends ZclMeteringCommand {
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
         sampleId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        sampleStartTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
+        sampleStartTime = (ZigBeeUtcTime) deserializer.deserialize(ZclDataType.UTCTIME);
         sampleType = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
         sampleRequestInterval = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
         numberOfSamples = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/GetSnapshot.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/GetSnapshot.java
@@ -7,12 +7,11 @@
  */
 package com.zsmartsystems.zigbee.zcl.clusters.metering;
 
-import java.util.Calendar;
-
 import javax.annotation.Generated;
 
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
+import com.zsmartsystems.zigbee.zcl.field.ZigBeeUtcTime;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
@@ -26,7 +25,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-12-25T10:11:19Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2022-12-09T01:34:23Z")
 public class GetSnapshot extends ZclMeteringCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -45,7 +44,7 @@ public class GetSnapshot extends ZclMeteringCommand {
      * corresponding Publish Snapshot command. Snapshots with a time stamp equal to or
      * greater than the specified Earliest Start Time shall be returned.
      */
-    private Calendar earliestStartTime;
+    private ZigBeeUtcTime earliestStartTime;
 
     /**
      * Latest End Time command message field.
@@ -54,7 +53,7 @@ public class GetSnapshot extends ZclMeteringCommand {
      * corresponding Publish Snapshot command. Snapshots with a time stamp less than the
      * specified Latest End Time shall be returned.
      */
-    private Calendar latestEndTime;
+    private ZigBeeUtcTime latestEndTime;
 
     /**
      * Snapshot Offset command message field.
@@ -91,14 +90,14 @@ public class GetSnapshot extends ZclMeteringCommand {
     /**
      * Constructor providing all required parameters.
      *
-     * @param earliestStartTime {@link Calendar} Earliest Start Time
-     * @param latestEndTime {@link Calendar} Latest End Time
+     * @param earliestStartTime {@link ZigBeeUtcTime} Earliest Start Time
+     * @param latestEndTime {@link ZigBeeUtcTime} Latest End Time
      * @param snapshotOffset {@link Integer} Snapshot Offset
      * @param snapshotCause {@link Integer} Snapshot Cause
      */
     public GetSnapshot(
-            Calendar earliestStartTime,
-            Calendar latestEndTime,
+            ZigBeeUtcTime earliestStartTime,
+            ZigBeeUtcTime latestEndTime,
             Integer snapshotOffset,
             Integer snapshotCause) {
 
@@ -122,7 +121,7 @@ public class GetSnapshot extends ZclMeteringCommand {
      *
      * @return the Earliest Start Time
      */
-    public Calendar getEarliestStartTime() {
+    public ZigBeeUtcTime getEarliestStartTime() {
         return earliestStartTime;
     }
 
@@ -137,7 +136,7 @@ public class GetSnapshot extends ZclMeteringCommand {
      * @deprecated as of 1.3.0. Use the parameterised constructor instead to ensure that all mandatory fields are provided.
      */
     @Deprecated
-    public void setEarliestStartTime(final Calendar earliestStartTime) {
+    public void setEarliestStartTime(final ZigBeeUtcTime earliestStartTime) {
         this.earliestStartTime = earliestStartTime;
     }
 
@@ -150,7 +149,7 @@ public class GetSnapshot extends ZclMeteringCommand {
      *
      * @return the Latest End Time
      */
-    public Calendar getLatestEndTime() {
+    public ZigBeeUtcTime getLatestEndTime() {
         return latestEndTime;
     }
 
@@ -165,7 +164,7 @@ public class GetSnapshot extends ZclMeteringCommand {
      * @deprecated as of 1.3.0. Use the parameterised constructor instead to ensure that all mandatory fields are provided.
      */
     @Deprecated
-    public void setLatestEndTime(final Calendar latestEndTime) {
+    public void setLatestEndTime(final ZigBeeUtcTime latestEndTime) {
         this.latestEndTime = latestEndTime;
     }
 
@@ -237,8 +236,8 @@ public class GetSnapshot extends ZclMeteringCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        earliestStartTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
-        latestEndTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
+        earliestStartTime = (ZigBeeUtcTime) deserializer.deserialize(ZclDataType.UTCTIME);
+        latestEndTime = (ZigBeeUtcTime) deserializer.deserialize(ZclDataType.UTCTIME);
         snapshotOffset = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
         snapshotCause = (Integer) deserializer.deserialize(ZclDataType.BITMAP_32_BIT);
     }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/PublishSnapshot.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/PublishSnapshot.java
@@ -7,12 +7,11 @@
  */
 package com.zsmartsystems.zigbee.zcl.clusters.metering;
 
-import java.util.Calendar;
-
 import javax.annotation.Generated;
 
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
+import com.zsmartsystems.zigbee.zcl.field.ZigBeeUtcTime;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
@@ -27,7 +26,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-12-25T10:11:19Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2022-12-09T01:34:23Z")
 public class PublishSnapshot extends ZclMeteringCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -52,7 +51,7 @@ public class PublishSnapshot extends ZclMeteringCommand {
      * This is a 32 bit value (in UTC Time) representing the time at which the data snapshot was
      * taken.
      */
-    private Calendar snapshotTime;
+    private ZigBeeUtcTime snapshotTime;
 
     /**
      * Total Snapshots Found command message field.
@@ -131,7 +130,7 @@ public class PublishSnapshot extends ZclMeteringCommand {
      * Constructor providing all required parameters.
      *
      * @param snapshotId {@link Integer} Snapshot ID
-     * @param snapshotTime {@link Calendar} Snapshot Time
+     * @param snapshotTime {@link ZigBeeUtcTime} Snapshot Time
      * @param totalSnapshotsFound {@link Integer} Total Snapshots Found
      * @param commandIndex {@link Integer} Command Index
      * @param totalNumberOfCommands {@link Integer} Total Number Of Commands
@@ -141,7 +140,7 @@ public class PublishSnapshot extends ZclMeteringCommand {
      */
     public PublishSnapshot(
             Integer snapshotId,
-            Calendar snapshotTime,
+            ZigBeeUtcTime snapshotTime,
             Integer totalSnapshotsFound,
             Integer commandIndex,
             Integer totalNumberOfCommands,
@@ -196,7 +195,7 @@ public class PublishSnapshot extends ZclMeteringCommand {
      *
      * @return the Snapshot Time
      */
-    public Calendar getSnapshotTime() {
+    public ZigBeeUtcTime getSnapshotTime() {
         return snapshotTime;
     }
 
@@ -210,7 +209,7 @@ public class PublishSnapshot extends ZclMeteringCommand {
      * @deprecated as of 1.3.0. Use the parameterised constructor instead to ensure that all mandatory fields are provided.
      */
     @Deprecated
-    public void setSnapshotTime(final Calendar snapshotTime) {
+    public void setSnapshotTime(final ZigBeeUtcTime snapshotTime) {
         this.snapshotTime = snapshotTime;
     }
 
@@ -409,7 +408,7 @@ public class PublishSnapshot extends ZclMeteringCommand {
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
         snapshotId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        snapshotTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
+        snapshotTime = (ZigBeeUtcTime) deserializer.deserialize(ZclDataType.UTCTIME);
         totalSnapshotsFound = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
         commandIndex = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
         totalNumberOfCommands = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/RequestFastPollModeResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/RequestFastPollModeResponse.java
@@ -7,12 +7,11 @@
  */
 package com.zsmartsystems.zigbee.zcl.clusters.metering;
 
-import java.util.Calendar;
-
 import javax.annotation.Generated;
 
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
+import com.zsmartsystems.zigbee.zcl.field.ZigBeeUtcTime;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
@@ -26,7 +25,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-12-25T10:11:19Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2022-12-09T01:34:23Z")
 public class RequestFastPollModeResponse extends ZclMeteringCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -58,7 +57,7 @@ public class RequestFastPollModeResponse extends ZclMeteringCommand {
      * poll mode. The intent is that the fast poll mode will not be extended since this scenario
      * would make it possible to be in fast poll mode longer than 15 minutes.
      */
-    private Calendar fastPollModeEndtime;
+    private ZigBeeUtcTime fastPollModeEndtime;
 
     /**
      * Default constructor.
@@ -77,11 +76,11 @@ public class RequestFastPollModeResponse extends ZclMeteringCommand {
      * Constructor providing all required parameters.
      *
      * @param appliedUpdatePeriod {@link Integer} Applied Update Period
-     * @param fastPollModeEndtime {@link Calendar} Fast Poll Mode Endtime
+     * @param fastPollModeEndtime {@link ZigBeeUtcTime} Fast Poll Mode Endtime
      */
     public RequestFastPollModeResponse(
             Integer appliedUpdatePeriod,
-            Calendar fastPollModeEndtime) {
+            ZigBeeUtcTime fastPollModeEndtime) {
 
         clusterId = CLUSTER_ID;
         commandId = COMMAND_ID;
@@ -135,7 +134,7 @@ public class RequestFastPollModeResponse extends ZclMeteringCommand {
      *
      * @return the Fast Poll Mode Endtime
      */
-    public Calendar getFastPollModeEndtime() {
+    public ZigBeeUtcTime getFastPollModeEndtime() {
         return fastPollModeEndtime;
     }
 
@@ -152,7 +151,7 @@ public class RequestFastPollModeResponse extends ZclMeteringCommand {
      * @deprecated as of 1.3.0. Use the parameterised constructor instead to ensure that all mandatory fields are provided.
      */
     @Deprecated
-    public void setFastPollModeEndtime(final Calendar fastPollModeEndtime) {
+    public void setFastPollModeEndtime(final ZigBeeUtcTime fastPollModeEndtime) {
         this.fastPollModeEndtime = fastPollModeEndtime;
     }
 
@@ -165,7 +164,7 @@ public class RequestFastPollModeResponse extends ZclMeteringCommand {
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
         appliedUpdatePeriod = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        fastPollModeEndtime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
+        fastPollModeEndtime = (ZigBeeUtcTime) deserializer.deserialize(ZclDataType.UTCTIME);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/SnapshotSchedulePayload.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/SnapshotSchedulePayload.java
@@ -6,13 +6,12 @@
  * http://www.eclipse.org/legal/epl-v10.html
  */
 package com.zsmartsystems.zigbee.zcl.clusters.metering;
-import java.util.Calendar;
-
 import javax.annotation.Generated;
 
 import com.zsmartsystems.zigbee.serialization.ZigBeeSerializable;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
+import com.zsmartsystems.zigbee.zcl.field.ZigBeeUtcTime;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
 /**
@@ -20,7 +19,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-12T12:02:05Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2022-12-09T01:34:23Z")
 public class SnapshotSchedulePayload implements ZigBeeSerializable {
     /**
      * Snapshot Schedule ID structure field.
@@ -30,7 +29,7 @@ public class SnapshotSchedulePayload implements ZigBeeSerializable {
     /**
      * Snapshot Start Time structure field.
      */
-    private Calendar snapshotStartTime;
+    private ZigBeeUtcTime snapshotStartTime;
 
     /**
      * Snapshot Schedule structure field.
@@ -61,14 +60,14 @@ public class SnapshotSchedulePayload implements ZigBeeSerializable {
      * Constructor providing all required parameters.
      *
      * @param snapshotScheduleId {@link Integer} Snapshot Schedule ID
-     * @param snapshotStartTime {@link Calendar} Snapshot Start Time
+     * @param snapshotStartTime {@link ZigBeeUtcTime} Snapshot Start Time
      * @param snapshotSchedule {@link Integer} Snapshot Schedule
      * @param snapshotPayloadType {@link Integer} Snapshot Payload Type
      * @param snapshotCause {@link Integer} Snapshot Cause
      */
     public SnapshotSchedulePayload(
             Integer snapshotScheduleId,
-            Calendar snapshotStartTime,
+            ZigBeeUtcTime snapshotStartTime,
             Integer snapshotSchedule,
             Integer snapshotPayloadType,
             Integer snapshotCause) {
@@ -105,7 +104,7 @@ public class SnapshotSchedulePayload implements ZigBeeSerializable {
      *
      * @return the Snapshot Start Time
      */
-    public Calendar getSnapshotStartTime() {
+    public ZigBeeUtcTime getSnapshotStartTime() {
         return snapshotStartTime;
     }
 
@@ -116,7 +115,7 @@ public class SnapshotSchedulePayload implements ZigBeeSerializable {
      * @deprecated as of 1.3.0. Use the parameterised constructor instead to ensure that all mandatory fields are provided.
      */
     @Deprecated
-    public void setSnapshotStartTime(final Calendar snapshotStartTime) {
+    public void setSnapshotStartTime(final ZigBeeUtcTime snapshotStartTime) {
         this.snapshotStartTime = snapshotStartTime;
     }
 
@@ -192,7 +191,7 @@ public class SnapshotSchedulePayload implements ZigBeeSerializable {
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
         snapshotScheduleId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        snapshotStartTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
+        snapshotStartTime = (ZigBeeUtcTime) deserializer.deserialize(ZclDataType.UTCTIME);
         snapshotSchedule = (Integer) deserializer.deserialize(ZclDataType.BITMAP_24_BIT);
         snapshotPayloadType = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
         snapshotCause = (Integer) deserializer.deserialize(ZclDataType.BITMAP_32_BIT);

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/StartSampling.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/StartSampling.java
@@ -7,12 +7,11 @@
  */
 package com.zsmartsystems.zigbee.zcl.clusters.metering;
 
-import java.util.Calendar;
-
 import javax.annotation.Generated;
 
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
+import com.zsmartsystems.zigbee.zcl.field.ZigBeeUtcTime;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
@@ -29,7 +28,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-12-25T10:11:19Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2022-12-09T01:34:23Z")
 public class StartSampling extends ZclMeteringCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -63,7 +62,7 @@ public class StartSampling extends ZclMeteringCommand {
      * Date/Time of 0xFFFFFFFF shall cause an existing StartSampling command with the same
      * Issuer Event ID to be cancelled.
      */
-    private Calendar startSamplingTime;
+    private ZigBeeUtcTime startSamplingTime;
 
     /**
      * Sample Type command message field.
@@ -103,14 +102,14 @@ public class StartSampling extends ZclMeteringCommand {
      * Constructor providing all required parameters.
      *
      * @param issuerEventId {@link Integer} Issuer Event ID
-     * @param startSamplingTime {@link Calendar} Start Sampling Time
+     * @param startSamplingTime {@link ZigBeeUtcTime} Start Sampling Time
      * @param sampleType {@link Integer} Sample Type
      * @param sampleRequestInterval {@link Integer} Sample Request Interval
      * @param maxNumberOfSamples {@link Integer} Max Number Of Samples
      */
     public StartSampling(
             Integer issuerEventId,
-            Calendar startSamplingTime,
+            ZigBeeUtcTime startSamplingTime,
             Integer sampleType,
             Integer sampleRequestInterval,
             Integer maxNumberOfSamples) {
@@ -175,7 +174,7 @@ public class StartSampling extends ZclMeteringCommand {
      *
      * @return the Start Sampling Time
      */
-    public Calendar getStartSamplingTime() {
+    public ZigBeeUtcTime getStartSamplingTime() {
         return startSamplingTime;
     }
 
@@ -191,7 +190,7 @@ public class StartSampling extends ZclMeteringCommand {
      * @deprecated as of 1.3.0. Use the parameterised constructor instead to ensure that all mandatory fields are provided.
      */
     @Deprecated
-    public void setStartSamplingTime(final Calendar startSamplingTime) {
+    public void setStartSamplingTime(final ZigBeeUtcTime startSamplingTime) {
         this.startSamplingTime = startSamplingTime;
     }
 
@@ -279,7 +278,7 @@ public class StartSampling extends ZclMeteringCommand {
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
         issuerEventId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        startSamplingTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
+        startSamplingTime = (ZigBeeUtcTime) deserializer.deserialize(ZclDataType.UTCTIME);
         sampleType = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
         sampleRequestInterval = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
         maxNumberOfSamples = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/SupplyStatusResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/SupplyStatusResponse.java
@@ -7,12 +7,11 @@
  */
 package com.zsmartsystems.zigbee.zcl.clusters.metering;
 
-import java.util.Calendar;
-
 import javax.annotation.Generated;
 
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
+import com.zsmartsystems.zigbee.zcl.field.ZigBeeUtcTime;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
@@ -26,7 +25,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-12-25T10:11:19Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2022-12-09T01:34:23Z")
 public class SupplyStatusResponse extends ZclMeteringCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -63,7 +62,7 @@ public class SupplyStatusResponse extends ZclMeteringCommand {
      * <p>
      * A UTC Time field to indicate the date at which the originating command was to be applied.
      */
-    private Calendar implementationDateTime;
+    private ZigBeeUtcTime implementationDateTime;
 
     /**
      * Supply Status command message field.
@@ -91,13 +90,13 @@ public class SupplyStatusResponse extends ZclMeteringCommand {
      *
      * @param providerId {@link Integer} Provider ID
      * @param issuerEventId {@link Integer} Issuer Event ID
-     * @param implementationDateTime {@link Calendar} Implementation Date Time
+     * @param implementationDateTime {@link ZigBeeUtcTime} Implementation Date Time
      * @param supplyStatus {@link Integer} Supply Status
      */
     public SupplyStatusResponse(
             Integer providerId,
             Integer issuerEventId,
-            Calendar implementationDateTime,
+            ZigBeeUtcTime implementationDateTime,
             Integer supplyStatus) {
 
         clusterId = CLUSTER_ID;
@@ -178,7 +177,7 @@ public class SupplyStatusResponse extends ZclMeteringCommand {
      *
      * @return the Implementation Date Time
      */
-    public Calendar getImplementationDateTime() {
+    public ZigBeeUtcTime getImplementationDateTime() {
         return implementationDateTime;
     }
 
@@ -191,7 +190,7 @@ public class SupplyStatusResponse extends ZclMeteringCommand {
      * @deprecated as of 1.3.0. Use the parameterised constructor instead to ensure that all mandatory fields are provided.
      */
     @Deprecated
-    public void setImplementationDateTime(final Calendar implementationDateTime) {
+    public void setImplementationDateTime(final ZigBeeUtcTime implementationDateTime) {
         this.implementationDateTime = implementationDateTime;
     }
 
@@ -233,7 +232,7 @@ public class SupplyStatusResponse extends ZclMeteringCommand {
     public void deserialize(final ZclFieldDeserializer deserializer) {
         providerId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
         issuerEventId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        implementationDateTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
+        implementationDateTime = (ZigBeeUtcTime) deserializer.deserialize(ZclDataType.UTCTIME);
         supplyStatus = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
     }
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/ChangeDebt.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/ChangeDebt.java
@@ -7,13 +7,12 @@
  */
 package com.zsmartsystems.zigbee.zcl.clusters.prepayment;
 
-import java.util.Calendar;
-
 import javax.annotation.Generated;
 
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.field.ByteArray;
+import com.zsmartsystems.zigbee.zcl.field.ZigBeeUtcTime;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
@@ -28,7 +27,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-12-25T10:11:19Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2022-12-09T01:34:23Z")
 public class ChangeDebt extends ZclPrepaymentCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -68,7 +67,7 @@ public class ChangeDebt extends ZclPrepaymentCommand {
     /**
      * Debt Recovery Start Time command message field.
      */
-    private Calendar debtRecoveryStartTime;
+    private ZigBeeUtcTime debtRecoveryStartTime;
 
     /**
      * Debt Recovery Collection Time command message field.
@@ -111,7 +110,7 @@ public class ChangeDebt extends ZclPrepaymentCommand {
      * @param debtAmount {@link Integer} Debt Amount
      * @param debtRecoveryMethod {@link Integer} Debt Recovery Method
      * @param debtAmountType {@link Integer} Debt Amount Type
-     * @param debtRecoveryStartTime {@link Calendar} Debt Recovery Start Time
+     * @param debtRecoveryStartTime {@link ZigBeeUtcTime} Debt Recovery Start Time
      * @param debtRecoveryCollectionTime {@link Integer} Debt Recovery Collection Time
      * @param debtRecoveryFrequency {@link Integer} Debt Recovery Frequency
      * @param debtRecoveryAmount {@link Integer} Debt Recovery Amount
@@ -123,7 +122,7 @@ public class ChangeDebt extends ZclPrepaymentCommand {
             Integer debtAmount,
             Integer debtRecoveryMethod,
             Integer debtAmountType,
-            Calendar debtRecoveryStartTime,
+            ZigBeeUtcTime debtRecoveryStartTime,
             Integer debtRecoveryCollectionTime,
             Integer debtRecoveryFrequency,
             Integer debtRecoveryAmount,
@@ -251,7 +250,7 @@ public class ChangeDebt extends ZclPrepaymentCommand {
      *
      * @return the Debt Recovery Start Time
      */
-    public Calendar getDebtRecoveryStartTime() {
+    public ZigBeeUtcTime getDebtRecoveryStartTime() {
         return debtRecoveryStartTime;
     }
 
@@ -262,7 +261,7 @@ public class ChangeDebt extends ZclPrepaymentCommand {
      * @deprecated as of 1.3.0. Use the parameterised constructor instead to ensure that all mandatory fields are provided.
      */
     @Deprecated
-    public void setDebtRecoveryStartTime(final Calendar debtRecoveryStartTime) {
+    public void setDebtRecoveryStartTime(final ZigBeeUtcTime debtRecoveryStartTime) {
         this.debtRecoveryStartTime = debtRecoveryStartTime;
     }
 
@@ -367,7 +366,7 @@ public class ChangeDebt extends ZclPrepaymentCommand {
         debtAmount = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
         debtRecoveryMethod = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
         debtAmountType = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        debtRecoveryStartTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
+        debtRecoveryStartTime = (ZigBeeUtcTime) deserializer.deserialize(ZclDataType.UTCTIME);
         debtRecoveryCollectionTime = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
         debtRecoveryFrequency = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
         debtRecoveryAmount = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/ChangePaymentMode.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/ChangePaymentMode.java
@@ -7,12 +7,11 @@
  */
 package com.zsmartsystems.zigbee.zcl.clusters.prepayment;
 
-import java.util.Calendar;
-
 import javax.annotation.Generated;
 
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
+import com.zsmartsystems.zigbee.zcl.field.ZigBeeUtcTime;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
@@ -27,7 +26,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-12-25T10:11:19Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2022-12-09T01:34:23Z")
 public class ChangePaymentMode extends ZclPrepaymentCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -52,7 +51,7 @@ public class ChangePaymentMode extends ZclPrepaymentCommand {
     /**
      * Implementation Date Time command message field.
      */
-    private Calendar implementationDateTime;
+    private ZigBeeUtcTime implementationDateTime;
 
     /**
      * Proposed Payment Control Configuration command message field.
@@ -82,14 +81,14 @@ public class ChangePaymentMode extends ZclPrepaymentCommand {
      *
      * @param providerId {@link Integer} Provider ID
      * @param issuerEventId {@link Integer} Issuer Event ID
-     * @param implementationDateTime {@link Calendar} Implementation Date Time
+     * @param implementationDateTime {@link ZigBeeUtcTime} Implementation Date Time
      * @param proposedPaymentControlConfiguration {@link Integer} Proposed Payment Control Configuration
      * @param cutOffValue {@link Integer} Cut Off Value
      */
     public ChangePaymentMode(
             Integer providerId,
             Integer issuerEventId,
-            Calendar implementationDateTime,
+            ZigBeeUtcTime implementationDateTime,
             Integer proposedPaymentControlConfiguration,
             Integer cutOffValue) {
 
@@ -150,7 +149,7 @@ public class ChangePaymentMode extends ZclPrepaymentCommand {
      *
      * @return the Implementation Date Time
      */
-    public Calendar getImplementationDateTime() {
+    public ZigBeeUtcTime getImplementationDateTime() {
         return implementationDateTime;
     }
 
@@ -161,7 +160,7 @@ public class ChangePaymentMode extends ZclPrepaymentCommand {
      * @deprecated as of 1.3.0. Use the parameterised constructor instead to ensure that all mandatory fields are provided.
      */
     @Deprecated
-    public void setImplementationDateTime(final Calendar implementationDateTime) {
+    public void setImplementationDateTime(final ZigBeeUtcTime implementationDateTime) {
         this.implementationDateTime = implementationDateTime;
     }
 
@@ -218,7 +217,7 @@ public class ChangePaymentMode extends ZclPrepaymentCommand {
     public void deserialize(final ZclFieldDeserializer deserializer) {
         providerId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
         issuerEventId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        implementationDateTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
+        implementationDateTime = (ZigBeeUtcTime) deserializer.deserialize(ZclDataType.UTCTIME);
         proposedPaymentControlConfiguration = (Integer) deserializer.deserialize(ZclDataType.BITMAP_16_BIT);
         cutOffValue = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
     }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/CreditAdjustment.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/CreditAdjustment.java
@@ -7,12 +7,11 @@
  */
 package com.zsmartsystems.zigbee.zcl.clusters.prepayment;
 
-import java.util.Calendar;
-
 import javax.annotation.Generated;
 
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
+import com.zsmartsystems.zigbee.zcl.field.ZigBeeUtcTime;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
@@ -27,7 +26,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-12-25T10:11:19Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2022-12-09T01:34:23Z")
 public class CreditAdjustment extends ZclPrepaymentCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -47,7 +46,7 @@ public class CreditAdjustment extends ZclPrepaymentCommand {
     /**
      * Start Time command message field.
      */
-    private Calendar startTime;
+    private ZigBeeUtcTime startTime;
 
     /**
      * Credit Adjustment Type command message field.
@@ -76,13 +75,13 @@ public class CreditAdjustment extends ZclPrepaymentCommand {
      * Constructor providing all required parameters.
      *
      * @param issuerEventId {@link Integer} Issuer Event ID
-     * @param startTime {@link Calendar} Start Time
+     * @param startTime {@link ZigBeeUtcTime} Start Time
      * @param creditAdjustmentType {@link Integer} Credit Adjustment Type
      * @param creditAdjustmentValue {@link Integer} Credit Adjustment Value
      */
     public CreditAdjustment(
             Integer issuerEventId,
-            Calendar startTime,
+            ZigBeeUtcTime startTime,
             Integer creditAdjustmentType,
             Integer creditAdjustmentValue) {
 
@@ -122,7 +121,7 @@ public class CreditAdjustment extends ZclPrepaymentCommand {
      *
      * @return the Start Time
      */
-    public Calendar getStartTime() {
+    public ZigBeeUtcTime getStartTime() {
         return startTime;
     }
 
@@ -133,7 +132,7 @@ public class CreditAdjustment extends ZclPrepaymentCommand {
      * @deprecated as of 1.3.0. Use the parameterised constructor instead to ensure that all mandatory fields are provided.
      */
     @Deprecated
-    public void setStartTime(final Calendar startTime) {
+    public void setStartTime(final ZigBeeUtcTime startTime) {
         this.startTime = startTime;
     }
 
@@ -188,7 +187,7 @@ public class CreditAdjustment extends ZclPrepaymentCommand {
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
         issuerEventId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        startTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
+        startTime = (ZigBeeUtcTime) deserializer.deserialize(ZclDataType.UTCTIME);
         creditAdjustmentType = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
         creditAdjustmentValue = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
     }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/DebtPayload.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/DebtPayload.java
@@ -6,13 +6,12 @@
  * http://www.eclipse.org/legal/epl-v10.html
  */
 package com.zsmartsystems.zigbee.zcl.clusters.prepayment;
-import java.util.Calendar;
-
 import javax.annotation.Generated;
 
 import com.zsmartsystems.zigbee.serialization.ZigBeeSerializable;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
+import com.zsmartsystems.zigbee.zcl.field.ZigBeeUtcTime;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
 /**
@@ -20,12 +19,12 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-12T12:02:05Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2022-12-09T01:34:23Z")
 public class DebtPayload implements ZigBeeSerializable {
     /**
      * Collection Time structure field.
      */
-    private Calendar collectionTime;
+    private ZigBeeUtcTime collectionTime;
 
     /**
      * Amount Collected structure field.
@@ -55,13 +54,13 @@ public class DebtPayload implements ZigBeeSerializable {
     /**
      * Constructor providing all required parameters.
      *
-     * @param collectionTime {@link Calendar} Collection Time
+     * @param collectionTime {@link ZigBeeUtcTime} Collection Time
      * @param amountCollected {@link Integer} Amount Collected
      * @param debtType {@link Integer} Debt Type
      * @param outstandingDebt {@link Integer} Outstanding Debt
      */
     public DebtPayload(
-            Calendar collectionTime,
+            ZigBeeUtcTime collectionTime,
             Integer amountCollected,
             Integer debtType,
             Integer outstandingDebt) {
@@ -77,7 +76,7 @@ public class DebtPayload implements ZigBeeSerializable {
      *
      * @return the Collection Time
      */
-    public Calendar getCollectionTime() {
+    public ZigBeeUtcTime getCollectionTime() {
         return collectionTime;
     }
 
@@ -88,7 +87,7 @@ public class DebtPayload implements ZigBeeSerializable {
      * @deprecated as of 1.3.0. Use the parameterised constructor instead to ensure that all mandatory fields are provided.
      */
     @Deprecated
-    public void setCollectionTime(final Calendar collectionTime) {
+    public void setCollectionTime(final ZigBeeUtcTime collectionTime) {
         this.collectionTime = collectionTime;
     }
 
@@ -162,7 +161,7 @@ public class DebtPayload implements ZigBeeSerializable {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        collectionTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
+        collectionTime = (ZigBeeUtcTime) deserializer.deserialize(ZclDataType.UTCTIME);
         amountCollected = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
         debtType = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
         outstandingDebt = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/EmergencyCreditSetup.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/EmergencyCreditSetup.java
@@ -7,12 +7,11 @@
  */
 package com.zsmartsystems.zigbee.zcl.clusters.prepayment;
 
-import java.util.Calendar;
-
 import javax.annotation.Generated;
 
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
+import com.zsmartsystems.zigbee.zcl.field.ZigBeeUtcTime;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
@@ -26,7 +25,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-12-25T10:11:19Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2022-12-09T01:34:23Z")
 public class EmergencyCreditSetup extends ZclPrepaymentCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -46,7 +45,7 @@ public class EmergencyCreditSetup extends ZclPrepaymentCommand {
     /**
      * Start Time command message field.
      */
-    private Calendar startTime;
+    private ZigBeeUtcTime startTime;
 
     /**
      * Emergency Credit Limit command message field.
@@ -75,13 +74,13 @@ public class EmergencyCreditSetup extends ZclPrepaymentCommand {
      * Constructor providing all required parameters.
      *
      * @param issuerEventId {@link Integer} Issuer Event ID
-     * @param startTime {@link Calendar} Start Time
+     * @param startTime {@link ZigBeeUtcTime} Start Time
      * @param emergencyCreditLimit {@link Integer} Emergency Credit Limit
      * @param emergencyCreditThreshold {@link Integer} Emergency Credit Threshold
      */
     public EmergencyCreditSetup(
             Integer issuerEventId,
-            Calendar startTime,
+            ZigBeeUtcTime startTime,
             Integer emergencyCreditLimit,
             Integer emergencyCreditThreshold) {
 
@@ -121,7 +120,7 @@ public class EmergencyCreditSetup extends ZclPrepaymentCommand {
      *
      * @return the Start Time
      */
-    public Calendar getStartTime() {
+    public ZigBeeUtcTime getStartTime() {
         return startTime;
     }
 
@@ -132,7 +131,7 @@ public class EmergencyCreditSetup extends ZclPrepaymentCommand {
      * @deprecated as of 1.3.0. Use the parameterised constructor instead to ensure that all mandatory fields are provided.
      */
     @Deprecated
-    public void setStartTime(final Calendar startTime) {
+    public void setStartTime(final ZigBeeUtcTime startTime) {
         this.startTime = startTime;
     }
 
@@ -187,7 +186,7 @@ public class EmergencyCreditSetup extends ZclPrepaymentCommand {
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
         issuerEventId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        startTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
+        startTime = (ZigBeeUtcTime) deserializer.deserialize(ZclDataType.UTCTIME);
         emergencyCreditLimit = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
         emergencyCreditThreshold = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
     }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/GetDebtRepaymentLog.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/GetDebtRepaymentLog.java
@@ -7,12 +7,11 @@
  */
 package com.zsmartsystems.zigbee.zcl.clusters.prepayment;
 
-import java.util.Calendar;
-
 import javax.annotation.Generated;
 
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
+import com.zsmartsystems.zigbee.zcl.field.ZigBeeUtcTime;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
@@ -26,7 +25,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-12-25T10:11:19Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2022-12-09T01:34:23Z")
 public class GetDebtRepaymentLog extends ZclPrepaymentCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -41,7 +40,7 @@ public class GetDebtRepaymentLog extends ZclPrepaymentCommand {
     /**
      * Latest End Time command message field.
      */
-    private Calendar latestEndTime;
+    private ZigBeeUtcTime latestEndTime;
 
     /**
      * Number Of Debts command message field.
@@ -69,12 +68,12 @@ public class GetDebtRepaymentLog extends ZclPrepaymentCommand {
     /**
      * Constructor providing all required parameters.
      *
-     * @param latestEndTime {@link Calendar} Latest End Time
+     * @param latestEndTime {@link ZigBeeUtcTime} Latest End Time
      * @param numberOfDebts {@link Integer} Number Of Debts
      * @param debtType {@link Integer} Debt Type
      */
     public GetDebtRepaymentLog(
-            Calendar latestEndTime,
+            ZigBeeUtcTime latestEndTime,
             Integer numberOfDebts,
             Integer debtType) {
 
@@ -93,7 +92,7 @@ public class GetDebtRepaymentLog extends ZclPrepaymentCommand {
      *
      * @return the Latest End Time
      */
-    public Calendar getLatestEndTime() {
+    public ZigBeeUtcTime getLatestEndTime() {
         return latestEndTime;
     }
 
@@ -104,7 +103,7 @@ public class GetDebtRepaymentLog extends ZclPrepaymentCommand {
      * @deprecated as of 1.3.0. Use the parameterised constructor instead to ensure that all mandatory fields are provided.
      */
     @Deprecated
-    public void setLatestEndTime(final Calendar latestEndTime) {
+    public void setLatestEndTime(final ZigBeeUtcTime latestEndTime) {
         this.latestEndTime = latestEndTime;
     }
 
@@ -157,7 +156,7 @@ public class GetDebtRepaymentLog extends ZclPrepaymentCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        latestEndTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
+        latestEndTime = (ZigBeeUtcTime) deserializer.deserialize(ZclDataType.UTCTIME);
         numberOfDebts = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
         debtType = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
     }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/GetPrepaySnapshot.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/GetPrepaySnapshot.java
@@ -7,12 +7,11 @@
  */
 package com.zsmartsystems.zigbee.zcl.clusters.prepayment;
 
-import java.util.Calendar;
-
 import javax.annotation.Generated;
 
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
+import com.zsmartsystems.zigbee.zcl.field.ZigBeeUtcTime;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
@@ -26,7 +25,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-12-25T10:11:19Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2022-12-09T01:34:23Z")
 public class GetPrepaySnapshot extends ZclPrepaymentCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -41,12 +40,12 @@ public class GetPrepaySnapshot extends ZclPrepaymentCommand {
     /**
      * Earliest Start Time command message field.
      */
-    private Calendar earliestStartTime;
+    private ZigBeeUtcTime earliestStartTime;
 
     /**
      * Latest End Time command message field.
      */
-    private Calendar latestEndTime;
+    private ZigBeeUtcTime latestEndTime;
 
     /**
      * Snapshot Offset command message field.
@@ -74,14 +73,14 @@ public class GetPrepaySnapshot extends ZclPrepaymentCommand {
     /**
      * Constructor providing all required parameters.
      *
-     * @param earliestStartTime {@link Calendar} Earliest Start Time
-     * @param latestEndTime {@link Calendar} Latest End Time
+     * @param earliestStartTime {@link ZigBeeUtcTime} Earliest Start Time
+     * @param latestEndTime {@link ZigBeeUtcTime} Latest End Time
      * @param snapshotOffset {@link Integer} Snapshot Offset
      * @param snapshotCause {@link Integer} Snapshot Cause
      */
     public GetPrepaySnapshot(
-            Calendar earliestStartTime,
-            Calendar latestEndTime,
+            ZigBeeUtcTime earliestStartTime,
+            ZigBeeUtcTime latestEndTime,
             Integer snapshotOffset,
             Integer snapshotCause) {
 
@@ -101,7 +100,7 @@ public class GetPrepaySnapshot extends ZclPrepaymentCommand {
      *
      * @return the Earliest Start Time
      */
-    public Calendar getEarliestStartTime() {
+    public ZigBeeUtcTime getEarliestStartTime() {
         return earliestStartTime;
     }
 
@@ -112,7 +111,7 @@ public class GetPrepaySnapshot extends ZclPrepaymentCommand {
      * @deprecated as of 1.3.0. Use the parameterised constructor instead to ensure that all mandatory fields are provided.
      */
     @Deprecated
-    public void setEarliestStartTime(final Calendar earliestStartTime) {
+    public void setEarliestStartTime(final ZigBeeUtcTime earliestStartTime) {
         this.earliestStartTime = earliestStartTime;
     }
 
@@ -121,7 +120,7 @@ public class GetPrepaySnapshot extends ZclPrepaymentCommand {
      *
      * @return the Latest End Time
      */
-    public Calendar getLatestEndTime() {
+    public ZigBeeUtcTime getLatestEndTime() {
         return latestEndTime;
     }
 
@@ -132,7 +131,7 @@ public class GetPrepaySnapshot extends ZclPrepaymentCommand {
      * @deprecated as of 1.3.0. Use the parameterised constructor instead to ensure that all mandatory fields are provided.
      */
     @Deprecated
-    public void setLatestEndTime(final Calendar latestEndTime) {
+    public void setLatestEndTime(final ZigBeeUtcTime latestEndTime) {
         this.latestEndTime = latestEndTime;
     }
 
@@ -186,8 +185,8 @@ public class GetPrepaySnapshot extends ZclPrepaymentCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        earliestStartTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
-        latestEndTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
+        earliestStartTime = (ZigBeeUtcTime) deserializer.deserialize(ZclDataType.UTCTIME);
+        latestEndTime = (ZigBeeUtcTime) deserializer.deserialize(ZclDataType.UTCTIME);
         snapshotOffset = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
         snapshotCause = (Integer) deserializer.deserialize(ZclDataType.BITMAP_32_BIT);
     }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/GetTopUpLog.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/GetTopUpLog.java
@@ -7,12 +7,11 @@
  */
 package com.zsmartsystems.zigbee.zcl.clusters.prepayment;
 
-import java.util.Calendar;
-
 import javax.annotation.Generated;
 
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
+import com.zsmartsystems.zigbee.zcl.field.ZigBeeUtcTime;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
@@ -27,7 +26,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-12-25T10:11:19Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2022-12-09T01:34:23Z")
 public class GetTopUpLog extends ZclPrepaymentCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -42,7 +41,7 @@ public class GetTopUpLog extends ZclPrepaymentCommand {
     /**
      * Latest End Time command message field.
      */
-    private Calendar latestEndTime;
+    private ZigBeeUtcTime latestEndTime;
 
     /**
      * Number Of Records command message field.
@@ -65,11 +64,11 @@ public class GetTopUpLog extends ZclPrepaymentCommand {
     /**
      * Constructor providing all required parameters.
      *
-     * @param latestEndTime {@link Calendar} Latest End Time
+     * @param latestEndTime {@link ZigBeeUtcTime} Latest End Time
      * @param numberOfRecords {@link Integer} Number Of Records
      */
     public GetTopUpLog(
-            Calendar latestEndTime,
+            ZigBeeUtcTime latestEndTime,
             Integer numberOfRecords) {
 
         clusterId = CLUSTER_ID;
@@ -86,7 +85,7 @@ public class GetTopUpLog extends ZclPrepaymentCommand {
      *
      * @return the Latest End Time
      */
-    public Calendar getLatestEndTime() {
+    public ZigBeeUtcTime getLatestEndTime() {
         return latestEndTime;
     }
 
@@ -97,7 +96,7 @@ public class GetTopUpLog extends ZclPrepaymentCommand {
      * @deprecated as of 1.3.0. Use the parameterised constructor instead to ensure that all mandatory fields are provided.
      */
     @Deprecated
-    public void setLatestEndTime(final Calendar latestEndTime) {
+    public void setLatestEndTime(final ZigBeeUtcTime latestEndTime) {
         this.latestEndTime = latestEndTime;
     }
 
@@ -129,7 +128,7 @@ public class GetTopUpLog extends ZclPrepaymentCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        latestEndTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
+        latestEndTime = (ZigBeeUtcTime) deserializer.deserialize(ZclDataType.UTCTIME);
         numberOfRecords = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
     }
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/PublishPrepaySnapshot.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/PublishPrepaySnapshot.java
@@ -7,12 +7,11 @@
  */
 package com.zsmartsystems.zigbee.zcl.clusters.prepayment;
 
-import java.util.Calendar;
-
 import javax.annotation.Generated;
 
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
+import com.zsmartsystems.zigbee.zcl.field.ZigBeeUtcTime;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
@@ -27,7 +26,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-12-25T10:11:19Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2022-12-09T01:34:23Z")
 public class PublishPrepaySnapshot extends ZclPrepaymentCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -47,7 +46,7 @@ public class PublishPrepaySnapshot extends ZclPrepaymentCommand {
     /**
      * Snapshot Time command message field.
      */
-    private Calendar snapshotTime;
+    private ZigBeeUtcTime snapshotTime;
 
     /**
      * Total Snapshots Found command message field.
@@ -96,7 +95,7 @@ public class PublishPrepaySnapshot extends ZclPrepaymentCommand {
      * Constructor providing all required parameters.
      *
      * @param snapshotId {@link Integer} Snapshot ID
-     * @param snapshotTime {@link Calendar} Snapshot Time
+     * @param snapshotTime {@link ZigBeeUtcTime} Snapshot Time
      * @param totalSnapshotsFound {@link Integer} Total Snapshots Found
      * @param commandIndex {@link Integer} Command Index
      * @param totalNumberOfCommands {@link Integer} Total Number Of Commands
@@ -106,7 +105,7 @@ public class PublishPrepaySnapshot extends ZclPrepaymentCommand {
      */
     public PublishPrepaySnapshot(
             Integer snapshotId,
-            Calendar snapshotTime,
+            ZigBeeUtcTime snapshotTime,
             Integer totalSnapshotsFound,
             Integer commandIndex,
             Integer totalNumberOfCommands,
@@ -154,7 +153,7 @@ public class PublishPrepaySnapshot extends ZclPrepaymentCommand {
      *
      * @return the Snapshot Time
      */
-    public Calendar getSnapshotTime() {
+    public ZigBeeUtcTime getSnapshotTime() {
         return snapshotTime;
     }
 
@@ -165,7 +164,7 @@ public class PublishPrepaySnapshot extends ZclPrepaymentCommand {
      * @deprecated as of 1.3.0. Use the parameterised constructor instead to ensure that all mandatory fields are provided.
      */
     @Deprecated
-    public void setSnapshotTime(final Calendar snapshotTime) {
+    public void setSnapshotTime(final ZigBeeUtcTime snapshotTime) {
         this.snapshotTime = snapshotTime;
     }
 
@@ -304,7 +303,7 @@ public class PublishPrepaySnapshot extends ZclPrepaymentCommand {
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
         snapshotId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        snapshotTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
+        snapshotTime = (ZigBeeUtcTime) deserializer.deserialize(ZclDataType.UTCTIME);
         totalSnapshotsFound = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
         commandIndex = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
         totalNumberOfCommands = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/SelectAvailableEmergencyCredit.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/SelectAvailableEmergencyCredit.java
@@ -7,13 +7,12 @@
  */
 package com.zsmartsystems.zigbee.zcl.clusters.prepayment;
 
-import java.util.Calendar;
-
 import javax.annotation.Generated;
 
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.field.ByteArray;
+import com.zsmartsystems.zigbee.zcl.field.ZigBeeUtcTime;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
@@ -28,7 +27,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-12-25T10:11:19Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2022-12-09T01:34:23Z")
 public class SelectAvailableEmergencyCredit extends ZclPrepaymentCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -43,7 +42,7 @@ public class SelectAvailableEmergencyCredit extends ZclPrepaymentCommand {
     /**
      * Command Issue Date Time command message field.
      */
-    private Calendar commandIssueDateTime;
+    private ZigBeeUtcTime commandIssueDateTime;
 
     /**
      * Originating Device command message field.
@@ -76,13 +75,13 @@ public class SelectAvailableEmergencyCredit extends ZclPrepaymentCommand {
     /**
      * Constructor providing all required parameters.
      *
-     * @param commandIssueDateTime {@link Calendar} Command Issue Date Time
+     * @param commandIssueDateTime {@link ZigBeeUtcTime} Command Issue Date Time
      * @param originatingDevice {@link Integer} Originating Device
      * @param siteId {@link ByteArray} Site ID
      * @param meterSerialNumber {@link ByteArray} Meter Serial Number
      */
     public SelectAvailableEmergencyCredit(
-            Calendar commandIssueDateTime,
+            ZigBeeUtcTime commandIssueDateTime,
             Integer originatingDevice,
             ByteArray siteId,
             ByteArray meterSerialNumber) {
@@ -103,7 +102,7 @@ public class SelectAvailableEmergencyCredit extends ZclPrepaymentCommand {
      *
      * @return the Command Issue Date Time
      */
-    public Calendar getCommandIssueDateTime() {
+    public ZigBeeUtcTime getCommandIssueDateTime() {
         return commandIssueDateTime;
     }
 
@@ -114,7 +113,7 @@ public class SelectAvailableEmergencyCredit extends ZclPrepaymentCommand {
      * @deprecated as of 1.3.0. Use the parameterised constructor instead to ensure that all mandatory fields are provided.
      */
     @Deprecated
-    public void setCommandIssueDateTime(final Calendar commandIssueDateTime) {
+    public void setCommandIssueDateTime(final ZigBeeUtcTime commandIssueDateTime) {
         this.commandIssueDateTime = commandIssueDateTime;
     }
 
@@ -188,7 +187,7 @@ public class SelectAvailableEmergencyCredit extends ZclPrepaymentCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        commandIssueDateTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
+        commandIssueDateTime = (ZigBeeUtcTime) deserializer.deserialize(ZclDataType.UTCTIME);
         originatingDevice = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
         siteId = (ByteArray) deserializer.deserialize(ZclDataType.OCTET_STRING);
         meterSerialNumber = (ByteArray) deserializer.deserialize(ZclDataType.OCTET_STRING);

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/SetMaximumCreditLimit.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/SetMaximumCreditLimit.java
@@ -7,12 +7,11 @@
  */
 package com.zsmartsystems.zigbee.zcl.clusters.prepayment;
 
-import java.util.Calendar;
-
 import javax.annotation.Generated;
 
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
+import com.zsmartsystems.zigbee.zcl.field.ZigBeeUtcTime;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
@@ -27,7 +26,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-12-25T10:11:19Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2022-12-09T01:34:23Z")
 public class SetMaximumCreditLimit extends ZclPrepaymentCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -52,7 +51,7 @@ public class SetMaximumCreditLimit extends ZclPrepaymentCommand {
     /**
      * Implementation Date Time command message field.
      */
-    private Calendar implementationDateTime;
+    private ZigBeeUtcTime implementationDateTime;
 
     /**
      * Maximum Credit Level command message field.
@@ -82,14 +81,14 @@ public class SetMaximumCreditLimit extends ZclPrepaymentCommand {
      *
      * @param providerId {@link Integer} Provider ID
      * @param issuerEventId {@link Integer} Issuer Event ID
-     * @param implementationDateTime {@link Calendar} Implementation Date Time
+     * @param implementationDateTime {@link ZigBeeUtcTime} Implementation Date Time
      * @param maximumCreditLevel {@link Integer} Maximum Credit Level
      * @param maximumCreditPerTopUp {@link Integer} Maximum Credit Per Top Up
      */
     public SetMaximumCreditLimit(
             Integer providerId,
             Integer issuerEventId,
-            Calendar implementationDateTime,
+            ZigBeeUtcTime implementationDateTime,
             Integer maximumCreditLevel,
             Integer maximumCreditPerTopUp) {
 
@@ -150,7 +149,7 @@ public class SetMaximumCreditLimit extends ZclPrepaymentCommand {
      *
      * @return the Implementation Date Time
      */
-    public Calendar getImplementationDateTime() {
+    public ZigBeeUtcTime getImplementationDateTime() {
         return implementationDateTime;
     }
 
@@ -161,7 +160,7 @@ public class SetMaximumCreditLimit extends ZclPrepaymentCommand {
      * @deprecated as of 1.3.0. Use the parameterised constructor instead to ensure that all mandatory fields are provided.
      */
     @Deprecated
-    public void setImplementationDateTime(final Calendar implementationDateTime) {
+    public void setImplementationDateTime(final ZigBeeUtcTime implementationDateTime) {
         this.implementationDateTime = implementationDateTime;
     }
 
@@ -218,7 +217,7 @@ public class SetMaximumCreditLimit extends ZclPrepaymentCommand {
     public void deserialize(final ZclFieldDeserializer deserializer) {
         providerId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
         issuerEventId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        implementationDateTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
+        implementationDateTime = (ZigBeeUtcTime) deserializer.deserialize(ZclDataType.UTCTIME);
         maximumCreditLevel = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
         maximumCreditPerTopUp = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
     }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/SetOverallDebtCap.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/SetOverallDebtCap.java
@@ -7,12 +7,11 @@
  */
 package com.zsmartsystems.zigbee.zcl.clusters.prepayment;
 
-import java.util.Calendar;
-
 import javax.annotation.Generated;
 
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
+import com.zsmartsystems.zigbee.zcl.field.ZigBeeUtcTime;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
@@ -27,7 +26,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-12-25T10:11:19Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2022-12-09T01:34:23Z")
 public class SetOverallDebtCap extends ZclPrepaymentCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -52,7 +51,7 @@ public class SetOverallDebtCap extends ZclPrepaymentCommand {
     /**
      * Implementation Date Time command message field.
      */
-    private Calendar implementationDateTime;
+    private ZigBeeUtcTime implementationDateTime;
 
     /**
      * Overall Debt Cap command message field.
@@ -77,13 +76,13 @@ public class SetOverallDebtCap extends ZclPrepaymentCommand {
      *
      * @param providerId {@link Integer} Provider ID
      * @param issuerEventId {@link Integer} Issuer Event ID
-     * @param implementationDateTime {@link Calendar} Implementation Date Time
+     * @param implementationDateTime {@link ZigBeeUtcTime} Implementation Date Time
      * @param overallDebtCap {@link Integer} Overall Debt Cap
      */
     public SetOverallDebtCap(
             Integer providerId,
             Integer issuerEventId,
-            Calendar implementationDateTime,
+            ZigBeeUtcTime implementationDateTime,
             Integer overallDebtCap) {
 
         clusterId = CLUSTER_ID;
@@ -142,7 +141,7 @@ public class SetOverallDebtCap extends ZclPrepaymentCommand {
      *
      * @return the Implementation Date Time
      */
-    public Calendar getImplementationDateTime() {
+    public ZigBeeUtcTime getImplementationDateTime() {
         return implementationDateTime;
     }
 
@@ -153,7 +152,7 @@ public class SetOverallDebtCap extends ZclPrepaymentCommand {
      * @deprecated as of 1.3.0. Use the parameterised constructor instead to ensure that all mandatory fields are provided.
      */
     @Deprecated
-    public void setImplementationDateTime(final Calendar implementationDateTime) {
+    public void setImplementationDateTime(final ZigBeeUtcTime implementationDateTime) {
         this.implementationDateTime = implementationDateTime;
     }
 
@@ -189,7 +188,7 @@ public class SetOverallDebtCap extends ZclPrepaymentCommand {
     public void deserialize(final ZclFieldDeserializer deserializer) {
         providerId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
         issuerEventId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        implementationDateTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
+        implementationDateTime = (ZigBeeUtcTime) deserializer.deserialize(ZclDataType.UTCTIME);
         overallDebtCap = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
     }
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/TopUpPayload.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/TopUpPayload.java
@@ -6,14 +6,13 @@
  * http://www.eclipse.org/legal/epl-v10.html
  */
 package com.zsmartsystems.zigbee.zcl.clusters.prepayment;
-import java.util.Calendar;
-
 import javax.annotation.Generated;
 
 import com.zsmartsystems.zigbee.serialization.ZigBeeSerializable;
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.field.ByteArray;
+import com.zsmartsystems.zigbee.zcl.field.ZigBeeUtcTime;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
 /**
@@ -21,7 +20,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-01-12T12:02:05Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2022-12-09T01:34:23Z")
 public class TopUpPayload implements ZigBeeSerializable {
     /**
      * Top Up Code structure field.
@@ -36,7 +35,7 @@ public class TopUpPayload implements ZigBeeSerializable {
     /**
      * Top Up Time structure field.
      */
-    private Calendar topUpTime;
+    private ZigBeeUtcTime topUpTime;
 
 
     /**
@@ -53,12 +52,12 @@ public class TopUpPayload implements ZigBeeSerializable {
      *
      * @param topUpCode {@link ByteArray} Top Up Code
      * @param topUpAmount {@link Integer} Top Up Amount
-     * @param topUpTime {@link Calendar} Top Up Time
+     * @param topUpTime {@link ZigBeeUtcTime} Top Up Time
      */
     public TopUpPayload(
             ByteArray topUpCode,
             Integer topUpAmount,
-            Calendar topUpTime) {
+            ZigBeeUtcTime topUpTime) {
 
         this.topUpCode = topUpCode;
         this.topUpAmount = topUpAmount;
@@ -110,7 +109,7 @@ public class TopUpPayload implements ZigBeeSerializable {
      *
      * @return the Top Up Time
      */
-    public Calendar getTopUpTime() {
+    public ZigBeeUtcTime getTopUpTime() {
         return topUpTime;
     }
 
@@ -121,7 +120,7 @@ public class TopUpPayload implements ZigBeeSerializable {
      * @deprecated as of 1.3.0. Use the parameterised constructor instead to ensure that all mandatory fields are provided.
      */
     @Deprecated
-    public void setTopUpTime(final Calendar topUpTime) {
+    public void setTopUpTime(final ZigBeeUtcTime topUpTime) {
         this.topUpTime = topUpTime;
     }
 
@@ -136,7 +135,7 @@ public class TopUpPayload implements ZigBeeSerializable {
     public void deserialize(final ZclFieldDeserializer deserializer) {
         topUpCode = (ByteArray) deserializer.deserialize(ZclDataType.OCTET_STRING);
         topUpAmount = (Integer) deserializer.deserialize(ZclDataType.SIGNED_32_BIT_INTEGER);
-        topUpTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
+        topUpTime = (ZigBeeUtcTime) deserializer.deserialize(ZclDataType.UTCTIME);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/GetBillingPeriodCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/GetBillingPeriodCommand.java
@@ -7,12 +7,11 @@
  */
 package com.zsmartsystems.zigbee.zcl.clusters.price;
 
-import java.util.Calendar;
-
 import javax.annotation.Generated;
 
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
+import com.zsmartsystems.zigbee.zcl.field.ZigBeeUtcTime;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
@@ -27,7 +26,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-12-25T10:11:19Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2022-12-09T01:34:23Z")
 public class GetBillingPeriodCommand extends ZclPriceCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -48,7 +47,7 @@ public class GetBillingPeriodCommand extends ZclPriceCommand {
      * at or after the stated EarliestStartTime. If more than one instance is requested, the
      * active and scheduled instances shall be sent with ascending ordered StartTime.
      */
-    private Calendar earliestStartTime;
+    private ZigBeeUtcTime earliestStartTime;
 
     /**
      * Min . Issuer Event ID command message field.
@@ -96,13 +95,13 @@ public class GetBillingPeriodCommand extends ZclPriceCommand {
     /**
      * Constructor providing all required parameters.
      *
-     * @param earliestStartTime {@link Calendar} Earliest Start Time
+     * @param earliestStartTime {@link ZigBeeUtcTime} Earliest Start Time
      * @param minIssuerEventId {@link Integer} Min . Issuer Event ID
      * @param numberOfCommands {@link Integer} Number Of Commands
      * @param tariffType {@link Integer} Tariff Type
      */
     public GetBillingPeriodCommand(
-            Calendar earliestStartTime,
+            ZigBeeUtcTime earliestStartTime,
             Integer minIssuerEventId,
             Integer numberOfCommands,
             Integer tariffType) {
@@ -129,7 +128,7 @@ public class GetBillingPeriodCommand extends ZclPriceCommand {
      *
      * @return the Earliest Start Time
      */
-    public Calendar getEarliestStartTime() {
+    public ZigBeeUtcTime getEarliestStartTime() {
         return earliestStartTime;
     }
 
@@ -146,7 +145,7 @@ public class GetBillingPeriodCommand extends ZclPriceCommand {
      * @deprecated as of 1.3.0. Use the parameterised constructor instead to ensure that all mandatory fields are provided.
      */
     @Deprecated
-    public void setEarliestStartTime(final Calendar earliestStartTime) {
+    public void setEarliestStartTime(final ZigBeeUtcTime earliestStartTime) {
         this.earliestStartTime = earliestStartTime;
     }
 
@@ -250,7 +249,7 @@ public class GetBillingPeriodCommand extends ZclPriceCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        earliestStartTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
+        earliestStartTime = (ZigBeeUtcTime) deserializer.deserialize(ZclDataType.UTCTIME);
         minIssuerEventId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
         numberOfCommands = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
         tariffType = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/GetBlockPeriodCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/GetBlockPeriodCommand.java
@@ -7,12 +7,11 @@
  */
 package com.zsmartsystems.zigbee.zcl.clusters.price;
 
-import java.util.Calendar;
-
 import javax.annotation.Generated;
 
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
+import com.zsmartsystems.zigbee.zcl.field.ZigBeeUtcTime;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
@@ -29,7 +28,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-12-25T10:11:19Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2022-12-09T01:34:23Z")
 public class GetBlockPeriodCommand extends ZclPriceCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -48,7 +47,7 @@ public class GetBlockPeriodCommand extends ZclPriceCommand {
      * block period events to be resent. If a command has a Start Time of 0x00000000, replace
      * that Start Time with the current time stamp.
      */
-    private Calendar startTime;
+    private ZigBeeUtcTime startTime;
 
     /**
      * Number Of Events command message field.
@@ -86,12 +85,12 @@ public class GetBlockPeriodCommand extends ZclPriceCommand {
     /**
      * Constructor providing all required parameters.
      *
-     * @param startTime {@link Calendar} Start Time
+     * @param startTime {@link ZigBeeUtcTime} Start Time
      * @param numberOfEvents {@link Integer} Number Of Events
      * @param tariffType {@link Integer} Tariff Type
      */
     public GetBlockPeriodCommand(
-            Calendar startTime,
+            ZigBeeUtcTime startTime,
             Integer numberOfEvents,
             Integer tariffType) {
 
@@ -114,7 +113,7 @@ public class GetBlockPeriodCommand extends ZclPriceCommand {
      *
      * @return the Start Time
      */
-    public Calendar getStartTime() {
+    public ZigBeeUtcTime getStartTime() {
         return startTime;
     }
 
@@ -129,7 +128,7 @@ public class GetBlockPeriodCommand extends ZclPriceCommand {
      * @deprecated as of 1.3.0. Use the parameterised constructor instead to ensure that all mandatory fields are provided.
      */
     @Deprecated
-    public void setStartTime(final Calendar startTime) {
+    public void setStartTime(final ZigBeeUtcTime startTime) {
         this.startTime = startTime;
     }
 
@@ -202,7 +201,7 @@ public class GetBlockPeriodCommand extends ZclPriceCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        startTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
+        startTime = (ZigBeeUtcTime) deserializer.deserialize(ZclDataType.UTCTIME);
         numberOfEvents = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
         tariffType = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
     }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/GetCalorificValueCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/GetCalorificValueCommand.java
@@ -7,12 +7,11 @@
  */
 package com.zsmartsystems.zigbee.zcl.clusters.price;
 
-import java.util.Calendar;
-
 import javax.annotation.Generated;
 
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
+import com.zsmartsystems.zigbee.zcl.field.ZigBeeUtcTime;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
@@ -29,7 +28,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-12-25T10:11:19Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2022-12-09T01:34:23Z")
 public class GetCalorificValueCommand extends ZclPriceCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -50,7 +49,7 @@ public class GetCalorificValueCommand extends ZclPriceCommand {
      * at or after the stated Earliest Start Time. If more than one instance is requested, the
      * active and scheduled instances shall be sent with ascending ordered Start Time.
      */
-    private Calendar earliestStartTime;
+    private ZigBeeUtcTime earliestStartTime;
 
     /**
      * Min . Issuer Event ID command message field.
@@ -87,12 +86,12 @@ public class GetCalorificValueCommand extends ZclPriceCommand {
     /**
      * Constructor providing all required parameters.
      *
-     * @param earliestStartTime {@link Calendar} Earliest Start Time
+     * @param earliestStartTime {@link ZigBeeUtcTime} Earliest Start Time
      * @param minIssuerEventId {@link Integer} Min . Issuer Event ID
      * @param numberOfCommands {@link Integer} Number Of Commands
      */
     public GetCalorificValueCommand(
-            Calendar earliestStartTime,
+            ZigBeeUtcTime earliestStartTime,
             Integer minIssuerEventId,
             Integer numberOfCommands) {
 
@@ -117,7 +116,7 @@ public class GetCalorificValueCommand extends ZclPriceCommand {
      *
      * @return the Earliest Start Time
      */
-    public Calendar getEarliestStartTime() {
+    public ZigBeeUtcTime getEarliestStartTime() {
         return earliestStartTime;
     }
 
@@ -134,7 +133,7 @@ public class GetCalorificValueCommand extends ZclPriceCommand {
      * @deprecated as of 1.3.0. Use the parameterised constructor instead to ensure that all mandatory fields are provided.
      */
     @Deprecated
-    public void setEarliestStartTime(final Calendar earliestStartTime) {
+    public void setEarliestStartTime(final ZigBeeUtcTime earliestStartTime) {
         this.earliestStartTime = earliestStartTime;
     }
 
@@ -205,7 +204,7 @@ public class GetCalorificValueCommand extends ZclPriceCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        earliestStartTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
+        earliestStartTime = (ZigBeeUtcTime) deserializer.deserialize(ZclDataType.UTCTIME);
         minIssuerEventId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
         numberOfCommands = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
     }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/GetCo2ValueCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/GetCo2ValueCommand.java
@@ -7,12 +7,11 @@
  */
 package com.zsmartsystems.zigbee.zcl.clusters.price;
 
-import java.util.Calendar;
-
 import javax.annotation.Generated;
 
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
+import com.zsmartsystems.zigbee.zcl.field.ZigBeeUtcTime;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
@@ -28,7 +27,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-12-25T10:11:19Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2022-12-09T01:34:23Z")
 public class GetCo2ValueCommand extends ZclPriceCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -49,7 +48,7 @@ public class GetCo2ValueCommand extends ZclPriceCommand {
      * EarliestStartTime. If more than one instance is requested, the active and scheduled
      * instances shall be sent with ascending ordered StartTime.
      */
-    private Calendar earliestStartTime;
+    private ZigBeeUtcTime earliestStartTime;
 
     /**
      * Min . Issuer Event ID command message field.
@@ -96,13 +95,13 @@ public class GetCo2ValueCommand extends ZclPriceCommand {
     /**
      * Constructor providing all required parameters.
      *
-     * @param earliestStartTime {@link Calendar} Earliest Start Time
+     * @param earliestStartTime {@link ZigBeeUtcTime} Earliest Start Time
      * @param minIssuerEventId {@link Integer} Min . Issuer Event ID
      * @param numberOfCommands {@link Integer} Number Of Commands
      * @param tariffType {@link Integer} Tariff Type
      */
     public GetCo2ValueCommand(
-            Calendar earliestStartTime,
+            ZigBeeUtcTime earliestStartTime,
             Integer minIssuerEventId,
             Integer numberOfCommands,
             Integer tariffType) {
@@ -129,7 +128,7 @@ public class GetCo2ValueCommand extends ZclPriceCommand {
      *
      * @return the Earliest Start Time
      */
-    public Calendar getEarliestStartTime() {
+    public ZigBeeUtcTime getEarliestStartTime() {
         return earliestStartTime;
     }
 
@@ -146,7 +145,7 @@ public class GetCo2ValueCommand extends ZclPriceCommand {
      * @deprecated as of 1.3.0. Use the parameterised constructor instead to ensure that all mandatory fields are provided.
      */
     @Deprecated
-    public void setEarliestStartTime(final Calendar earliestStartTime) {
+    public void setEarliestStartTime(final ZigBeeUtcTime earliestStartTime) {
         this.earliestStartTime = earliestStartTime;
     }
 
@@ -248,7 +247,7 @@ public class GetCo2ValueCommand extends ZclPriceCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        earliestStartTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
+        earliestStartTime = (ZigBeeUtcTime) deserializer.deserialize(ZclDataType.UTCTIME);
         minIssuerEventId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
         numberOfCommands = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
         tariffType = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/GetConsolidatedBillCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/GetConsolidatedBillCommand.java
@@ -7,12 +7,11 @@
  */
 package com.zsmartsystems.zigbee.zcl.clusters.price;
 
-import java.util.Calendar;
-
 import javax.annotation.Generated;
 
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
+import com.zsmartsystems.zigbee.zcl.field.ZigBeeUtcTime;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
@@ -27,7 +26,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-12-25T10:11:19Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2022-12-09T01:34:23Z")
 public class GetConsolidatedBillCommand extends ZclPriceCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -49,7 +48,7 @@ public class GetConsolidatedBillCommand extends ZclPriceCommand {
      * requested, the active and scheduled instances shall be sent with ascending ordered
      * StartTime.
      */
-    private Calendar earliestStartTime;
+    private ZigBeeUtcTime earliestStartTime;
 
     /**
      * Min . Issuer Event ID command message field.
@@ -97,13 +96,13 @@ public class GetConsolidatedBillCommand extends ZclPriceCommand {
     /**
      * Constructor providing all required parameters.
      *
-     * @param earliestStartTime {@link Calendar} Earliest Start Time
+     * @param earliestStartTime {@link ZigBeeUtcTime} Earliest Start Time
      * @param minIssuerEventId {@link Integer} Min . Issuer Event ID
      * @param numberOfCommands {@link Integer} Number Of Commands
      * @param tariffType {@link Integer} Tariff Type
      */
     public GetConsolidatedBillCommand(
-            Calendar earliestStartTime,
+            ZigBeeUtcTime earliestStartTime,
             Integer minIssuerEventId,
             Integer numberOfCommands,
             Integer tariffType) {
@@ -131,7 +130,7 @@ public class GetConsolidatedBillCommand extends ZclPriceCommand {
      *
      * @return the Earliest Start Time
      */
-    public Calendar getEarliestStartTime() {
+    public ZigBeeUtcTime getEarliestStartTime() {
         return earliestStartTime;
     }
 
@@ -149,7 +148,7 @@ public class GetConsolidatedBillCommand extends ZclPriceCommand {
      * @deprecated as of 1.3.0. Use the parameterised constructor instead to ensure that all mandatory fields are provided.
      */
     @Deprecated
-    public void setEarliestStartTime(final Calendar earliestStartTime) {
+    public void setEarliestStartTime(final ZigBeeUtcTime earliestStartTime) {
         this.earliestStartTime = earliestStartTime;
     }
 
@@ -253,7 +252,7 @@ public class GetConsolidatedBillCommand extends ZclPriceCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        earliestStartTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
+        earliestStartTime = (ZigBeeUtcTime) deserializer.deserialize(ZclDataType.UTCTIME);
         minIssuerEventId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
         numberOfCommands = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
         tariffType = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/GetConversionFactorCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/GetConversionFactorCommand.java
@@ -7,12 +7,11 @@
  */
 package com.zsmartsystems.zigbee.zcl.clusters.price;
 
-import java.util.Calendar;
-
 import javax.annotation.Generated;
 
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
+import com.zsmartsystems.zigbee.zcl.field.ZigBeeUtcTime;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
@@ -30,7 +29,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-12-25T10:11:19Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2022-12-09T01:34:23Z")
 public class GetConversionFactorCommand extends ZclPriceCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -57,7 +56,7 @@ public class GetConversionFactorCommand extends ZclPriceCommand {
      * 0xFFFFFFFF means not specified; the server shall return values irrespective of the
      * value of the Issuer Event ID.
      */
-    private Calendar earliestStartTime;
+    private ZigBeeUtcTime earliestStartTime;
 
     /**
      * Min . Issuer Event ID command message field.
@@ -89,12 +88,12 @@ public class GetConversionFactorCommand extends ZclPriceCommand {
     /**
      * Constructor providing all required parameters.
      *
-     * @param earliestStartTime {@link Calendar} Earliest Start Time
+     * @param earliestStartTime {@link ZigBeeUtcTime} Earliest Start Time
      * @param minIssuerEventId {@link Integer} Min . Issuer Event ID
      * @param numberOfCommands {@link Integer} Number Of Commands
      */
     public GetConversionFactorCommand(
-            Calendar earliestStartTime,
+            ZigBeeUtcTime earliestStartTime,
             Integer minIssuerEventId,
             Integer numberOfCommands) {
 
@@ -125,7 +124,7 @@ public class GetConversionFactorCommand extends ZclPriceCommand {
      *
      * @return the Earliest Start Time
      */
-    public Calendar getEarliestStartTime() {
+    public ZigBeeUtcTime getEarliestStartTime() {
         return earliestStartTime;
     }
 
@@ -148,7 +147,7 @@ public class GetConversionFactorCommand extends ZclPriceCommand {
      * @deprecated as of 1.3.0. Use the parameterised constructor instead to ensure that all mandatory fields are provided.
      */
     @Deprecated
-    public void setEarliestStartTime(final Calendar earliestStartTime) {
+    public void setEarliestStartTime(final ZigBeeUtcTime earliestStartTime) {
         this.earliestStartTime = earliestStartTime;
     }
 
@@ -209,7 +208,7 @@ public class GetConversionFactorCommand extends ZclPriceCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        earliestStartTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
+        earliestStartTime = (ZigBeeUtcTime) deserializer.deserialize(ZclDataType.UTCTIME);
         minIssuerEventId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
         numberOfCommands = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
     }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/GetCreditPaymentCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/GetCreditPaymentCommand.java
@@ -7,12 +7,11 @@
  */
 package com.zsmartsystems.zigbee.zcl.clusters.price;
 
-import java.util.Calendar;
-
 import javax.annotation.Generated;
 
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
+import com.zsmartsystems.zigbee.zcl.field.ZigBeeUtcTime;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
@@ -27,7 +26,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-12-25T10:11:19Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2022-12-09T01:34:23Z")
 public class GetCreditPaymentCommand extends ZclPriceCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -47,7 +46,7 @@ public class GetCreditPaymentCommand extends ZclPriceCommand {
      * PublishCreditPayment command shall be the most recent record with its
      * CreditPaymentDate equal to or older than the Latest End Time provided.
      */
-    private Calendar latestEndTime;
+    private ZigBeeUtcTime latestEndTime;
 
     /**
      * Number Of Records command message field.
@@ -77,11 +76,11 @@ public class GetCreditPaymentCommand extends ZclPriceCommand {
     /**
      * Constructor providing all required parameters.
      *
-     * @param latestEndTime {@link Calendar} Latest End Time
+     * @param latestEndTime {@link ZigBeeUtcTime} Latest End Time
      * @param numberOfRecords {@link Integer} Number Of Records
      */
     public GetCreditPaymentCommand(
-            Calendar latestEndTime,
+            ZigBeeUtcTime latestEndTime,
             Integer numberOfRecords) {
 
         clusterId = CLUSTER_ID;
@@ -103,7 +102,7 @@ public class GetCreditPaymentCommand extends ZclPriceCommand {
      *
      * @return the Latest End Time
      */
-    public Calendar getLatestEndTime() {
+    public ZigBeeUtcTime getLatestEndTime() {
         return latestEndTime;
     }
 
@@ -119,7 +118,7 @@ public class GetCreditPaymentCommand extends ZclPriceCommand {
      * @deprecated as of 1.3.0. Use the parameterised constructor instead to ensure that all mandatory fields are provided.
      */
     @Deprecated
-    public void setLatestEndTime(final Calendar latestEndTime) {
+    public void setLatestEndTime(final ZigBeeUtcTime latestEndTime) {
         this.latestEndTime = latestEndTime;
     }
 
@@ -165,7 +164,7 @@ public class GetCreditPaymentCommand extends ZclPriceCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        latestEndTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
+        latestEndTime = (ZigBeeUtcTime) deserializer.deserialize(ZclDataType.UTCTIME);
         numberOfRecords = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
     }
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/GetScheduledPricesCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/GetScheduledPricesCommand.java
@@ -7,12 +7,11 @@
  */
 package com.zsmartsystems.zigbee.zcl.clusters.price;
 
-import java.util.Calendar;
-
 import javax.annotation.Generated;
 
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
+import com.zsmartsystems.zigbee.zcl.field.ZigBeeUtcTime;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
@@ -28,7 +27,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-12-25T10:11:19Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2022-12-09T01:34:23Z")
 public class GetScheduledPricesCommand extends ZclPriceCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -47,7 +46,7 @@ public class GetScheduledPricesCommand extends ZclPriceCommand {
      * active pricing events to be resent. If a command has a StartTime of 0x00000000, replace
      * that StartTime with the current time stamp.
      */
-    private Calendar startTime;
+    private ZigBeeUtcTime startTime;
 
     /**
      * Number Of Events command message field.
@@ -76,11 +75,11 @@ public class GetScheduledPricesCommand extends ZclPriceCommand {
     /**
      * Constructor providing all required parameters.
      *
-     * @param startTime {@link Calendar} Start Time
+     * @param startTime {@link ZigBeeUtcTime} Start Time
      * @param numberOfEvents {@link Integer} Number Of Events
      */
     public GetScheduledPricesCommand(
-            Calendar startTime,
+            ZigBeeUtcTime startTime,
             Integer numberOfEvents) {
 
         clusterId = CLUSTER_ID;
@@ -101,7 +100,7 @@ public class GetScheduledPricesCommand extends ZclPriceCommand {
      *
      * @return the Start Time
      */
-    public Calendar getStartTime() {
+    public ZigBeeUtcTime getStartTime() {
         return startTime;
     }
 
@@ -116,7 +115,7 @@ public class GetScheduledPricesCommand extends ZclPriceCommand {
      * @deprecated as of 1.3.0. Use the parameterised constructor instead to ensure that all mandatory fields are provided.
      */
     @Deprecated
-    public void setStartTime(final Calendar startTime) {
+    public void setStartTime(final ZigBeeUtcTime startTime) {
         this.startTime = startTime;
     }
 
@@ -160,7 +159,7 @@ public class GetScheduledPricesCommand extends ZclPriceCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        startTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
+        startTime = (ZigBeeUtcTime) deserializer.deserialize(ZclDataType.UTCTIME);
         numberOfEvents = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
     }
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/GetTariffInformationCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/GetTariffInformationCommand.java
@@ -7,12 +7,11 @@
  */
 package com.zsmartsystems.zigbee.zcl.clusters.price;
 
-import java.util.Calendar;
-
 import javax.annotation.Generated;
 
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
+import com.zsmartsystems.zigbee.zcl.field.ZigBeeUtcTime;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
@@ -31,7 +30,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-12-25T10:11:19Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2022-12-09T01:34:23Z")
 public class GetTariffInformationCommand extends ZclPriceCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -52,7 +51,7 @@ public class GetTariffInformationCommand extends ZclPriceCommand {
      * active at or after the stated EarliestStartTime. If more than one command is requested,
      * the active and scheduled commands shall be sent with ascending ordered StartTime.
      */
-    private Calendar earliestStartTime;
+    private ZigBeeUtcTime earliestStartTime;
 
     /**
      * Min . Issuer Event ID command message field.
@@ -98,13 +97,13 @@ public class GetTariffInformationCommand extends ZclPriceCommand {
     /**
      * Constructor providing all required parameters.
      *
-     * @param earliestStartTime {@link Calendar} Earliest Start Time
+     * @param earliestStartTime {@link ZigBeeUtcTime} Earliest Start Time
      * @param minIssuerEventId {@link Integer} Min . Issuer Event ID
      * @param numberOfCommands {@link Integer} Number Of Commands
      * @param tariffType {@link Integer} Tariff Type
      */
     public GetTariffInformationCommand(
-            Calendar earliestStartTime,
+            ZigBeeUtcTime earliestStartTime,
             Integer minIssuerEventId,
             Integer numberOfCommands,
             Integer tariffType) {
@@ -131,7 +130,7 @@ public class GetTariffInformationCommand extends ZclPriceCommand {
      *
      * @return the Earliest Start Time
      */
-    public Calendar getEarliestStartTime() {
+    public ZigBeeUtcTime getEarliestStartTime() {
         return earliestStartTime;
     }
 
@@ -148,7 +147,7 @@ public class GetTariffInformationCommand extends ZclPriceCommand {
      * @deprecated as of 1.3.0. Use the parameterised constructor instead to ensure that all mandatory fields are provided.
      */
     @Deprecated
-    public void setEarliestStartTime(final Calendar earliestStartTime) {
+    public void setEarliestStartTime(final ZigBeeUtcTime earliestStartTime) {
         this.earliestStartTime = earliestStartTime;
     }
 
@@ -248,7 +247,7 @@ public class GetTariffInformationCommand extends ZclPriceCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        earliestStartTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
+        earliestStartTime = (ZigBeeUtcTime) deserializer.deserialize(ZclDataType.UTCTIME);
         minIssuerEventId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
         numberOfCommands = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
         tariffType = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PriceAcknowledgementCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PriceAcknowledgementCommand.java
@@ -7,12 +7,11 @@
  */
 package com.zsmartsystems.zigbee.zcl.clusters.price;
 
-import java.util.Calendar;
-
 import javax.annotation.Generated;
 
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
+import com.zsmartsystems.zigbee.zcl.field.ZigBeeUtcTime;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
@@ -28,7 +27,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-12-25T10:11:19Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2022-12-09T01:34:23Z")
 public class PriceAcknowledgementCommand extends ZclPriceCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -59,7 +58,7 @@ public class PriceAcknowledgementCommand extends ZclPriceCommand {
      * <p>
      * Time price acknowledgement generated.
      */
-    private Calendar priceAckTime;
+    private ZigBeeUtcTime priceAckTime;
 
     /**
      * Control command message field.
@@ -86,13 +85,13 @@ public class PriceAcknowledgementCommand extends ZclPriceCommand {
      *
      * @param providerId {@link Integer} Provider ID
      * @param issuerEventId {@link Integer} Issuer Event ID
-     * @param priceAckTime {@link Calendar} Price Ack Time
+     * @param priceAckTime {@link ZigBeeUtcTime} Price Ack Time
      * @param control {@link Integer} Control
      */
     public PriceAcknowledgementCommand(
             Integer providerId,
             Integer issuerEventId,
-            Calendar priceAckTime,
+            ZigBeeUtcTime priceAckTime,
             Integer control) {
 
         clusterId = CLUSTER_ID;
@@ -161,7 +160,7 @@ public class PriceAcknowledgementCommand extends ZclPriceCommand {
      *
      * @return the Price Ack Time
      */
-    public Calendar getPriceAckTime() {
+    public ZigBeeUtcTime getPriceAckTime() {
         return priceAckTime;
     }
 
@@ -174,7 +173,7 @@ public class PriceAcknowledgementCommand extends ZclPriceCommand {
      * @deprecated as of 1.3.0. Use the parameterised constructor instead to ensure that all mandatory fields are provided.
      */
     @Deprecated
-    public void setPriceAckTime(final Calendar priceAckTime) {
+    public void setPriceAckTime(final ZigBeeUtcTime priceAckTime) {
         this.priceAckTime = priceAckTime;
     }
 
@@ -214,7 +213,7 @@ public class PriceAcknowledgementCommand extends ZclPriceCommand {
     public void deserialize(final ZclFieldDeserializer deserializer) {
         providerId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
         issuerEventId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        priceAckTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
+        priceAckTime = (ZigBeeUtcTime) deserializer.deserialize(ZclDataType.UTCTIME);
         control = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
     }
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishBillingPeriodCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishBillingPeriodCommand.java
@@ -7,12 +7,11 @@
  */
 package com.zsmartsystems.zigbee.zcl.clusters.price;
 
-import java.util.Calendar;
-
 import javax.annotation.Generated;
 
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
+import com.zsmartsystems.zigbee.zcl.field.ZigBeeUtcTime;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
@@ -32,7 +31,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-12-25T10:11:19Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2022-12-09T01:34:23Z")
 public class PublishBillingPeriodCommand extends ZclPriceCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -76,7 +75,7 @@ public class PublishBillingPeriodCommand extends ZclPriceCommand {
      * replacement/superseding PublishBillingPeriod command is used in place of this
      * cancellation mechanism).
      */
-    private Calendar billingPeriodStartTime;
+    private ZigBeeUtcTime billingPeriodStartTime;
 
     /**
      * Billing Period Duration command message field.
@@ -124,7 +123,7 @@ public class PublishBillingPeriodCommand extends ZclPriceCommand {
      *
      * @param providerId {@link Integer} Provider ID
      * @param issuerEventId {@link Integer} Issuer Event ID
-     * @param billingPeriodStartTime {@link Calendar} Billing Period Start Time
+     * @param billingPeriodStartTime {@link ZigBeeUtcTime} Billing Period Start Time
      * @param billingPeriodDuration {@link Integer} Billing Period Duration
      * @param billingPeriodDurationType {@link Integer} Billing Period Duration Type
      * @param tariffType {@link Integer} Tariff Type
@@ -132,7 +131,7 @@ public class PublishBillingPeriodCommand extends ZclPriceCommand {
     public PublishBillingPeriodCommand(
             Integer providerId,
             Integer issuerEventId,
-            Calendar billingPeriodStartTime,
+            ZigBeeUtcTime billingPeriodStartTime,
             Integer billingPeriodDuration,
             Integer billingPeriodDurationType,
             Integer tariffType) {
@@ -225,7 +224,7 @@ public class PublishBillingPeriodCommand extends ZclPriceCommand {
      *
      * @return the Billing Period Start Time
      */
-    public Calendar getBillingPeriodStartTime() {
+    public ZigBeeUtcTime getBillingPeriodStartTime() {
         return billingPeriodStartTime;
     }
 
@@ -244,7 +243,7 @@ public class PublishBillingPeriodCommand extends ZclPriceCommand {
      * @deprecated as of 1.3.0. Use the parameterised constructor instead to ensure that all mandatory fields are provided.
      */
     @Deprecated
-    public void setBillingPeriodStartTime(final Calendar billingPeriodStartTime) {
+    public void setBillingPeriodStartTime(final ZigBeeUtcTime billingPeriodStartTime) {
         this.billingPeriodStartTime = billingPeriodStartTime;
     }
 
@@ -348,7 +347,7 @@ public class PublishBillingPeriodCommand extends ZclPriceCommand {
     public void deserialize(final ZclFieldDeserializer deserializer) {
         providerId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
         issuerEventId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        billingPeriodStartTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
+        billingPeriodStartTime = (ZigBeeUtcTime) deserializer.deserialize(ZclDataType.UTCTIME);
         billingPeriodDuration = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_24_BIT_INTEGER);
         billingPeriodDurationType = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
         tariffType = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishBlockPeriodCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishBlockPeriodCommand.java
@@ -7,12 +7,11 @@
  */
 package com.zsmartsystems.zigbee.zcl.clusters.price;
 
-import java.util.Calendar;
-
 import javax.annotation.Generated;
 
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
+import com.zsmartsystems.zigbee.zcl.field.ZigBeeUtcTime;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
@@ -36,7 +35,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-12-25T10:11:19Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2022-12-09T01:34:23Z")
 public class PublishBlockPeriodCommand extends ZclPriceCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -88,7 +87,7 @@ public class PublishBlockPeriodCommand extends ZclPriceCommand {
      * and where Duration Control is set to End of Timebase, the Block Period Start Time shall be
      * set to 23:59:59 on the applicable date.
      */
-    private Calendar blockPeriodStartTime;
+    private ZigBeeUtcTime blockPeriodStartTime;
 
     /**
      * Block Period Duration command message field.
@@ -167,7 +166,7 @@ public class PublishBlockPeriodCommand extends ZclPriceCommand {
      *
      * @param providerId {@link Integer} Provider ID
      * @param issuerEventId {@link Integer} Issuer Event ID
-     * @param blockPeriodStartTime {@link Calendar} Block Period Start Time
+     * @param blockPeriodStartTime {@link ZigBeeUtcTime} Block Period Start Time
      * @param blockPeriodDuration {@link Integer} Block Period Duration
      * @param blockPeriodControl {@link Integer} Block Period Control
      * @param blockPeriodDurationType {@link Integer} Block Period Duration Type
@@ -177,7 +176,7 @@ public class PublishBlockPeriodCommand extends ZclPriceCommand {
     public PublishBlockPeriodCommand(
             Integer providerId,
             Integer issuerEventId,
-            Calendar blockPeriodStartTime,
+            ZigBeeUtcTime blockPeriodStartTime,
             Integer blockPeriodDuration,
             Integer blockPeriodControl,
             Integer blockPeriodDurationType,
@@ -283,7 +282,7 @@ public class PublishBlockPeriodCommand extends ZclPriceCommand {
      *
      * @return the Block Period Start Time
      */
-    public Calendar getBlockPeriodStartTime() {
+    public ZigBeeUtcTime getBlockPeriodStartTime() {
         return blockPeriodStartTime;
     }
 
@@ -309,7 +308,7 @@ public class PublishBlockPeriodCommand extends ZclPriceCommand {
      * @deprecated as of 1.3.0. Use the parameterised constructor instead to ensure that all mandatory fields are provided.
      */
     @Deprecated
-    public void setBlockPeriodStartTime(final Calendar blockPeriodStartTime) {
+    public void setBlockPeriodStartTime(final ZigBeeUtcTime blockPeriodStartTime) {
         this.blockPeriodStartTime = blockPeriodStartTime;
     }
 
@@ -497,7 +496,7 @@ public class PublishBlockPeriodCommand extends ZclPriceCommand {
     public void deserialize(final ZclFieldDeserializer deserializer) {
         providerId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
         issuerEventId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        blockPeriodStartTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
+        blockPeriodStartTime = (ZigBeeUtcTime) deserializer.deserialize(ZclDataType.UTCTIME);
         blockPeriodDuration = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_24_BIT_INTEGER);
         blockPeriodControl = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
         blockPeriodDurationType = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishBlockThresholdsCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishBlockThresholdsCommand.java
@@ -7,13 +7,12 @@
  */
 package com.zsmartsystems.zigbee.zcl.clusters.price;
 
-import java.util.Calendar;
-
 import javax.annotation.Generated;
 
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.clusters.price.BlockThresholdSubPayload;
+import com.zsmartsystems.zigbee.zcl.field.ZigBeeUtcTime;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
@@ -38,7 +37,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-12-25T10:11:19Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2022-12-09T01:34:23Z")
 public class PublishBlockThresholdsCommand extends ZclPriceCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -74,7 +73,7 @@ public class PublishBlockThresholdsCommand extends ZclPriceCommand {
      * date/time of 0x00000000 shall indicate that the command should be executed
      * immediately.
      */
-    private Calendar startTime;
+    private ZigBeeUtcTime startTime;
 
     /**
      * Issuer Tariff ID command message field.
@@ -142,7 +141,7 @@ public class PublishBlockThresholdsCommand extends ZclPriceCommand {
      *
      * @param providerId {@link Integer} Provider ID
      * @param issuerEventId {@link Integer} Issuer Event ID
-     * @param startTime {@link Calendar} Start Time
+     * @param startTime {@link ZigBeeUtcTime} Start Time
      * @param issuerTariffId {@link Integer} Issuer Tariff ID
      * @param commandIndex {@link Integer} Command Index
      * @param totalNumberOfCommands {@link Integer} Total Number Of Commands
@@ -152,7 +151,7 @@ public class PublishBlockThresholdsCommand extends ZclPriceCommand {
     public PublishBlockThresholdsCommand(
             Integer providerId,
             Integer issuerEventId,
-            Calendar startTime,
+            ZigBeeUtcTime startTime,
             Integer issuerTariffId,
             Integer commandIndex,
             Integer totalNumberOfCommands,
@@ -237,7 +236,7 @@ public class PublishBlockThresholdsCommand extends ZclPriceCommand {
      *
      * @return the Start Time
      */
-    public Calendar getStartTime() {
+    public ZigBeeUtcTime getStartTime() {
         return startTime;
     }
 
@@ -252,7 +251,7 @@ public class PublishBlockThresholdsCommand extends ZclPriceCommand {
      * @deprecated as of 1.3.0. Use the parameterised constructor instead to ensure that all mandatory fields are provided.
      */
     @Deprecated
-    public void setStartTime(final Calendar startTime) {
+    public void setStartTime(final ZigBeeUtcTime startTime) {
         this.startTime = startTime;
     }
 
@@ -418,7 +417,7 @@ public class PublishBlockThresholdsCommand extends ZclPriceCommand {
     public void deserialize(final ZclFieldDeserializer deserializer) {
         providerId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
         issuerEventId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        startTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
+        startTime = (ZigBeeUtcTime) deserializer.deserialize(ZclDataType.UTCTIME);
         issuerTariffId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
         commandIndex = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
         totalNumberOfCommands = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishCalorificValueCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishCalorificValueCommand.java
@@ -7,12 +7,11 @@
  */
 package com.zsmartsystems.zigbee.zcl.clusters.price;
 
-import java.util.Calendar;
-
 import javax.annotation.Generated;
 
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
+import com.zsmartsystems.zigbee.zcl.field.ZigBeeUtcTime;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
@@ -28,7 +27,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-12-25T10:11:19Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2022-12-09T01:34:23Z")
 public class PublishCalorificValueCommand extends ZclPriceCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -48,7 +47,7 @@ public class PublishCalorificValueCommand extends ZclPriceCommand {
     /**
      * Start Time command message field.
      */
-    private Calendar startTime;
+    private ZigBeeUtcTime startTime;
 
     /**
      * Calorific Value command message field.
@@ -82,14 +81,14 @@ public class PublishCalorificValueCommand extends ZclPriceCommand {
      * Constructor providing all required parameters.
      *
      * @param issuerEventId {@link Integer} Issuer Event ID
-     * @param startTime {@link Calendar} Start Time
+     * @param startTime {@link ZigBeeUtcTime} Start Time
      * @param calorificValue {@link Integer} Calorific Value
      * @param calorificValueUnit {@link Integer} Calorific Value Unit
      * @param calorificValueTrailingDigit {@link Integer} Calorific Value Trailing Digit
      */
     public PublishCalorificValueCommand(
             Integer issuerEventId,
-            Calendar startTime,
+            ZigBeeUtcTime startTime,
             Integer calorificValue,
             Integer calorificValueUnit,
             Integer calorificValueTrailingDigit) {
@@ -131,7 +130,7 @@ public class PublishCalorificValueCommand extends ZclPriceCommand {
      *
      * @return the Start Time
      */
-    public Calendar getStartTime() {
+    public ZigBeeUtcTime getStartTime() {
         return startTime;
     }
 
@@ -142,7 +141,7 @@ public class PublishCalorificValueCommand extends ZclPriceCommand {
      * @deprecated as of 1.3.0. Use the parameterised constructor instead to ensure that all mandatory fields are provided.
      */
     @Deprecated
-    public void setStartTime(final Calendar startTime) {
+    public void setStartTime(final ZigBeeUtcTime startTime) {
         this.startTime = startTime;
     }
 
@@ -218,7 +217,7 @@ public class PublishCalorificValueCommand extends ZclPriceCommand {
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
         issuerEventId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        startTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
+        startTime = (ZigBeeUtcTime) deserializer.deserialize(ZclDataType.UTCTIME);
         calorificValue = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
         calorificValueUnit = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
         calorificValueTrailingDigit = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishCo2ValueCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishCo2ValueCommand.java
@@ -7,12 +7,11 @@
  */
 package com.zsmartsystems.zigbee.zcl.clusters.price;
 
-import java.util.Calendar;
-
 import javax.annotation.Generated;
 
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
+import com.zsmartsystems.zigbee.zcl.field.ZigBeeUtcTime;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
@@ -28,7 +27,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-12-25T10:11:19Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2022-12-09T01:34:23Z")
 public class PublishCo2ValueCommand extends ZclPriceCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -72,7 +71,7 @@ public class PublishCo2ValueCommand extends ZclPriceCommand {
      * replacement/superseding PublishCO2Value command is used in place of this
      * cancellation mechanism).
      */
-    private Calendar startTime;
+    private ZigBeeUtcTime startTime;
 
     /**
      * Tariff Type command message field.
@@ -127,7 +126,7 @@ public class PublishCo2ValueCommand extends ZclPriceCommand {
      *
      * @param providerId {@link Integer} Provider ID
      * @param issuerEventId {@link Integer} Issuer Event ID
-     * @param startTime {@link Calendar} Start Time
+     * @param startTime {@link ZigBeeUtcTime} Start Time
      * @param tariffType {@link Integer} Tariff Type
      * @param co2Value {@link Integer} CO2 Value
      * @param co2ValueUnit {@link Integer} CO2 Value Unit
@@ -136,7 +135,7 @@ public class PublishCo2ValueCommand extends ZclPriceCommand {
     public PublishCo2ValueCommand(
             Integer providerId,
             Integer issuerEventId,
-            Calendar startTime,
+            ZigBeeUtcTime startTime,
             Integer tariffType,
             Integer co2Value,
             Integer co2ValueUnit,
@@ -231,7 +230,7 @@ public class PublishCo2ValueCommand extends ZclPriceCommand {
      *
      * @return the Start Time
      */
-    public Calendar getStartTime() {
+    public ZigBeeUtcTime getStartTime() {
         return startTime;
     }
 
@@ -250,7 +249,7 @@ public class PublishCo2ValueCommand extends ZclPriceCommand {
      * @deprecated as of 1.3.0. Use the parameterised constructor instead to ensure that all mandatory fields are provided.
      */
     @Deprecated
-    public void setStartTime(final Calendar startTime) {
+    public void setStartTime(final ZigBeeUtcTime startTime) {
         this.startTime = startTime;
     }
 
@@ -379,7 +378,7 @@ public class PublishCo2ValueCommand extends ZclPriceCommand {
     public void deserialize(final ZclFieldDeserializer deserializer) {
         providerId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
         issuerEventId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        startTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
+        startTime = (ZigBeeUtcTime) deserializer.deserialize(ZclDataType.UTCTIME);
         tariffType = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
         co2Value = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
         co2ValueUnit = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishConsolidatedBillCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishConsolidatedBillCommand.java
@@ -7,12 +7,11 @@
  */
 package com.zsmartsystems.zigbee.zcl.clusters.price;
 
-import java.util.Calendar;
-
 import javax.annotation.Generated;
 
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
+import com.zsmartsystems.zigbee.zcl.field.ZigBeeUtcTime;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
@@ -33,7 +32,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-12-25T10:11:19Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2022-12-09T01:34:23Z")
 public class PublishConsolidatedBillCommand extends ZclPriceCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -77,7 +76,7 @@ public class PublishConsolidatedBillCommand extends ZclPriceCommand {
      * required for billing purposes, it is recommended that a replacement/superseding
      * PublishConsolidatedBill command is used in place of this cancellation mechanism).
      */
-    private Calendar billingPeriodStartTime;
+    private ZigBeeUtcTime billingPeriodStartTime;
 
     /**
      * Billing Period Duration command message field.
@@ -149,7 +148,7 @@ public class PublishConsolidatedBillCommand extends ZclPriceCommand {
      *
      * @param providerId {@link Integer} Provider ID
      * @param issuerEventId {@link Integer} Issuer Event ID
-     * @param billingPeriodStartTime {@link Calendar} Billing Period Start Time
+     * @param billingPeriodStartTime {@link ZigBeeUtcTime} Billing Period Start Time
      * @param billingPeriodDuration {@link Integer} Billing Period Duration
      * @param billingPeriodDurationType {@link Integer} Billing Period Duration Type
      * @param tariffType {@link Integer} Tariff Type
@@ -160,7 +159,7 @@ public class PublishConsolidatedBillCommand extends ZclPriceCommand {
     public PublishConsolidatedBillCommand(
             Integer providerId,
             Integer issuerEventId,
-            Calendar billingPeriodStartTime,
+            ZigBeeUtcTime billingPeriodStartTime,
             Integer billingPeriodDuration,
             Integer billingPeriodDurationType,
             Integer tariffType,
@@ -259,7 +258,7 @@ public class PublishConsolidatedBillCommand extends ZclPriceCommand {
      *
      * @return the Billing Period Start Time
      */
-    public Calendar getBillingPeriodStartTime() {
+    public ZigBeeUtcTime getBillingPeriodStartTime() {
         return billingPeriodStartTime;
     }
 
@@ -278,7 +277,7 @@ public class PublishConsolidatedBillCommand extends ZclPriceCommand {
      * @deprecated as of 1.3.0. Use the parameterised constructor instead to ensure that all mandatory fields are provided.
      */
     @Deprecated
-    public void setBillingPeriodStartTime(final Calendar billingPeriodStartTime) {
+    public void setBillingPeriodStartTime(final ZigBeeUtcTime billingPeriodStartTime) {
         this.billingPeriodStartTime = billingPeriodStartTime;
     }
 
@@ -463,7 +462,7 @@ public class PublishConsolidatedBillCommand extends ZclPriceCommand {
     public void deserialize(final ZclFieldDeserializer deserializer) {
         providerId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
         issuerEventId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        billingPeriodStartTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
+        billingPeriodStartTime = (ZigBeeUtcTime) deserializer.deserialize(ZclDataType.UTCTIME);
         billingPeriodDuration = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_24_BIT_INTEGER);
         billingPeriodDurationType = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
         tariffType = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishConversionFactorCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishConversionFactorCommand.java
@@ -7,12 +7,11 @@
  */
 package com.zsmartsystems.zigbee.zcl.clusters.price;
 
-import java.util.Calendar;
-
 import javax.annotation.Generated;
 
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
+import com.zsmartsystems.zigbee.zcl.field.ZigBeeUtcTime;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
@@ -28,7 +27,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-12-25T10:11:19Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2022-12-09T01:34:23Z")
 public class PublishConversionFactorCommand extends ZclPriceCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -53,7 +52,7 @@ public class PublishConversionFactorCommand extends ZclPriceCommand {
      * A UTCTime field to denote the time at which the value becomes valid. The value remains
      * valid until replaced by a newer one.
      */
-    private Calendar startTime;
+    private ZigBeeUtcTime startTime;
 
     /**
      * Conversion Factor command message field.
@@ -86,13 +85,13 @@ public class PublishConversionFactorCommand extends ZclPriceCommand {
      * Constructor providing all required parameters.
      *
      * @param issuerEventId {@link Integer} Issuer Event ID
-     * @param startTime {@link Calendar} Start Time
+     * @param startTime {@link ZigBeeUtcTime} Start Time
      * @param conversionFactor {@link Integer} Conversion Factor
      * @param conversionFactorTrailingDigit {@link Integer} Conversion Factor Trailing Digit
      */
     public PublishConversionFactorCommand(
             Integer issuerEventId,
-            Calendar startTime,
+            ZigBeeUtcTime startTime,
             Integer conversionFactor,
             Integer conversionFactorTrailingDigit) {
 
@@ -139,7 +138,7 @@ public class PublishConversionFactorCommand extends ZclPriceCommand {
      *
      * @return the Start Time
      */
-    public Calendar getStartTime() {
+    public ZigBeeUtcTime getStartTime() {
         return startTime;
     }
 
@@ -153,7 +152,7 @@ public class PublishConversionFactorCommand extends ZclPriceCommand {
      * @deprecated as of 1.3.0. Use the parameterised constructor instead to ensure that all mandatory fields are provided.
      */
     @Deprecated
-    public void setStartTime(final Calendar startTime) {
+    public void setStartTime(final ZigBeeUtcTime startTime) {
         this.startTime = startTime;
     }
 
@@ -216,7 +215,7 @@ public class PublishConversionFactorCommand extends ZclPriceCommand {
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
         issuerEventId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        startTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
+        startTime = (ZigBeeUtcTime) deserializer.deserialize(ZclDataType.UTCTIME);
         conversionFactor = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
         conversionFactorTrailingDigit = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
     }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishCppEventCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishCppEventCommand.java
@@ -7,12 +7,11 @@
  */
 package com.zsmartsystems.zigbee.zcl.clusters.price;
 
-import java.util.Calendar;
-
 import javax.annotation.Generated;
 
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
+import com.zsmartsystems.zigbee.zcl.field.ZigBeeUtcTime;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
@@ -33,7 +32,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-12-25T10:11:19Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2022-12-09T01:34:23Z")
 public class PublishCppEventCommand extends ZclPriceCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -76,7 +75,7 @@ public class PublishCppEventCommand extends ZclPriceCommand {
     /**
      * Start Time command message field.
      */
-    private Calendar startTime;
+    private ZigBeeUtcTime startTime;
 
     /**
      * Duration In Minutes command message field.
@@ -126,7 +125,7 @@ public class PublishCppEventCommand extends ZclPriceCommand {
      *
      * @param providerId {@link Integer} Provider ID
      * @param issuerEventId {@link Integer} Issuer Event ID
-     * @param startTime {@link Calendar} Start Time
+     * @param startTime {@link ZigBeeUtcTime} Start Time
      * @param durationInMinutes {@link Integer} Duration In Minutes
      * @param tariffType {@link Integer} Tariff Type
      * @param cppPriceTier {@link Integer} Cpp Price Tier
@@ -135,7 +134,7 @@ public class PublishCppEventCommand extends ZclPriceCommand {
     public PublishCppEventCommand(
             Integer providerId,
             Integer issuerEventId,
-            Calendar startTime,
+            ZigBeeUtcTime startTime,
             Integer durationInMinutes,
             Integer tariffType,
             Integer cppPriceTier,
@@ -236,7 +235,7 @@ public class PublishCppEventCommand extends ZclPriceCommand {
      *
      * @return the Start Time
      */
-    public Calendar getStartTime() {
+    public ZigBeeUtcTime getStartTime() {
         return startTime;
     }
 
@@ -247,7 +246,7 @@ public class PublishCppEventCommand extends ZclPriceCommand {
      * @deprecated as of 1.3.0. Use the parameterised constructor instead to ensure that all mandatory fields are provided.
      */
     @Deprecated
-    public void setStartTime(final Calendar startTime) {
+    public void setStartTime(final ZigBeeUtcTime startTime) {
         this.startTime = startTime;
     }
 
@@ -366,7 +365,7 @@ public class PublishCppEventCommand extends ZclPriceCommand {
     public void deserialize(final ZclFieldDeserializer deserializer) {
         providerId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
         issuerEventId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        startTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
+        startTime = (ZigBeeUtcTime) deserializer.deserialize(ZclDataType.UTCTIME);
         durationInMinutes = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
         tariffType = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
         cppPriceTier = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishCreditPaymentCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishCreditPaymentCommand.java
@@ -7,13 +7,12 @@
  */
 package com.zsmartsystems.zigbee.zcl.clusters.price;
 
-import java.util.Calendar;
-
 import javax.annotation.Generated;
 
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.field.ByteArray;
+import com.zsmartsystems.zigbee.zcl.field.ZigBeeUtcTime;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
@@ -31,7 +30,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-12-25T10:11:19Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2022-12-09T01:34:23Z")
 public class PublishCreditPaymentCommand extends ZclPriceCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -69,7 +68,7 @@ public class PublishCreditPaymentCommand extends ZclPriceCommand {
      * <p>
      * A UTCTime field containing the time that the next credit payment is due.
      */
-    private Calendar creditPaymentDueDate;
+    private ZigBeeUtcTime creditPaymentDueDate;
 
     /**
      * Credit Payment Overdue Amount command message field.
@@ -99,7 +98,7 @@ public class PublishCreditPaymentCommand extends ZclPriceCommand {
      * <p>
      * A UTCTime field containing the time at which the last credit payment was made.
      */
-    private Calendar creditPaymentDate;
+    private ZigBeeUtcTime creditPaymentDate;
 
     /**
      * Credit Payment Ref command message field.
@@ -127,21 +126,21 @@ public class PublishCreditPaymentCommand extends ZclPriceCommand {
      *
      * @param providerId {@link Integer} Provider ID
      * @param issuerEventId {@link Integer} Issuer Event ID
-     * @param creditPaymentDueDate {@link Calendar} Credit Payment Due Date
+     * @param creditPaymentDueDate {@link ZigBeeUtcTime} Credit Payment Due Date
      * @param creditPaymentOverdueAmount {@link Integer} Credit Payment Overdue Amount
      * @param creditPaymentStatus {@link Integer} Credit Payment Status
      * @param creditPayment {@link Integer} Credit Payment
-     * @param creditPaymentDate {@link Calendar} Credit Payment Date
+     * @param creditPaymentDate {@link ZigBeeUtcTime} Credit Payment Date
      * @param creditPaymentRef {@link ByteArray} Credit Payment Ref
      */
     public PublishCreditPaymentCommand(
             Integer providerId,
             Integer issuerEventId,
-            Calendar creditPaymentDueDate,
+            ZigBeeUtcTime creditPaymentDueDate,
             Integer creditPaymentOverdueAmount,
             Integer creditPaymentStatus,
             Integer creditPayment,
-            Calendar creditPaymentDate,
+            ZigBeeUtcTime creditPaymentDate,
             ByteArray creditPaymentRef) {
 
         clusterId = CLUSTER_ID;
@@ -228,7 +227,7 @@ public class PublishCreditPaymentCommand extends ZclPriceCommand {
      *
      * @return the Credit Payment Due Date
      */
-    public Calendar getCreditPaymentDueDate() {
+    public ZigBeeUtcTime getCreditPaymentDueDate() {
         return creditPaymentDueDate;
     }
 
@@ -241,7 +240,7 @@ public class PublishCreditPaymentCommand extends ZclPriceCommand {
      * @deprecated as of 1.3.0. Use the parameterised constructor instead to ensure that all mandatory fields are provided.
      */
     @Deprecated
-    public void setCreditPaymentDueDate(final Calendar creditPaymentDueDate) {
+    public void setCreditPaymentDueDate(final ZigBeeUtcTime creditPaymentDueDate) {
         this.creditPaymentDueDate = creditPaymentDueDate;
     }
 
@@ -328,7 +327,7 @@ public class PublishCreditPaymentCommand extends ZclPriceCommand {
      *
      * @return the Credit Payment Date
      */
-    public Calendar getCreditPaymentDate() {
+    public ZigBeeUtcTime getCreditPaymentDate() {
         return creditPaymentDate;
     }
 
@@ -341,7 +340,7 @@ public class PublishCreditPaymentCommand extends ZclPriceCommand {
      * @deprecated as of 1.3.0. Use the parameterised constructor instead to ensure that all mandatory fields are provided.
      */
     @Deprecated
-    public void setCreditPaymentDate(final Calendar creditPaymentDate) {
+    public void setCreditPaymentDate(final ZigBeeUtcTime creditPaymentDate) {
         this.creditPaymentDate = creditPaymentDate;
     }
 
@@ -387,11 +386,11 @@ public class PublishCreditPaymentCommand extends ZclPriceCommand {
     public void deserialize(final ZclFieldDeserializer deserializer) {
         providerId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
         issuerEventId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        creditPaymentDueDate = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
+        creditPaymentDueDate = (ZigBeeUtcTime) deserializer.deserialize(ZclDataType.UTCTIME);
         creditPaymentOverdueAmount = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
         creditPaymentStatus = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
         creditPayment = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        creditPaymentDate = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
+        creditPaymentDate = (ZigBeeUtcTime) deserializer.deserialize(ZclDataType.UTCTIME);
         creditPaymentRef = (ByteArray) deserializer.deserialize(ZclDataType.OCTET_STRING);
     }
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishCurrencyConversionCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishCurrencyConversionCommand.java
@@ -7,12 +7,11 @@
  */
 package com.zsmartsystems.zigbee.zcl.clusters.price;
 
-import java.util.Calendar;
-
 import javax.annotation.Generated;
 
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
+import com.zsmartsystems.zigbee.zcl.field.ZigBeeUtcTime;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
@@ -27,7 +26,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-12-25T10:11:19Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2022-12-09T01:34:23Z")
 public class PublishCurrencyConversionCommand extends ZclPriceCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -69,7 +68,7 @@ public class PublishCurrencyConversionCommand extends ZclPriceCommand {
      * PublishCurrencyConversion command with the same Provider ID and Issuer Event ID to be
      * cancelled.
      */
-    private Calendar startTime;
+    private ZigBeeUtcTime startTime;
 
     /**
      * Old Currency command message field.
@@ -130,7 +129,7 @@ public class PublishCurrencyConversionCommand extends ZclPriceCommand {
      *
      * @param providerId {@link Integer} Provider ID
      * @param issuerEventId {@link Integer} Issuer Event ID
-     * @param startTime {@link Calendar} Start Time
+     * @param startTime {@link ZigBeeUtcTime} Start Time
      * @param oldCurrency {@link Integer} Old Currency
      * @param newCurrency {@link Integer} New Currency
      * @param conversionFactor {@link Integer} Conversion Factor
@@ -140,7 +139,7 @@ public class PublishCurrencyConversionCommand extends ZclPriceCommand {
     public PublishCurrencyConversionCommand(
             Integer providerId,
             Integer issuerEventId,
-            Calendar startTime,
+            ZigBeeUtcTime startTime,
             Integer oldCurrency,
             Integer newCurrency,
             Integer conversionFactor,
@@ -235,7 +234,7 @@ public class PublishCurrencyConversionCommand extends ZclPriceCommand {
      *
      * @return the Start Time
      */
-    public Calendar getStartTime() {
+    public ZigBeeUtcTime getStartTime() {
         return startTime;
     }
 
@@ -252,7 +251,7 @@ public class PublishCurrencyConversionCommand extends ZclPriceCommand {
      * @deprecated as of 1.3.0. Use the parameterised constructor instead to ensure that all mandatory fields are provided.
      */
     @Deprecated
-    public void setStartTime(final Calendar startTime) {
+    public void setStartTime(final ZigBeeUtcTime startTime) {
         this.startTime = startTime;
     }
 
@@ -404,7 +403,7 @@ public class PublishCurrencyConversionCommand extends ZclPriceCommand {
     public void deserialize(final ZclFieldDeserializer deserializer) {
         providerId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
         issuerEventId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        startTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
+        startTime = (ZigBeeUtcTime) deserializer.deserialize(ZclDataType.UTCTIME);
         oldCurrency = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
         newCurrency = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
         conversionFactor = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishPriceCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishPriceCommand.java
@@ -7,13 +7,12 @@
  */
 package com.zsmartsystems.zigbee.zcl.clusters.price;
 
-import java.util.Calendar;
-
 import javax.annotation.Generated;
 
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.field.ByteArray;
+import com.zsmartsystems.zigbee.zcl.field.ZigBeeUtcTime;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
@@ -46,7 +45,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-12-25T10:11:19Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2022-12-09T01:34:23Z")
 public class PublishPriceCommand extends ZclPriceCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -96,7 +95,7 @@ public class PublishPriceCommand extends ZclPriceCommand {
      * A UTCTime field containing the current time as determined by the device. This field
      * provides an extra value-added feature for the broadcast price signals.
      */
-    private Calendar currentTime;
+    private ZigBeeUtcTime currentTime;
 
     /**
      * Unit Of Measure command message field.
@@ -153,7 +152,7 @@ public class PublishPriceCommand extends ZclPriceCommand {
      * If Block Charging only is in use, the Duration in Minutes field of the Publish Price
      * command shall be set to 0xFFFF indicating the price is valid “until changed”.
      */
-    private Calendar startTime;
+    private ZigBeeUtcTime startTime;
 
     /**
      * Duration command message field.
@@ -284,12 +283,12 @@ public class PublishPriceCommand extends ZclPriceCommand {
      * @param providerId {@link Integer} Provider ID
      * @param rateLabel {@link ByteArray} Rate Label
      * @param issuerEventId {@link Integer} Issuer Event ID
-     * @param currentTime {@link Calendar} Current Time
+     * @param currentTime {@link ZigBeeUtcTime} Current Time
      * @param unitOfMeasure {@link Integer} Unit Of Measure
      * @param currency {@link Integer} Currency
      * @param priceTrailingDigitAndTier {@link Integer} Price Trailing Digit And Tier
      * @param numberOfPriceTiers {@link Integer} Number Of Price Tiers
-     * @param startTime {@link Calendar} Start Time
+     * @param startTime {@link ZigBeeUtcTime} Start Time
      * @param duration {@link Integer} Duration
      * @param price {@link Integer} Price
      * @param priceRatio {@link Integer} Price Ratio
@@ -310,12 +309,12 @@ public class PublishPriceCommand extends ZclPriceCommand {
             Integer providerId,
             ByteArray rateLabel,
             Integer issuerEventId,
-            Calendar currentTime,
+            ZigBeeUtcTime currentTime,
             Integer unitOfMeasure,
             Integer currency,
             Integer priceTrailingDigitAndTier,
             Integer numberOfPriceTiers,
-            Calendar startTime,
+            ZigBeeUtcTime startTime,
             Integer duration,
             Integer price,
             Integer priceRatio,
@@ -465,7 +464,7 @@ public class PublishPriceCommand extends ZclPriceCommand {
      *
      * @return the Current Time
      */
-    public Calendar getCurrentTime() {
+    public ZigBeeUtcTime getCurrentTime() {
         return currentTime;
     }
 
@@ -479,7 +478,7 @@ public class PublishPriceCommand extends ZclPriceCommand {
      * @deprecated as of 1.3.0. Use the parameterised constructor instead to ensure that all mandatory fields are provided.
      */
     @Deprecated
-    public void setCurrentTime(final Calendar currentTime) {
+    public void setCurrentTime(final ZigBeeUtcTime currentTime) {
         this.currentTime = currentTime;
     }
 
@@ -624,7 +623,7 @@ public class PublishPriceCommand extends ZclPriceCommand {
      *
      * @return the Start Time
      */
-    public Calendar getStartTime() {
+    public ZigBeeUtcTime getStartTime() {
         return startTime;
     }
 
@@ -643,7 +642,7 @@ public class PublishPriceCommand extends ZclPriceCommand {
      * @deprecated as of 1.3.0. Use the parameterised constructor instead to ensure that all mandatory fields are provided.
      */
     @Deprecated
-    public void setStartTime(final Calendar startTime) {
+    public void setStartTime(final ZigBeeUtcTime startTime) {
         this.startTime = startTime;
     }
 
@@ -1050,12 +1049,12 @@ public class PublishPriceCommand extends ZclPriceCommand {
         providerId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
         rateLabel = (ByteArray) deserializer.deserialize(ZclDataType.OCTET_STRING);
         issuerEventId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        currentTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
+        currentTime = (ZigBeeUtcTime) deserializer.deserialize(ZclDataType.UTCTIME);
         unitOfMeasure = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
         currency = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
         priceTrailingDigitAndTier = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
         numberOfPriceTiers = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
-        startTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
+        startTime = (ZigBeeUtcTime) deserializer.deserialize(ZclDataType.UTCTIME);
         duration = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
         price = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
         priceRatio = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishPriceMatrixCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishPriceMatrixCommand.java
@@ -7,13 +7,12 @@
  */
 package com.zsmartsystems.zigbee.zcl.clusters.price;
 
-import java.util.Calendar;
-
 import javax.annotation.Generated;
 
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.clusters.price.PriceMatrixSubPayload;
+import com.zsmartsystems.zigbee.zcl.field.ZigBeeUtcTime;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
@@ -41,7 +40,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-12-25T10:11:19Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2022-12-09T01:34:23Z")
 public class PublishPriceMatrixCommand extends ZclPriceCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -81,7 +80,7 @@ public class PublishPriceMatrixCommand extends ZclPriceCommand {
      * date/time of 0x00000000 shall indicate that the command should be executed
      * immediately.
      */
-    private Calendar startTime;
+    private ZigBeeUtcTime startTime;
 
     /**
      * Issuer Tariff ID command message field.
@@ -140,7 +139,7 @@ public class PublishPriceMatrixCommand extends ZclPriceCommand {
      *
      * @param providerId {@link Integer} Provider ID
      * @param issuerEventId {@link Integer} Issuer Event ID
-     * @param startTime {@link Calendar} Start Time
+     * @param startTime {@link ZigBeeUtcTime} Start Time
      * @param issuerTariffId {@link Integer} Issuer Tariff ID
      * @param commandIndex {@link Integer} Command Index
      * @param totalNumberOfCommands {@link Integer} Total Number Of Commands
@@ -150,7 +149,7 @@ public class PublishPriceMatrixCommand extends ZclPriceCommand {
     public PublishPriceMatrixCommand(
             Integer providerId,
             Integer issuerEventId,
-            Calendar startTime,
+            ZigBeeUtcTime startTime,
             Integer issuerTariffId,
             Integer commandIndex,
             Integer totalNumberOfCommands,
@@ -243,7 +242,7 @@ public class PublishPriceMatrixCommand extends ZclPriceCommand {
      *
      * @return the Start Time
      */
-    public Calendar getStartTime() {
+    public ZigBeeUtcTime getStartTime() {
         return startTime;
     }
 
@@ -258,7 +257,7 @@ public class PublishPriceMatrixCommand extends ZclPriceCommand {
      * @deprecated as of 1.3.0. Use the parameterised constructor instead to ensure that all mandatory fields are provided.
      */
     @Deprecated
-    public void setStartTime(final Calendar startTime) {
+    public void setStartTime(final ZigBeeUtcTime startTime) {
         this.startTime = startTime;
     }
 
@@ -406,7 +405,7 @@ public class PublishPriceMatrixCommand extends ZclPriceCommand {
     public void deserialize(final ZclFieldDeserializer deserializer) {
         providerId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
         issuerEventId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        startTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
+        startTime = (ZigBeeUtcTime) deserializer.deserialize(ZclDataType.UTCTIME);
         issuerTariffId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
         commandIndex = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
         totalNumberOfCommands = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishTariffInformationCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishTariffInformationCommand.java
@@ -7,13 +7,12 @@
  */
 package com.zsmartsystems.zigbee.zcl.clusters.price;
 
-import java.util.Calendar;
-
 import javax.annotation.Generated;
 
 import com.zsmartsystems.zigbee.zcl.ZclFieldDeserializer;
 import com.zsmartsystems.zigbee.zcl.ZclFieldSerializer;
 import com.zsmartsystems.zigbee.zcl.field.ByteArray;
+import com.zsmartsystems.zigbee.zcl.field.ZigBeeUtcTime;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
@@ -34,7 +33,7 @@ import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
  * <p>
  * Code is auto-generated. Modifications may be overwritten!
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2020-12-25T10:11:19Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2022-12-09T01:34:23Z")
 public class PublishTariffInformationCommand extends ZclPriceCommand {
     /**
      * The cluster ID to which this command belongs.
@@ -84,7 +83,7 @@ public class PublishTariffInformationCommand extends ZclPriceCommand {
      * in Table D-108 (Generation Meters shall use the ‘Received’ Tariff), the most
      * significant nibble represents an enumeration specifying the charging scheme
      */
-    private Calendar startTime;
+    private ZigBeeUtcTime startTime;
 
     /**
      * Tariff Type command message field.
@@ -198,7 +197,7 @@ public class PublishTariffInformationCommand extends ZclPriceCommand {
      * @param providerId {@link Integer} Provider ID
      * @param issuerEventId {@link Integer} Issuer Event ID
      * @param issuerTariffId {@link Integer} Issuer Tariff ID
-     * @param startTime {@link Calendar} Start Time
+     * @param startTime {@link ZigBeeUtcTime} Start Time
      * @param tariffType {@link Integer} Tariff Type
      * @param tariffLabel {@link ByteArray} Tariff Label
      * @param numberOfPriceTiers {@link Integer} Number Of Price Tiers
@@ -215,7 +214,7 @@ public class PublishTariffInformationCommand extends ZclPriceCommand {
             Integer providerId,
             Integer issuerEventId,
             Integer issuerTariffId,
-            Calendar startTime,
+            ZigBeeUtcTime startTime,
             Integer tariffType,
             ByteArray tariffLabel,
             Integer numberOfPriceTiers,
@@ -348,7 +347,7 @@ public class PublishTariffInformationCommand extends ZclPriceCommand {
      *
      * @return the Start Time
      */
-    public Calendar getStartTime() {
+    public ZigBeeUtcTime getStartTime() {
         return startTime;
     }
 
@@ -366,7 +365,7 @@ public class PublishTariffInformationCommand extends ZclPriceCommand {
      * @deprecated as of 1.3.0. Use the parameterised constructor instead to ensure that all mandatory fields are provided.
      */
     @Deprecated
-    public void setStartTime(final Calendar startTime) {
+    public void setStartTime(final ZigBeeUtcTime startTime) {
         this.startTime = startTime;
     }
 
@@ -690,7 +689,7 @@ public class PublishTariffInformationCommand extends ZclPriceCommand {
         providerId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
         issuerEventId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
         issuerTariffId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        startTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
+        startTime = (ZigBeeUtcTime) deserializer.deserialize(ZclDataType.UTCTIME);
         tariffType = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
         tariffLabel = (ByteArray) deserializer.deserialize(ZclDataType.OCTET_STRING);
         numberOfPriceTiers = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/field/ZigBeeUtcTime.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/field/ZigBeeUtcTime.java
@@ -1,0 +1,202 @@
+/**
+ * Copyright (c) 2016-2023 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.zcl.field;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+/**
+ * Representation of a ZigBee UTC time type.
+ * <p>
+ * UTCTime is an unsigned 32-bit value representing the number of seconds since 0 hours, 0 minutes, 0 seconds, on the
+ * 1st of January, 2000 UTC (Universal Coordinated Time). The value that represents an invalid value of this type is
+ * 0xffffffff.
+ * <p>
+ * This class is immutable and thread-safe.
+ *
+ * @author Chris Jackson
+ *
+ */
+public class ZigBeeUtcTime implements Comparable<ZigBeeUtcTime> {
+    /**
+     * Seconds between 1/1/1970 and 1/1/2000
+     */
+    private static final long JAVA_OFFSET = 946684800;
+
+    /**
+     * The ZigBee value transferred when the time is invalid
+     */
+    private static final long INVALID_TIME = 0xffffffff;
+
+    /**
+     * ISO 8601 date formatter
+     */
+    private static final DateFormat dfIso8601 = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+
+    /**
+     * The time value
+     */
+    private final long zigbeeSecond;
+
+    /**
+     * Constructor returning an invalid or unknown time value
+     */
+    public ZigBeeUtcTime() {
+        this.zigbeeSecond = INVALID_TIME;
+    }
+
+    /**
+     * Private constructor creating the {@link ZigBeeUtcTime} given epoch time of the ZigBee reference of
+     * 2000-01-01T00:00:00Z.
+     *
+     * @param zigbeeSecond the number of seconds since 2000-01-01T00:00:00Z.
+     */
+    private ZigBeeUtcTime(long zigbeeSecond) {
+        this.zigbeeSecond = zigbeeSecond;
+    }
+
+    /**
+     * Obtains the current {@link ZigBeeUtcTime} from the system clock.
+     *
+     * @return {@link ZigBeeUtcTime}
+     */
+    public static ZigBeeUtcTime now() {
+        return new ZigBeeUtcTime(System.currentTimeMillis() / 1000 - JAVA_OFFSET);
+    }
+
+    /**
+     * Returns a new {@link ZigBeeUtcTime} with the specified amount added.
+     *
+     * @param amountToAdd the number of seconds to add
+     * @return a copy of this {@link ZigBeeUtcTime} with the specified amount added.
+     */
+    public ZigBeeUtcTime plus(long amountToAdd) {
+        return new ZigBeeUtcTime(getZigBeeSecond() + amountToAdd);
+    }
+
+    /**
+     * Returns a new {@link ZigBeeUtcTime} with the specified amount subtracted.
+     *
+     * @param amountToSubtract the number of seconds to subtract
+     * @return a copy of this {@link ZigBeeUtcTime} with the specified amount subtracted.
+     */
+    public ZigBeeUtcTime minus(long amountToSubtract) {
+        return new ZigBeeUtcTime(getZigBeeSecond() - amountToSubtract);
+    }
+
+    /**
+     * Obtains an instance of {@link ZigBeeUtcTime} using seconds from the epoch of 1970-01-01T00:00:00Z.
+     *
+     * @param epochSecond the seconds since 1970-01-01T00:00:00Z
+     * @return {@link ZigBeeUtcTime}
+     */
+    public static ZigBeeUtcTime ofEpochSecond(long epochSecond) {
+        return new ZigBeeUtcTime(epochSecond - JAVA_OFFSET);
+    }
+
+    /**
+     * Obtains an instance of {@link ZigBeeUtcTime} using seconds from the epoch of 2000-01-01T00:00:00Z.
+     *
+     * @param zigbeeSecond the number of seconds since 2000-01-01T00:00:00Z
+     * @return {@link ZigBeeUtcTime}
+     */
+    public static ZigBeeUtcTime ofZigBeeSecond(long zigbeeSecond) {
+        return new ZigBeeUtcTime(zigbeeSecond);
+    }
+
+    /**
+     * Gets the current ZigBee second. This is referenced to the epoch of 2000-01-01T00:00:00Z.
+     *
+     * @return the number of seconds referenced to the epoch of 2000-01-01T00:00:00Z.
+     */
+    public long getZigBeeSecond() {
+        return zigbeeSecond;
+    }
+
+    /**
+     * Gets the current Epoch second. This is referenced to the epoch of 1970-01-01T00:00:00Z.
+     *
+     * @return the number of seconds referenced to the epoch of 1970-01-01T00:00:00Z.
+     */
+    public long getEpochSecond() {
+        if (zigbeeSecond == INVALID_TIME) {
+            return INVALID_TIME;
+        }
+
+        return zigbeeSecond + JAVA_OFFSET;
+    }
+
+    /**
+     * Checks if this instant is before the specified instant. This will return false if either time is invalid.
+     *
+     * @param testTime the {@link ZigBeeUtcTime} to test against
+     * @return true if the testTime is before this instant
+     */
+    public boolean isBefore(ZigBeeUtcTime testTime) {
+        if (zigbeeSecond == INVALID_TIME || testTime.getZigBeeSecond() == INVALID_TIME) {
+            return false;
+        }
+        return zigbeeSecond < testTime.getZigBeeSecond();
+    }
+
+    /**
+     * Checks if this instant is after the specified instant. This will return false if either time is invalid.
+     *
+     * @param testTime the {@link ZigBeeUtcTime} to test against
+     * @return true if the testTime is after this instant
+     */
+    public boolean isAfter(ZigBeeUtcTime testTime) {
+        if (zigbeeSecond == INVALID_TIME || testTime.getZigBeeSecond() == INVALID_TIME) {
+            return false;
+        }
+        return zigbeeSecond > testTime.getZigBeeSecond();
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + (int) (zigbeeSecond ^ (zigbeeSecond >>> 32));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        ZigBeeUtcTime other = (ZigBeeUtcTime) obj;
+        if (zigbeeSecond != other.zigbeeSecond) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * A string representation of this {@link ZigBeeUtcTime} using ISO-8601 representation.
+     */
+    @Override
+    public String toString() {
+        if (zigbeeSecond == INVALID_TIME) {
+            return "INVALID_TIME";
+        }
+        return dfIso8601.format(new Date(getEpochSecond() * 1000));
+    }
+
+    @Override
+    public int compareTo(ZigBeeUtcTime otherTime) {
+        return Long.compare(otherTime.zigbeeSecond, zigbeeSecond);
+    }
+}

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/protocol/ZclDataType.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/protocol/ZclDataType.java
@@ -7,7 +7,6 @@
  */
 package com.zsmartsystems.zigbee.zcl.protocol;
 
-import java.util.Calendar;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -29,16 +28,17 @@ import com.zsmartsystems.zigbee.zcl.field.NeighborInformation;
 import com.zsmartsystems.zigbee.zcl.field.ReadAttributeStatusRecord;
 import com.zsmartsystems.zigbee.zcl.field.WriteAttributeRecord;
 import com.zsmartsystems.zigbee.zcl.field.WriteAttributeStatusRecord;
+import com.zsmartsystems.zigbee.zcl.field.ZigBeeUtcTime;
 import com.zsmartsystems.zigbee.zdo.ZdoStatus;
 import com.zsmartsystems.zigbee.zdo.field.BindingTable;
 import com.zsmartsystems.zigbee.zdo.field.ComplexDescriptor;
 import com.zsmartsystems.zigbee.zdo.field.NeighborTable;
 import com.zsmartsystems.zigbee.zdo.field.NodeDescriptor;
+import com.zsmartsystems.zigbee.zdo.field.ParentAnnounceChildInfo;
 import com.zsmartsystems.zigbee.zdo.field.PowerDescriptor;
 import com.zsmartsystems.zigbee.zdo.field.RoutingTable;
 import com.zsmartsystems.zigbee.zdo.field.SimpleDescriptor;
 import com.zsmartsystems.zigbee.zdo.field.UserDescriptor;
-import com.zsmartsystems.zigbee.zdo.field.ParentAnnounceChildInfo;
 
 /**
  * Enumeration of the ZCL data types
@@ -95,7 +95,7 @@ public enum ZclDataType {
     COLLECTION_BAG(null, 0x51, false),
     TIME_OF_DAY(null, 0xE0, true),
     DATE(null, 0xE1, true),
-    UTCTIME(Calendar.class, 0xE2, true),
+    UTCTIME(ZigBeeUtcTime.class, 0xE2, true),
     CLUSTERID(Integer.class, 0xE8, false),
     ATTRIBUTEID(null, 0xE9, false),
     BACNET_OID(null, 0xEA, false),

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeNetworkManagerTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeNetworkManagerTest.java
@@ -40,6 +40,7 @@ import org.mockito.Mockito;
 import com.zsmartsystems.zigbee.ZigBeeNode.ZigBeeNodeState;
 import com.zsmartsystems.zigbee.app.ZigBeeNetworkExtension;
 import com.zsmartsystems.zigbee.app.otaserver.ZigBeeOtaUpgradeExtension;
+import com.zsmartsystems.zigbee.app.time.ZigBeeTimeExtension;
 import com.zsmartsystems.zigbee.aps.ZigBeeApsFrame;
 import com.zsmartsystems.zigbee.database.ZigBeeNetworkDataStore;
 import com.zsmartsystems.zigbee.database.ZigBeeNetworkDatabaseManager;
@@ -1079,6 +1080,17 @@ public class ZigBeeNetworkManagerTest
         TestUtilities.setField(ZigBeeNetworkManager.class, manager, "networkState", ZigBeeNetworkState.INITIALISING);
 
         assertEquals(ZigBeeStatus.SUCCESS, manager.addExtension(new ZigBeeOtaUpgradeExtension()));
+        returnedExtension = manager.getExtension(ZigBeeOtaUpgradeExtension.class);
+        assertTrue(returnedExtension instanceof ZigBeeOtaUpgradeExtension);
+
+        returnedExtension = manager.getExtension(ZigBeeTimeExtension.class);
+        assertNull(returnedExtension);
+
+        manager.addExtension(new ZigBeeTimeExtension());
+
+        returnedExtension = manager.getExtension(ZigBeeTimeExtension.class);
+        assertTrue(returnedExtension instanceof ZigBeeTimeExtension);
+
         returnedExtension = manager.getExtension(ZigBeeOtaUpgradeExtension.class);
         assertTrue(returnedExtension instanceof ZigBeeOtaUpgradeExtension);
 

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/app/time/ZclTimeServerTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/app/time/ZclTimeServerTest.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2016-2023 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.app.time;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import com.zsmartsystems.zigbee.ZigBeeCommand;
+import com.zsmartsystems.zigbee.ZigBeeEndpointAddress;
+import com.zsmartsystems.zigbee.ZigBeeNetworkManager;
+import com.zsmartsystems.zigbee.zcl.clusters.ZclTimeCluster;
+import com.zsmartsystems.zigbee.zcl.clusters.general.ReadAttributesCommand;
+import com.zsmartsystems.zigbee.zcl.clusters.general.ReadAttributesResponse;
+import com.zsmartsystems.zigbee.zcl.field.ReadAttributeStatusRecord;
+import com.zsmartsystems.zigbee.zcl.protocol.ZclCommandDirection;
+
+/**
+ *
+ * @author Chris Jackson
+ *
+ */
+public class ZclTimeServerTest {
+
+    @Test
+    public void test() {
+        ArgumentCaptor<ZigBeeCommand> commandListener = ArgumentCaptor.forClass(ZigBeeCommand.class);
+
+        ZigBeeNetworkManager manager = Mockito.mock(ZigBeeNetworkManager.class);
+        Mockito.when(manager.sendCommand(commandListener.capture())).thenReturn(true);
+
+        ZclTimeServer server = new ZclTimeServer(manager);
+
+        List<Integer> identifiers = new ArrayList<>();
+        identifiers.add(ZclTimeCluster.ATTR_DSTSTART);
+        identifiers.add(ZclTimeCluster.ATTR_DSTEND);
+        identifiers.add(ZclTimeCluster.ATTR_DSTSHIFT);
+        identifiers.add(ZclTimeCluster.ATTR_TIMEZONE);
+        identifiers.add(ZclTimeCluster.ATTR_TIMESTATUS);
+
+        ReadAttributesCommand readAttributes = new ReadAttributesCommand();
+        readAttributes.setClusterId(ZclTimeCluster.CLUSTER_ID);
+        readAttributes.setCommandDirection(ZclCommandDirection.CLIENT_TO_SERVER);
+        readAttributes.setSourceAddress(new ZigBeeEndpointAddress(1234));
+        readAttributes.setDestinationAddress(new ZigBeeEndpointAddress(0));
+        readAttributes.setIdentifiers(identifiers);
+        readAttributes.setTransactionId(88);
+
+        server.commandReceived(readAttributes);
+
+        assertEquals(1, commandListener.getAllValues().size());
+
+        ReadAttributesResponse response = (ReadAttributesResponse) commandListener.getValue();
+
+        assertEquals(Integer.valueOf(ZclTimeCluster.CLUSTER_ID), response.getClusterId());
+        assertEquals(ZclCommandDirection.SERVER_TO_CLIENT, response.getCommandDirection());
+        assertEquals(new ZigBeeEndpointAddress(1234), response.getDestinationAddress());
+        assertEquals(new ZigBeeEndpointAddress(0), response.getSourceAddress());
+        assertEquals(Integer.valueOf(88), response.getTransactionId());
+        assertEquals(5, response.getRecords().size());
+
+        for (ReadAttributeStatusRecord record : response.getRecords()) {
+            switch (record.getAttributeIdentifier()) {
+                case ZclTimeCluster.ATTR_DSTSTART:
+                    break;
+                case ZclTimeCluster.ATTR_DSTEND:
+                    break;
+                case ZclTimeCluster.ATTR_DSTSHIFT:
+                    break;
+                case ZclTimeCluster.ATTR_TIMEZONE:
+                    break;
+                case ZclTimeCluster.ATTR_TIMESTATUS:
+                    break;
+            }
+        }
+    }
+}

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/serialization/DefaultSerializerTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/serialization/DefaultSerializerTest.java
@@ -18,6 +18,7 @@ import org.junit.Test;
 import com.zsmartsystems.zigbee.ExtendedPanId;
 import com.zsmartsystems.zigbee.IeeeAddress;
 import com.zsmartsystems.zigbee.zcl.field.ByteArray;
+import com.zsmartsystems.zigbee.zcl.field.ZigBeeUtcTime;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 
 /**
@@ -71,6 +72,13 @@ public class DefaultSerializerTest {
         ExtendedPanId valIn = new ExtendedPanId("1234567890123456");
         int[] valOut = { 0x56, 0x34, 0x12, 0x90, 0x78, 0x56, 0x34, 0x12 };
         testSerializedData(valIn, valOut, ZclDataType.EXTENDED_PANID);
+    }
+
+    @Test
+    public void testSerialize_UTCTIME() {
+        ZigBeeUtcTime valIn = ZigBeeUtcTime.ofZigBeeSecond(0x12345678);
+        int[] valOut = { 0x78, 0x56, 0x34, 0x12 };
+        testSerializedData(valIn, valOut, ZclDataType.UTCTIME);
     }
 
     @Test

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/serialization/SerializerIntegrationTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/serialization/SerializerIntegrationTest.java
@@ -23,6 +23,7 @@ import com.zsmartsystems.zigbee.zcl.ZclStatus;
 import com.zsmartsystems.zigbee.zcl.field.ByteArray;
 import com.zsmartsystems.zigbee.zcl.field.ExtensionFieldSet;
 import com.zsmartsystems.zigbee.zcl.field.ZclArrayList;
+import com.zsmartsystems.zigbee.zcl.field.ZigBeeUtcTime;
 import com.zsmartsystems.zigbee.zcl.protocol.ZclDataType;
 import com.zsmartsystems.zigbee.zdo.ZdoStatus;
 import com.zsmartsystems.zigbee.zdo.field.BindingTable;
@@ -151,6 +152,12 @@ public class SerializerIntegrationTest {
     public void testDeserialize_DATA_16_BIT() {
         int valIn = 0x9119;
         testSerializer(valIn, ZclDataType.DATA_16_BIT);
+    }
+
+    @Test
+    public void testDeserialize_UTCTIME() {
+        ZigBeeUtcTime valIn = ZigBeeUtcTime.ofZigBeeSecond(12345678);
+        testSerializer(valIn, ZclDataType.UTCTIME);
     }
 
     @Test

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zcl/field/ZigBeeUtcTimeTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zcl/field/ZigBeeUtcTimeTest.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2016-2023 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.zcl.field;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+/**
+ * Tests for the {@link ZigBeeUtcTime} class
+ *
+ * @author Chris Jackson
+ *
+ */
+public class ZigBeeUtcTimeTest {
+    @Test
+    public void test() {
+        ZigBeeUtcTime time = ZigBeeUtcTime.ofEpochSecond(946684800);
+
+        assertEquals(0, time.getZigBeeSecond());
+        assertEquals(946684800, time.getEpochSecond());
+
+        time = time.plus(100);
+        assertEquals(100, time.getZigBeeSecond());
+
+        time = time.minus(10);
+        assertEquals(90, time.getZigBeeSecond());
+        assertEquals(946684890, time.getEpochSecond());
+
+        time = ZigBeeUtcTime.ofZigBeeSecond(20);
+        assertEquals(20, time.getZigBeeSecond());
+        assertEquals(946684820, time.getEpochSecond());
+
+        time = ZigBeeUtcTime.ofZigBeeSecond(0x235A75A2);
+        System.out.println(time.toString());
+
+        time = new ZigBeeUtcTime();
+        assertEquals(0xffffffff, time.getZigBeeSecond());
+        System.out.println(time.toString());
+
+        System.out.println(ZigBeeUtcTime.now().toString());
+    }
+
+    @Test
+    public void compare() {
+        ZigBeeUtcTime time1 = ZigBeeUtcTime.ofEpochSecond(946684800);
+        ZigBeeUtcTime time2 = ZigBeeUtcTime.ofEpochSecond(946684801);
+        ZigBeeUtcTime invalidTime = new ZigBeeUtcTime();
+
+        assertFalse(time1.equals(time2));
+
+        assertTrue(time1.isBefore(time2));
+        assertFalse(time1.isBefore(invalidTime));
+        assertTrue(time2.isAfter(time1));
+        assertFalse(time2.isAfter(invalidTime));
+        assertFalse(invalidTime.isBefore(time1));
+        assertFalse(invalidTime.isAfter(time1));
+
+        time2 = ZigBeeUtcTime.ofEpochSecond(946684800);
+        assertTrue(time1.equals(time2));
+    }
+
+}


### PR DESCRIPTION
This is something I wrote a while back but didn't create a PR so I need to try and remember how it all works :)

This creates a `ZigBeeUtcTime` class for managing time on a remote device. It then supports a `ZigBeeTimeExtension` which in turn can provide a local `ZclTimeClient` or `ZclTimeServer` to manage the time on the remote device.

The `ZclTimeServer` is relatively simple in that it just responds to requests from the device.

The `ZclTimeClient` is in itself also simple in that it provides methods to set the time on the remote.

The `ZigBeeTimeExtension` tries to automate the time management by working out drift rates, and setting the clock proactively if the time has drifted outside spec and the device didn't update the time through a request to the `ZclTimeServer`.

There is also a `ZigBeeConsoleTimeCommand` console command to get or set the time, and display the various information.

This is potentially a breaking change if people are using time at the moment since this changes some interfaces from `Calendar` to `ZigBeeUtcTime`.

I welcome comments on this and will wait a week or two before merging.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>