### PR TITLE
Fix warnings for rawtypes

### DIFF
--- a/com.zsmartsystems.zigbee.console.main/src/main/java/com/zsmartsystems/zigbee/console/main/IeeeAddressConverter.java
+++ b/com.zsmartsystems.zigbee.console.main/src/main/java/com/zsmartsystems/zigbee/console/main/IeeeAddressConverter.java
@@ -22,7 +22,7 @@ import com.zsmartsystems.zigbee.IeeeAddress;
  */
 public class IeeeAddressConverter implements Converter {
     @Override
-    public boolean canConvert(Class clazz) {
+    public boolean canConvert(@SuppressWarnings("rawtypes") Class clazz) {
         return clazz.equals(IeeeAddress.class);
     }
 

--- a/com.zsmartsystems.zigbee.console.main/src/main/java/com/zsmartsystems/zigbee/console/main/KeyArrayConverter.java
+++ b/com.zsmartsystems.zigbee.console.main/src/main/java/com/zsmartsystems/zigbee/console/main/KeyArrayConverter.java
@@ -22,7 +22,7 @@ import com.zsmartsystems.zigbee.security.ZigBeeKey;
  */
 public class KeyArrayConverter implements Converter {
     @Override
-    public boolean canConvert(Class clazz) {
+    public boolean canConvert(@SuppressWarnings("rawtypes") Class clazz) {
         return clazz.equals(int[].class);
     }
 

--- a/com.zsmartsystems.zigbee.console.main/src/main/java/com/zsmartsystems/zigbee/console/main/ZigBeeConsole.java
+++ b/com.zsmartsystems.zigbee.console.main/src/main/java/com/zsmartsystems/zigbee/console/main/ZigBeeConsole.java
@@ -1342,7 +1342,7 @@ public final class ZigBeeConsole {
      * @return the {@link Object} containing the field value
      * @throws Exception
      */
-    private Object getField(Class clazz, Object object, String fieldName) throws Exception {
+    private Object getField(Class<?> clazz, Object object, String fieldName) throws Exception {
         Field field = clazz.getDeclaredField(fieldName);
         field.setAccessible(true);
         Field modifiersField = Field.class.getDeclaredField("modifiers");

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/TestUtilities.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/TestUtilities.java
@@ -29,7 +29,7 @@ public class TestUtilities {
      * @param newValue the Object to be set
      * @throws Exception
      */
-    public static void setField(Class clazz, Object object, String fieldName, Object newValue) throws Exception {
+    public static void setField(Class<?> clazz, Object object, String fieldName, Object newValue) throws Exception {
         Field field = clazz.getDeclaredField(fieldName);
         field.setAccessible(true);
         Field modifiersField = Field.class.getDeclaredField("modifiers");
@@ -52,7 +52,7 @@ public class TestUtilities {
      * @throws IllegalArgumentException
      * @throws InvocationTargetException
      */
-    public static Object invokeMethod(Class clazz, Object object, String methodName, Object... params)
+    public static Object invokeMethod(Class<?> clazz, Object object, String methodName, Object... params)
             throws NoSuchMethodException, SecurityException, IllegalAccessException, IllegalArgumentException,
             InvocationTargetException {
         int paramCount = params.length;
@@ -60,7 +60,7 @@ public class TestUtilities {
         Class<?>[] classArray = new Class<?>[paramCount / 2];
         Object[] paramArray = new Object[paramCount / 2];
         for (int i = 0; i < paramCount; i += 2) {
-            classArray[i] = (Class) params[i];
+            classArray[i] = (Class<?>) params[i];
             paramArray[i] = params[i + 1];
         }
         method = clazz.getDeclaredMethod(methodName, classArray);
@@ -77,7 +77,7 @@ public class TestUtilities {
      * @return the {@link Object} containing the field value
      * @throws Exception
      */
-    public static Object getField(Class clazz, Object object, String fieldName) throws Exception {
+    public static Object getField(Class<?> clazz, Object object, String fieldName) throws Exception {
         Field field = clazz.getDeclaredField(fieldName);
         field.setAccessible(true);
         Field modifiersField = Field.class.getDeclaredField("modifiers");

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeNetworkManagerTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeNetworkManagerTest.java
@@ -1377,7 +1377,7 @@ public class ZigBeeNetworkManagerTest
         }
     }
 
-    private Object convertData(String data, Class clazz) {
+    private Object convertData(String data, Class<?> clazz) {
         return null;
     }
 


### PR DESCRIPTION
Some rawtype usages are induced by method signatures of external APIs (XStream) and are suppressed as the cannot be avoided. Other occurences were fixed.
