### PR TITLE
Add check to avoid NPE when adding application with no supporting cluster

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeEndpoint.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeEndpoint.java
@@ -399,17 +399,21 @@ public class ZigBeeEndpoint {
      *
      * @param application the new {@link ZigBeeApplication}
      * @return the {@link ZigBeeStatus} of the call. {@link ZigBeeStatus.SUCCESS} if the application was registered and
-     *         started, and {@link ZigBeeStatus.INVALID_STATE} if an application is already registered to the cluster
+     *         started, {@link ZigBeeStatus.INVALID_STATE} if an application is already registered to the cluster, and
+     *         {@link ZigBeeStatus.UNSUPPORTED} if a valid cluster cannot be found in the endpoint
      */
     public ZigBeeStatus addApplication(ZigBeeApplication application) {
         if (applications.get(application.getClusterId()) != null) {
             return ZigBeeStatus.INVALID_STATE;
         }
-        applications.put(application.getClusterId(), application);
         ZclCluster cluster = outputClusters.get(application.getClusterId());
         if (cluster == null) {
             cluster = inputClusters.get(application.getClusterId());
         }
+        if (cluster == null) {
+            return ZigBeeStatus.UNSUPPORTED;
+        }
+        applications.put(application.getClusterId(), application);
         return application.appStartup(cluster);
     }
 
@@ -610,10 +614,10 @@ public class ZigBeeEndpoint {
         command.setDestinationAddress(getEndpointAddress());
         return node.sendTransaction(command, responseMatcher);
     }
-    
+
     /**
      * Gets the {@link NotificationService} provided by the {@link ZigBeeNetworkManager}.
-     * 
+     *
      * @return the {@link NotificationService} provided by the {@link ZigBeeNetworkManager}.
      */
     public NotificationService getNotificationService() {

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeEndpointTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeEndpointTest.java
@@ -10,6 +10,7 @@ package com.zsmartsystems.zigbee;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
@@ -21,6 +22,7 @@ import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
 import com.zsmartsystems.zigbee.app.ZigBeeApplication;
+import com.zsmartsystems.zigbee.app.otaserver.ZclOtaUpgradeServer;
 import com.zsmartsystems.zigbee.database.ZigBeeEndpointDao;
 import com.zsmartsystems.zigbee.transaction.ZigBeeTransactionMatcher;
 import com.zsmartsystems.zigbee.zcl.ZclCluster;
@@ -32,6 +34,7 @@ import com.zsmartsystems.zigbee.zcl.clusters.ZclColorControlCluster;
 import com.zsmartsystems.zigbee.zcl.clusters.ZclCustomCluster;
 import com.zsmartsystems.zigbee.zcl.clusters.ZclDoorLockCluster;
 import com.zsmartsystems.zigbee.zcl.clusters.ZclLevelControlCluster;
+import com.zsmartsystems.zigbee.zcl.clusters.ZclOtaUpgradeCluster;
 import com.zsmartsystems.zigbee.zcl.clusters.ZclScenesCluster;
 import com.zsmartsystems.zigbee.zcl.clusters.general.DefaultResponse;
 import com.zsmartsystems.zigbee.zcl.clusters.general.ReportAttributesCommand;
@@ -268,6 +271,31 @@ public class ZigBeeEndpointTest {
         assertEquals(2, endpoint.getDeviceId());
         assertEquals(3, endpoint.getDeviceVersion());
         assertEquals(4, endpoint.getProfileId());
+    }
+
+    @Test
+    public void addApplication() {
+        ZigBeeEndpoint endpoint = getEndpoint();
+
+        ZclOtaUpgradeServer otaServer = (ZclOtaUpgradeServer) endpoint
+                .getApplication(ZclOtaUpgradeCluster.CLUSTER_ID);
+
+        assertNull(endpoint.getApplication(ZclOtaUpgradeCluster.CLUSTER_ID));
+
+        assertEquals(ZigBeeStatus.UNSUPPORTED, endpoint.addApplication(new ZclOtaUpgradeServer()));
+        assertNull(endpoint.getApplication(ZclOtaUpgradeCluster.CLUSTER_ID));
+
+        endpoint.addInputCluster(new ZclOtaUpgradeCluster(endpoint));
+        assertEquals(ZigBeeStatus.SUCCESS, endpoint.addApplication(new ZclOtaUpgradeServer()));
+
+        endpoint.addInputCluster(new ZclOtaUpgradeCluster(endpoint));
+        assertEquals(ZigBeeStatus.INVALID_STATE, endpoint.addApplication(new ZclOtaUpgradeServer()));
+
+        otaServer = (ZclOtaUpgradeServer) endpoint.getApplication(ZclOtaUpgradeCluster.CLUSTER_ID);
+        assertNotNull(otaServer);
+
+        endpoint.removeApplication(ZclOtaUpgradeCluster.CLUSTER_ID);
+        assertNull(endpoint.getApplication(ZclOtaUpgradeCluster.CLUSTER_ID));
     }
 
     private ZigBeeEndpoint getEndpoint() {


### PR DESCRIPTION
This ensures the cluster is available before starting the application.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>