### PR TITLE
Make ZigBeeDongleTelegesis return NO_NETWORK when NoPAN

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.telegesis/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/ZigBeeDongleTelegesis.java
+++ b/com.zsmartsystems.zigbee.dongle.telegesis/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/ZigBeeDongleTelegesis.java
@@ -493,6 +493,11 @@ public class ZigBeeDongleTelegesis
         if (frameHandler.sendRequest(networkInfo) == null || networkInfo.getStatus() != TelegesisStatusCode.SUCCESS) {
             return ZigBeeStatus.BAD_RESPONSE;
         }
+        if (networkInfo.getDevice() == TelegesisDeviceType.NOPAN) {
+            logger.debug("Telegesis network information is {}. Returning status {}.", TelegesisDeviceType.NOPAN,
+                    ZigBeeStatus.NO_NETWORK);
+            return ZigBeeStatus.NO_NETWORK;
+        }
         if (networkInfo.getDevice() != TelegesisDeviceType.COO) {
             return ZigBeeStatus.INVALID_STATE;
         }


### PR DESCRIPTION
This PR makes ZigBeeDongleTelegesis return `ZigBeeStatus.NO_NETWORK` when the result of the "Display Product Identification" command is `NoPAN`.

Closes #1382 