### PR TITLE
Fix missing line break when outputting in class generators

### DIFF
--- a/com.zsmartsystems.zigbee.autocode/src/main/java/com/zsmartsystems/zigbee/autocode/ZigBeeBaseClassGenerator.java
+++ b/com.zsmartsystems.zigbee.autocode/src/main/java/com/zsmartsystems/zigbee/autocode/ZigBeeBaseClassGenerator.java
@@ -286,9 +286,8 @@ public abstract class ZigBeeBaseClassGenerator {
                 len += word.length();
             }
 
-            if (len != 2 + indent.length()) {
-                out.println();
-            }
+            // loop or skipping loop doesn't end line so we do
+            out.println();
         }
     }
 

--- a/com.zsmartsystems.zigbee.dongle.ember.autocode/src/main/java/com/zsmartsystems/zigbee/dongle/ember/autocode/ClassGenerator.java
+++ b/com.zsmartsystems.zigbee.dongle.ember.autocode/src/main/java/com/zsmartsystems/zigbee/dongle/ember/autocode/ClassGenerator.java
@@ -211,9 +211,8 @@ public abstract class ClassGenerator {
             len += word.length();
         }
 
-        if (len != 2) {
-            out.println();
-        }
+        // loop or skipping loop doesn't end line so we do
+        out.println();
     }
 
     protected String formatParameterString(Parameter parameter) {

--- a/com.zsmartsystems.zigbee.dongle.telegesis.autocode/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/autocode/ClassGenerator.java
+++ b/com.zsmartsystems.zigbee.dongle.telegesis.autocode/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/autocode/ClassGenerator.java
@@ -174,9 +174,8 @@ public abstract class ClassGenerator {
             len += word.length();
         }
 
-        if (len != 2) {
-            out.println();
-        }
+        // loop or skipping loop doesn't end line so we do
+        out.println();
     }
 
     protected String formatParameterString(Parameter parameter) {

--- a/com.zsmartsystems.zigbee.dongle.xbee.autocode/src/main/java/com/zsmartsystems/zigbee/dongle/xbee/autocode/ClassGenerator.java
+++ b/com.zsmartsystems.zigbee.dongle.xbee.autocode/src/main/java/com/zsmartsystems/zigbee/dongle/xbee/autocode/ClassGenerator.java
@@ -171,9 +171,8 @@ public abstract class ClassGenerator {
             len += word.length();
         }
 
-        if (len != 2) {
-            out.println();
-        }
+        // loop or skipping loop doesn't end line so we do
+        out.println();
     }
 
     protected String formatParameterString(Parameter parameter) {


### PR DESCRIPTION
Fixes the method `outputWithLinebreak` which doesn't output line breaks in some cases.