### PR TITLE
Remove animal-sniffer on some projects

### DIFF
--- a/com.zsmartsystems.zigbee.autocode/pom.xml
+++ b/com.zsmartsystems.zigbee.autocode/pom.xml
@@ -1,32 +1,34 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.zsmartsystems.zigbee</groupId>
-    <artifactId>com.zsmartsystems.zigbee.autocode</artifactId>
-    <packaging>jar</packaging>
+	<groupId>com.zsmartsystems.zigbee</groupId>
+	<artifactId>com.zsmartsystems.zigbee.autocode</artifactId>
+	<packaging>jar</packaging>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.main.skip>true</maven.main.skip>
-    </properties>
-    
-    <parent>
-        <groupId>com.zsmartsystems</groupId>
-        <artifactId>zigbee</artifactId>
-        <version>1.4.12-SNAPSHOT</version>
-    </parent>
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+		<maven.main.skip>true</maven.main.skip>
+	</properties>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <version>2.5</version>
-            </plugin>
- 
-           	<plugin>
+	<parent>
+		<groupId>com.zsmartsystems</groupId>
+		<artifactId>zigbee</artifactId>
+		<version>1.4.12-SNAPSHOT</version>
+	</parent>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<version>2.5</version>
+			</plugin>
+
+			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-source-plugin</artifactId>
 				<executions>
@@ -42,19 +44,14 @@
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>animal-sniffer-maven-plugin</artifactId>
 				<configuration>
+					<skip>true</skip>
 				</configuration>
-				<executions>
-					<execution>
-						<id>animal-sniffer</id>
-						<phase />
-					</execution>
-				</executions>
 			</plugin>
-        </plugins>
-    </build>
+		</plugins>
+	</build>
 
-    <dependencies>
+	<dependencies>
 
-    </dependencies>
+	</dependencies>
 
 </project>

--- a/com.zsmartsystems.zigbee.console.main/pom.xml
+++ b/com.zsmartsystems.zigbee.console.main/pom.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>com.zsmartsystems.zigbee</groupId>
@@ -119,7 +121,8 @@
 						<manifest>
 							<addClasspath>true</addClasspath>
 							<classpathPrefix>lib/</classpathPrefix>
-							<mainClass>com.zsmartsystems.zigbee.console.main.ZigBeeConsoleMain</mainClass>
+							<mainClass>
+								com.zsmartsystems.zigbee.console.main.ZigBeeConsoleMain</mainClass>
 						</manifest>
 					</archive>
 				</configuration>
@@ -131,7 +134,8 @@
 						<manifest>
 							<addClasspath>true</addClasspath>
 							<classpathPrefix>lib/</classpathPrefix>
-							<mainClass>com.zsmartsystems.zigbee.console.main.ZigBeeConsoleMain</mainClass>
+							<mainClass>
+								com.zsmartsystems.zigbee.console.main.ZigBeeConsoleMain</mainClass>
 						</manifest>
 					</archive>
 					<descriptorRefs>
@@ -152,13 +156,8 @@
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>animal-sniffer-maven-plugin</artifactId>
 				<configuration>
+					<skip>true</skip>
 				</configuration>
-				<executions>
-					<execution>
-						<id>animal-sniffer</id>
-						<phase />
-					</execution>
-				</executions>
 			</plugin>
 		</plugins>
 	</build>

--- a/com.zsmartsystems.zigbee.console/pom.xml
+++ b/com.zsmartsystems.zigbee.console/pom.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>com.zsmartsystems.zigbee</groupId>
@@ -40,13 +42,8 @@
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>animal-sniffer-maven-plugin</artifactId>
 				<configuration>
+					<skip>true</skip>
 				</configuration>
-				<executions>
-					<execution>
-						<id>animal-sniffer</id>
-						<phase />
-					</execution>
-				</executions>
 			</plugin>
 		</plugins>
 	</build>


### PR DESCRIPTION
Animal sniffer is not applicable on some projects - ie those that are not compatible with Android. Typically this are the console application, and the autocode generators.

Closes #1390