### PR TITLE
Rework queue management for concurrency

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransactionManager.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransactionManager.java
@@ -399,15 +399,17 @@ public class ZigBeeTransactionManager implements ZigBeeNetworkNodeListener {
                 return defaultQueue;
             }
             // Add the transaction to the device queue - if it doesn't currently exist, create it
-            ZigBeeTransactionQueue queue = nodeQueue.get(node.getIeeeAddress());
-            if (queue == null && createIfNotExist) {
-                logger.debug("{}: Creating new Transaction Queue", node.getIeeeAddress());
-                queue = new ZigBeeTransactionQueue(node.getIeeeAddress().toString(), node.getIeeeAddress());
-                setQueueType(node, queue);
+            return nodeQueue.compute(node.getIeeeAddress(), (nodeAddress, queue) -> {
+                if (queue == null && createIfNotExist) {
+                    logger.debug("{}: Creating new Transaction Queue", node.getIeeeAddress());
+                    ZigBeeTransactionQueue createdQueue = new ZigBeeTransactionQueue(node.getIeeeAddress().toString(),
+                            node.getIeeeAddress());
+                    setQueueType(node, createdQueue);
 
-                nodeQueue.put(node.getIeeeAddress(), queue);
-            }
-            return queue;
+                    return createdQueue;
+                }
+                return queue;
+            });
         } else if (address instanceof ZigBeeEndpointAddress
                 && ZigBeeBroadcastDestination.isBroadcast(address.getAddress())) {
             return broadcastQueue;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransactionManager.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransactionManager.java
@@ -8,14 +8,14 @@
 package com.zsmartsystems.zigbee.transaction;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
@@ -65,7 +65,12 @@ import com.zsmartsystems.zigbee.zdo.field.NodeDescriptor.MacCapabilitiesType;
  * attempt to send the next transaction in order to keep the transport layer full, while also fulfilling the various
  * constraints in the queues.
  * <p>
- * When sending, queues are polled in random order to ensure that all queues get a fair chance at sending data.
+ * When sending, queues are polled in order. Order is kept by a queue of queues. This outer queue can have multiple
+ * entries of the same transaction queue. Every time the transaction manager is called to send a transaction, the 
+ * transaction will be a added to a respective transaction queue which will be added to the outer queue.
+ * Every time a transaction queue is polled from the outer queue only one single transaction is attempted to be sent.
+ * If no transaction is retrieved from the transaction queue (e.g. due to inter-transaction delays) the transaction is
+ * added back to the outer queue.
  *
  * @author Chris Jackson
  *
@@ -153,9 +158,9 @@ public class ZigBeeTransactionManager implements ZigBeeNetworkNodeListener {
     private final AtomicInteger transactionIdCounter = new AtomicInteger();
 
     /**
-     * A List of queues with outstanding commands. This is used for random access when sending transactions.
+     * A Queue of queues with outstanding commands. This is used for ordered access when sending transactions.
      */
-    private final List<ZigBeeTransactionQueue> outstandingQueues = new CopyOnWriteArrayList<>();
+    private final Queue<ZigBeeTransactionQueue> outstandingQueues = new ConcurrentLinkedQueue<>();
 
     private final ZigBeeTransactionQueue defaultQueue;
     private final ZigBeeTransactionQueue broadcastQueue;
@@ -366,7 +371,8 @@ public class ZigBeeTransactionManager implements ZigBeeNetworkNodeListener {
         }
 
         queue.addToQueue(transaction);
-        if (!queue.isEmpty() && !outstandingQueues.contains(queue)) {
+        if (!queue.isEmpty()) {
+            // always add since only one transaction is processed from one add
             outstandingQueues.add(queue);
         }
 
@@ -618,14 +624,14 @@ public class ZigBeeTransactionManager implements ZigBeeNetworkNodeListener {
             }
         }
         nodeQueue.remove(address);
-        outstandingQueues.remove(queue);
     }
 
     /**
      * Polls the queues to send outstanding transactions. This will send as many transactions as necessary, or available
      * within the constraints that have been set (e.g. the maxOutstandingTransactions).
      * <p>
-     * The order of transmission from each queue is randomised to ensure a fair ordering of transactions to each device.
+     * The transaction queues are processed in order so that overall order is kept expect when transmission is delayed
+     * (e.g. due to inter-transaction delays).
      * If a queue returns null, then it does not have transactions to send at that time and we let the timer take care
      * of rescheduling the transmission.
      */
@@ -639,7 +645,7 @@ public class ZigBeeTransactionManager implements ZigBeeNetworkNodeListener {
 
             ZigBeeTransaction transaction;
 
-            // Randomly loop through all queues, taking a transaction from each one in turn
+            // Loop through all queues, taking a transaction from each one in turn
             // If we have more transactions outstanding than we're allowed, then exit
             // If we get through an iteration of all queues without sending anything, then exit
             //
@@ -647,19 +653,22 @@ public class ZigBeeTransactionManager implements ZigBeeNetworkNodeListener {
             // * Queues may have more than one transaction to send
             // * Queues may have transactions to send, but be unable to send them at this time
 
-            List<ZigBeeTransactionQueue> emptyQueues = new ArrayList<>();
+            List<ZigBeeTransactionQueue> sleepyOrDelayedQueues = new ArrayList<>();
+
             boolean sendDone;
             do {
                 // Exit unless we send at least one transaction
                 sendDone = true;
 
-                // Randomise the lists
-                Collections.shuffle(outstandingQueues);
+                // ensure we start with a clean list for this iteration
+                sleepyOrDelayedQueues.clear();
 
-                // Clear the list of queues that have been emptied
-                emptyQueues.clear();
+                while (!outstandingQueues.isEmpty()) {
+                    ZigBeeTransactionQueue queue = outstandingQueues.poll();
+                    if (queue == null) {
+                        continue;
+                    }
 
-                for (ZigBeeTransactionQueue queue : outstandingQueues) {
                     // Check if we've reached the maximum number of commands we can send
                     if (outstandingTransactions.size() >= maxOutstandingTransactions) {
                         sendDone = true;
@@ -668,6 +677,7 @@ public class ZigBeeTransactionManager implements ZigBeeNetworkNodeListener {
 
                     // If this is a sleepy queue, and we've exceeded the sleepy transmissions, then ignore the queue
                     if (queue.isSleepy() && sleepyTransactions >= maxSleepyTransactions) {
+                        sleepyOrDelayedQueues.add(queue);
                         continue;
                     }
 
@@ -681,16 +691,14 @@ public class ZigBeeTransactionManager implements ZigBeeNetworkNodeListener {
                         // Send the transaction.
                         send(transaction);
                         sendDone = false;
-                    }
-
-                    // If the queue has no more transactions,
-                    // remove it from the list of queues with outstanding transactions.
-                    if (queue.isEmpty()) {
-                        emptyQueues.add(queue);
+                    } else {
+                        sleepyOrDelayedQueues.add(queue);
                     }
                 }
 
-                outstandingQueues.removeAll(emptyQueues);
+                // re-add sleepy or delayed queues (in order)
+                outstandingQueues.addAll(sleepyOrDelayedQueues);
+
             } while (!sendDone);
 
             // Loop through all outstanding queues and find the next release time

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransactionManagerTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/transaction/ZigBeeTransactionManagerTest.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -326,7 +327,7 @@ public class ZigBeeTransactionManagerTest {
         nodeQueue.put(new IeeeAddress("2222222222222222"), queue2);
         nodeQueue.put(new IeeeAddress("3333333333333333"), queue3);
 
-        List<ZigBeeTransactionQueue> outstandingQueues = new ArrayList<>();
+        Queue<ZigBeeTransactionQueue> outstandingQueues = new ConcurrentLinkedQueue<>();
         outstandingQueues.add(queue1);
         outstandingQueues.add(queue2);
         outstandingQueues.add(queue3);


### PR DESCRIPTION
Changes the transaction queue handling for hopefully better concurrency.
Instead of iteration over transaction queues, each with their own order, there is now a queue of queues.
Each time a transaction is submitted for sending, its queue is added to the main queue resulting into an ordered sequence of transactions, indirectly represented by the queued transaction queues.
For each entry in the main queue only one transaction is processed. Sleepy queues and queues with a release time in the future will be readded to the main queue.

This should fix #1363 and #1291.
