### PR TITLE
Explicitly remove transactions from queue on shutdown

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransactionQueue.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransactionQueue.java
@@ -132,7 +132,11 @@ public class ZigBeeTransactionQueue {
         isShutdown = true;
 
         // Cancel any queued transactions
-        for (ZigBeeTransaction transaction : queue) {
+        while (!queue.isEmpty()) {
+            ZigBeeTransaction transaction = queue.poll();
+            if (transaction == null) {
+                break;
+            }
             transaction.cancel();
         }
 


### PR DESCRIPTION
This explicitly removes transactions from the queue when the queue is shutdown to avoid the possibility of an endless loop as seen in #1375.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>