### PR TITLE
Integrate Error Prone for static code analysis

### DIFF
--- a/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleOtaUpgradeCommand.java
+++ b/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleOtaUpgradeCommand.java
@@ -133,10 +133,16 @@ public class ZigBeeConsoleOtaUpgradeCommand extends ZigBeeConsoleAbstractCommand
 
     private void cmdDisplayNode(ZigBeeEndpoint endpoint, ZclOtaUpgradeServer otaServer, PrintStream out) {
         Object fileVersion = otaServer.getCurrentFileVersion();
+        String fileVersionAsStr;
+        if (fileVersion instanceof Integer) {
+            fileVersionAsStr = String.format("%08X", ((Integer) fileVersion).intValue());
+        } else {
+            fileVersionAsStr = "Unknown";
+        }
 
         out.println("OTA Upgrade configuration for " + endpoint.getEndpointAddress());
         out.println("Current state    : " + otaServer.getServerStatus());
-        out.println("Firmware Version : " + (fileVersion == null ? "Unknown" : String.format("%08X", fileVersion)));
+        out.println("Firmware Version : " + fileVersionAsStr);
     }
 
     private Map<Integer, ZigBeeEndpoint> getApplications(ZigBeeNetworkManager networkManager, int clusterId) {

--- a/com.zsmartsystems.zigbee.dongle.cc2531/src/main/java/com/zsmartsystems/zigbee/dongle/cc2531/network/impl/CommandInterfaceImpl.java
+++ b/com.zsmartsystems.zigbee.dongle.cc2531/src/main/java/com/zsmartsystems/zigbee/dongle/cc2531/network/impl/CommandInterfaceImpl.java
@@ -242,7 +242,7 @@ public class CommandInterfaceImpl implements ZToolPacketHandler, CommandInterfac
         if (supportMultipleSynchrounsCommand) {
             synchronized (synchronousCommandListeners) {
                 final short id = (short) (cmdId.get16BitValue() & 0x1FFF);
-                while (synchronousCommandListeners.get(cmdId) != null) {
+                while (synchronousCommandListeners.get(id) != null) {
                     try {
                         logger.trace("Waiting for other request {} to complete", id);
                         synchronousCommandListeners.wait(500);

--- a/com.zsmartsystems.zigbee.dongle.cc2531/src/main/java/com/zsmartsystems/zigbee/dongle/cc2531/zigbee/util/ZToolAddress64.java
+++ b/com.zsmartsystems.zigbee.dongle.cc2531/src/main/java/com/zsmartsystems/zigbee/dongle/cc2531/zigbee/util/ZToolAddress64.java
@@ -33,7 +33,6 @@
 package com.zsmartsystems.zigbee.dongle.cc2531.zigbee.util;
 
 import java.util.Arrays;
-import java.util.Objects;
 
 /**
  * Big Endian container for 64-bit XBee Address
@@ -78,7 +77,7 @@ public class ZToolAddress64 extends ZToolAddress {
 
     @Override
     public int hashCode() {
-        return Objects.hash(address);
+        return Arrays.hashCode(address);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/groups/ZigBeeGroup.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/groups/ZigBeeGroup.java
@@ -38,7 +38,7 @@ import com.zsmartsystems.zigbee.zcl.clusters.groups.RemoveGroupResponse;
  *
  * @author Chris Jackson
  */
-public class ZigBeeGroup implements Comparable<Object> {
+public class ZigBeeGroup implements Comparable<ZigBeeGroup> {
     static final int MAX_LABEL_LENGTH = 16;
 
     static final int GROUP_ID_MIN = 0x0000;
@@ -365,7 +365,7 @@ public class ZigBeeGroup implements Comparable<Object> {
     }
 
     @Override
-    public int compareTo(Object that) {
+    public int compareTo(ZigBeeGroup that) {
         if (this == that) {
             return 0;
         }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/field/ZclArrayList.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/field/ZclArrayList.java
@@ -144,12 +144,12 @@ public class ZclArrayList implements List<Object> {
 
     @Override
     public Object remove(int index) {
-        return remove(index);
+        return list.remove(index);
     }
 
     @Override
     public int indexOf(Object o) {
-        return indexOf(o);
+        return list.indexOf(o);
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -39,11 +39,14 @@
 
 	<properties>
 		<license.year>2023</license.year>
+		<source.version>1.8</source.version>
+		<target.version>1.8</target.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<slf4j.version>1.7.30</slf4j.version>
 		<log4j.version>1.2.17</log4j.version>
 		<animal.sniffer.version>1.23</animal.sniffer.version>
+		<error-prone.version>2.10.0</error-prone.version>
 	</properties>
 
 	<scm>
@@ -126,6 +129,11 @@
 						</signature>
 					</configuration>
 				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-compiler-plugin</artifactId>
+					<version>3.8.0</version>
+				</plugin>
 			</plugins>
 		</pluginManagement>
 
@@ -133,10 +141,9 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.8.0</version>
 				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
+					<source>${source.version}</source>
+					<target>${target.version}</target>
 					<compilerArgs>-Xpkginfo:always</compilerArgs>
 				</configuration>
 			</plugin>
@@ -341,6 +348,49 @@
 								</goals>
 							</execution>
 						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		<profile>
+			<!--
+			This profile can either be selected explicitly:
+			  mvn -P error-prone-check clean compile
+			or implicitly by injecting a JDK in the version range [11,16)
+			  JAVA_HOME=/Library/Java/JavaVirtualMachines/adoptopenjdk-11.jdk/Contents/Home mvn clean compile
+			-->
+			<id>error-prone-check</id>
+			<activation>
+				<!-- ErrorProne requires at least version 11 due to compiler hooks
+				and starts to require additional flags with version 16... -->
+				<jdk>[11,16)</jdk>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-compiler-plugin</artifactId>
+						<configuration combine.self="override">
+							<source>${source.version}</source>
+							<target>${target.version}</target>
+							<encoding>${project.build.sourceEncoding}</encoding>
+							<compilerArgs>
+								<arg>-XDcompilePolicy=simple</arg>
+								<arg>-Xplugin:ErrorProne</arg>
+							</compilerArgs>
+							<forceJavacCompilerUse>true</forceJavacCompilerUse>
+							<annotationProcessorPaths>
+								<path>
+									<groupId>com.google.errorprone</groupId>
+									<artifactId>error_prone_core</artifactId>
+									<version>${error-prone.version}</version>
+								</path>
+								<!-- Other annotation processors go here.
+								If 'annotationProcessorPaths' is set, processors will no longer be 
+								discovered on the regular -classpath; see also 'Using Error Prone
+								together with other annotation processors' below. -->
+							</annotationProcessorPaths>
+						</configuration>
 					</plugin>
 				</plugins>
 			</build>


### PR DESCRIPTION
[Error Prone](https://errorprone.info/) provides compile time static code analysis.
It requires at least JDK 11 since it makes use of some compiler hooks which are only available starting with JDK 11.
The setup allows usage of a JDK up to version 15 (version 16 and higher require addtional configuration).

This change does NOT change the default compilation source and target.
To avoid any interference between code analysis and production code, there is a special profile enabling code analysis.

This profile can either be selected explicitly:
```sh
mvn -P error-prone-check clean compile
```

or implicitly by injecting a JDK in the version range [11,16)
```sh
JAVA_HOME=/Library/Java/JavaVirtualMachines/adoptopenjdk-11.jdk/Contents/Home mvn clean compile
```