### PR TITLE
Add type inference to avoid warnings due to explicit casting

### DIFF
--- a/com.zsmartsystems.zigbee.autocode/src/main/java/com/zsmartsystems/zigbee/autocode/ZigBeeBaseFieldGenerator.java
+++ b/com.zsmartsystems.zigbee.autocode/src/main/java/com/zsmartsystems/zigbee/autocode/ZigBeeBaseFieldGenerator.java
@@ -164,8 +164,8 @@ public class ZigBeeBaseFieldGenerator extends ZigBeeBaseClassGenerator {
                 }
                 if (getAutoSized(fields, stringToLowerCamelCase(field.name)) != null) {
                     out.println(
-                            "        Integer " + stringToLowerCamelCase(field.name) + " = (" + getDataTypeClass(field)
-                                    + ") deserializer.deserialize(" + "ZclDataType." + field.type + ");");
+                            "        Integer " + stringToLowerCamelCase(field.name) + " = deserializer.deserialize(" +
+                            "ZclDataType." + field.type + ");");
                     continue;
                 }
 
@@ -175,8 +175,8 @@ public class ZigBeeBaseFieldGenerator extends ZigBeeBaseClassGenerator {
 
                     out.println("        if (" + field.sizer + " != null) {");
                     out.println("            for (int cnt = 0; cnt < " + field.sizer + "; cnt++) {");
-                    out.println("                " + stringToLowerCamelCase(field.name) + ".add((" + dataType
-                            + ") deserializer.deserialize(" + "ZclDataType." + field.type + "));");
+                    out.println("                " + stringToLowerCamelCase(field.name) +
+                            ".add(deserializer.deserialize(" + "ZclDataType." + field.type + "));");
                     out.println("            }");
                     out.println("        }");
                 } else if (field.condition != null) {
@@ -185,7 +185,7 @@ public class ZigBeeBaseFieldGenerator extends ZigBeeBaseClassGenerator {
                         // This checks for a single response
                         out.println("        if (deserializer.getRemainingLength() == 1) {");
                         out.println(
-                                "            status = (ZclStatus) deserializer.deserialize(ZclDataType.ZCL_STATUS);");
+                                "            status = deserializer.deserialize(ZclDataType.ZCL_STATUS);");
                         out.println("            return;");
                         out.println("        }");
                         continue;
@@ -196,13 +196,13 @@ public class ZigBeeBaseFieldGenerator extends ZigBeeBaseClassGenerator {
                         out.println("        if (" + field.condition.field + " " + getOperator(field.condition.operator)
                                 + " " + field.condition.value + ") {");
                     }
-                    out.println("            " + stringToLowerCamelCase(field.name) + " = (" + getDataTypeClass(field)
-                            + ") deserializer.deserialize(" + "ZclDataType." + field.type + ");");
+                    out.println("            " + stringToLowerCamelCase(field.name) + " = deserializer.deserialize(" + 
+                                "ZclDataType." + field.type + ");");
                     out.println("        }");
                 } else {
                     if (!field.type.isEmpty()) {
-                        out.println("        " + stringToLowerCamelCase(field.name) + " = (" + getDataTypeClass(field)
-                                + ") deserializer.deserialize(" + "ZclDataType." + field.type + ");");
+                        out.println("        " + stringToLowerCamelCase(field.name) + " = deserializer.deserialize(" +
+                                "ZclDataType." + field.type + ");");
                     } else {
                         out.println("        " + stringToLowerCamelCase(field.name) + " = new "
                                 + getDataTypeClass(field) + "();");

--- a/com.zsmartsystems.zigbee.autocode/src/main/java/com/zsmartsystems/zigbee/autocode/ZigBeeZclSceneGenerator.java
+++ b/com.zsmartsystems.zigbee.autocode/src/main/java/com/zsmartsystems/zigbee/autocode/ZigBeeZclSceneGenerator.java
@@ -183,15 +183,15 @@ public class ZigBeeZclSceneGenerator extends ZigBeeBaseClassGenerator {
         out.println();
         out.println("    @Override");
         out.println("    public void deserialize(final ZigBeeDeserializer deserializer) {");
-        out.println("        clusterId = (int) deserializer.readZigBeeType(ZclDataType.UNSIGNED_16_BIT_INTEGER);");
-        out.println("        int size = (int) deserializer.readZigBeeType(ZclDataType.UNSIGNED_8_BIT_INTEGER);");
+        out.println("        clusterId = deserializer.readZigBeeType(ZclDataType.UNSIGNED_16_BIT_INTEGER);");
+        out.println("        int size = deserializer.readZigBeeType(ZclDataType.UNSIGNED_8_BIT_INTEGER);");
         for (final String attributeName : cluster.scenes.extensionField.attributes) {
             ZigBeeXmlAttribute attribute = getSceneAttribute(cluster, attributeName);
 
             length += ZclDataType.getDataTypeMapping().get(attribute.type).length;
             out.println("        if (size >= " + length + ") {");
-            out.println("            " + stringToLowerCamelCase(attribute.name) + " = (" + getDataTypeClass(attribute)
-                    + ") deserializer.readZigBeeType(ZclDataType." + attribute.type + ");");
+            out.println("            " + stringToLowerCamelCase(attribute.name) +
+                    " = deserializer.readZigBeeType(ZclDataType." + attribute.type + ");");
             out.println("        }");
         }
         out.println("    }");

--- a/com.zsmartsystems.zigbee.autocode/src/main/java/com/zsmartsystems/zigbee/autocode/xml/ZigBeeXmlParser.java
+++ b/com.zsmartsystems.zigbee.autocode/src/main/java/com/zsmartsystems/zigbee/autocode/xml/ZigBeeXmlParser.java
@@ -51,7 +51,7 @@ public class ZigBeeXmlParser {
 
                 // Get all cluster specific definitions
                 NodeList nList = doc.getElementsByTagName("cluster");
-                ZigBeeXmlCluster cluster = (ZigBeeXmlCluster) processNode(nList.item(0));
+                ZigBeeXmlCluster cluster = processNode(nList.item(0));
                 clusters.add(cluster);
             }
         } catch (Exception e) {
@@ -78,7 +78,7 @@ public class ZigBeeXmlParser {
 
                 // Get all global specific definitions
                 NodeList nList = doc.getElementsByTagName("zigbee");
-                ZigBeeXmlGlobal global = (ZigBeeXmlGlobal) processNode(nList.item(0));
+                ZigBeeXmlGlobal global = processNode(nList.item(0));
                 globals.constants.addAll(global.constants);
             }
         } catch (Exception e) {
@@ -89,7 +89,7 @@ public class ZigBeeXmlParser {
         return globals;
     }
 
-    Object processNode(Node node) {
+    <R> R processNode(Node node) {
         NodeList nodes = node.getChildNodes();
         Element e;
 
@@ -99,11 +99,14 @@ public class ZigBeeXmlParser {
                 global.constants = new ArrayList<>();
                 for (int temp = 0; temp < nodes.getLength(); temp++) {
                     if (nodes.item(temp).getNodeName().equals("constant")) {
-                        global.constants.add((ZigBeeXmlConstant) processNode(nodes.item(temp)));
+                        global.constants.add(processNode(nodes.item(temp)));
                     }
                 }
                 System.out.println("Done: Global");
-                return global;
+
+                @SuppressWarnings("unchecked")
+                R globalResult = (R) global;
+                return globalResult;
 
             case "cluster":
                 ZigBeeXmlCluster cluster = new ZigBeeXmlCluster();
@@ -122,29 +125,31 @@ public class ZigBeeXmlParser {
                         cluster.name = nodes.item(temp).getTextContent().trim();
                     }
                     if (nodes.item(temp).getNodeName().equals("description")) {
-                        ZigBeeXmlDescription description = (ZigBeeXmlDescription) processNode(nodes.item(temp));
+                        ZigBeeXmlDescription description = processNode(nodes.item(temp));
                         if (description != null) {
                             cluster.description.add(description);
                         }
                     }
                     if (nodes.item(temp).getNodeName().equals("command")) {
-                        cluster.commands.add((ZigBeeXmlCommand) processNode(nodes.item(temp)));
+                        cluster.commands.add(processNode(nodes.item(temp)));
                     }
                     if (nodes.item(temp).getNodeName().equals("attribute")) {
-                        cluster.attributes.add((ZigBeeXmlAttribute) processNode(nodes.item(temp)));
+                        cluster.attributes.add(processNode(nodes.item(temp)));
                     }
                     if (nodes.item(temp).getNodeName().equals("constant")) {
-                        cluster.constants.add((ZigBeeXmlConstant) processNode(nodes.item(temp)));
+                        cluster.constants.add(processNode(nodes.item(temp)));
                     }
                     if (nodes.item(temp).getNodeName().equals("struct")) {
-                        cluster.structures.add((ZigBeeXmlStructure) processNode(nodes.item(temp)));
+                        cluster.structures.add(processNode(nodes.item(temp)));
                     }
                     if (nodes.item(temp).getNodeName().equals("scenes")) {
-                        cluster.scenes = (ZigBeeXmlScenes) processNode(nodes.item(temp));
+                        cluster.scenes = processNode(nodes.item(temp));
                     }
                 }
                 System.out.println("Done: Cluster - " + cluster.name);
-                return cluster;
+                @SuppressWarnings("unchecked")
+                R clusterResult = (R) cluster;
+                return clusterResult;
 
             case "attribute":
                 ZigBeeXmlAttribute attribute = new ZigBeeXmlAttribute();
@@ -177,14 +182,16 @@ public class ZigBeeXmlParser {
                         attribute.name = nodes.item(temp).getTextContent().trim();
                     }
                     if (nodes.item(temp).getNodeName().equals("description")) {
-                        ZigBeeXmlDescription description = (ZigBeeXmlDescription) processNode(nodes.item(temp));
+                        ZigBeeXmlDescription description = processNode(nodes.item(temp));
                         if (description != null) {
                             attribute.description.add(description);
                         }
                     }
                 }
 
-                return attribute;
+                @SuppressWarnings("unchecked")
+                R attributeResult = (R) attribute;
+                return attributeResult;
 
             case "command":
                 ZigBeeXmlCommand command = new ZigBeeXmlCommand();
@@ -202,20 +209,22 @@ public class ZigBeeXmlParser {
                         command.name = nodes.item(temp).getTextContent().trim();
                     }
                     if (nodes.item(temp).getNodeName().equals("description")) {
-                        ZigBeeXmlDescription description = (ZigBeeXmlDescription) processNode(nodes.item(temp));
+                        ZigBeeXmlDescription description = processNode(nodes.item(temp));
                         if (description != null) {
                             command.description.add(description);
                         }
                     }
                     if (nodes.item(temp).getNodeName().equals("field")) {
-                        command.fields.add((ZigBeeXmlField) processNode(nodes.item(temp)));
+                        command.fields.add(processNode(nodes.item(temp)));
                     }
                     if (nodes.item(temp).getNodeName().equals("response")) {
-                        command.response = (ZigBeeXmlResponse) processNode(nodes.item(temp));
+                        command.response = processNode(nodes.item(temp));
                     }
                 }
                 System.out.println("Done: Command - " + command.name);
-                return command;
+                @SuppressWarnings("unchecked")
+                R commandResult = (R) command;
+                return commandResult;
 
             case "field":
                 ZigBeeXmlField field = new ZigBeeXmlField();
@@ -239,20 +248,22 @@ public class ZigBeeXmlParser {
                         field.sizer = nodes.item(temp).getTextContent().trim();
                     }
                     if (nodes.item(temp).getNodeName().equals("description")) {
-                        ZigBeeXmlDescription description = (ZigBeeXmlDescription) processNode(nodes.item(temp));
+                        ZigBeeXmlDescription description = processNode(nodes.item(temp));
                         if (description != null) {
                             field.description.add(description);
                         }
                     }
                     if (nodes.item(temp).getNodeName().equals("conditional")) {
-                        field.condition = (ZigBeeXmlCondition) processNode(nodes.item(temp));
+                        field.condition = processNode(nodes.item(temp));
                     }
                     if (nodes.item(temp).getNodeName().equals("format")) {
                         field.format = nodes.item(temp).getTextContent().trim();
                     }
                 }
                 System.out.println("Done: Field - " + field.name);
-                return field;
+                @SuppressWarnings("unchecked")
+                R fieldResult = (R) field;
+                return fieldResult;
 
             case "constant":
                 ZigBeeXmlConstant constant = new ZigBeeXmlConstant();
@@ -269,7 +280,7 @@ public class ZigBeeXmlParser {
                         constant.name = nodes.item(temp).getTextContent().trim();
                     }
                     if (nodes.item(temp).getNodeName().equals("description")) {
-                        ZigBeeXmlDescription description = (ZigBeeXmlDescription) processNode(nodes.item(temp));
+                        ZigBeeXmlDescription description = processNode(nodes.item(temp));
                         if (description != null) {
                             constant.description.add(description);
                         }
@@ -284,7 +295,9 @@ public class ZigBeeXmlParser {
                     }
                 }
 
-                return constant;
+                @SuppressWarnings("unchecked")
+                R constantResult = (R) constant;
+                return constantResult;
 
             case "struct":
                 ZigBeeXmlStructure structure = new ZigBeeXmlStructure();
@@ -301,17 +314,19 @@ public class ZigBeeXmlParser {
                         structure.name = nodes.item(temp).getTextContent().trim();
                     }
                     if (nodes.item(temp).getNodeName().equals("description")) {
-                        ZigBeeXmlDescription description = (ZigBeeXmlDescription) processNode(nodes.item(temp));
+                        ZigBeeXmlDescription description = processNode(nodes.item(temp));
                         if (description != null) {
                             structure.description.add(description);
                         }
                     }
                     if (nodes.item(temp).getNodeName().equals("field")) {
-                        structure.fields.add((ZigBeeXmlField) processNode(nodes.item(temp)));
+                        structure.fields.add(processNode(nodes.item(temp)));
                     }
                 }
                 System.out.println("Done: Structure - " + structure.name);
-                return structure;
+                @SuppressWarnings("unchecked")
+                R structureResult = (R) structure;
+                return structureResult;
 
             case "description":
                 ZigBeeXmlDescription description = new ZigBeeXmlDescription();
@@ -328,7 +343,9 @@ public class ZigBeeXmlParser {
                 if (description.description == null || description.description.isEmpty()) {
                     return null;
                 }
-                return description;
+                @SuppressWarnings("unchecked")
+                R descriptionResult = (R) description;
+                return descriptionResult;
 
             case "conditional":
                 ZigBeeXmlCondition condition = new ZigBeeXmlCondition();
@@ -346,7 +363,9 @@ public class ZigBeeXmlParser {
                     }
                 }
                 System.out.println("Done: Condition - " + condition.field);
-                return condition;
+                @SuppressWarnings("unchecked")
+                R conditionResult = (R) condition;
+                return conditionResult;
 
             case "response":
                 ZigBeeXmlResponse response = new ZigBeeXmlResponse();
@@ -355,7 +374,9 @@ public class ZigBeeXmlParser {
                 response.command = e.getAttribute("command").trim();
 
                 System.out.println("Done: Response - " + response.command);
-                return response;
+                @SuppressWarnings("unchecked")
+                R responseResult = (R) response;
+                return responseResult;
 
             case "scenes":
                 ZigBeeXmlScenes scenes = new ZigBeeXmlScenes();
@@ -363,12 +384,14 @@ public class ZigBeeXmlParser {
                 e = (Element) node;
                 for (int temp = 0; temp < nodes.getLength(); temp++) {
                     if (nodes.item(temp).getNodeName().equals("extensionfield")) {
-                        scenes.extensionField = (ZigBeeXmlExtensionField) processNode(nodes.item(temp));
+                        scenes.extensionField = processNode(nodes.item(temp));
                     }
                 }
 
                 System.out.println("Done: Scenes - " + scenes);
-                return scenes;
+                @SuppressWarnings("unchecked")
+                R scenesResult = (R) scenes;
+                return scenesResult;
 
             case "extensionfield":
                 ZigBeeXmlExtensionField extensionField = new ZigBeeXmlExtensionField();
@@ -382,7 +405,9 @@ public class ZigBeeXmlParser {
                 }
 
                 System.out.println("Done: ExtensionField - " + extensionField);
-                return extensionField;
+                @SuppressWarnings("unchecked")
+                R extensionFieldResult = (R) extensionField;
+                return extensionFieldResult;
         }
 
         return null;

--- a/com.zsmartsystems.zigbee.dongle.cc2531/src/main/java/com/zsmartsystems/zigbee/dongle/cc2531/ZigBeeDongleTiCc2531.java
+++ b/com.zsmartsystems.zigbee.dongle.cc2531/src/main/java/com/zsmartsystems/zigbee/dongle/cc2531/ZigBeeDongleTiCc2531.java
@@ -9,7 +9,6 @@ package com.zsmartsystems.zigbee.dongle.cc2531;
 
 import java.lang.reflect.Field;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -208,7 +207,6 @@ public class ZigBeeDongleTiCc2531
         return new ZigBeeKey();
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public void updateTransportConfig(TransportConfig configuration) {
         for (TransportConfigOption option : configuration.getOptions()) {
@@ -216,17 +214,17 @@ public class ZigBeeDongleTiCc2531
                 switch (option) {
                     case SUPPORTED_INPUT_CLUSTERS:
                         configuration.setResult(option, setSupportedInputClusters(
-                                new ArrayList<Integer>((Collection<Integer>) configuration.getValue(option))));
+                                new ArrayList<Integer>(configuration.getValue(option))));
                         break;
 
                     case SUPPORTED_OUTPUT_CLUSTERS:
                         configuration.setResult(option, setSupportedOutputClusters(
-                                new ArrayList<Integer>((Collection<Integer>) configuration.getValue(option))));
+                                new ArrayList<Integer>(configuration.getValue(option))));
                         break;
 
                     case RADIO_TX_POWER:
                         configuration.setResult(option,
-                                networkManager.setTxPower((int) configuration.getValue(option)));
+                                networkManager.setTxPower(configuration.getValue(option)));
                         break;
 
                     default:

--- a/com.zsmartsystems.zigbee.dongle.ember.autocode/src/main/java/com/zsmartsystems/zigbee/dongle/ember/autocode/EmberAutocoder.java
+++ b/com.zsmartsystems.zigbee.dongle.ember.autocode/src/main/java/com/zsmartsystems/zigbee/dongle/ember/autocode/EmberAutocoder.java
@@ -47,7 +47,7 @@ public class EmberAutocoder {
             doc.getDocumentElement().normalize();
 
             NodeList nList = doc.getElementsByTagName("protocol");
-            protocol = (Protocol) processNode(nList.item(0));
+            protocol = processNode(nList.item(0));
 
         } catch (Exception e) {
             e.printStackTrace();
@@ -63,7 +63,7 @@ public class EmberAutocoder {
         }
     }
 
-    private static Object processNode(Node node) {
+    private static <R> R processNode(Node node) {
         System.out.println("\nCurrent Element :" + node.getNodeName());
 
         NodeList nodes = node.getChildNodes();
@@ -77,16 +77,18 @@ public class EmberAutocoder {
 
                 for (int temp = 0; temp < nodes.getLength(); temp++) {
                     if (nodes.item(temp).getNodeName().equals("command")) {
-                        protocol.commands.add((Command) processNode(nodes.item(temp)));
+                        protocol.commands.add(processNode(nodes.item(temp)));
                     }
                     if (nodes.item(temp).getNodeName().equals("structure")) {
-                        protocol.structures.add((Structure) processNode(nodes.item(temp)));
+                        protocol.structures.add(processNode(nodes.item(temp)));
                     }
                     if (nodes.item(temp).getNodeName().equals("enum")) {
-                        protocol.enumerations.add((Enumeration) processNode(nodes.item(temp)));
+                        protocol.enumerations.add(processNode(nodes.item(temp)));
                     }
                 }
-                return protocol;
+                @SuppressWarnings("unchecked")
+                R protocolResult = (R) protocol;
+                return protocolResult;
             case "command":
                 Command command = new Command();
                 command.command_parameters = new ArrayList<Parameter>();
@@ -109,14 +111,17 @@ public class EmberAutocoder {
                     }
 
                     if (nodes.item(temp).getNodeName().equals("command_parameters")) {
-                        command.command_parameters = (List<Parameter>) processNode(nodes.item(temp));
+                        command.command_parameters = processNode(nodes.item(temp));
                     }
                     if (nodes.item(temp).getNodeName().equals("response_parameters")) {
-                        command.response_parameters = (List<Parameter>) processNode(nodes.item(temp));
+                        command.response_parameters = processNode(nodes.item(temp));
                     }
                 }
                 System.out.println("Done: Command - " + command.name);
-                return command;
+                @SuppressWarnings("unchecked")
+                R commandResult = (R) command;
+                return commandResult;
+
             case "command_parameters":
             case "response_parameters":
             case "parameters":
@@ -124,10 +129,12 @@ public class EmberAutocoder {
 
                 for (int temp = 0; temp < nodes.getLength(); temp++) {
                     if (nodes.item(temp).getNodeName().equals("parameter")) {
-                        parameters.add((Parameter) processNode(nodes.item(temp)));
+                        parameters.add(processNode(nodes.item(temp)));
                     }
                 }
-                return parameters;
+                @SuppressWarnings("unchecked")
+                R parametersResult = (R) parameters;
+                return parametersResult;
             case "parameter":
                 Parameter parameter = new Parameter();
                 for (int temp = 0; temp < nodes.getLength(); temp++) {
@@ -159,7 +166,9 @@ public class EmberAutocoder {
                     }
                 }
                 System.out.println("Done: Parameter - " + parameter.name);
-                return parameter;
+                @SuppressWarnings("unchecked")
+                R parameterResult = (R) parameter;
+                return parameterResult;
             case "structure":
                 Structure structure = new Structure();
                 structure.parameters = new ArrayList<Parameter>();
@@ -173,11 +182,13 @@ public class EmberAutocoder {
                     }
 
                     if (nodes.item(temp).getNodeName().equals("parameters")) {
-                        structure.parameters = (List<Parameter>) processNode(nodes.item(temp));
+                        structure.parameters = processNode(nodes.item(temp));
                     }
                 }
                 System.out.println("Done: Structure - " + structure.name);
-                return structure;
+                @SuppressWarnings("unchecked")
+                R structureResult = (R) structure;
+                return structureResult;
             case "enum":
                 Enumeration enumeration = new Enumeration();
                 enumeration.values = new ArrayList<Value>();
@@ -190,23 +201,27 @@ public class EmberAutocoder {
                         enumeration.description = nodes.item(temp).getTextContent();
                     }
                     if (nodes.item(temp).getNodeName().equals("values")) {
-                        enumeration.values = (List<Value>) processNode(nodes.item(temp));
+                        enumeration.values = processNode(nodes.item(temp));
                     }
                     if (nodes.item(temp).getNodeName().equals("format")) {
                         enumeration.format = nodes.item(temp).getTextContent();
                     }
                 }
                 System.out.println("Done: Enum - " + enumeration.name);
-                return enumeration;
+                @SuppressWarnings("unchecked")
+                R enumerationResult = (R) enumeration;
+                return enumerationResult;
             case "values":
                 List<Value> values = new ArrayList<Value>();
 
                 for (int temp = 0; temp < nodes.getLength(); temp++) {
                     if (nodes.item(temp).getNodeName().equals("value")) {
-                        values.add((Value) processNode(nodes.item(temp)));
+                        values.add(processNode(nodes.item(temp)));
                     }
                 }
-                return values;
+                @SuppressWarnings("unchecked")
+                R valuesResult = (R) values;
+                return valuesResult;
             case "value":
                 Value value = new Value();
                 for (int temp = 0; temp < nodes.getLength(); temp++) {
@@ -226,7 +241,9 @@ public class EmberAutocoder {
                     }
                 }
                 System.out.println("Done: Value - " + value.name);
-                return value;
+                @SuppressWarnings("unchecked")
+                R valueResult = (R) value;
+                return valueResult;
             default:
                 System.out.println("Uknown node " + node.getNodeName());
                 break;

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
@@ -1147,12 +1147,12 @@ public class ZigBeeDongleEzsp implements ZigBeeTransportTransmit, ZigBeeTranspor
                 switch (option) {
                     case CONCENTRATOR_CONFIG:
                         configuration.setResult(option,
-                                setConcentrator((ConcentratorConfig) configuration.getValue(option)));
+                                setConcentrator(configuration.getValue(option)));
                         break;
 
                     case INSTALL_KEY:
                         EmberNcp ncp = getEmberNcp();
-                        ZigBeeKey nodeKey = (ZigBeeKey) configuration.getValue(option);
+                        ZigBeeKey nodeKey = configuration.getValue(option);
                         if (!nodeKey.hasAddress()) {
                             logger.debug("Attempt to set INSTALL_KEY without setting address");
                             configuration.setResult(option, ZigBeeStatus.FAILURE);
@@ -1165,32 +1165,32 @@ public class ZigBeeDongleEzsp implements ZigBeeTransportTransmit, ZigBeeTranspor
                         break;
 
                     case RADIO_TX_POWER:
-                        configuration.setResult(option, setEmberTxPower((int) configuration.getValue(option)));
+                        configuration.setResult(option, setEmberTxPower(configuration.getValue(option)));
                         break;
 
                     case DEVICE_TYPE:
-                        deviceType = (DeviceType) configuration.getValue(option);
+                        deviceType = configuration.getValue(option);
                         configuration.setResult(option, ZigBeeStatus.SUCCESS);
                         break;
 
                     case TRUST_CENTRE_LINK_KEY:
-                        setTcLinkKey((ZigBeeKey) configuration.getValue(option));
+                        setTcLinkKey(configuration.getValue(option));
                         configuration.setResult(option, ZigBeeStatus.SUCCESS);
                         break;
 
                     case TRUST_CENTRE_JOIN_MODE:
                         configuration.setResult(option,
-                                setTcJoinMode((TrustCentreJoinMode) configuration.getValue(option)));
+                                setTcJoinMode(configuration.getValue(option)));
                         break;
 
                     case SUPPORTED_INPUT_CLUSTERS:
                         configuration.setResult(option,
-                                setSupportedInputClusters((Collection<Integer>) configuration.getValue(option)));
+                                setSupportedInputClusters(configuration.getValue(option)));
                         break;
 
                     case SUPPORTED_OUTPUT_CLUSTERS:
                         configuration.setResult(option,
-                                setSupportedOutputClusters((Collection<Integer>) configuration.getValue(option)));
+                                setSupportedOutputClusters(configuration.getValue(option)));
                         break;
 
                     default:

--- a/com.zsmartsystems.zigbee.dongle.telegesis.autocode/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/autocode/TelegesisAutocoder.java
+++ b/com.zsmartsystems.zigbee.dongle.telegesis.autocode/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/autocode/TelegesisAutocoder.java
@@ -46,7 +46,7 @@ public class TelegesisAutocoder {
             doc.getDocumentElement().normalize();
 
             NodeList nList = doc.getElementsByTagName("protocol");
-            protocol = (Protocol) processNode(nList.item(0));
+            protocol = processNode(nList.item(0));
 
         } catch (Exception e) {
             e.printStackTrace();
@@ -63,7 +63,7 @@ public class TelegesisAutocoder {
         }
     }
 
-    static Object processNode(Node node) {
+    static <R> R processNode(Node node) {
         System.out.println("\nCurrent Element :" + node.getNodeName());
 
         NodeList nodes = node.getChildNodes();
@@ -77,16 +77,19 @@ public class TelegesisAutocoder {
 
                 for (int temp = 0; temp < nodes.getLength(); temp++) {
                     if (nodes.item(temp).getNodeName().equals("command")) {
-                        protocol.commands.add((Command) processNode(nodes.item(temp)));
+                        protocol.commands.add(processNode(nodes.item(temp)));
                     }
                     if (nodes.item(temp).getNodeName().equals("structure")) {
-                        protocol.structures.add((Structure) processNode(nodes.item(temp)));
+                        protocol.structures.add(processNode(nodes.item(temp)));
                     }
                     if (nodes.item(temp).getNodeName().equals("enum")) {
-                        protocol.enumerations.add((Enumeration) processNode(nodes.item(temp)));
+                        protocol.enumerations.add(processNode(nodes.item(temp)));
                     }
                 }
-                return protocol;
+
+                @SuppressWarnings("unchecked")
+                R protocolResult = (R) protocol;
+                return protocolResult;
             case "command":
                 Command command = new Command();
                 command.command_parameters = new ArrayList<ParameterGroup>();
@@ -117,14 +120,16 @@ public class TelegesisAutocoder {
                     }
 
                     if (nodes.item(temp).getNodeName().equals("command_parameters")) {
-                        command.command_parameters.add((ParameterGroup) processNode(nodes.item(temp)));
+                        command.command_parameters.add(processNode(nodes.item(temp)));
                     }
                     if (nodes.item(temp).getNodeName().equals("response_parameters")) {
-                        command.response_parameters.add((ParameterGroup) processNode(nodes.item(temp)));
+                        command.response_parameters.add(processNode(nodes.item(temp)));
                     }
                 }
                 System.out.println("Done: Command - " + command.name);
-                return command;
+                @SuppressWarnings("unchecked")
+                R commandResult = (R) command;
+                return commandResult;
             case "command_parameters":
             case "response_parameters":
                 ParameterGroup parameterGroup = new ParameterGroup();
@@ -150,10 +155,12 @@ public class TelegesisAutocoder {
                         parameterGroup.prompt = nodes.item(temp).getTextContent();
                     }
                     if (nodes.item(temp).getNodeName().equals("parameter")) {
-                        parameterGroup.parameters.add((Parameter) processNode(nodes.item(temp)));
+                        parameterGroup.parameters.add(processNode(nodes.item(temp)));
                     }
                 }
-                return parameterGroup;
+                @SuppressWarnings("unchecked")
+                R parameterGroupResult = (R) parameterGroup;
+                return parameterGroupResult;
             case "parameter":
                 Parameter parameter = new Parameter();
                 for (int temp = 0; temp < nodes.getLength(); temp++) {
@@ -201,7 +208,9 @@ public class TelegesisAutocoder {
                     }
                 }
                 System.out.println("Done: Parameter - " + parameter.name);
-                return parameter;
+                @SuppressWarnings("unchecked")
+                R parameterResult = (R) parameter;
+                return parameterResult;
             case "structure":
                 Structure structure = new Structure();
                 structure.parameters = new ArrayList<Parameter>();
@@ -215,11 +224,13 @@ public class TelegesisAutocoder {
                     }
 
                     if (nodes.item(temp).getNodeName().equals("parameters")) {
-                        structure.parameters = (List<Parameter>) processNode(nodes.item(temp));
+                        structure.parameters = processNode(nodes.item(temp));
                     }
                 }
                 System.out.println("Done: Structure - " + structure.name);
-                return structure;
+                @SuppressWarnings("unchecked")
+                R structureResult = (R) structure;
+                return structureResult;
             case "enum":
                 Enumeration enumeration = new Enumeration();
                 enumeration.values = new ArrayList<Value>();
@@ -232,23 +243,27 @@ public class TelegesisAutocoder {
                         enumeration.description = nodes.item(temp).getTextContent();
                     }
                     if (nodes.item(temp).getNodeName().equals("values")) {
-                        enumeration.values = (List<Value>) processNode(nodes.item(temp));
+                        enumeration.values = processNode(nodes.item(temp));
                     }
                     if (nodes.item(temp).getNodeName().equals("format")) {
                         enumeration.format = nodes.item(temp).getTextContent();
                     }
                 }
                 System.out.println("Done: Enum - " + enumeration.name);
-                return enumeration;
+                @SuppressWarnings("unchecked")
+                R enumerationResult = (R) enumeration;
+                return enumerationResult;
             case "values":
                 List<Value> values = new ArrayList<Value>();
 
                 for (int temp = 0; temp < nodes.getLength(); temp++) {
                     if (nodes.item(temp).getNodeName().equals("value")) {
-                        values.add((Value) processNode(nodes.item(temp)));
+                        values.add(processNode(nodes.item(temp)));
                     }
                 }
-                return values;
+                @SuppressWarnings("unchecked")
+                R valuesResult = (R) values;
+                return valuesResult;
             case "value":
                 Value value = new Value();
                 for (int temp = 0; temp < nodes.getLength(); temp++) {
@@ -264,7 +279,9 @@ public class TelegesisAutocoder {
                     }
                 }
                 System.out.println("Done: Value - " + value.name);
-                return value;
+                @SuppressWarnings("unchecked")
+                R valueResult = (R) value;
+                return valueResult;
         }
 
         return null;

--- a/com.zsmartsystems.zigbee.dongle.telegesis/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/ZigBeeDongleTelegesis.java
+++ b/com.zsmartsystems.zigbee.dongle.telegesis/src/main/java/com/zsmartsystems/zigbee/dongle/telegesis/ZigBeeDongleTelegesis.java
@@ -1096,7 +1096,6 @@ public class ZigBeeDongleTelegesis
         return linkKey;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public void updateTransportConfig(TransportConfig configuration) {
         for (TransportConfigOption option : configuration.getOptions()) {
@@ -1104,21 +1103,21 @@ public class ZigBeeDongleTelegesis
                 switch (option) {
                     case SUPPORTED_INPUT_CLUSTERS:
                         configuration.setResult(option,
-                                setSupportedInputClusters((Collection<Integer>) configuration.getValue(option)));
+                                setSupportedInputClusters(configuration.getValue(option)));
                         break;
 
                     case SUPPORTED_OUTPUT_CLUSTERS:
                         configuration.setResult(option,
-                                setSupportedOutputClusters((Collection<Integer>) configuration.getValue(option)));
+                                setSupportedOutputClusters(configuration.getValue(option)));
                         break;
 
                     case TRUST_CENTRE_JOIN_MODE:
                         configuration.setResult(option,
-                                setTcJoinMode((TrustCentreJoinMode) configuration.getValue(option)));
+                                setTcJoinMode(configuration.getValue(option)));
                         break;
 
                     case TRUST_CENTRE_LINK_KEY:
-                        configuration.setResult(option, setTcLinkKey((ZigBeeKey) configuration.getValue(option)));
+                        configuration.setResult(option, setTcLinkKey(configuration.getValue(option)));
                         break;
 
                     default:

--- a/com.zsmartsystems.zigbee.dongle.xbee.autocode/src/main/java/com/zsmartsystems/zigbee/dongle/xbee/autocode/XBeeAutocoder.java
+++ b/com.zsmartsystems.zigbee.dongle.xbee.autocode/src/main/java/com/zsmartsystems/zigbee/dongle/xbee/autocode/XBeeAutocoder.java
@@ -46,7 +46,7 @@ public class XBeeAutocoder {
             doc.getDocumentElement().normalize();
 
             NodeList nList = doc.getElementsByTagName("protocol");
-            protocol = (Protocol) processNode(nList.item(0));
+            protocol = processNode(nList.item(0));
 
         } catch (Exception e) {
             e.printStackTrace();
@@ -63,7 +63,7 @@ public class XBeeAutocoder {
         }
     }
 
-    static Object processNode(Node node) {
+    static <R> R processNode(Node node) {
         System.out.println("\nCurrent Element :" + node.getNodeName());
 
         NodeList nodes = node.getChildNodes();
@@ -78,19 +78,21 @@ public class XBeeAutocoder {
 
                 for (int temp = 0; temp < nodes.getLength(); temp++) {
                     if (nodes.item(temp).getNodeName().equals("command")) {
-                        protocol.commands.add((Command) processNode(nodes.item(temp)));
+                        protocol.commands.add(processNode(nodes.item(temp)));
                     }
                     if (nodes.item(temp).getNodeName().equals("at_command")) {
-                        protocol.at_commands.add((Command) processNode(nodes.item(temp)));
+                        protocol.at_commands.add(processNode(nodes.item(temp)));
                     }
                     if (nodes.item(temp).getNodeName().equals("structure")) {
-                        protocol.structures.add((Structure) processNode(nodes.item(temp)));
+                        protocol.structures.add(processNode(nodes.item(temp)));
                     }
                     if (nodes.item(temp).getNodeName().equals("enum")) {
-                        protocol.enumerations.add((Enumeration) processNode(nodes.item(temp)));
+                        protocol.enumerations.add(processNode(nodes.item(temp)));
                     }
                 }
-                return protocol;
+                @SuppressWarnings("unchecked")
+                R protocolResult = (R) protocol;
+                return protocolResult;
             case "command":
             case "at_command":
                 Command command = new Command();
@@ -119,10 +121,10 @@ public class XBeeAutocoder {
                     }
 
                     if (nodes.item(temp).getNodeName().equals("command_parameters")) {
-                        command.command_parameters.add((ParameterGroup) processNode(nodes.item(temp)));
+                        command.command_parameters.add(processNode(nodes.item(temp)));
                     }
                     if (nodes.item(temp).getNodeName().equals("response_parameters")) {
-                        command.response_parameters.add((ParameterGroup) processNode(nodes.item(temp)));
+                        command.response_parameters.add(processNode(nodes.item(temp)));
                     }
                     if (nodes.item(temp).getNodeName().equals("getter")) {
                         command.getter = Boolean.valueOf(nodes.item(temp).getTextContent());
@@ -132,7 +134,9 @@ public class XBeeAutocoder {
                     }
                 }
                 System.out.println("Done: Command - " + command.name);
-                return command;
+                @SuppressWarnings("unchecked")
+                R commandResult = (R) command;
+                return commandResult;
             case "command_parameters":
             case "response_parameters":
                 ParameterGroup parameterGroup = new ParameterGroup();
@@ -155,10 +159,12 @@ public class XBeeAutocoder {
                         parameterGroup.name = nodes.item(temp).getTextContent();
                     }
                     if (nodes.item(temp).getNodeName().equals("parameter")) {
-                        parameterGroup.parameters.add((Parameter) processNode(nodes.item(temp)));
+                        parameterGroup.parameters.add(processNode(nodes.item(temp)));
                     }
                 }
-                return parameterGroup;
+                @SuppressWarnings("unchecked")
+                R parameterGroupResult = (R) parameterGroup;
+                return parameterGroupResult;
             case "parameter":
                 Parameter parameter = new Parameter();
                 for (int temp = 0; temp < nodes.getLength(); temp++) {
@@ -210,7 +216,9 @@ public class XBeeAutocoder {
                     }
                 }
                 System.out.println("Done: Parameter - " + parameter.name);
-                return parameter;
+                @SuppressWarnings("unchecked")
+                R parameterResult = (R) parameter;
+                return parameterResult;
             case "structure":
                 Structure structure = new Structure();
                 structure.parameters = new ArrayList<Parameter>();
@@ -224,11 +232,13 @@ public class XBeeAutocoder {
                     }
 
                     if (nodes.item(temp).getNodeName().equals("parameters")) {
-                        structure.parameters = (List<Parameter>) processNode(nodes.item(temp));
+                        structure.parameters = processNode(nodes.item(temp));
                     }
                 }
                 System.out.println("Done: Structure - " + structure.name);
-                return structure;
+                @SuppressWarnings("unchecked")
+                R structureResult = (R) structure;
+                return structureResult;
             case "enum":
                 Enumeration enumeration = new Enumeration();
                 enumeration.values = new ArrayList<Value>();
@@ -241,23 +251,27 @@ public class XBeeAutocoder {
                         enumeration.description = nodes.item(temp).getTextContent();
                     }
                     if (nodes.item(temp).getNodeName().equals("values")) {
-                        enumeration.values = (List<Value>) processNode(nodes.item(temp));
+                        enumeration.values = processNode(nodes.item(temp));
                     }
                     if (nodes.item(temp).getNodeName().equals("format")) {
                         enumeration.format = nodes.item(temp).getTextContent();
                     }
                 }
                 System.out.println("Done: Enum - " + enumeration.name);
-                return enumeration;
+                @SuppressWarnings("unchecked")
+                R enumerationResult = (R) enumeration;
+                return enumerationResult;
             case "values":
                 List<Value> values = new ArrayList<Value>();
 
                 for (int temp = 0; temp < nodes.getLength(); temp++) {
                     if (nodes.item(temp).getNodeName().equals("value")) {
-                        values.add((Value) processNode(nodes.item(temp)));
+                        values.add(processNode(nodes.item(temp)));
                     }
                 }
-                return values;
+                @SuppressWarnings("unchecked")
+                R valuesResult = (R) values;
+                return valuesResult;
             case "value":
                 Value value = new Value();
                 for (int temp = 0; temp < nodes.getLength(); temp++) {
@@ -273,7 +287,9 @@ public class XBeeAutocoder {
                     }
                 }
                 System.out.println("Done: Value - " + value.name);
-                return value;
+                @SuppressWarnings("unchecked")
+                R valueResult = (R) value;
+                return valueResult;
         }
 
         return null;

--- a/com.zsmartsystems.zigbee.dongle.xbee/src/main/java/com/zsmartsystems/zigbee/dongle/xbee/ZigBeeDongleXBee.java
+++ b/com.zsmartsystems.zigbee.dongle.xbee/src/main/java/com/zsmartsystems/zigbee/dongle/xbee/ZigBeeDongleXBee.java
@@ -536,7 +536,7 @@ public class ZigBeeDongleXBee implements ZigBeeTransportTransmit, XBeeEventListe
             try {
                 switch (option) {
                     case TRUST_CENTRE_LINK_KEY:
-                        configuration.setResult(option, setTcLinkKey((ZigBeeKey) configuration.getValue(option)));
+                        configuration.setResult(option, setTcLinkKey(configuration.getValue(option)));
                         break;
 
                     default:

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/serialization/DefaultDeserializer.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/serialization/DefaultDeserializer.java
@@ -68,7 +68,7 @@ public class DefaultDeserializer implements ZigBeeDeserializer {
     /**
      * {@inheritDoc}
      */
-    public Object readZigBeeType(ZclDataType type) {
+    public <R> R readZigBeeType(ZclDataType type) {
         if (index == payload.length) {
             return null;
         }
@@ -351,6 +351,10 @@ public class DefaultDeserializer implements ZigBeeDeserializer {
                 throw new IllegalArgumentException("No reader defined in " + ZigBeeDeserializer.class.getSimpleName()
                         + " for " + type.toString() + String.format(" (0x%02X)", type.getId()));
         }
-        return value[0];
+
+        @SuppressWarnings("unchecked")
+        R typedValue = (R) value[0];
+
+        return typedValue;
     }
 }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/serialization/ZigBeeDeserializer.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/serialization/ZigBeeDeserializer.java
@@ -18,7 +18,7 @@ public interface ZigBeeDeserializer {
 
     public boolean isEndOfStream();
 
-    public Object readZigBeeType(ZclDataType type);
+    public <R> R readZigBeeType(ZclDataType type);
 
     public int getPosition();
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transport/TransportConfig.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/transport/TransportConfig.java
@@ -75,11 +75,14 @@ public class TransportConfig {
     /**
      * Gets a value for the specified {@link TransportConfigOption}
      *
+     * @type <R> type of returned value
      * @param option the {@link TransportConfigOption} to retrieve
      * @return the {@link Object}
      */
-    public Object getValue(TransportConfigOption option) {
-        return request.get(option);
+    public <R> R getValue(TransportConfigOption option) {
+        @SuppressWarnings("unchecked")
+        R value = (R) request.get(option);
+        return value;
     }
 
     /**

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/ZclFieldDeserializer.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/ZclFieldDeserializer.java
@@ -55,13 +55,14 @@ public class ZclFieldDeserializer {
     /**
      * Deserializes a field.
      *
+     * @type <R> type of returned field
      * @param dataType the {@link ZclDataType} of the field.
      * @return the value
      */
-    public Object deserialize(final ZclDataType dataType) {
+    public <R> R deserialize(final ZclDataType dataType) {
         if (ZclListItemField.class.isAssignableFrom(dataType.getDataClass())) {
             final Class<?> dataTypeClass = dataType.getDataClass();
-            final List<ZclListItemField> list = new ArrayList<ZclListItemField>();
+            final List<ZclListItemField> list = new ArrayList<>();
             try {
                 while (deserializer.getSize() - deserializer.getPosition() > 0) {
                     final ZclListItemField item;
@@ -76,7 +77,10 @@ public class ZclFieldDeserializer {
             } catch (ArrayIndexOutOfBoundsException e) {
                 // Eat the exception - this terminates the list!
             }
-            return list;
+
+            @SuppressWarnings("unchecked")
+            R typeList = (R) list;
+            return typeList;
         }
 
         return deserializer.readZigBeeType(dataType);

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/alarms/AlarmCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/alarms/AlarmCommand.java
@@ -129,8 +129,8 @@ public class AlarmCommand extends ZclAlarmsCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        alarmCode = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        clusterIdentifier = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        alarmCode = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        clusterIdentifier = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/alarms/GetAlarmResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/alarms/GetAlarmResponse.java
@@ -188,10 +188,10 @@ public class GetAlarmResponse extends ZclAlarmsCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        status = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        alarmCode = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        clusterIdentifier = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        timestamp = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        status = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        alarmCode = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        clusterIdentifier = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        timestamp = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/alarms/ResetAlarmCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/alarms/ResetAlarmCommand.java
@@ -128,8 +128,8 @@ public class ResetAlarmCommand extends ZclAlarmsCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        alarmCode = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        clusterIdentifier = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        alarmCode = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        clusterIdentifier = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/ColorLoopSetCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/ColorLoopSetCommand.java
@@ -214,11 +214,11 @@ public class ColorLoopSetCommand extends ZclColorControlCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        updateFlags = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
-        action = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        direction = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        transitionTime = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        startHue = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        updateFlags = deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
+        action = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        direction = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        transitionTime = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        startHue = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/EnhancedMoveHueCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/EnhancedMoveHueCommand.java
@@ -131,8 +131,8 @@ public class EnhancedMoveHueCommand extends ZclColorControlCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        moveMode = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        rate = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        moveMode = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        rate = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/EnhancedMoveToHueAndSaturationCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/EnhancedMoveToHueAndSaturationCommand.java
@@ -157,9 +157,9 @@ public class EnhancedMoveToHueAndSaturationCommand extends ZclColorControlComman
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        enhancedHue = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        saturation = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        transitionTime = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        enhancedHue = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        saturation = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        transitionTime = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/EnhancedMoveToHueCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/EnhancedMoveToHueCommand.java
@@ -163,9 +163,9 @@ public class EnhancedMoveToHueCommand extends ZclColorControlCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        enhancedHue = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        direction = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        transitionTime = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        enhancedHue = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        direction = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        transitionTime = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/EnhancedStepHueCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/EnhancedStepHueCommand.java
@@ -156,9 +156,9 @@ public class EnhancedStepHueCommand extends ZclColorControlCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        stepMode = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        stepSize = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        transitionTime = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        stepMode = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        stepSize = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        transitionTime = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/MoveColorCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/MoveColorCommand.java
@@ -124,8 +124,8 @@ public class MoveColorCommand extends ZclColorControlCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        rateX = (Integer) deserializer.deserialize(ZclDataType.SIGNED_16_BIT_INTEGER);
-        rateY = (Integer) deserializer.deserialize(ZclDataType.SIGNED_16_BIT_INTEGER);
+        rateX = deserializer.deserialize(ZclDataType.SIGNED_16_BIT_INTEGER);
+        rateY = deserializer.deserialize(ZclDataType.SIGNED_16_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/MoveColorTemperatureCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/MoveColorTemperatureCommand.java
@@ -185,10 +185,10 @@ public class MoveColorTemperatureCommand extends ZclColorControlCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        moveMode = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
-        rate = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        colorTemperatureMinimum = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        colorTemperatureMaximum = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        moveMode = deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
+        rate = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        colorTemperatureMinimum = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        colorTemperatureMaximum = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/MoveHueCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/MoveHueCommand.java
@@ -124,8 +124,8 @@ public class MoveHueCommand extends ZclColorControlCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        moveMode = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        rate = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        moveMode = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        rate = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/MoveSaturationCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/MoveSaturationCommand.java
@@ -124,8 +124,8 @@ public class MoveSaturationCommand extends ZclColorControlCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        moveMode = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        rate = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        moveMode = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        rate = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/MoveToColorCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/MoveToColorCommand.java
@@ -153,9 +153,9 @@ public class MoveToColorCommand extends ZclColorControlCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        colorX = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        colorY = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        transitionTime = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        colorX = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        colorY = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        transitionTime = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/MoveToColorTemperatureCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/MoveToColorTemperatureCommand.java
@@ -131,8 +131,8 @@ public class MoveToColorTemperatureCommand extends ZclColorControlCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        colorTemperature = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        transitionTime = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        colorTemperature = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        transitionTime = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/MoveToHueAndSaturationCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/MoveToHueAndSaturationCommand.java
@@ -153,9 +153,9 @@ public class MoveToHueAndSaturationCommand extends ZclColorControlCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        hue = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        saturation = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        transitionTime = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        hue = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        saturation = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        transitionTime = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/MoveToHueCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/MoveToHueCommand.java
@@ -153,9 +153,9 @@ public class MoveToHueCommand extends ZclColorControlCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        hue = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        direction = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        transitionTime = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        hue = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        direction = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        transitionTime = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/MoveToSaturationCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/MoveToSaturationCommand.java
@@ -124,8 +124,8 @@ public class MoveToSaturationCommand extends ZclColorControlCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        saturation = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        transitionTime = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        saturation = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        transitionTime = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/StepColorCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/StepColorCommand.java
@@ -153,9 +153,9 @@ public class StepColorCommand extends ZclColorControlCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        stepX = (Integer) deserializer.deserialize(ZclDataType.SIGNED_16_BIT_INTEGER);
-        stepY = (Integer) deserializer.deserialize(ZclDataType.SIGNED_16_BIT_INTEGER);
-        transitionTime = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        stepX = deserializer.deserialize(ZclDataType.SIGNED_16_BIT_INTEGER);
+        stepY = deserializer.deserialize(ZclDataType.SIGNED_16_BIT_INTEGER);
+        transitionTime = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/StepColorTemperatureCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/StepColorTemperatureCommand.java
@@ -214,11 +214,11 @@ public class StepColorTemperatureCommand extends ZclColorControlCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        stepMode = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        stepSize = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        transitionTime = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        colorTemperatureMinimum = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        colorTemperatureMaximum = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        stepMode = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        stepSize = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        transitionTime = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        colorTemperatureMinimum = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        colorTemperatureMaximum = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/StepHueCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/StepHueCommand.java
@@ -153,9 +153,9 @@ public class StepHueCommand extends ZclColorControlCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        stepMode = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        stepSize = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        transitionTime = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        stepMode = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        stepSize = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        transitionTime = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/StepSaturationCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/StepSaturationCommand.java
@@ -153,9 +153,9 @@ public class StepSaturationCommand extends ZclColorControlCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        stepMode = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        stepSize = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        transitionTime = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        stepMode = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        stepSize = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        transitionTime = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/ZclColorControlExtensionField.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/colorcontrol/ZclColorControlExtensionField.java
@@ -268,31 +268,31 @@ public class ZclColorControlExtensionField extends ExtensionFieldSet {
 
     @Override
     public void deserialize(final ZigBeeDeserializer deserializer) {
-        clusterId = (int) deserializer.readZigBeeType(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        int size = (int) deserializer.readZigBeeType(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        clusterId = deserializer.readZigBeeType(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        int size = deserializer.readZigBeeType(ZclDataType.UNSIGNED_8_BIT_INTEGER);
         if (size >= 2) {
-            currentX = (Integer) deserializer.readZigBeeType(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+            currentX = deserializer.readZigBeeType(ZclDataType.UNSIGNED_16_BIT_INTEGER);
         }
         if (size >= 4) {
-            currentY = (Integer) deserializer.readZigBeeType(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+            currentY = deserializer.readZigBeeType(ZclDataType.UNSIGNED_16_BIT_INTEGER);
         }
         if (size >= 6) {
-            enhancedCurrentHue = (Integer) deserializer.readZigBeeType(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+            enhancedCurrentHue = deserializer.readZigBeeType(ZclDataType.UNSIGNED_16_BIT_INTEGER);
         }
         if (size >= 7) {
-            currentSaturation = (Integer) deserializer.readZigBeeType(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+            currentSaturation = deserializer.readZigBeeType(ZclDataType.UNSIGNED_8_BIT_INTEGER);
         }
         if (size >= 8) {
-            colorLoopActive = (Integer) deserializer.readZigBeeType(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+            colorLoopActive = deserializer.readZigBeeType(ZclDataType.UNSIGNED_8_BIT_INTEGER);
         }
         if (size >= 9) {
-            colorLoopDirection = (Integer) deserializer.readZigBeeType(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+            colorLoopDirection = deserializer.readZigBeeType(ZclDataType.UNSIGNED_8_BIT_INTEGER);
         }
         if (size >= 11) {
-            colorLoopTime = (Integer) deserializer.readZigBeeType(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+            colorLoopTime = deserializer.readZigBeeType(ZclDataType.UNSIGNED_16_BIT_INTEGER);
         }
         if (size >= 13) {
-            colorTemperature = (Integer) deserializer.readZigBeeType(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+            colorTemperature = deserializer.readZigBeeType(ZclDataType.UNSIGNED_16_BIT_INTEGER);
         }
     }
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/commissioning/ResetStartupParametersCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/commissioning/ResetStartupParametersCommand.java
@@ -124,8 +124,8 @@ public class ResetStartupParametersCommand extends ZclCommissioningCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        option = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
-        index = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        option = deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
+        index = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/commissioning/ResetStartupParametersResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/commissioning/ResetStartupParametersResponse.java
@@ -95,7 +95,7 @@ public class ResetStartupParametersResponse extends ZclCommissioningCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        status = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        status = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/commissioning/RestartDeviceCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/commissioning/RestartDeviceCommand.java
@@ -153,9 +153,9 @@ public class RestartDeviceCommand extends ZclCommissioningCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        option = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
-        delay = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        jitter = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        option = deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
+        delay = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        jitter = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/commissioning/RestartDeviceResponseResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/commissioning/RestartDeviceResponseResponse.java
@@ -95,7 +95,7 @@ public class RestartDeviceResponseResponse extends ZclCommissioningCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        status = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        status = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/commissioning/RestoreStartupParametersCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/commissioning/RestoreStartupParametersCommand.java
@@ -124,8 +124,8 @@ public class RestoreStartupParametersCommand extends ZclCommissioningCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        option = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
-        index = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        option = deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
+        index = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/commissioning/RestoreStartupParametersResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/commissioning/RestoreStartupParametersResponse.java
@@ -95,7 +95,7 @@ public class RestoreStartupParametersResponse extends ZclCommissioningCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        status = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        status = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/commissioning/SaveStartupParametersCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/commissioning/SaveStartupParametersCommand.java
@@ -124,8 +124,8 @@ public class SaveStartupParametersCommand extends ZclCommissioningCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        option = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
-        index = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        option = deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
+        index = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/commissioning/SaveStartupParametersResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/commissioning/SaveStartupParametersResponse.java
@@ -95,7 +95,7 @@ public class SaveStartupParametersResponse extends ZclCommissioningCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        status = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        status = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/demandresponseandloadcontrol/CancelAllLoadControlEvents.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/demandresponseandloadcontrol/CancelAllLoadControlEvents.java
@@ -95,7 +95,7 @@ public class CancelAllLoadControlEvents extends ZclDemandResponseAndLoadControlC
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        cancelControl = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
+        cancelControl = deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/demandresponseandloadcontrol/CancelLoadControlEvent.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/demandresponseandloadcontrol/CancelLoadControlEvent.java
@@ -312,11 +312,11 @@ public class CancelLoadControlEvent extends ZclDemandResponseAndLoadControlComma
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        issuerEventId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        deviceClass = (Integer) deserializer.deserialize(ZclDataType.BITMAP_16_BIT);
-        utilityEnrollmentGroup = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        cancelControl = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
-        effectiveTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
+        issuerEventId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        deviceClass = deserializer.deserialize(ZclDataType.BITMAP_16_BIT);
+        utilityEnrollmentGroup = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        cancelControl = deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
+        effectiveTime = deserializer.deserialize(ZclDataType.UTCTIME);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/demandresponseandloadcontrol/GetScheduledEvents.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/demandresponseandloadcontrol/GetScheduledEvents.java
@@ -161,8 +161,8 @@ public class GetScheduledEvents extends ZclDemandResponseAndLoadControlCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        startTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
-        numberOfEvents = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        startTime = deserializer.deserialize(ZclDataType.UTCTIME);
+        numberOfEvents = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/demandresponseandloadcontrol/LoadControlEventCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/demandresponseandloadcontrol/LoadControlEventCommand.java
@@ -688,19 +688,19 @@ public class LoadControlEventCommand extends ZclDemandResponseAndLoadControlComm
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        issuerEventId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        deviceClass = (Integer) deserializer.deserialize(ZclDataType.BITMAP_16_BIT);
-        utilityEnrollmentGroup = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        startTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
-        durationInMinutes = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        criticalityLevel = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        coolingTemperatureOffset = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        heatingTemperatureOffset = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        coolingTemperatureSetPoint = (Integer) deserializer.deserialize(ZclDataType.SIGNED_16_BIT_INTEGER);
-        heatingTemperatureSetPoint = (Integer) deserializer.deserialize(ZclDataType.SIGNED_16_BIT_INTEGER);
-        averageLoadAdjustmentPercentage = (Integer) deserializer.deserialize(ZclDataType.SIGNED_8_BIT_INTEGER);
-        dutyCycle = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        eventControl = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
+        issuerEventId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        deviceClass = deserializer.deserialize(ZclDataType.BITMAP_16_BIT);
+        utilityEnrollmentGroup = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        startTime = deserializer.deserialize(ZclDataType.UTCTIME);
+        durationInMinutes = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        criticalityLevel = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        coolingTemperatureOffset = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        heatingTemperatureOffset = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        coolingTemperatureSetPoint = deserializer.deserialize(ZclDataType.SIGNED_16_BIT_INTEGER);
+        heatingTemperatureSetPoint = deserializer.deserialize(ZclDataType.SIGNED_16_BIT_INTEGER);
+        averageLoadAdjustmentPercentage = deserializer.deserialize(ZclDataType.SIGNED_8_BIT_INTEGER);
+        dutyCycle = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        eventControl = deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/demandresponseandloadcontrol/ReportEventStatus.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/demandresponseandloadcontrol/ReportEventStatus.java
@@ -499,17 +499,17 @@ public class ReportEventStatus extends ZclDemandResponseAndLoadControlCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        issuerEventId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        eventStatus = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        eventStatusTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
-        criticalityLevelApplied = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        coolingTemperatureSetPointApplied = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        heatingTemperatureSetPointApplied = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        averageLoadAdjustmentPercentageApplied = (Integer) deserializer.deserialize(ZclDataType.SIGNED_8_BIT_INTEGER);
-        dutyCycleApplied = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        eventControl = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
-        signatureType = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        signature = (ByteArray) deserializer.deserialize(ZclDataType.OCTET_STRING);
+        issuerEventId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        eventStatus = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        eventStatusTime = deserializer.deserialize(ZclDataType.UTCTIME);
+        criticalityLevelApplied = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        coolingTemperatureSetPointApplied = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        heatingTemperatureSetPointApplied = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        averageLoadAdjustmentPercentageApplied = deserializer.deserialize(ZclDataType.SIGNED_8_BIT_INTEGER);
+        dutyCycleApplied = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        eventControl = deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
+        signatureType = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        signature = deserializer.deserialize(ZclDataType.OCTET_STRING);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/doorlock/LockDoorCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/doorlock/LockDoorCommand.java
@@ -100,7 +100,7 @@ public class LockDoorCommand extends ZclDoorLockCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        pinCode = (ByteArray) deserializer.deserialize(ZclDataType.OCTET_STRING);
+        pinCode = deserializer.deserialize(ZclDataType.OCTET_STRING);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/doorlock/LockDoorResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/doorlock/LockDoorResponse.java
@@ -102,7 +102,7 @@ public class LockDoorResponse extends ZclDoorLockCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        status = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        status = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/doorlock/Toggle.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/doorlock/Toggle.java
@@ -99,7 +99,7 @@ public class Toggle extends ZclDoorLockCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        pin = (String) deserializer.deserialize(ZclDataType.CHARACTER_STRING);
+        pin = deserializer.deserialize(ZclDataType.CHARACTER_STRING);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/doorlock/ToggleResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/doorlock/ToggleResponse.java
@@ -102,7 +102,7 @@ public class ToggleResponse extends ZclDoorLockCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        status = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        status = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/doorlock/UnlockDoorCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/doorlock/UnlockDoorCommand.java
@@ -104,7 +104,7 @@ public class UnlockDoorCommand extends ZclDoorLockCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        pinCode = (ByteArray) deserializer.deserialize(ZclDataType.OCTET_STRING);
+        pinCode = deserializer.deserialize(ZclDataType.OCTET_STRING);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/doorlock/UnlockDoorResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/doorlock/UnlockDoorResponse.java
@@ -102,7 +102,7 @@ public class UnlockDoorResponse extends ZclDoorLockCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        status = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        status = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/doorlock/UnlockWithTimeout.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/doorlock/UnlockWithTimeout.java
@@ -131,8 +131,8 @@ public class UnlockWithTimeout extends ZclDoorLockCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        timeoutInSeconds = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        pin = (String) deserializer.deserialize(ZclDataType.CHARACTER_STRING);
+        timeoutInSeconds = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        pin = deserializer.deserialize(ZclDataType.CHARACTER_STRING);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/doorlock/UnlockWithTimeoutResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/doorlock/UnlockWithTimeoutResponse.java
@@ -101,7 +101,7 @@ public class UnlockWithTimeoutResponse extends ZclDoorLockCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        status = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        status = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/electricalmeasurement/GetMeasurementProfileCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/electricalmeasurement/GetMeasurementProfileCommand.java
@@ -156,9 +156,9 @@ public class GetMeasurementProfileCommand extends ZclElectricalMeasurementComman
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        attributeId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        startTime = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        numberOfIntervals = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        attributeId = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        startTime = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        numberOfIntervals = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/electricalmeasurement/GetMeasurementProfileResponseCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/electricalmeasurement/GetMeasurementProfileResponseCommand.java
@@ -244,12 +244,12 @@ public class GetMeasurementProfileResponseCommand extends ZclElectricalMeasureme
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        startTime = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        status = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        profileIntervalPeriod = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        numberOfIntervalsDelivered = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        attributeId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        intervals = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        startTime = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        status = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        profileIntervalPeriod = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        numberOfIntervalsDelivered = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        attributeId = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        intervals = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/electricalmeasurement/GetProfileInfoResponseCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/electricalmeasurement/GetProfileInfoResponseCommand.java
@@ -186,10 +186,10 @@ public class GetProfileInfoResponseCommand extends ZclElectricalMeasurementComma
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        profileCount = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        profileIntervalPeriod = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        maxNumberOfIntervals = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        listOfAttributes = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        profileCount = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        profileIntervalPeriod = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        maxNumberOfIntervals = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        listOfAttributes = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/ConfigureReportingCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/ConfigureReportingCommand.java
@@ -109,7 +109,7 @@ public class ConfigureReportingCommand extends ZclGeneralCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        records = (List<AttributeReportingConfigurationRecord>) deserializer.deserialize(ZclDataType.N_X_ATTRIBUTE_REPORTING_CONFIGURATION_RECORD);
+        records = deserializer.deserialize(ZclDataType.N_X_ATTRIBUTE_REPORTING_CONFIGURATION_RECORD);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/ConfigureReportingResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/ConfigureReportingResponse.java
@@ -168,10 +168,10 @@ public class ConfigureReportingResponse extends ZclGeneralCommand {
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
         if (deserializer.getRemainingLength() == 1) {
-            status = (ZclStatus) deserializer.deserialize(ZclDataType.ZCL_STATUS);
+            status = deserializer.deserialize(ZclDataType.ZCL_STATUS);
             return;
         }
-        records = (List<AttributeStatusRecord>) deserializer.deserialize(ZclDataType.N_X_ATTRIBUTE_STATUS_RECORD);
+        records = deserializer.deserialize(ZclDataType.N_X_ATTRIBUTE_STATUS_RECORD);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/DefaultResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/DefaultResponse.java
@@ -135,8 +135,8 @@ public class DefaultResponse extends ZclGeneralCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        commandIdentifier = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        statusCode = (ZclStatus) deserializer.deserialize(ZclDataType.ZCL_STATUS);
+        commandIdentifier = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        statusCode = deserializer.deserialize(ZclDataType.ZCL_STATUS);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/DiscoverAttributesCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/DiscoverAttributesCommand.java
@@ -155,8 +155,8 @@ public class DiscoverAttributesCommand extends ZclGeneralCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        startAttributeIdentifier = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        maximumAttributeIdentifiers = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        startAttributeIdentifier = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        maximumAttributeIdentifiers = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/DiscoverAttributesExtended.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/DiscoverAttributesExtended.java
@@ -135,8 +135,8 @@ public class DiscoverAttributesExtended extends ZclGeneralCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        startAttributeIdentifier = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        maximumAttributeIdentifiers = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        startAttributeIdentifier = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        maximumAttributeIdentifiers = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/DiscoverAttributesExtendedResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/DiscoverAttributesExtendedResponse.java
@@ -136,8 +136,8 @@ public class DiscoverAttributesExtendedResponse extends ZclGeneralCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        discoveryComplete = (Boolean) deserializer.deserialize(ZclDataType.BOOLEAN);
-        attributeInformation = (List<ExtendedAttributeInformation>) deserializer.deserialize(ZclDataType.N_X_EXTENDED_ATTRIBUTE_INFORMATION);
+        discoveryComplete = deserializer.deserialize(ZclDataType.BOOLEAN);
+        attributeInformation = deserializer.deserialize(ZclDataType.N_X_EXTENDED_ATTRIBUTE_INFORMATION);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/DiscoverAttributesResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/DiscoverAttributesResponse.java
@@ -163,8 +163,8 @@ public class DiscoverAttributesResponse extends ZclGeneralCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        discoveryComplete = (Boolean) deserializer.deserialize(ZclDataType.BOOLEAN);
-        attributeInformation = (List<AttributeInformation>) deserializer.deserialize(ZclDataType.N_X_ATTRIBUTE_INFORMATION);
+        discoveryComplete = deserializer.deserialize(ZclDataType.BOOLEAN);
+        attributeInformation = deserializer.deserialize(ZclDataType.N_X_ATTRIBUTE_INFORMATION);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/DiscoverCommandsGenerated.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/DiscoverCommandsGenerated.java
@@ -134,8 +134,8 @@ public class DiscoverCommandsGenerated extends ZclGeneralCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        startCommandIdentifier = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        maximumCommandIdentifiers = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        startCommandIdentifier = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        maximumCommandIdentifiers = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/DiscoverCommandsGeneratedResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/DiscoverCommandsGeneratedResponse.java
@@ -135,8 +135,8 @@ public class DiscoverCommandsGeneratedResponse extends ZclGeneralCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        discoveryComplete = (Boolean) deserializer.deserialize(ZclDataType.BOOLEAN);
-        commandIdentifiers = (List<Integer>) deserializer.deserialize(ZclDataType.X_UNSIGNED_8_BIT_INTEGER);
+        discoveryComplete = deserializer.deserialize(ZclDataType.BOOLEAN);
+        commandIdentifiers = deserializer.deserialize(ZclDataType.X_UNSIGNED_8_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/DiscoverCommandsReceived.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/DiscoverCommandsReceived.java
@@ -133,8 +133,8 @@ public class DiscoverCommandsReceived extends ZclGeneralCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        startCommandIdentifier = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        maximumCommandIdentifiers = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        startCommandIdentifier = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        maximumCommandIdentifiers = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/DiscoverCommandsReceivedResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/DiscoverCommandsReceivedResponse.java
@@ -135,8 +135,8 @@ public class DiscoverCommandsReceivedResponse extends ZclGeneralCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        discoveryComplete = (Boolean) deserializer.deserialize(ZclDataType.BOOLEAN);
-        commandIdentifiers = (List<Integer>) deserializer.deserialize(ZclDataType.X_UNSIGNED_8_BIT_INTEGER);
+        discoveryComplete = deserializer.deserialize(ZclDataType.BOOLEAN);
+        commandIdentifiers = deserializer.deserialize(ZclDataType.X_UNSIGNED_8_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/ReadAttributesCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/ReadAttributesCommand.java
@@ -107,7 +107,7 @@ public class ReadAttributesCommand extends ZclGeneralCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        identifiers = (List<Integer>) deserializer.deserialize(ZclDataType.N_X_ATTRIBUTE_IDENTIFIER);
+        identifiers = deserializer.deserialize(ZclDataType.N_X_ATTRIBUTE_IDENTIFIER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/ReadAttributesResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/ReadAttributesResponse.java
@@ -111,7 +111,7 @@ public class ReadAttributesResponse extends ZclGeneralCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        records = (List<ReadAttributeStatusRecord>) deserializer.deserialize(ZclDataType.N_X_READ_ATTRIBUTE_STATUS_RECORD);
+        records = deserializer.deserialize(ZclDataType.N_X_READ_ATTRIBUTE_STATUS_RECORD);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/ReadAttributesStructuredCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/ReadAttributesStructuredCommand.java
@@ -105,7 +105,7 @@ public class ReadAttributesStructuredCommand extends ZclGeneralCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        attributeSelectors = (Object) deserializer.deserialize(ZclDataType.N_X_ATTRIBUTE_SELECTOR);
+        attributeSelectors = deserializer.deserialize(ZclDataType.N_X_ATTRIBUTE_SELECTOR);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/ReadReportingConfigurationCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/ReadReportingConfigurationCommand.java
@@ -107,7 +107,7 @@ public class ReadReportingConfigurationCommand extends ZclGeneralCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        records = (List<AttributeRecord>) deserializer.deserialize(ZclDataType.N_X_ATTRIBUTE_RECORD);
+        records = deserializer.deserialize(ZclDataType.N_X_ATTRIBUTE_RECORD);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/ReadReportingConfigurationResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/ReadReportingConfigurationResponse.java
@@ -107,7 +107,7 @@ public class ReadReportingConfigurationResponse extends ZclGeneralCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        records = (List<AttributeReportingStatusRecord>) deserializer.deserialize(ZclDataType.N_X_ATTRIBUTE_REPORTING_STATUS_RECORD);
+        records = deserializer.deserialize(ZclDataType.N_X_ATTRIBUTE_REPORTING_STATUS_RECORD);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/ReportAttributesCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/ReportAttributesCommand.java
@@ -108,7 +108,7 @@ public class ReportAttributesCommand extends ZclGeneralCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        reports = (List<AttributeReport>) deserializer.deserialize(ZclDataType.N_X_ATTRIBUTE_REPORT);
+        reports = deserializer.deserialize(ZclDataType.N_X_ATTRIBUTE_REPORT);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/WriteAttributesCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/WriteAttributesCommand.java
@@ -108,7 +108,7 @@ public class WriteAttributesCommand extends ZclGeneralCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        records = (List<WriteAttributeRecord>) deserializer.deserialize(ZclDataType.N_X_WRITE_ATTRIBUTE_RECORD);
+        records = deserializer.deserialize(ZclDataType.N_X_WRITE_ATTRIBUTE_RECORD);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/WriteAttributesNoResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/WriteAttributesNoResponse.java
@@ -109,7 +109,7 @@ public class WriteAttributesNoResponse extends ZclGeneralCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        records = (List<WriteAttributeRecord>) deserializer.deserialize(ZclDataType.N_X_WRITE_ATTRIBUTE_RECORD);
+        records = deserializer.deserialize(ZclDataType.N_X_WRITE_ATTRIBUTE_RECORD);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/WriteAttributesResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/WriteAttributesResponse.java
@@ -107,7 +107,7 @@ public class WriteAttributesResponse extends ZclGeneralCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        records = (List<WriteAttributeStatusRecord>) deserializer.deserialize(ZclDataType.N_X_WRITE_ATTRIBUTE_STATUS_RECORD);
+        records = deserializer.deserialize(ZclDataType.N_X_WRITE_ATTRIBUTE_STATUS_RECORD);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/WriteAttributesStructuredCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/WriteAttributesStructuredCommand.java
@@ -170,10 +170,10 @@ public class WriteAttributesStructuredCommand extends ZclGeneralCommand {
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
         if (deserializer.getRemainingLength() == 1) {
-            status = (ZclStatus) deserializer.deserialize(ZclDataType.ZCL_STATUS);
+            status = deserializer.deserialize(ZclDataType.ZCL_STATUS);
             return;
         }
-        attributeSelectors = (Object) deserializer.deserialize(ZclDataType.N_X_ATTRIBUTE_SELECTOR);
+        attributeSelectors = deserializer.deserialize(ZclDataType.N_X_ATTRIBUTE_SELECTOR);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/WriteAttributesStructuredResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/WriteAttributesStructuredResponse.java
@@ -171,10 +171,10 @@ public class WriteAttributesStructuredResponse extends ZclGeneralCommand {
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
         if (deserializer.getRemainingLength() == 1) {
-            status = (ZclStatus) deserializer.deserialize(ZclDataType.ZCL_STATUS);
+            status = deserializer.deserialize(ZclDataType.ZCL_STATUS);
             return;
         }
-        records = (List<WriteAttributeStatusRecord>) deserializer.deserialize(ZclDataType.N_X_WRITE_ATTRIBUTE_STATUS_RECORD);
+        records = deserializer.deserialize(ZclDataType.N_X_WRITE_ATTRIBUTE_STATUS_RECORD);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/WriteAttributesUndividedCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/general/WriteAttributesUndividedCommand.java
@@ -112,7 +112,7 @@ public class WriteAttributesUndividedCommand extends ZclGeneralCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        records = (List<WriteAttributeRecord>) deserializer.deserialize(ZclDataType.N_X_WRITE_ATTRIBUTE_RECORD);
+        records = deserializer.deserialize(ZclDataType.N_X_WRITE_ATTRIBUTE_RECORD);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpCommissioningNotification.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpCommissioningNotification.java
@@ -365,16 +365,16 @@ public class GpCommissioningNotification extends ZclGreenPowerCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        options = (Integer) deserializer.deserialize(ZclDataType.BITMAP_16_BIT);
-        gpdSrcId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        gpdIeee = (IeeeAddress) deserializer.deserialize(ZclDataType.IEEE_ADDRESS);
-        endpoint = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        gpdSecurityFrameCounter = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        gpdCommandId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        gpdCommandPayload = (ByteArray) deserializer.deserialize(ZclDataType.OCTET_STRING);
-        gppShortAddress = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        gppLink = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        mic = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        options = deserializer.deserialize(ZclDataType.BITMAP_16_BIT);
+        gpdSrcId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        gpdIeee = deserializer.deserialize(ZclDataType.IEEE_ADDRESS);
+        endpoint = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        gpdSecurityFrameCounter = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        gpdCommandId = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        gpdCommandPayload = deserializer.deserialize(ZclDataType.OCTET_STRING);
+        gppShortAddress = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        gppLink = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        mic = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpNotification.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpNotification.java
@@ -336,15 +336,15 @@ public class GpNotification extends ZclGreenPowerCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        options = (Integer) deserializer.deserialize(ZclDataType.BITMAP_16_BIT);
-        gpdSrcId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        gpdIeee = (IeeeAddress) deserializer.deserialize(ZclDataType.IEEE_ADDRESS);
-        gpdEndpoint = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        gpdSecurityFrameCounter = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        gpdCommandId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        gpdCommandPayload = (ByteArray) deserializer.deserialize(ZclDataType.OCTET_STRING);
-        gppShortAddress = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        gppDistance = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        options = deserializer.deserialize(ZclDataType.BITMAP_16_BIT);
+        gpdSrcId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        gpdIeee = deserializer.deserialize(ZclDataType.IEEE_ADDRESS);
+        gpdEndpoint = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        gpdSecurityFrameCounter = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        gpdCommandId = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        gpdCommandPayload = deserializer.deserialize(ZclDataType.OCTET_STRING);
+        gppShortAddress = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        gppDistance = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpNotificationResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpNotificationResponse.java
@@ -187,10 +187,10 @@ public class GpNotificationResponse extends ZclGreenPowerCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        options = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
-        gpdSrcId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        gpdIeee = (IeeeAddress) deserializer.deserialize(ZclDataType.IEEE_ADDRESS);
-        gpdSecurityFrameCounter = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        options = deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
+        gpdSrcId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        gpdIeee = deserializer.deserialize(ZclDataType.IEEE_ADDRESS);
+        gpdSecurityFrameCounter = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpPairing.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpPairing.java
@@ -420,18 +420,18 @@ public class GpPairing extends ZclGreenPowerCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        options = (Integer) deserializer.deserialize(ZclDataType.BITMAP_24_BIT);
-        gpdSrcId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        gpdIeee = (IeeeAddress) deserializer.deserialize(ZclDataType.IEEE_ADDRESS);
-        endpoint = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        sinkIeeeAddress = (IeeeAddress) deserializer.deserialize(ZclDataType.IEEE_ADDRESS);
-        sinkNwkAddress = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        sinkGroupId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        deviceId = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        gpdSecurityFrameCounter = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        gpdKey = (ZigBeeKey) deserializer.deserialize(ZclDataType.SECURITY_KEY);
-        assignedAlias = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        forwardingRadius = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        options = deserializer.deserialize(ZclDataType.BITMAP_24_BIT);
+        gpdSrcId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        gpdIeee = deserializer.deserialize(ZclDataType.IEEE_ADDRESS);
+        endpoint = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        sinkIeeeAddress = deserializer.deserialize(ZclDataType.IEEE_ADDRESS);
+        sinkNwkAddress = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        sinkGroupId = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        deviceId = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        gpdSecurityFrameCounter = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        gpdKey = deserializer.deserialize(ZclDataType.SECURITY_KEY);
+        assignedAlias = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        forwardingRadius = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpPairingConfiguration.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpPairingConfiguration.java
@@ -744,30 +744,30 @@ public class GpPairingConfiguration extends ZclGreenPowerCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        actions = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
-        options = (Integer) deserializer.deserialize(ZclDataType.BITMAP_16_BIT);
-        gpdSrcId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        gpdIeee = (IeeeAddress) deserializer.deserialize(ZclDataType.IEEE_ADDRESS);
-        endpoint = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        deviceId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        groupListCount = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        actions = deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
+        options = deserializer.deserialize(ZclDataType.BITMAP_16_BIT);
+        gpdSrcId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        gpdIeee = deserializer.deserialize(ZclDataType.IEEE_ADDRESS);
+        endpoint = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        deviceId = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        groupListCount = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
         groupList = new GpPairingConfigurationGroupList();
         groupList.deserialize(deserializer);
-        gpdAssignedAlias = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        forwardingRadius = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        securityOptions = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        gpdSecurityFrameCounter = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        gpdSecurityKey = (ZigBeeKey) deserializer.deserialize(ZclDataType.SECURITY_KEY);
-        numberOfPairedEndpoints = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        pairedEndpoints = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        applicationInformation = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
-        manufacturerId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        modeId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        numberOfGpdCommands = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        gpdCommandIdList = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        clusterIdListCount = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        clusterListServer = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        clusterListClient = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        gpdAssignedAlias = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        forwardingRadius = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        securityOptions = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        gpdSecurityFrameCounter = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        gpdSecurityKey = deserializer.deserialize(ZclDataType.SECURITY_KEY);
+        numberOfPairedEndpoints = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        pairedEndpoints = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        applicationInformation = deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
+        manufacturerId = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        modeId = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        numberOfGpdCommands = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        gpdCommandIdList = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        clusterIdListCount = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        clusterListServer = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        clusterListClient = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpPairingConfigurationGroupList.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpPairingConfigurationGroupList.java
@@ -102,8 +102,8 @@ public class GpPairingConfigurationGroupList implements ZigBeeSerializable {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        sinkGroup = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        alias = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        sinkGroup = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        alias = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpPairingSearch.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpPairingSearch.java
@@ -189,10 +189,10 @@ public class GpPairingSearch extends ZclGreenPowerCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        options = (Integer) deserializer.deserialize(ZclDataType.BITMAP_16_BIT);
-        gpdSrcId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        gpdIeee = (IeeeAddress) deserializer.deserialize(ZclDataType.IEEE_ADDRESS);
-        endpoint = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        options = deserializer.deserialize(ZclDataType.BITMAP_16_BIT);
+        gpdSrcId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        gpdIeee = deserializer.deserialize(ZclDataType.IEEE_ADDRESS);
+        endpoint = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpProxyCommissioningMode.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpProxyCommissioningMode.java
@@ -157,9 +157,9 @@ public class GpProxyCommissioningMode extends ZclGreenPowerCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        options = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
-        commissioningWindow = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        channel = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        options = deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
+        commissioningWindow = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        channel = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpProxyTableRequest.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpProxyTableRequest.java
@@ -214,11 +214,11 @@ public class GpProxyTableRequest extends ZclGreenPowerCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        options = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
-        gpdSrcId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        gpdIeee = (IeeeAddress) deserializer.deserialize(ZclDataType.IEEE_ADDRESS);
-        endpoint = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        index = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        options = deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
+        gpdSrcId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        gpdIeee = deserializer.deserialize(ZclDataType.IEEE_ADDRESS);
+        endpoint = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        index = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpProxyTableResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpProxyTableResponse.java
@@ -218,11 +218,11 @@ public class GpProxyTableResponse extends ZclGreenPowerCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        status = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        totalNumberOfNonEmptyProxyTableEntries = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        startIndex = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        entriesCount = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        proxyTableEntries = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        status = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        totalNumberOfNonEmptyProxyTableEntries = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        startIndex = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        entriesCount = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        proxyTableEntries = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpResponse.java
@@ -303,14 +303,14 @@ public class GpResponse extends ZclGreenPowerCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        options = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
-        tempMasterShortAddress = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        tempMasterTxChannel = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
-        gpdSrcId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        gpdIeee = (IeeeAddress) deserializer.deserialize(ZclDataType.IEEE_ADDRESS);
-        endpoint = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        gpdCommandId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        gpdCommandPayload = (ByteArray) deserializer.deserialize(ZclDataType.OCTET_STRING);
+        options = deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
+        tempMasterShortAddress = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        tempMasterTxChannel = deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
+        gpdSrcId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        gpdIeee = deserializer.deserialize(ZclDataType.IEEE_ADDRESS);
+        endpoint = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        gpdCommandId = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        gpdCommandPayload = deserializer.deserialize(ZclDataType.OCTET_STRING);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpSinkCommissioningMode.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpSinkCommissioningMode.java
@@ -185,10 +185,10 @@ public class GpSinkCommissioningMode extends ZclGreenPowerCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        options = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
-        gpmAddrForSecurity = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        gpmAddrForPairing = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        sinkEndpoint = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        options = deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
+        gpmAddrForSecurity = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        gpmAddrForPairing = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        sinkEndpoint = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpSinkTableRequest.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpSinkTableRequest.java
@@ -215,11 +215,11 @@ public class GpSinkTableRequest extends ZclGreenPowerCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        options = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        gpdSrcId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        gpdIeee = (IeeeAddress) deserializer.deserialize(ZclDataType.IEEE_ADDRESS);
-        endpoint = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        index = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        options = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        gpdSrcId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        gpdIeee = deserializer.deserialize(ZclDataType.IEEE_ADDRESS);
+        endpoint = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        index = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpSinkTableResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpSinkTableResponse.java
@@ -213,11 +213,11 @@ public class GpSinkTableResponse extends ZclGreenPowerCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        status = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        totalNumberofNonEmptySinkTableEntries = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        startIndex = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        sinkTableEntriesCount = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        sinkTableEntries = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        status = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        totalNumberofNonEmptySinkTableEntries = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        startIndex = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        sinkTableEntriesCount = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        sinkTableEntries = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpTranslationTableRequest.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpTranslationTableRequest.java
@@ -98,7 +98,7 @@ public class GpTranslationTableRequest extends ZclGreenPowerCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        startIndex = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        startIndex = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpTranslationTableUpdate.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpTranslationTableUpdate.java
@@ -215,10 +215,10 @@ public class GpTranslationTableUpdate extends ZclGreenPowerCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        options = (Integer) deserializer.deserialize(ZclDataType.BITMAP_16_BIT);
-        gpdSrcId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        gpdIeee = (IeeeAddress) deserializer.deserialize(ZclDataType.IEEE_ADDRESS);
-        endpoint = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        options = deserializer.deserialize(ZclDataType.BITMAP_16_BIT);
+        gpdSrcId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        gpdIeee = deserializer.deserialize(ZclDataType.IEEE_ADDRESS);
+        endpoint = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
         translations = new GpTranslationTableUpdateTranslation();
         translations.deserialize(deserializer);
     }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpTranslationTableUpdateTranslation.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpTranslationTableUpdateTranslation.java
@@ -248,13 +248,13 @@ public class GpTranslationTableUpdateTranslation implements ZigBeeSerializable {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        index = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        gpdCommandId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        endpoint = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        profile = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        cluster = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        zigbeeCommandId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        zigbeeCommandPayload = (ByteArray) deserializer.deserialize(ZclDataType.OCTET_STRING);
+        index = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        gpdCommandId = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        endpoint = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        profile = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        cluster = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        zigbeeCommandId = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        zigbeeCommandPayload = deserializer.deserialize(ZclDataType.OCTET_STRING);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpTunnelingStop.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/greenpower/GpTunnelingStop.java
@@ -273,13 +273,13 @@ public class GpTunnelingStop extends ZclGreenPowerCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        options = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
-        gpdSrcId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        gpdIeee = (IeeeAddress) deserializer.deserialize(ZclDataType.IEEE_ADDRESS);
-        endpoint = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        gpdSecurityFrameCounter = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        gppShortAddress = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        gppDistance = (Integer) deserializer.deserialize(ZclDataType.SIGNED_8_BIT_INTEGER);
+        options = deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
+        gpdSrcId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        gpdIeee = deserializer.deserialize(ZclDataType.IEEE_ADDRESS);
+        endpoint = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        gpdSecurityFrameCounter = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        gppShortAddress = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        gppDistance = deserializer.deserialize(ZclDataType.SIGNED_8_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/groups/AddGroupCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/groups/AddGroupCommand.java
@@ -127,8 +127,8 @@ public class AddGroupCommand extends ZclGroupsCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        groupId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        groupName = (String) deserializer.deserialize(ZclDataType.CHARACTER_STRING);
+        groupId = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        groupName = deserializer.deserialize(ZclDataType.CHARACTER_STRING);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/groups/AddGroupIfIdentifyingCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/groups/AddGroupIfIdentifyingCommand.java
@@ -128,8 +128,8 @@ public class AddGroupIfIdentifyingCommand extends ZclGroupsCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        groupId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        groupName = (String) deserializer.deserialize(ZclDataType.CHARACTER_STRING);
+        groupId = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        groupName = deserializer.deserialize(ZclDataType.CHARACTER_STRING);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/groups/AddGroupResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/groups/AddGroupResponse.java
@@ -128,8 +128,8 @@ public class AddGroupResponse extends ZclGroupsCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        status = (ZclStatus) deserializer.deserialize(ZclDataType.ZCL_STATUS);
-        groupId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        status = deserializer.deserialize(ZclDataType.ZCL_STATUS);
+        groupId = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/groups/GetGroupMembershipCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/groups/GetGroupMembershipCommand.java
@@ -107,10 +107,10 @@ public class GetGroupMembershipCommand extends ZclGroupsCommand {
         // Create lists
         groupList = new ArrayList<Integer>();
 
-        Integer groupCount = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        Integer groupCount = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
         if (groupCount != null) {
             for (int cnt = 0; cnt < groupCount; cnt++) {
-                groupList.add((Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER));
+                groupList.add(deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER));
             }
         }
     }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/groups/GetGroupMembershipResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/groups/GetGroupMembershipResponse.java
@@ -136,11 +136,11 @@ public class GetGroupMembershipResponse extends ZclGroupsCommand {
         // Create lists
         groupList = new ArrayList<Integer>();
 
-        capacity = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        Integer groupCount = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        capacity = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        Integer groupCount = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
         if (groupCount != null) {
             for (int cnt = 0; cnt < groupCount; cnt++) {
-                groupList.add((Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER));
+                groupList.add(deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER));
             }
         }
     }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/groups/RemoveGroupCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/groups/RemoveGroupCommand.java
@@ -98,7 +98,7 @@ public class RemoveGroupCommand extends ZclGroupsCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        groupId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        groupId = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/groups/RemoveGroupResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/groups/RemoveGroupResponse.java
@@ -128,8 +128,8 @@ public class RemoveGroupResponse extends ZclGroupsCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        status = (ZclStatus) deserializer.deserialize(ZclDataType.ZCL_STATUS);
-        groupId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        status = deserializer.deserialize(ZclDataType.ZCL_STATUS);
+        groupId = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/groups/ViewGroupCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/groups/ViewGroupCommand.java
@@ -99,7 +99,7 @@ public class ViewGroupCommand extends ZclGroupsCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        groupId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        groupId = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/groups/ViewGroupResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/groups/ViewGroupResponse.java
@@ -157,9 +157,9 @@ public class ViewGroupResponse extends ZclGroupsCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        status = (ZclStatus) deserializer.deserialize(ZclDataType.ZCL_STATUS);
-        groupId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        groupName = (String) deserializer.deserialize(ZclDataType.CHARACTER_STRING);
+        status = deserializer.deserialize(ZclDataType.ZCL_STATUS);
+        groupId = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        groupName = deserializer.deserialize(ZclDataType.CHARACTER_STRING);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/ArmCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/ArmCommand.java
@@ -203,9 +203,9 @@ public class ArmCommand extends ZclIasAceCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        armMode = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        armDisarmCode = (String) deserializer.deserialize(ZclDataType.CHARACTER_STRING);
-        zoneId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        armMode = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        armDisarmCode = deserializer.deserialize(ZclDataType.CHARACTER_STRING);
+        zoneId = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/ArmResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/ArmResponse.java
@@ -95,7 +95,7 @@ public class ArmResponse extends ZclIasAceCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        armNotification = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        armNotification = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/BypassCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/BypassCommand.java
@@ -184,9 +184,9 @@ public class BypassCommand extends ZclIasAceCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        numberOfZones = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        zoneIds = (List<Integer>) deserializer.deserialize(ZclDataType.N_X_UNSIGNED_8_BIT_INTEGER);
-        armDisarmCode = (String) deserializer.deserialize(ZclDataType.CHARACTER_STRING);
+        numberOfZones = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        zoneIds = deserializer.deserialize(ZclDataType.N_X_UNSIGNED_8_BIT_INTEGER);
+        armDisarmCode = deserializer.deserialize(ZclDataType.CHARACTER_STRING);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/BypassResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/BypassResponse.java
@@ -112,7 +112,7 @@ public class BypassResponse extends ZclIasAceCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        bypassResult = (List<Integer>) deserializer.deserialize(ZclDataType.N_X_UNSIGNED_8_BIT_INTEGER);
+        bypassResult = deserializer.deserialize(ZclDataType.N_X_UNSIGNED_8_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/GetPanelStatusResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/GetPanelStatusResponse.java
@@ -242,10 +242,10 @@ public class GetPanelStatusResponse extends ZclIasAceCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        panelStatus = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        secondsRemaining = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        audibleNotification = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        alarmStatus = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        panelStatus = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        secondsRemaining = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        audibleNotification = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        alarmStatus = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/GetZoneIdMapResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/GetZoneIdMapResponse.java
@@ -534,22 +534,22 @@ public class GetZoneIdMapResponse extends ZclIasAceCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        zoneIdMapSection0 = (Integer) deserializer.deserialize(ZclDataType.BITMAP_16_BIT);
-        zoneIdMapSection1 = (Integer) deserializer.deserialize(ZclDataType.BITMAP_16_BIT);
-        zoneIdMapSection2 = (Integer) deserializer.deserialize(ZclDataType.BITMAP_16_BIT);
-        zoneIdMapSection3 = (Integer) deserializer.deserialize(ZclDataType.BITMAP_16_BIT);
-        zoneIdMapSection4 = (Integer) deserializer.deserialize(ZclDataType.BITMAP_16_BIT);
-        zoneIdMapSection5 = (Integer) deserializer.deserialize(ZclDataType.BITMAP_16_BIT);
-        zoneIdMapSection6 = (Integer) deserializer.deserialize(ZclDataType.BITMAP_16_BIT);
-        zoneIdMapSection7 = (Integer) deserializer.deserialize(ZclDataType.BITMAP_16_BIT);
-        zoneIdMapSection8 = (Integer) deserializer.deserialize(ZclDataType.BITMAP_16_BIT);
-        zoneIdMapSection9 = (Integer) deserializer.deserialize(ZclDataType.BITMAP_16_BIT);
-        zoneIdMapSection10 = (Integer) deserializer.deserialize(ZclDataType.BITMAP_16_BIT);
-        zoneIdMapSection11 = (Integer) deserializer.deserialize(ZclDataType.BITMAP_16_BIT);
-        zoneIdMapSection12 = (Integer) deserializer.deserialize(ZclDataType.BITMAP_16_BIT);
-        zoneIdMapSection13 = (Integer) deserializer.deserialize(ZclDataType.BITMAP_16_BIT);
-        zoneIdMapSection14 = (Integer) deserializer.deserialize(ZclDataType.BITMAP_16_BIT);
-        zoneIdMapSection15 = (Integer) deserializer.deserialize(ZclDataType.BITMAP_16_BIT);
+        zoneIdMapSection0 = deserializer.deserialize(ZclDataType.BITMAP_16_BIT);
+        zoneIdMapSection1 = deserializer.deserialize(ZclDataType.BITMAP_16_BIT);
+        zoneIdMapSection2 = deserializer.deserialize(ZclDataType.BITMAP_16_BIT);
+        zoneIdMapSection3 = deserializer.deserialize(ZclDataType.BITMAP_16_BIT);
+        zoneIdMapSection4 = deserializer.deserialize(ZclDataType.BITMAP_16_BIT);
+        zoneIdMapSection5 = deserializer.deserialize(ZclDataType.BITMAP_16_BIT);
+        zoneIdMapSection6 = deserializer.deserialize(ZclDataType.BITMAP_16_BIT);
+        zoneIdMapSection7 = deserializer.deserialize(ZclDataType.BITMAP_16_BIT);
+        zoneIdMapSection8 = deserializer.deserialize(ZclDataType.BITMAP_16_BIT);
+        zoneIdMapSection9 = deserializer.deserialize(ZclDataType.BITMAP_16_BIT);
+        zoneIdMapSection10 = deserializer.deserialize(ZclDataType.BITMAP_16_BIT);
+        zoneIdMapSection11 = deserializer.deserialize(ZclDataType.BITMAP_16_BIT);
+        zoneIdMapSection12 = deserializer.deserialize(ZclDataType.BITMAP_16_BIT);
+        zoneIdMapSection13 = deserializer.deserialize(ZclDataType.BITMAP_16_BIT);
+        zoneIdMapSection14 = deserializer.deserialize(ZclDataType.BITMAP_16_BIT);
+        zoneIdMapSection15 = deserializer.deserialize(ZclDataType.BITMAP_16_BIT);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/GetZoneInformationCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/GetZoneInformationCommand.java
@@ -95,7 +95,7 @@ public class GetZoneInformationCommand extends ZclIasAceCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        zoneId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        zoneId = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/GetZoneInformationResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/GetZoneInformationResponse.java
@@ -204,10 +204,10 @@ public class GetZoneInformationResponse extends ZclIasAceCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        zoneId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        zoneType = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_16_BIT);
-        ieeeAddress = (IeeeAddress) deserializer.deserialize(ZclDataType.IEEE_ADDRESS);
-        zoneLabel = (String) deserializer.deserialize(ZclDataType.CHARACTER_STRING);
+        zoneId = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        zoneType = deserializer.deserialize(ZclDataType.ENUMERATION_16_BIT);
+        ieeeAddress = deserializer.deserialize(ZclDataType.IEEE_ADDRESS);
+        zoneLabel = deserializer.deserialize(ZclDataType.CHARACTER_STRING);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/GetZoneStatusCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/GetZoneStatusCommand.java
@@ -284,10 +284,10 @@ public class GetZoneStatusCommand extends ZclIasAceCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        startingZoneId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        maxZoneIDs = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        zoneStatusMaskFlag = (Boolean) deserializer.deserialize(ZclDataType.BOOLEAN);
-        zoneStatusMask = (Integer) deserializer.deserialize(ZclDataType.BITMAP_16_BIT);
+        startingZoneId = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        maxZoneIDs = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        zoneStatusMaskFlag = deserializer.deserialize(ZclDataType.BOOLEAN);
+        zoneStatusMask = deserializer.deserialize(ZclDataType.BITMAP_16_BIT);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/GetZoneStatusResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/GetZoneStatusResponse.java
@@ -241,11 +241,11 @@ public class GetZoneStatusResponse extends ZclIasAceCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        zoneStatusComplete = (Boolean) deserializer.deserialize(ZclDataType.BOOLEAN);
-        numberOfZones = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        iasAceZoneStatus = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        zoneId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        zoneStatus = (Integer) deserializer.deserialize(ZclDataType.BITMAP_16_BIT);
+        zoneStatusComplete = deserializer.deserialize(ZclDataType.BOOLEAN);
+        numberOfZones = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        iasAceZoneStatus = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        zoneId = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        zoneStatus = deserializer.deserialize(ZclDataType.BITMAP_16_BIT);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/IasAceZoneStatusResult.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/IasAceZoneStatusResult.java
@@ -102,8 +102,8 @@ public class IasAceZoneStatusResult implements ZigBeeSerializable {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        zoneId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        zoneStatus = (Integer) deserializer.deserialize(ZclDataType.BITMAP_16_BIT);
+        zoneId = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        zoneStatus = deserializer.deserialize(ZclDataType.BITMAP_16_BIT);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/PanelStatusChangedCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/PanelStatusChangedCommand.java
@@ -212,10 +212,10 @@ public class PanelStatusChangedCommand extends ZclIasAceCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        panelStatus = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        secondsRemaining = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        audibleNotification = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        alarmStatus = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        panelStatus = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        secondsRemaining = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        audibleNotification = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        alarmStatus = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/SetBypassedZoneListCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/SetBypassedZoneListCommand.java
@@ -116,7 +116,7 @@ public class SetBypassedZoneListCommand extends ZclIasAceCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        zoneId = (List<Integer>) deserializer.deserialize(ZclDataType.N_X_UNSIGNED_8_BIT_INTEGER);
+        zoneId = deserializer.deserialize(ZclDataType.N_X_UNSIGNED_8_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/ZoneStatusChangedCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iasace/ZoneStatusChangedCommand.java
@@ -212,10 +212,10 @@ public class ZoneStatusChangedCommand extends ZclIasAceCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        zoneId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        zoneStatus = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_16_BIT);
-        audibleNotification = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        zoneLabel = (String) deserializer.deserialize(ZclDataType.CHARACTER_STRING);
+        zoneId = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        zoneStatus = deserializer.deserialize(ZclDataType.ENUMERATION_16_BIT);
+        audibleNotification = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        zoneLabel = deserializer.deserialize(ZclDataType.CHARACTER_STRING);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iaswd/Squawk.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iaswd/Squawk.java
@@ -99,7 +99,7 @@ public class Squawk extends ZclIasWdCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        squawkInfo = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
+        squawkInfo = deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iaswd/SquawkCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iaswd/SquawkCommand.java
@@ -65,7 +65,7 @@ public class SquawkCommand extends ZclCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        header = (Integer) deserializer.deserialize(ZclDataType.DATA_8_BIT);
+        header = deserializer.deserialize(ZclDataType.DATA_8_BIT);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iaswd/StartWarningCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iaswd/StartWarningCommand.java
@@ -128,8 +128,8 @@ public class StartWarningCommand extends ZclIasWdCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        header = (Integer) deserializer.deserialize(ZclDataType.DATA_8_BIT);
-        warningDuration = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        header = deserializer.deserialize(ZclDataType.DATA_8_BIT);
+        warningDuration = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iaszone/InitiateTestModeCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iaszone/InitiateTestModeCommand.java
@@ -169,8 +169,8 @@ public class InitiateTestModeCommand extends ZclIasZoneCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        testModeDuration = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        currentZoneSensitivityLevel = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        testModeDuration = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        currentZoneSensitivityLevel = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iaszone/ZoneEnrollRequestCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iaszone/ZoneEnrollRequestCommand.java
@@ -128,8 +128,8 @@ public class ZoneEnrollRequestCommand extends ZclIasZoneCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        zoneType = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_16_BIT);
-        manufacturerCode = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        zoneType = deserializer.deserialize(ZclDataType.ENUMERATION_16_BIT);
+        manufacturerCode = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iaszone/ZoneEnrollResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iaszone/ZoneEnrollResponse.java
@@ -124,8 +124,8 @@ public class ZoneEnrollResponse extends ZclIasZoneCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        enrollResponseCode = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        zoneId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        enrollResponseCode = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        zoneId = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iaszone/ZoneStatusChangeNotificationCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/iaszone/ZoneStatusChangeNotificationCommand.java
@@ -224,10 +224,10 @@ public class ZoneStatusChangeNotificationCommand extends ZclIasZoneCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        zoneStatus = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_16_BIT);
-        extendedStatus = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        zoneId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        delay = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        zoneStatus = deserializer.deserialize(ZclDataType.ENUMERATION_16_BIT);
+        extendedStatus = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        zoneId = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        delay = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/identify/IdentifyCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/identify/IdentifyCommand.java
@@ -97,7 +97,7 @@ public class IdentifyCommand extends ZclIdentifyCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        identifyTime = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        identifyTime = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/identify/IdentifyQueryResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/identify/IdentifyQueryResponse.java
@@ -98,7 +98,7 @@ public class IdentifyQueryResponse extends ZclIdentifyCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        identifyTime = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        identifyTime = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/keyestablishment/ConfirmKeyDataRequestCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/keyestablishment/ConfirmKeyDataRequestCommand.java
@@ -101,7 +101,7 @@ public class ConfirmKeyDataRequestCommand extends ZclKeyEstablishmentCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        secureMessageAuthenticationCode = (ByteArray) deserializer.deserialize(ZclDataType.RAW_OCTET);
+        secureMessageAuthenticationCode = deserializer.deserialize(ZclDataType.RAW_OCTET);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/keyestablishment/ConfirmKeyResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/keyestablishment/ConfirmKeyResponse.java
@@ -100,7 +100,7 @@ public class ConfirmKeyResponse extends ZclKeyEstablishmentCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        secureMessageAuthenticationCode = (ByteArray) deserializer.deserialize(ZclDataType.RAW_OCTET);
+        secureMessageAuthenticationCode = deserializer.deserialize(ZclDataType.RAW_OCTET);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/keyestablishment/EphemeralDataRequestCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/keyestablishment/EphemeralDataRequestCommand.java
@@ -99,7 +99,7 @@ public class EphemeralDataRequestCommand extends ZclKeyEstablishmentCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        ephemeralData = (ByteArray) deserializer.deserialize(ZclDataType.RAW_OCTET);
+        ephemeralData = deserializer.deserialize(ZclDataType.RAW_OCTET);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/keyestablishment/EphemeralDataResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/keyestablishment/EphemeralDataResponse.java
@@ -99,7 +99,7 @@ public class EphemeralDataResponse extends ZclKeyEstablishmentCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        ephemeralData = (ByteArray) deserializer.deserialize(ZclDataType.RAW_OCTET);
+        ephemeralData = deserializer.deserialize(ZclDataType.RAW_OCTET);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/keyestablishment/InitiateKeyEstablishmentRequestCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/keyestablishment/InitiateKeyEstablishmentRequestCommand.java
@@ -239,10 +239,10 @@ public class InitiateKeyEstablishmentRequestCommand extends ZclKeyEstablishmentC
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        keyEstablishmentSuite = (Integer) deserializer.deserialize(ZclDataType.BITMAP_16_BIT);
-        ephemeralDataGenerateTime = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        confirmKeyGenerateTime = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        identity = (ByteArray) deserializer.deserialize(ZclDataType.RAW_OCTET);
+        keyEstablishmentSuite = deserializer.deserialize(ZclDataType.BITMAP_16_BIT);
+        ephemeralDataGenerateTime = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        confirmKeyGenerateTime = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        identity = deserializer.deserialize(ZclDataType.RAW_OCTET);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/keyestablishment/InitiateKeyEstablishmentResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/keyestablishment/InitiateKeyEstablishmentResponse.java
@@ -226,10 +226,10 @@ public class InitiateKeyEstablishmentResponse extends ZclKeyEstablishmentCommand
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        requestedKeyEstablishmentSuite = (Integer) deserializer.deserialize(ZclDataType.BITMAP_16_BIT);
-        ephemeralDataGenerateTime = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        confirmKeyGenerateTime = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        identity = (ByteArray) deserializer.deserialize(ZclDataType.RAW_OCTET);
+        requestedKeyEstablishmentSuite = deserializer.deserialize(ZclDataType.BITMAP_16_BIT);
+        ephemeralDataGenerateTime = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        confirmKeyGenerateTime = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        identity = deserializer.deserialize(ZclDataType.RAW_OCTET);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/keyestablishment/TerminateKeyEstablishment.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/keyestablishment/TerminateKeyEstablishment.java
@@ -174,9 +174,9 @@ public class TerminateKeyEstablishment extends ZclKeyEstablishmentCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        statusCode = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        waitTime = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        keyEstablishmentSuite = (Integer) deserializer.deserialize(ZclDataType.BITMAP_16_BIT);
+        statusCode = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        waitTime = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        keyEstablishmentSuite = deserializer.deserialize(ZclDataType.BITMAP_16_BIT);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/levelcontrol/MoveCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/levelcontrol/MoveCommand.java
@@ -124,8 +124,8 @@ public class MoveCommand extends ZclLevelControlCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        moveMode = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        rate = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        moveMode = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        rate = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/levelcontrol/MoveToLevelCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/levelcontrol/MoveToLevelCommand.java
@@ -134,8 +134,8 @@ public class MoveToLevelCommand extends ZclLevelControlCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        level = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        transitionTime = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        level = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        transitionTime = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/levelcontrol/MoveToLevelWithOnOffCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/levelcontrol/MoveToLevelWithOnOffCommand.java
@@ -134,8 +134,8 @@ public class MoveToLevelWithOnOffCommand extends ZclLevelControlCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        level = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        transitionTime = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        level = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        transitionTime = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/levelcontrol/MoveWithOnOffCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/levelcontrol/MoveWithOnOffCommand.java
@@ -124,8 +124,8 @@ public class MoveWithOnOffCommand extends ZclLevelControlCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        moveMode = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        rate = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        moveMode = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        rate = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/levelcontrol/StepCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/levelcontrol/StepCommand.java
@@ -153,9 +153,9 @@ public class StepCommand extends ZclLevelControlCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        stepMode = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        stepSize = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        transitionTime = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        stepMode = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        stepSize = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        transitionTime = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/levelcontrol/StepWithOnOffCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/levelcontrol/StepWithOnOffCommand.java
@@ -153,9 +153,9 @@ public class StepWithOnOffCommand extends ZclLevelControlCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        stepMode = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        stepSize = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        transitionTime = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        stepMode = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        stepSize = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        transitionTime = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/levelcontrol/ZclLevelControlExtensionField.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/levelcontrol/ZclLevelControlExtensionField.java
@@ -80,13 +80,13 @@ public class ZclLevelControlExtensionField extends ExtensionFieldSet {
 
     @Override
     public void deserialize(final ZigBeeDeserializer deserializer) {
-        clusterId = (int) deserializer.readZigBeeType(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        int size = (int) deserializer.readZigBeeType(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        clusterId = deserializer.readZigBeeType(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        int size = deserializer.readZigBeeType(ZclDataType.UNSIGNED_8_BIT_INTEGER);
         if (size >= 1) {
-            currentLevel = (Integer) deserializer.readZigBeeType(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+            currentLevel = deserializer.readZigBeeType(ZclDataType.UNSIGNED_8_BIT_INTEGER);
         }
         if (size >= 3) {
-            currentFrequency = (Integer) deserializer.readZigBeeType(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+            currentFrequency = deserializer.readZigBeeType(ZclDataType.UNSIGNED_16_BIT_INTEGER);
         }
     }
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/messaging/CancelAllMessages.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/messaging/CancelAllMessages.java
@@ -109,7 +109,7 @@ public class CancelAllMessages extends ZclMessagingCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        implementationDateTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
+        implementationDateTime = deserializer.deserialize(ZclDataType.UTCTIME);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/messaging/CancelAllMessagesCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/messaging/CancelAllMessagesCommand.java
@@ -100,7 +100,7 @@ public class CancelAllMessagesCommand extends ZclMessagingCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        implementationTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
+        implementationTime = deserializer.deserialize(ZclDataType.UTCTIME);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/messaging/CancelMessageCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/messaging/CancelMessageCommand.java
@@ -150,8 +150,8 @@ public class CancelMessageCommand extends ZclMessagingCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        messageId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        messageControl = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
+        messageId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        messageControl = deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/messaging/DisplayMessageCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/messaging/DisplayMessageCommand.java
@@ -326,12 +326,12 @@ public class DisplayMessageCommand extends ZclMessagingCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        messageId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        messageControl = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
-        startTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
-        durationInMinutes = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        message = (String) deserializer.deserialize(ZclDataType.CHARACTER_STRING);
-        extendedMessageControl = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
+        messageId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        messageControl = deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
+        startTime = deserializer.deserialize(ZclDataType.UTCTIME);
+        durationInMinutes = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        message = deserializer.deserialize(ZclDataType.CHARACTER_STRING);
+        extendedMessageControl = deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/messaging/DisplayProtectedMessageCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/messaging/DisplayProtectedMessageCommand.java
@@ -332,12 +332,12 @@ public class DisplayProtectedMessageCommand extends ZclMessagingCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        messageId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        messageControl = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
-        startTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
-        durationInMinutes = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        message = (String) deserializer.deserialize(ZclDataType.CHARACTER_STRING);
-        extendedMessageControl = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
+        messageId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        messageControl = deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
+        startTime = deserializer.deserialize(ZclDataType.UTCTIME);
+        durationInMinutes = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        message = deserializer.deserialize(ZclDataType.CHARACTER_STRING);
+        extendedMessageControl = deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/messaging/GetLastMessage.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/messaging/GetLastMessage.java
@@ -246,12 +246,12 @@ public class GetLastMessage extends ZclMessagingCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        messageId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        messageControl = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
-        startTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
-        durationInMinutes = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        message = (String) deserializer.deserialize(ZclDataType.CHARACTER_STRING);
-        optionalExtendedMessageControl = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
+        messageId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        messageControl = deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
+        startTime = deserializer.deserialize(ZclDataType.UTCTIME);
+        durationInMinutes = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        message = deserializer.deserialize(ZclDataType.CHARACTER_STRING);
+        optionalExtendedMessageControl = deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/messaging/GetMessageCancellation.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/messaging/GetMessageCancellation.java
@@ -110,7 +110,7 @@ public class GetMessageCancellation extends ZclMessagingCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        earliestImplementationTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
+        earliestImplementationTime = deserializer.deserialize(ZclDataType.UTCTIME);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/messaging/MessageConfirmation.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/messaging/MessageConfirmation.java
@@ -223,10 +223,10 @@ public class MessageConfirmation extends ZclMessagingCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        messageId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        confirmationTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
-        messageConfirmationControl = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
-        messageConfirmationResponse = (ByteArray) deserializer.deserialize(ZclDataType.OCTET_STRING);
+        messageId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        confirmationTime = deserializer.deserialize(ZclDataType.UTCTIME);
+        messageConfirmationControl = deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
+        messageConfirmationResponse = deserializer.deserialize(ZclDataType.OCTET_STRING);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/ChangeSupply.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/ChangeSupply.java
@@ -317,12 +317,12 @@ public class ChangeSupply extends ZclMeteringCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        providerId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        issuerEventId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        requestDateTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
-        implementationDateTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
-        proposedSupplyStatus = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        supplyControlBits = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
+        providerId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        issuerEventId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        requestDateTime = deserializer.deserialize(ZclDataType.UTCTIME);
+        implementationDateTime = deserializer.deserialize(ZclDataType.UTCTIME);
+        proposedSupplyStatus = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        supplyControlBits = deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/ConfigureMirror.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/ConfigureMirror.java
@@ -260,10 +260,10 @@ public class ConfigureMirror extends ZclMeteringCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        issuerEventId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        reportingInterval = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_24_BIT_INTEGER);
-        mirrorNotificationReporting = (Boolean) deserializer.deserialize(ZclDataType.BOOLEAN);
-        notificationScheme = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        issuerEventId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        reportingInterval = deserializer.deserialize(ZclDataType.UNSIGNED_24_BIT_INTEGER);
+        mirrorNotificationReporting = deserializer.deserialize(ZclDataType.BOOLEAN);
+        notificationScheme = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/ConfigureNotificationFlags.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/ConfigureNotificationFlags.java
@@ -225,9 +225,9 @@ public class ConfigureNotificationFlags extends ZclMeteringCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        issuerEventId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        notificationScheme = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        notificationFlagAttributeId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        issuerEventId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        notificationScheme = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        notificationFlagAttributeId = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
         subPayload = new NotificationCommandSubPayload();
         subPayload.deserialize(deserializer);
     }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/ConfigureNotificationScheme.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/ConfigureNotificationScheme.java
@@ -196,9 +196,9 @@ public class ConfigureNotificationScheme extends ZclMeteringCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        issuerEventId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        notificationScheme = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        notificationFlagOrder = (Integer) deserializer.deserialize(ZclDataType.BITMAP_32_BIT);
+        issuerEventId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        notificationScheme = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        notificationFlagOrder = deserializer.deserialize(ZclDataType.BITMAP_32_BIT);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/GetNotifiedMessage.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/GetNotifiedMessage.java
@@ -182,9 +182,9 @@ public class GetNotifiedMessage extends ZclMeteringCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        notificationScheme = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        notificationFlagAttributeId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        notificationFlagsN = (Integer) deserializer.deserialize(ZclDataType.BITMAP_32_BIT);
+        notificationScheme = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        notificationFlagAttributeId = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        notificationFlagsN = deserializer.deserialize(ZclDataType.BITMAP_32_BIT);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/GetProfile.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/GetProfile.java
@@ -206,9 +206,9 @@ public class GetProfile extends ZclMeteringCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        intervalChannel = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        endTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
-        numberOfPeriods = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        intervalChannel = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        endTime = deserializer.deserialize(ZclDataType.UTCTIME);
+        numberOfPeriods = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/GetProfileResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/GetProfileResponse.java
@@ -281,11 +281,11 @@ public class GetProfileResponse extends ZclMeteringCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        endTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
-        status = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        profileIntervalPeriod = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        numberOfPeriodsDelivered = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        intervals = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_24_BIT_INTEGER);
+        endTime = deserializer.deserialize(ZclDataType.UTCTIME);
+        status = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        profileIntervalPeriod = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        numberOfPeriodsDelivered = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        intervals = deserializer.deserialize(ZclDataType.UNSIGNED_24_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/GetSampledData.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/GetSampledData.java
@@ -233,10 +233,10 @@ public class GetSampledData extends ZclMeteringCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        sampleId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        earliestSampleTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
-        sampleType = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        numberOfSamples = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        sampleId = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        earliestSampleTime = deserializer.deserialize(ZclDataType.UTCTIME);
+        sampleType = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        numberOfSamples = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/GetSampledDataResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/GetSampledDataResponse.java
@@ -308,12 +308,12 @@ public class GetSampledDataResponse extends ZclMeteringCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        sampleId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        sampleStartTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
-        sampleType = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        sampleRequestInterval = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        numberOfSamples = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        samples = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_24_BIT_INTEGER);
+        sampleId = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        sampleStartTime = deserializer.deserialize(ZclDataType.UTCTIME);
+        sampleType = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        sampleRequestInterval = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        numberOfSamples = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        samples = deserializer.deserialize(ZclDataType.UNSIGNED_24_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/GetSnapshot.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/GetSnapshot.java
@@ -237,10 +237,10 @@ public class GetSnapshot extends ZclMeteringCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        earliestStartTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
-        latestEndTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
-        snapshotOffset = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        snapshotCause = (Integer) deserializer.deserialize(ZclDataType.BITMAP_32_BIT);
+        earliestStartTime = deserializer.deserialize(ZclDataType.UTCTIME);
+        latestEndTime = deserializer.deserialize(ZclDataType.UTCTIME);
+        snapshotOffset = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        snapshotCause = deserializer.deserialize(ZclDataType.BITMAP_32_BIT);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/LocalChangeSupply.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/LocalChangeSupply.java
@@ -108,7 +108,7 @@ public class LocalChangeSupply extends ZclMeteringCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        proposedSupplyStatus = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        proposedSupplyStatus = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/MirrorRemoved.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/MirrorRemoved.java
@@ -107,7 +107,7 @@ public class MirrorRemoved extends ZclMeteringCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        removedEndpointId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        removedEndpointId = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/MirrorReportAttributeResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/MirrorReportAttributeResponse.java
@@ -136,8 +136,8 @@ public class MirrorReportAttributeResponse extends ZclMeteringCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        notificationScheme = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        notificationFlags = (Integer) deserializer.deserialize(ZclDataType.BITMAP_32_BIT);
+        notificationScheme = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        notificationFlags = deserializer.deserialize(ZclDataType.BITMAP_32_BIT);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/NotificationCommandSubPayload.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/NotificationCommandSubPayload.java
@@ -199,10 +199,10 @@ public class NotificationCommandSubPayload implements ZigBeeSerializable {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        clusterId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        manufacturerCode = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        numberOfCommands = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        commandIds = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        clusterId = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        manufacturerCode = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        numberOfCommands = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        commandIds = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/PublishSnapshot.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/PublishSnapshot.java
@@ -408,14 +408,14 @@ public class PublishSnapshot extends ZclMeteringCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        snapshotId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        snapshotTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
-        totalSnapshotsFound = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        commandIndex = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        totalNumberOfCommands = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        snapshotCause = (Integer) deserializer.deserialize(ZclDataType.BITMAP_32_BIT);
-        snapshotPayloadType = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        snapshotPayload = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        snapshotId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        snapshotTime = deserializer.deserialize(ZclDataType.UTCTIME);
+        totalSnapshotsFound = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        commandIndex = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        totalNumberOfCommands = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        snapshotCause = deserializer.deserialize(ZclDataType.BITMAP_32_BIT);
+        snapshotPayloadType = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        snapshotPayload = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/RequestFastPollMode.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/RequestFastPollMode.java
@@ -139,8 +139,8 @@ public class RequestFastPollMode extends ZclMeteringCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        fastPollUpdatePeriod = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        duration = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        fastPollUpdatePeriod = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        duration = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/RequestFastPollModeResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/RequestFastPollModeResponse.java
@@ -164,8 +164,8 @@ public class RequestFastPollModeResponse extends ZclMeteringCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        appliedUpdatePeriod = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        fastPollModeEndtime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
+        appliedUpdatePeriod = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        fastPollModeEndtime = deserializer.deserialize(ZclDataType.UTCTIME);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/RequestMirrorResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/RequestMirrorResponse.java
@@ -119,7 +119,7 @@ public class RequestMirrorResponse extends ZclMeteringCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        endpointId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        endpointId = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/ResetLoadLimitCounter.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/ResetLoadLimitCounter.java
@@ -151,8 +151,8 @@ public class ResetLoadLimitCounter extends ZclMeteringCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        providerId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        issuerEventId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        providerId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        issuerEventId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/ScheduleSnapshot.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/ScheduleSnapshot.java
@@ -233,9 +233,9 @@ public class ScheduleSnapshot extends ZclMeteringCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        issuerEventId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        commandIndex = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        totalNumberOfCommands = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        issuerEventId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        commandIndex = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        totalNumberOfCommands = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
         snapshotSchedulePayload = new SnapshotSchedulePayload();
         snapshotSchedulePayload.deserialize(deserializer);
     }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/ScheduleSnapshotResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/ScheduleSnapshotResponse.java
@@ -152,7 +152,7 @@ public class ScheduleSnapshotResponse extends ZclMeteringCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        issuerEventId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        issuerEventId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
         snapshotResponsePayload = new SnapshotResponsePayload();
         snapshotResponsePayload.deserialize(deserializer);
     }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/SetSupplyStatus.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/SetSupplyStatus.java
@@ -271,11 +271,11 @@ public class SetSupplyStatus extends ZclMeteringCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        issuerEventId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        supplyTamperState = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        supplyDepletionState = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        supplyUncontrolledFlowState = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        loadLimitSupplyState = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        issuerEventId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        supplyTamperState = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        supplyDepletionState = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        supplyUncontrolledFlowState = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        loadLimitSupplyState = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/SetUncontrolledFlowThreshold.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/SetUncontrolledFlowThreshold.java
@@ -400,14 +400,14 @@ public class SetUncontrolledFlowThreshold extends ZclMeteringCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        providerId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        issuerEventId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        uncontrolledFlowThreshold = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        unitOfMeasure = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        multiplier = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        divisor = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        stabilisationPeriod = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        measurementPeriod = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        providerId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        issuerEventId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        uncontrolledFlowThreshold = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        unitOfMeasure = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        multiplier = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        divisor = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        stabilisationPeriod = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        measurementPeriod = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/SnapshotResponsePayload.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/SnapshotResponsePayload.java
@@ -102,8 +102,8 @@ public class SnapshotResponsePayload implements ZigBeeSerializable {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        snapshotScheduleId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        snapshotScheduleConfirmation = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        snapshotScheduleId = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        snapshotScheduleConfirmation = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/SnapshotSchedulePayload.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/SnapshotSchedulePayload.java
@@ -191,11 +191,11 @@ public class SnapshotSchedulePayload implements ZigBeeSerializable {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        snapshotScheduleId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        snapshotStartTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
-        snapshotSchedule = (Integer) deserializer.deserialize(ZclDataType.BITMAP_24_BIT);
-        snapshotPayloadType = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        snapshotCause = (Integer) deserializer.deserialize(ZclDataType.BITMAP_32_BIT);
+        snapshotScheduleId = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        snapshotStartTime = deserializer.deserialize(ZclDataType.UTCTIME);
+        snapshotSchedule = deserializer.deserialize(ZclDataType.BITMAP_24_BIT);
+        snapshotPayloadType = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        snapshotCause = deserializer.deserialize(ZclDataType.BITMAP_32_BIT);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/StartSampling.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/StartSampling.java
@@ -278,11 +278,11 @@ public class StartSampling extends ZclMeteringCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        issuerEventId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        startSamplingTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
-        sampleType = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        sampleRequestInterval = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        maxNumberOfSamples = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        issuerEventId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        startSamplingTime = deserializer.deserialize(ZclDataType.UTCTIME);
+        sampleType = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        sampleRequestInterval = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        maxNumberOfSamples = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/StartSamplingResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/StartSamplingResponse.java
@@ -127,7 +127,7 @@ public class StartSamplingResponse extends ZclMeteringCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        sampleId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        sampleId = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/SupplyStatusResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/SupplyStatusResponse.java
@@ -231,10 +231,10 @@ public class SupplyStatusResponse extends ZclMeteringCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        providerId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        issuerEventId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        implementationDateTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
-        supplyStatus = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        providerId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        issuerEventId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        implementationDateTime = deserializer.deserialize(ZclDataType.UTCTIME);
+        supplyStatus = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/TakeSnapshot.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/TakeSnapshot.java
@@ -106,7 +106,7 @@ public class TakeSnapshot extends ZclMeteringCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        snapshotCause = (Integer) deserializer.deserialize(ZclDataType.BITMAP_32_BIT);
+        snapshotCause = deserializer.deserialize(ZclDataType.BITMAP_32_BIT);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/TakeSnapshotResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/metering/TakeSnapshotResponse.java
@@ -145,8 +145,8 @@ public class TakeSnapshotResponse extends ZclMeteringCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        snapshotId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        snapshotConfirmation = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        snapshotId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        snapshotConfirmation = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/onoff/OffWithEffectCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/onoff/OffWithEffectCommand.java
@@ -150,8 +150,8 @@ public class OffWithEffectCommand extends ZclOnOffCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        effectIdentifier = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        effectVariant = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        effectIdentifier = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        effectVariant = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/onoff/OnWithTimedOffCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/onoff/OnWithTimedOffCommand.java
@@ -192,9 +192,9 @@ public class OnWithTimedOffCommand extends ZclOnOffCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        onOffControl = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        onTime = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        offWaitTime = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        onOffControl = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        onTime = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        offWaitTime = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/onoff/ZclOnOffExtensionField.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/onoff/ZclOnOffExtensionField.java
@@ -58,10 +58,10 @@ public class ZclOnOffExtensionField extends ExtensionFieldSet {
 
     @Override
     public void deserialize(final ZigBeeDeserializer deserializer) {
-        clusterId = (int) deserializer.readZigBeeType(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        int size = (int) deserializer.readZigBeeType(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        clusterId = deserializer.readZigBeeType(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        int size = deserializer.readZigBeeType(ZclDataType.UNSIGNED_8_BIT_INTEGER);
         if (size >= 1) {
-            onOff = (Boolean) deserializer.readZigBeeType(ZclDataType.BOOLEAN);
+            onOff = deserializer.readZigBeeType(ZclDataType.BOOLEAN);
         }
     }
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/otaupgrade/ImageBlockCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/otaupgrade/ImageBlockCommand.java
@@ -316,17 +316,17 @@ public class ImageBlockCommand extends ZclOtaUpgradeCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        fieldControl = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
-        manufacturerCode = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        imageType = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        fileVersion = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        fileOffset = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        maximumDataSize = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        fieldControl = deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
+        manufacturerCode = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        imageType = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        fileVersion = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        fileOffset = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        maximumDataSize = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
         if ((fieldControl & 0x01) != 0) {
-            requestNodeAddress = (IeeeAddress) deserializer.deserialize(ZclDataType.IEEE_ADDRESS);
+            requestNodeAddress = deserializer.deserialize(ZclDataType.IEEE_ADDRESS);
         }
         if ((fieldControl & 0x02) != 0) {
-            blockRequestDelay = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+            blockRequestDelay = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
         }
     }
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/otaupgrade/ImageBlockResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/otaupgrade/ImageBlockResponse.java
@@ -261,12 +261,12 @@ public class ImageBlockResponse extends ZclOtaUpgradeCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        status = (ZclStatus) deserializer.deserialize(ZclDataType.ZCL_STATUS);
-        manufacturerCode = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        imageType = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        fileVersion = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        fileOffset = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        imageData = (ByteArray) deserializer.deserialize(ZclDataType.BYTE_ARRAY);
+        status = deserializer.deserialize(ZclDataType.ZCL_STATUS);
+        manufacturerCode = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        imageType = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        fileVersion = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        fileOffset = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        imageData = deserializer.deserialize(ZclDataType.BYTE_ARRAY);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/otaupgrade/ImageNotifyCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/otaupgrade/ImageNotifyCommand.java
@@ -233,18 +233,18 @@ public class ImageNotifyCommand extends ZclOtaUpgradeCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        payloadType = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        payloadType = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
         if (payloadType >= 0) {
-            queryJitter = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+            queryJitter = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
         }
         if (payloadType >= 1) {
-            manufacturerCode = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+            manufacturerCode = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
         }
         if (payloadType >= 2) {
-            imageType = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+            imageType = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
         }
         if (payloadType >= 3) {
-            newFileVersion = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+            newFileVersion = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
         }
     }
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/otaupgrade/ImagePageCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/otaupgrade/ImagePageCommand.java
@@ -345,16 +345,16 @@ public class ImagePageCommand extends ZclOtaUpgradeCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        fieldControl = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
-        manufacturerCode = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        imageType = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        fileVersion = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        fileOffset = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        maximumDataSize = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        pageSize = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        responseSpacing = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        fieldControl = deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
+        manufacturerCode = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        imageType = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        fileVersion = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        fileOffset = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        maximumDataSize = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        pageSize = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        responseSpacing = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
         if ((fieldControl & 0x01) != 0) {
-            requestNodeAddress = (IeeeAddress) deserializer.deserialize(ZclDataType.IEEE_ADDRESS);
+            requestNodeAddress = deserializer.deserialize(ZclDataType.IEEE_ADDRESS);
         }
     }
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/otaupgrade/QueryNextImageCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/otaupgrade/QueryNextImageCommand.java
@@ -227,12 +227,12 @@ public class QueryNextImageCommand extends ZclOtaUpgradeCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        fieldControl = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
-        manufacturerCode = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        imageType = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        fileVersion = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        fieldControl = deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
+        manufacturerCode = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        imageType = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        fileVersion = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
         if ((fieldControl & 0x01) != 0) {
-            hardwareVersion = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+            hardwareVersion = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
         }
     }
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/otaupgrade/QueryNextImageResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/otaupgrade/QueryNextImageResponse.java
@@ -232,18 +232,18 @@ public class QueryNextImageResponse extends ZclOtaUpgradeCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        status = (ZclStatus) deserializer.deserialize(ZclDataType.ZCL_STATUS);
+        status = deserializer.deserialize(ZclDataType.ZCL_STATUS);
         if (status == ZclStatus.SUCCESS) {
-            manufacturerCode = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+            manufacturerCode = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
         }
         if (status == ZclStatus.SUCCESS) {
-            imageType = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+            imageType = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
         }
         if (status == ZclStatus.SUCCESS) {
-            fileVersion = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+            fileVersion = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
         }
         if (status == ZclStatus.SUCCESS) {
-            imageSize = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+            imageSize = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
         }
     }
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/otaupgrade/QuerySpecificFileCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/otaupgrade/QuerySpecificFileCommand.java
@@ -220,11 +220,11 @@ public class QuerySpecificFileCommand extends ZclOtaUpgradeCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        requestNodeAddress = (IeeeAddress) deserializer.deserialize(ZclDataType.IEEE_ADDRESS);
-        manufacturerCode = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        imageType = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        fileVersion = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        zigbeeStackVersion = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        requestNodeAddress = deserializer.deserialize(ZclDataType.IEEE_ADDRESS);
+        manufacturerCode = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        imageType = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        fileVersion = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        zigbeeStackVersion = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/otaupgrade/QuerySpecificFileResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/otaupgrade/QuerySpecificFileResponse.java
@@ -230,18 +230,18 @@ public class QuerySpecificFileResponse extends ZclOtaUpgradeCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        status = (ZclStatus) deserializer.deserialize(ZclDataType.ZCL_STATUS);
+        status = deserializer.deserialize(ZclDataType.ZCL_STATUS);
         if (status == ZclStatus.SUCCESS) {
-            manufacturerCode = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+            manufacturerCode = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
         }
         if (status == ZclStatus.SUCCESS) {
-            imageType = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+            imageType = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
         }
         if (status == ZclStatus.SUCCESS) {
-            fileVersion = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+            fileVersion = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
         }
         if (status == ZclStatus.SUCCESS) {
-            imageSize = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+            imageSize = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
         }
     }
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/otaupgrade/UpgradeEndCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/otaupgrade/UpgradeEndCommand.java
@@ -200,10 +200,10 @@ public class UpgradeEndCommand extends ZclOtaUpgradeCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        status = (ZclStatus) deserializer.deserialize(ZclDataType.ZCL_STATUS);
-        manufacturerCode = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        imageType = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        fileVersion = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        status = deserializer.deserialize(ZclDataType.ZCL_STATUS);
+        manufacturerCode = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        imageType = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        fileVersion = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/otaupgrade/UpgradeEndResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/otaupgrade/UpgradeEndResponse.java
@@ -223,11 +223,11 @@ public class UpgradeEndResponse extends ZclOtaUpgradeCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        manufacturerCode = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        imageType = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        fileVersion = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        currentTime = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        upgradeTime = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        manufacturerCode = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        imageType = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        fileVersion = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        currentTime = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        upgradeTime = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/pollcontrol/CheckInResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/pollcontrol/CheckInResponse.java
@@ -208,8 +208,8 @@ public class CheckInResponse extends ZclPollControlCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        startFastPolling = (Boolean) deserializer.deserialize(ZclDataType.BOOLEAN);
-        fastPollTimeout = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        startFastPolling = deserializer.deserialize(ZclDataType.BOOLEAN);
+        fastPollTimeout = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/pollcontrol/SetLongPollIntervalCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/pollcontrol/SetLongPollIntervalCommand.java
@@ -103,7 +103,7 @@ public class SetLongPollIntervalCommand extends ZclPollControlCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        newLongPollInterval = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        newLongPollInterval = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/pollcontrol/SetShortPollIntervalCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/pollcontrol/SetShortPollIntervalCommand.java
@@ -103,7 +103,7 @@ public class SetShortPollIntervalCommand extends ZclPollControlCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        newShortPollInterval = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        newShortPollInterval = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/ChangeDebt.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/ChangeDebt.java
@@ -362,16 +362,16 @@ public class ChangeDebt extends ZclPrepaymentCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        issuerEventId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        debtLabel = (ByteArray) deserializer.deserialize(ZclDataType.OCTET_STRING);
-        debtAmount = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        debtRecoveryMethod = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        debtAmountType = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        debtRecoveryStartTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
-        debtRecoveryCollectionTime = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        debtRecoveryFrequency = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        debtRecoveryAmount = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        debtRecoveryBalancePercentage = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        issuerEventId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        debtLabel = deserializer.deserialize(ZclDataType.OCTET_STRING);
+        debtAmount = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        debtRecoveryMethod = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        debtAmountType = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        debtRecoveryStartTime = deserializer.deserialize(ZclDataType.UTCTIME);
+        debtRecoveryCollectionTime = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        debtRecoveryFrequency = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        debtRecoveryAmount = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        debtRecoveryBalancePercentage = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/ChangePaymentMode.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/ChangePaymentMode.java
@@ -216,11 +216,11 @@ public class ChangePaymentMode extends ZclPrepaymentCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        providerId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        issuerEventId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        implementationDateTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
-        proposedPaymentControlConfiguration = (Integer) deserializer.deserialize(ZclDataType.BITMAP_16_BIT);
-        cutOffValue = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        providerId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        issuerEventId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        implementationDateTime = deserializer.deserialize(ZclDataType.UTCTIME);
+        proposedPaymentControlConfiguration = deserializer.deserialize(ZclDataType.BITMAP_16_BIT);
+        cutOffValue = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/ChangePaymentModeResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/ChangePaymentModeResponse.java
@@ -184,10 +184,10 @@ public class ChangePaymentModeResponse extends ZclPrepaymentCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        friendlyCredit = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
-        friendlyCreditCalendarId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        emergencyCreditLimit = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        emergencyCreditThreshold = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        friendlyCredit = deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
+        friendlyCreditCalendarId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        emergencyCreditLimit = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        emergencyCreditThreshold = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/ConsumerTopUp.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/ConsumerTopUp.java
@@ -128,8 +128,8 @@ public class ConsumerTopUp extends ZclPrepaymentCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        originatingDevice = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        topUpCode = (ByteArray) deserializer.deserialize(ZclDataType.OCTET_STRING);
+        originatingDevice = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        topUpCode = deserializer.deserialize(ZclDataType.OCTET_STRING);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/ConsumerTopUpResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/ConsumerTopUpResponse.java
@@ -184,10 +184,10 @@ public class ConsumerTopUpResponse extends ZclPrepaymentCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        resultType = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        topUpValue = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        sourceOfTopUp = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        creditRemaining = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        resultType = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        topUpValue = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        sourceOfTopUp = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        creditRemaining = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/CreditAdjustment.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/CreditAdjustment.java
@@ -187,10 +187,10 @@ public class CreditAdjustment extends ZclPrepaymentCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        issuerEventId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        startTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
-        creditAdjustmentType = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        creditAdjustmentValue = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        issuerEventId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        startTime = deserializer.deserialize(ZclDataType.UTCTIME);
+        creditAdjustmentType = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        creditAdjustmentValue = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/DebtPayload.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/DebtPayload.java
@@ -162,10 +162,10 @@ public class DebtPayload implements ZigBeeSerializable {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        collectionTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
-        amountCollected = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        debtType = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        outstandingDebt = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        collectionTime = deserializer.deserialize(ZclDataType.UTCTIME);
+        amountCollected = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        debtType = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        outstandingDebt = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/EmergencyCreditSetup.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/EmergencyCreditSetup.java
@@ -186,10 +186,10 @@ public class EmergencyCreditSetup extends ZclPrepaymentCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        issuerEventId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        startTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
-        emergencyCreditLimit = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        emergencyCreditThreshold = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        issuerEventId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        startTime = deserializer.deserialize(ZclDataType.UTCTIME);
+        emergencyCreditLimit = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        emergencyCreditThreshold = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/GetDebtRepaymentLog.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/GetDebtRepaymentLog.java
@@ -157,9 +157,9 @@ public class GetDebtRepaymentLog extends ZclPrepaymentCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        latestEndTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
-        numberOfDebts = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        debtType = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        latestEndTime = deserializer.deserialize(ZclDataType.UTCTIME);
+        numberOfDebts = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        debtType = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/GetPrepaySnapshot.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/GetPrepaySnapshot.java
@@ -186,10 +186,10 @@ public class GetPrepaySnapshot extends ZclPrepaymentCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        earliestStartTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
-        latestEndTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
-        snapshotOffset = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        snapshotCause = (Integer) deserializer.deserialize(ZclDataType.BITMAP_32_BIT);
+        earliestStartTime = deserializer.deserialize(ZclDataType.UTCTIME);
+        latestEndTime = deserializer.deserialize(ZclDataType.UTCTIME);
+        snapshotOffset = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        snapshotCause = deserializer.deserialize(ZclDataType.BITMAP_32_BIT);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/GetTopUpLog.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/GetTopUpLog.java
@@ -129,8 +129,8 @@ public class GetTopUpLog extends ZclPrepaymentCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        latestEndTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
-        numberOfRecords = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        latestEndTime = deserializer.deserialize(ZclDataType.UTCTIME);
+        numberOfRecords = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/PublishDebtLog.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/PublishDebtLog.java
@@ -156,8 +156,8 @@ public class PublishDebtLog extends ZclPrepaymentCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        commandIndex = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        totalNumberOfCommands = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        commandIndex = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        totalNumberOfCommands = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
         debtPayload = new DebtPayload();
         debtPayload.deserialize(deserializer);
     }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/PublishPrepaySnapshot.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/PublishPrepaySnapshot.java
@@ -303,14 +303,14 @@ public class PublishPrepaySnapshot extends ZclPrepaymentCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        snapshotId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        snapshotTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
-        totalSnapshotsFound = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        commandIndex = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        totalNumberOfCommands = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        snapshotCause = (Integer) deserializer.deserialize(ZclDataType.BITMAP_32_BIT);
-        snapshotPayloadType = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        snapshotPayload = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        snapshotId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        snapshotTime = deserializer.deserialize(ZclDataType.UTCTIME);
+        totalSnapshotsFound = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        commandIndex = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        totalNumberOfCommands = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        snapshotCause = deserializer.deserialize(ZclDataType.BITMAP_32_BIT);
+        snapshotPayloadType = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        snapshotPayload = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/PublishTopUpLog.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/PublishTopUpLog.java
@@ -156,8 +156,8 @@ public class PublishTopUpLog extends ZclPrepaymentCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        commandIndex = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        totalNumberOfCommands = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        commandIndex = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        totalNumberOfCommands = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
         topUpPayload = new TopUpPayload();
         topUpPayload.deserialize(deserializer);
     }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/SelectAvailableEmergencyCredit.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/SelectAvailableEmergencyCredit.java
@@ -188,10 +188,10 @@ public class SelectAvailableEmergencyCredit extends ZclPrepaymentCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        commandIssueDateTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
-        originatingDevice = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        siteId = (ByteArray) deserializer.deserialize(ZclDataType.OCTET_STRING);
-        meterSerialNumber = (ByteArray) deserializer.deserialize(ZclDataType.OCTET_STRING);
+        commandIssueDateTime = deserializer.deserialize(ZclDataType.UTCTIME);
+        originatingDevice = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        siteId = deserializer.deserialize(ZclDataType.OCTET_STRING);
+        meterSerialNumber = deserializer.deserialize(ZclDataType.OCTET_STRING);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/SetLowCreditWarningLevel.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/SetLowCreditWarningLevel.java
@@ -98,7 +98,7 @@ public class SetLowCreditWarningLevel extends ZclPrepaymentCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        lowCreditWarningLevel = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        lowCreditWarningLevel = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/SetMaximumCreditLimit.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/SetMaximumCreditLimit.java
@@ -216,11 +216,11 @@ public class SetMaximumCreditLimit extends ZclPrepaymentCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        providerId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        issuerEventId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        implementationDateTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
-        maximumCreditLevel = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        maximumCreditPerTopUp = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        providerId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        issuerEventId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        implementationDateTime = deserializer.deserialize(ZclDataType.UTCTIME);
+        maximumCreditLevel = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        maximumCreditPerTopUp = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/SetOverallDebtCap.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/SetOverallDebtCap.java
@@ -187,10 +187,10 @@ public class SetOverallDebtCap extends ZclPrepaymentCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        providerId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        issuerEventId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        implementationDateTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
-        overallDebtCap = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        providerId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        issuerEventId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        implementationDateTime = deserializer.deserialize(ZclDataType.UTCTIME);
+        overallDebtCap = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/TopUpPayload.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/prepayment/TopUpPayload.java
@@ -134,9 +134,9 @@ public class TopUpPayload implements ZigBeeSerializable {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        topUpCode = (ByteArray) deserializer.deserialize(ZclDataType.OCTET_STRING);
-        topUpAmount = (Integer) deserializer.deserialize(ZclDataType.SIGNED_32_BIT_INTEGER);
-        topUpTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
+        topUpCode = deserializer.deserialize(ZclDataType.OCTET_STRING);
+        topUpAmount = deserializer.deserialize(ZclDataType.SIGNED_32_BIT_INTEGER);
+        topUpTime = deserializer.deserialize(ZclDataType.UTCTIME);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/BlockThresholdSubPayload.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/BlockThresholdSubPayload.java
@@ -102,8 +102,8 @@ public class BlockThresholdSubPayload implements ZigBeeSerializable {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        tierNumberOfBlockThresholds = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        blockThreshold = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_48_BIT_INTEGER);
+        tierNumberOfBlockThresholds = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        blockThreshold = deserializer.deserialize(ZclDataType.UNSIGNED_48_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/CancelTariffCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/CancelTariffCommand.java
@@ -192,9 +192,9 @@ public class CancelTariffCommand extends ZclPriceCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        providerId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        issuerTariffId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        tariffType = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
+        providerId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        issuerTariffId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        tariffType = deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/CppEventResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/CppEventResponse.java
@@ -157,8 +157,8 @@ public class CppEventResponse extends ZclPriceCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        issuerEventId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        cppAuth = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        issuerEventId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        cppAuth = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/GetBillingPeriodCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/GetBillingPeriodCommand.java
@@ -250,10 +250,10 @@ public class GetBillingPeriodCommand extends ZclPriceCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        earliestStartTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
-        minIssuerEventId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        numberOfCommands = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        tariffType = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
+        earliestStartTime = deserializer.deserialize(ZclDataType.UTCTIME);
+        minIssuerEventId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        numberOfCommands = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        tariffType = deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/GetBlockPeriodCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/GetBlockPeriodCommand.java
@@ -202,9 +202,9 @@ public class GetBlockPeriodCommand extends ZclPriceCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        startTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
-        numberOfEvents = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        tariffType = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
+        startTime = deserializer.deserialize(ZclDataType.UTCTIME);
+        numberOfEvents = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        tariffType = deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/GetBlockThresholdsCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/GetBlockThresholdsCommand.java
@@ -106,7 +106,7 @@ public class GetBlockThresholdsCommand extends ZclPriceCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        issuerTariffId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        issuerTariffId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/GetCalorificValueCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/GetCalorificValueCommand.java
@@ -205,9 +205,9 @@ public class GetCalorificValueCommand extends ZclPriceCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        earliestStartTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
-        minIssuerEventId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        numberOfCommands = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        earliestStartTime = deserializer.deserialize(ZclDataType.UTCTIME);
+        minIssuerEventId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        numberOfCommands = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/GetCo2ValueCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/GetCo2ValueCommand.java
@@ -248,10 +248,10 @@ public class GetCo2ValueCommand extends ZclPriceCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        earliestStartTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
-        minIssuerEventId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        numberOfCommands = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        tariffType = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
+        earliestStartTime = deserializer.deserialize(ZclDataType.UTCTIME);
+        minIssuerEventId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        numberOfCommands = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        tariffType = deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/GetConsolidatedBillCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/GetConsolidatedBillCommand.java
@@ -253,10 +253,10 @@ public class GetConsolidatedBillCommand extends ZclPriceCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        earliestStartTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
-        minIssuerEventId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        numberOfCommands = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        tariffType = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
+        earliestStartTime = deserializer.deserialize(ZclDataType.UTCTIME);
+        minIssuerEventId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        numberOfCommands = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        tariffType = deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/GetConversionFactorCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/GetConversionFactorCommand.java
@@ -209,9 +209,9 @@ public class GetConversionFactorCommand extends ZclPriceCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        earliestStartTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
-        minIssuerEventId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        numberOfCommands = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        earliestStartTime = deserializer.deserialize(ZclDataType.UTCTIME);
+        minIssuerEventId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        numberOfCommands = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/GetCreditPaymentCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/GetCreditPaymentCommand.java
@@ -165,8 +165,8 @@ public class GetCreditPaymentCommand extends ZclPriceCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        latestEndTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
-        numberOfRecords = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        latestEndTime = deserializer.deserialize(ZclDataType.UTCTIME);
+        numberOfRecords = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/GetCurrentPriceCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/GetCurrentPriceCommand.java
@@ -98,7 +98,7 @@ public class GetCurrentPriceCommand extends ZclPriceCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        commandOptions = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
+        commandOptions = deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/GetPriceMatrixCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/GetPriceMatrixCommand.java
@@ -106,7 +106,7 @@ public class GetPriceMatrixCommand extends ZclPriceCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        issuerTariffId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        issuerTariffId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/GetScheduledPricesCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/GetScheduledPricesCommand.java
@@ -160,8 +160,8 @@ public class GetScheduledPricesCommand extends ZclPriceCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        startTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
-        numberOfEvents = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        startTime = deserializer.deserialize(ZclDataType.UTCTIME);
+        numberOfEvents = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/GetTariffInformationCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/GetTariffInformationCommand.java
@@ -248,10 +248,10 @@ public class GetTariffInformationCommand extends ZclPriceCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        earliestStartTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
-        minIssuerEventId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        numberOfCommands = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        tariffType = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
+        earliestStartTime = deserializer.deserialize(ZclDataType.UTCTIME);
+        minIssuerEventId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        numberOfCommands = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        tariffType = deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/GetTierLabelsCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/GetTierLabelsCommand.java
@@ -107,7 +107,7 @@ public class GetTierLabelsCommand extends ZclPriceCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        issuerTariffId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        issuerTariffId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PriceAcknowledgementCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PriceAcknowledgementCommand.java
@@ -212,10 +212,10 @@ public class PriceAcknowledgementCommand extends ZclPriceCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        providerId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        issuerEventId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        priceAckTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
-        control = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
+        providerId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        issuerEventId = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        priceAckTime = deserializer.deserialize(ZclDataType.UTCTIME);
+        control = deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PriceMatrixSubPayload.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PriceMatrixSubPayload.java
@@ -102,8 +102,8 @@ public class PriceMatrixSubPayload implements ZigBeeSerializable {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        tierBlockId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        price = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        tierBlockId = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        price = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishBillingPeriodCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishBillingPeriodCommand.java
@@ -346,12 +346,12 @@ public class PublishBillingPeriodCommand extends ZclPriceCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        providerId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        issuerEventId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        billingPeriodStartTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
-        billingPeriodDuration = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_24_BIT_INTEGER);
-        billingPeriodDurationType = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        tariffType = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
+        providerId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        issuerEventId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        billingPeriodStartTime = deserializer.deserialize(ZclDataType.UTCTIME);
+        billingPeriodDuration = deserializer.deserialize(ZclDataType.UNSIGNED_24_BIT_INTEGER);
+        billingPeriodDurationType = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        tariffType = deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishBlockPeriodCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishBlockPeriodCommand.java
@@ -495,14 +495,14 @@ public class PublishBlockPeriodCommand extends ZclPriceCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        providerId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        issuerEventId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        blockPeriodStartTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
-        blockPeriodDuration = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_24_BIT_INTEGER);
-        blockPeriodControl = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
-        blockPeriodDurationType = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
-        tariffType = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
-        tariffResolutionPeriod = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        providerId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        issuerEventId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        blockPeriodStartTime = deserializer.deserialize(ZclDataType.UTCTIME);
+        blockPeriodDuration = deserializer.deserialize(ZclDataType.UNSIGNED_24_BIT_INTEGER);
+        blockPeriodControl = deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
+        blockPeriodDurationType = deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
+        tariffType = deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
+        tariffResolutionPeriod = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishBlockThresholdsCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishBlockThresholdsCommand.java
@@ -416,13 +416,13 @@ public class PublishBlockThresholdsCommand extends ZclPriceCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        providerId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        issuerEventId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        startTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
-        issuerTariffId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        commandIndex = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        totalNumberOfCommands = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        subPayloadControl = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
+        providerId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        issuerEventId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        startTime = deserializer.deserialize(ZclDataType.UTCTIME);
+        issuerTariffId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        commandIndex = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        totalNumberOfCommands = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        subPayloadControl = deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
         blockThresholdSubPayload = new BlockThresholdSubPayload();
         blockThresholdSubPayload.deserialize(deserializer);
     }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishCalorificValueCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishCalorificValueCommand.java
@@ -217,11 +217,11 @@ public class PublishCalorificValueCommand extends ZclPriceCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        issuerEventId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        startTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
-        calorificValue = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        calorificValueUnit = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        calorificValueTrailingDigit = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
+        issuerEventId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        startTime = deserializer.deserialize(ZclDataType.UTCTIME);
+        calorificValue = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        calorificValueUnit = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        calorificValueTrailingDigit = deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishCo2ValueCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishCo2ValueCommand.java
@@ -377,13 +377,13 @@ public class PublishCo2ValueCommand extends ZclPriceCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        providerId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        issuerEventId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        startTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
-        tariffType = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
-        co2Value = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        co2ValueUnit = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        co2ValueTrailingDigit = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
+        providerId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        issuerEventId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        startTime = deserializer.deserialize(ZclDataType.UTCTIME);
+        tariffType = deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
+        co2Value = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        co2ValueUnit = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        co2ValueTrailingDigit = deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishConsolidatedBillCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishConsolidatedBillCommand.java
@@ -461,15 +461,15 @@ public class PublishConsolidatedBillCommand extends ZclPriceCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        providerId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        issuerEventId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        billingPeriodStartTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
-        billingPeriodDuration = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_24_BIT_INTEGER);
-        billingPeriodDurationType = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        tariffType = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
-        consolidatedBill = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        currency = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        billTrailingDigit = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
+        providerId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        issuerEventId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        billingPeriodStartTime = deserializer.deserialize(ZclDataType.UTCTIME);
+        billingPeriodDuration = deserializer.deserialize(ZclDataType.UNSIGNED_24_BIT_INTEGER);
+        billingPeriodDurationType = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        tariffType = deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
+        consolidatedBill = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        currency = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        billTrailingDigit = deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishConversionFactorCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishConversionFactorCommand.java
@@ -215,10 +215,10 @@ public class PublishConversionFactorCommand extends ZclPriceCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        issuerEventId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        startTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
-        conversionFactor = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        conversionFactorTrailingDigit = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
+        issuerEventId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        startTime = deserializer.deserialize(ZclDataType.UTCTIME);
+        conversionFactor = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        conversionFactorTrailingDigit = deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishCppEventCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishCppEventCommand.java
@@ -364,13 +364,13 @@ public class PublishCppEventCommand extends ZclPriceCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        providerId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        issuerEventId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        startTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
-        durationInMinutes = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        tariffType = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
-        cppPriceTier = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        cppAuth = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        providerId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        issuerEventId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        startTime = deserializer.deserialize(ZclDataType.UTCTIME);
+        durationInMinutes = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        tariffType = deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
+        cppPriceTier = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        cppAuth = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishCreditPaymentCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishCreditPaymentCommand.java
@@ -385,14 +385,14 @@ public class PublishCreditPaymentCommand extends ZclPriceCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        providerId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        issuerEventId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        creditPaymentDueDate = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
-        creditPaymentOverdueAmount = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        creditPaymentStatus = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        creditPayment = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        creditPaymentDate = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
-        creditPaymentRef = (ByteArray) deserializer.deserialize(ZclDataType.OCTET_STRING);
+        providerId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        issuerEventId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        creditPaymentDueDate = deserializer.deserialize(ZclDataType.UTCTIME);
+        creditPaymentOverdueAmount = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        creditPaymentStatus = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        creditPayment = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        creditPaymentDate = deserializer.deserialize(ZclDataType.UTCTIME);
+        creditPaymentRef = deserializer.deserialize(ZclDataType.OCTET_STRING);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishCurrencyConversionCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishCurrencyConversionCommand.java
@@ -402,14 +402,14 @@ public class PublishCurrencyConversionCommand extends ZclPriceCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        providerId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        issuerEventId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        startTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
-        oldCurrency = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        newCurrency = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        conversionFactor = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        conversionFactorTrailingDigit = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
-        currencyChangeControlFlags = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        providerId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        issuerEventId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        startTime = deserializer.deserialize(ZclDataType.UTCTIME);
+        oldCurrency = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        newCurrency = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        conversionFactor = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        conversionFactorTrailingDigit = deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
+        currencyChangeControlFlags = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishPriceCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishPriceCommand.java
@@ -1047,30 +1047,30 @@ public class PublishPriceCommand extends ZclPriceCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        providerId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        rateLabel = (ByteArray) deserializer.deserialize(ZclDataType.OCTET_STRING);
-        issuerEventId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        currentTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
-        unitOfMeasure = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        currency = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        priceTrailingDigitAndTier = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
-        numberOfPriceTiers = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
-        startTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
-        duration = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        price = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        priceRatio = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        generationPrice = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        generationPriceRatio = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        alternateCostDelivered = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        alternateCostUnit = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        alternateCostTrailingDigit = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
-        numberOfBlockThresholds = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        priceControl = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
-        numberOfGenerationTiers = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        generationTier = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        extendedNumberOfPriceTiers = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        extendedPriceTier = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        extendedRegisterTier = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        providerId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        rateLabel = deserializer.deserialize(ZclDataType.OCTET_STRING);
+        issuerEventId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        currentTime = deserializer.deserialize(ZclDataType.UTCTIME);
+        unitOfMeasure = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        currency = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        priceTrailingDigitAndTier = deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
+        numberOfPriceTiers = deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
+        startTime = deserializer.deserialize(ZclDataType.UTCTIME);
+        duration = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        price = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        priceRatio = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        generationPrice = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        generationPriceRatio = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        alternateCostDelivered = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        alternateCostUnit = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        alternateCostTrailingDigit = deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
+        numberOfBlockThresholds = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        priceControl = deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
+        numberOfGenerationTiers = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        generationTier = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        extendedNumberOfPriceTiers = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        extendedPriceTier = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        extendedRegisterTier = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishPriceMatrixCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishPriceMatrixCommand.java
@@ -404,13 +404,13 @@ public class PublishPriceMatrixCommand extends ZclPriceCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        providerId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        issuerEventId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        startTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
-        issuerTariffId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        commandIndex = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        totalNumberOfCommands = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        subPayloadControl = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
+        providerId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        issuerEventId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        startTime = deserializer.deserialize(ZclDataType.UTCTIME);
+        issuerTariffId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        commandIndex = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        totalNumberOfCommands = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        subPayloadControl = deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
         priceMatrixSubPayload = new PriceMatrixSubPayload();
         priceMatrixSubPayload.deserialize(deserializer);
     }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishTariffInformationCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishTariffInformationCommand.java
@@ -687,21 +687,21 @@ public class PublishTariffInformationCommand extends ZclPriceCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        providerId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        issuerEventId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        issuerTariffId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        startTime = (Calendar) deserializer.deserialize(ZclDataType.UTCTIME);
-        tariffType = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
-        tariffLabel = (ByteArray) deserializer.deserialize(ZclDataType.OCTET_STRING);
-        numberOfPriceTiers = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        numberOfBlockThresholds = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        unitOfMeasure = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        currency = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        priceTrailingDigit = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
-        standingCharge = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        tierBlockMode = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        blockThresholdMultiplier = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_24_BIT_INTEGER);
-        blockThresholdDivisor = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_24_BIT_INTEGER);
+        providerId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        issuerEventId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        issuerTariffId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        startTime = deserializer.deserialize(ZclDataType.UTCTIME);
+        tariffType = deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
+        tariffLabel = deserializer.deserialize(ZclDataType.OCTET_STRING);
+        numberOfPriceTiers = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        numberOfBlockThresholds = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        unitOfMeasure = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        currency = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        priceTrailingDigit = deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
+        standingCharge = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        tierBlockMode = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        blockThresholdMultiplier = deserializer.deserialize(ZclDataType.UNSIGNED_24_BIT_INTEGER);
+        blockThresholdDivisor = deserializer.deserialize(ZclDataType.UNSIGNED_24_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishTierLabelsCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/price/PublishTierLabelsCommand.java
@@ -392,14 +392,14 @@ public class PublishTierLabelsCommand extends ZclPriceCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        providerId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        issuerEventId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        issuerTariffId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        commandIndex = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        totalNumberOfCommands = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        numberOfLabels = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        tierId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        tierLabel = (ByteArray) deserializer.deserialize(ZclDataType.OCTET_STRING);
+        providerId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        issuerEventId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        issuerTariffId = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        commandIndex = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        totalNumberOfCommands = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        numberOfLabels = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        tierId = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        tierLabel = deserializer.deserialize(ZclDataType.OCTET_STRING);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/rssilocation/AnchorNodeAnnounceCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/rssilocation/AnchorNodeAnnounceCommand.java
@@ -183,10 +183,10 @@ public class AnchorNodeAnnounceCommand extends ZclRssiLocationCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        anchorNodeAddress = (IeeeAddress) deserializer.deserialize(ZclDataType.IEEE_ADDRESS);
-        coordinate1 = (Integer) deserializer.deserialize(ZclDataType.SIGNED_16_BIT_INTEGER);
-        coordinate2 = (Integer) deserializer.deserialize(ZclDataType.SIGNED_16_BIT_INTEGER);
-        coordinate3 = (Integer) deserializer.deserialize(ZclDataType.SIGNED_16_BIT_INTEGER);
+        anchorNodeAddress = deserializer.deserialize(ZclDataType.IEEE_ADDRESS);
+        coordinate1 = deserializer.deserialize(ZclDataType.SIGNED_16_BIT_INTEGER);
+        coordinate2 = deserializer.deserialize(ZclDataType.SIGNED_16_BIT_INTEGER);
+        coordinate3 = deserializer.deserialize(ZclDataType.SIGNED_16_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/rssilocation/DeviceConfigurationResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/rssilocation/DeviceConfigurationResponse.java
@@ -240,12 +240,12 @@ public class DeviceConfigurationResponse extends ZclRssiLocationCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        status = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        power = (Integer) deserializer.deserialize(ZclDataType.SIGNED_16_BIT_INTEGER);
-        pathLossExponent = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        calculationPeriod = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        numberRssiMeasurements = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        reportingPeriod = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        status = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        power = deserializer.deserialize(ZclDataType.SIGNED_16_BIT_INTEGER);
+        pathLossExponent = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        calculationPeriod = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        numberRssiMeasurements = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        reportingPeriod = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/rssilocation/GetDeviceConfigurationCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/rssilocation/GetDeviceConfigurationCommand.java
@@ -96,7 +96,7 @@ public class GetDeviceConfigurationCommand extends ZclRssiLocationCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        targetAddress = (IeeeAddress) deserializer.deserialize(ZclDataType.IEEE_ADDRESS);
+        targetAddress = deserializer.deserialize(ZclDataType.IEEE_ADDRESS);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/rssilocation/GetLocationDataCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/rssilocation/GetLocationDataCommand.java
@@ -154,9 +154,9 @@ public class GetLocationDataCommand extends ZclRssiLocationCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        header = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
-        numberResponses = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        targetAddress = (IeeeAddress) deserializer.deserialize(ZclDataType.IEEE_ADDRESS);
+        header = deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
+        numberResponses = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        targetAddress = deserializer.deserialize(ZclDataType.IEEE_ADDRESS);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/rssilocation/LocationDataNotificationCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/rssilocation/LocationDataNotificationCommand.java
@@ -327,15 +327,15 @@ public class LocationDataNotificationCommand extends ZclRssiLocationCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        locationType = (Integer) deserializer.deserialize(ZclDataType.DATA_8_BIT);
-        coordinate1 = (Integer) deserializer.deserialize(ZclDataType.SIGNED_16_BIT_INTEGER);
-        coordinate2 = (Integer) deserializer.deserialize(ZclDataType.SIGNED_16_BIT_INTEGER);
-        coordinate3 = (Integer) deserializer.deserialize(ZclDataType.SIGNED_16_BIT_INTEGER);
-        power = (Integer) deserializer.deserialize(ZclDataType.SIGNED_16_BIT_INTEGER);
-        pathLossExponent = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        locationMethod = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        qualityMeasure = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        locationAge = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        locationType = deserializer.deserialize(ZclDataType.DATA_8_BIT);
+        coordinate1 = deserializer.deserialize(ZclDataType.SIGNED_16_BIT_INTEGER);
+        coordinate2 = deserializer.deserialize(ZclDataType.SIGNED_16_BIT_INTEGER);
+        coordinate3 = deserializer.deserialize(ZclDataType.SIGNED_16_BIT_INTEGER);
+        power = deserializer.deserialize(ZclDataType.SIGNED_16_BIT_INTEGER);
+        pathLossExponent = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        locationMethod = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        qualityMeasure = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        locationAge = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/rssilocation/LocationDataResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/rssilocation/LocationDataResponse.java
@@ -356,16 +356,16 @@ public class LocationDataResponse extends ZclRssiLocationCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        status = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        locationType = (Integer) deserializer.deserialize(ZclDataType.DATA_8_BIT);
-        coordinate1 = (Integer) deserializer.deserialize(ZclDataType.SIGNED_16_BIT_INTEGER);
-        coordinate2 = (Integer) deserializer.deserialize(ZclDataType.SIGNED_16_BIT_INTEGER);
-        coordinate3 = (Integer) deserializer.deserialize(ZclDataType.SIGNED_16_BIT_INTEGER);
-        power = (Integer) deserializer.deserialize(ZclDataType.SIGNED_16_BIT_INTEGER);
-        pathLossExponent = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        locationMethod = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        qualityMeasure = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        locationAge = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        status = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        locationType = deserializer.deserialize(ZclDataType.DATA_8_BIT);
+        coordinate1 = deserializer.deserialize(ZclDataType.SIGNED_16_BIT_INTEGER);
+        coordinate2 = deserializer.deserialize(ZclDataType.SIGNED_16_BIT_INTEGER);
+        coordinate3 = deserializer.deserialize(ZclDataType.SIGNED_16_BIT_INTEGER);
+        power = deserializer.deserialize(ZclDataType.SIGNED_16_BIT_INTEGER);
+        pathLossExponent = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        locationMethod = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        qualityMeasure = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        locationAge = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/rssilocation/ReportRssiMeasurementsCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/rssilocation/ReportRssiMeasurementsCommand.java
@@ -157,9 +157,9 @@ public class ReportRssiMeasurementsCommand extends ZclRssiLocationCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        reportingAddress = (IeeeAddress) deserializer.deserialize(ZclDataType.IEEE_ADDRESS);
-        numberOfNeighbors = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        neighborsInformation = (List<NeighborInformation>) deserializer.deserialize(ZclDataType.N_X_NEIGHBORS_INFORMATION);
+        reportingAddress = deserializer.deserialize(ZclDataType.IEEE_ADDRESS);
+        numberOfNeighbors = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        neighborsInformation = deserializer.deserialize(ZclDataType.N_X_NEIGHBORS_INFORMATION);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/rssilocation/RequestOwnLocationCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/rssilocation/RequestOwnLocationCommand.java
@@ -96,7 +96,7 @@ public class RequestOwnLocationCommand extends ZclRssiLocationCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        requestingAddress = (IeeeAddress) deserializer.deserialize(ZclDataType.IEEE_ADDRESS);
+        requestingAddress = deserializer.deserialize(ZclDataType.IEEE_ADDRESS);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/rssilocation/RssiPingCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/rssilocation/RssiPingCommand.java
@@ -95,7 +95,7 @@ public class RssiPingCommand extends ZclRssiLocationCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        locationType = (Integer) deserializer.deserialize(ZclDataType.DATA_8_BIT);
+        locationType = deserializer.deserialize(ZclDataType.DATA_8_BIT);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/rssilocation/RssiResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/rssilocation/RssiResponse.java
@@ -241,12 +241,12 @@ public class RssiResponse extends ZclRssiLocationCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        replyingDevice = (IeeeAddress) deserializer.deserialize(ZclDataType.IEEE_ADDRESS);
-        coordinate1 = (Integer) deserializer.deserialize(ZclDataType.SIGNED_16_BIT_INTEGER);
-        coordinate2 = (Integer) deserializer.deserialize(ZclDataType.SIGNED_16_BIT_INTEGER);
-        coordinate3 = (Integer) deserializer.deserialize(ZclDataType.SIGNED_16_BIT_INTEGER);
-        rssi = (Integer) deserializer.deserialize(ZclDataType.SIGNED_8_BIT_INTEGER);
-        numberRssiMeasurements = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        replyingDevice = deserializer.deserialize(ZclDataType.IEEE_ADDRESS);
+        coordinate1 = deserializer.deserialize(ZclDataType.SIGNED_16_BIT_INTEGER);
+        coordinate2 = deserializer.deserialize(ZclDataType.SIGNED_16_BIT_INTEGER);
+        coordinate3 = deserializer.deserialize(ZclDataType.SIGNED_16_BIT_INTEGER);
+        rssi = deserializer.deserialize(ZclDataType.SIGNED_8_BIT_INTEGER);
+        numberRssiMeasurements = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/rssilocation/SendPingsCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/rssilocation/SendPingsCommand.java
@@ -154,9 +154,9 @@ public class SendPingsCommand extends ZclRssiLocationCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        targetAddress = (IeeeAddress) deserializer.deserialize(ZclDataType.IEEE_ADDRESS);
-        numberRssiMeasurements = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        calculationPeriod = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        targetAddress = deserializer.deserialize(ZclDataType.IEEE_ADDRESS);
+        numberRssiMeasurements = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        calculationPeriod = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/rssilocation/SetAbsoluteLocationCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/rssilocation/SetAbsoluteLocationCommand.java
@@ -211,11 +211,11 @@ public class SetAbsoluteLocationCommand extends ZclRssiLocationCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        coordinate1 = (Integer) deserializer.deserialize(ZclDataType.SIGNED_16_BIT_INTEGER);
-        coordinate2 = (Integer) deserializer.deserialize(ZclDataType.SIGNED_16_BIT_INTEGER);
-        coordinate3 = (Integer) deserializer.deserialize(ZclDataType.SIGNED_16_BIT_INTEGER);
-        power = (Integer) deserializer.deserialize(ZclDataType.SIGNED_16_BIT_INTEGER);
-        pathLossExponent = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        coordinate1 = deserializer.deserialize(ZclDataType.SIGNED_16_BIT_INTEGER);
+        coordinate2 = deserializer.deserialize(ZclDataType.SIGNED_16_BIT_INTEGER);
+        coordinate3 = deserializer.deserialize(ZclDataType.SIGNED_16_BIT_INTEGER);
+        power = deserializer.deserialize(ZclDataType.SIGNED_16_BIT_INTEGER);
+        pathLossExponent = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/rssilocation/SetDeviceConfigurationCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/rssilocation/SetDeviceConfigurationCommand.java
@@ -211,11 +211,11 @@ public class SetDeviceConfigurationCommand extends ZclRssiLocationCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        power = (Integer) deserializer.deserialize(ZclDataType.SIGNED_16_BIT_INTEGER);
-        pathLossExponent = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        calculationPeriod = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        numberRssiMeasurements = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        reportingPeriod = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        power = deserializer.deserialize(ZclDataType.SIGNED_16_BIT_INTEGER);
+        pathLossExponent = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        calculationPeriod = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        numberRssiMeasurements = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        reportingPeriod = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/AddSceneCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/AddSceneCommand.java
@@ -216,11 +216,11 @@ public class AddSceneCommand extends ZclScenesCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        groupId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        sceneId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        transitionTime = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        sceneName = (String) deserializer.deserialize(ZclDataType.CHARACTER_STRING);
-        extensionFieldSets = (List<ExtensionFieldSet>) deserializer.deserialize(ZclDataType.N_X_EXTENSION_FIELD_SET);
+        groupId = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        sceneId = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        transitionTime = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        sceneName = deserializer.deserialize(ZclDataType.CHARACTER_STRING);
+        extensionFieldSets = deserializer.deserialize(ZclDataType.N_X_EXTENSION_FIELD_SET);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/AddSceneResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/AddSceneResponse.java
@@ -154,9 +154,9 @@ public class AddSceneResponse extends ZclScenesCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        status = (ZclStatus) deserializer.deserialize(ZclDataType.ZCL_STATUS);
-        groupId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        sceneId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        status = deserializer.deserialize(ZclDataType.ZCL_STATUS);
+        groupId = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        sceneId = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/CopySceneCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/CopySceneCommand.java
@@ -214,11 +214,11 @@ public class CopySceneCommand extends ZclScenesCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        mode = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        groupIdFrom = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        sceneIdFrom = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        groupIdTo = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        sceneIdTo = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        mode = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        groupIdFrom = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        sceneIdFrom = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        groupIdTo = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        sceneIdTo = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/CopySceneResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/CopySceneResponse.java
@@ -154,9 +154,9 @@ public class CopySceneResponse extends ZclScenesCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        status = (ZclStatus) deserializer.deserialize(ZclDataType.ZCL_STATUS);
-        groupId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        sceneId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        status = deserializer.deserialize(ZclDataType.ZCL_STATUS);
+        groupId = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        sceneId = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/EnhancedAddSceneCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/EnhancedAddSceneCommand.java
@@ -217,11 +217,11 @@ public class EnhancedAddSceneCommand extends ZclScenesCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        groupId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        sceneId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        transitionTime = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        sceneName = (String) deserializer.deserialize(ZclDataType.CHARACTER_STRING);
-        extensionFieldSets = (List<ExtensionFieldSet>) deserializer.deserialize(ZclDataType.N_X_EXTENSION_FIELD_SET);
+        groupId = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        sceneId = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        transitionTime = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        sceneName = deserializer.deserialize(ZclDataType.CHARACTER_STRING);
+        extensionFieldSets = deserializer.deserialize(ZclDataType.N_X_EXTENSION_FIELD_SET);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/EnhancedAddSceneResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/EnhancedAddSceneResponse.java
@@ -154,9 +154,9 @@ public class EnhancedAddSceneResponse extends ZclScenesCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        status = (ZclStatus) deserializer.deserialize(ZclDataType.ZCL_STATUS);
-        groupId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        sceneId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        status = deserializer.deserialize(ZclDataType.ZCL_STATUS);
+        groupId = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        sceneId = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/EnhancedViewSceneCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/EnhancedViewSceneCommand.java
@@ -127,8 +127,8 @@ public class EnhancedViewSceneCommand extends ZclScenesCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        groupId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        sceneId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        groupId = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        sceneId = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/EnhancedViewSceneResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/EnhancedViewSceneResponse.java
@@ -244,12 +244,12 @@ public class EnhancedViewSceneResponse extends ZclScenesCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        status = (ZclStatus) deserializer.deserialize(ZclDataType.ZCL_STATUS);
-        groupId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        sceneId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        transitionTime = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        sceneName = (String) deserializer.deserialize(ZclDataType.CHARACTER_STRING);
-        extensionFieldSets = (List<ExtensionFieldSet>) deserializer.deserialize(ZclDataType.N_X_EXTENSION_FIELD_SET);
+        status = deserializer.deserialize(ZclDataType.ZCL_STATUS);
+        groupId = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        sceneId = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        transitionTime = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        sceneName = deserializer.deserialize(ZclDataType.CHARACTER_STRING);
+        extensionFieldSets = deserializer.deserialize(ZclDataType.N_X_EXTENSION_FIELD_SET);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/GetSceneMembershipCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/GetSceneMembershipCommand.java
@@ -99,7 +99,7 @@ public class GetSceneMembershipCommand extends ZclScenesCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        groupId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        groupId = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/GetSceneMembershipResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/GetSceneMembershipResponse.java
@@ -214,11 +214,11 @@ public class GetSceneMembershipResponse extends ZclScenesCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        status = (ZclStatus) deserializer.deserialize(ZclDataType.ZCL_STATUS);
-        capacity = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        groupId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        sceneCount = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        sceneList = (List<Integer>) deserializer.deserialize(ZclDataType.N_X_UNSIGNED_8_BIT_INTEGER);
+        status = deserializer.deserialize(ZclDataType.ZCL_STATUS);
+        capacity = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        groupId = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        sceneCount = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        sceneList = deserializer.deserialize(ZclDataType.N_X_UNSIGNED_8_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/RecallSceneCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/RecallSceneCommand.java
@@ -176,9 +176,9 @@ public class RecallSceneCommand extends ZclScenesCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        groupId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        sceneId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        transitionTime = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        groupId = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        sceneId = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        transitionTime = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/RemoveAllScenesCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/RemoveAllScenesCommand.java
@@ -97,7 +97,7 @@ public class RemoveAllScenesCommand extends ZclScenesCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        groupId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        groupId = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/RemoveAllScenesResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/RemoveAllScenesResponse.java
@@ -125,8 +125,8 @@ public class RemoveAllScenesResponse extends ZclScenesCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        status = (ZclStatus) deserializer.deserialize(ZclDataType.ZCL_STATUS);
-        groupId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        status = deserializer.deserialize(ZclDataType.ZCL_STATUS);
+        groupId = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/RemoveSceneCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/RemoveSceneCommand.java
@@ -126,8 +126,8 @@ public class RemoveSceneCommand extends ZclScenesCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        groupId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        sceneId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        groupId = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        sceneId = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/RemoveSceneResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/RemoveSceneResponse.java
@@ -154,9 +154,9 @@ public class RemoveSceneResponse extends ZclScenesCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        status = (ZclStatus) deserializer.deserialize(ZclDataType.ZCL_STATUS);
-        groupId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        sceneId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        status = deserializer.deserialize(ZclDataType.ZCL_STATUS);
+        groupId = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        sceneId = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/StoreSceneCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/StoreSceneCommand.java
@@ -126,8 +126,8 @@ public class StoreSceneCommand extends ZclScenesCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        groupId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        sceneId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        groupId = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        sceneId = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/StoreSceneResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/StoreSceneResponse.java
@@ -154,9 +154,9 @@ public class StoreSceneResponse extends ZclScenesCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        status = (ZclStatus) deserializer.deserialize(ZclDataType.ZCL_STATUS);
-        groupId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        sceneId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        status = deserializer.deserialize(ZclDataType.ZCL_STATUS);
+        groupId = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        sceneId = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/ViewSceneCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/ViewSceneCommand.java
@@ -126,8 +126,8 @@ public class ViewSceneCommand extends ZclScenesCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        groupId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        sceneId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        groupId = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        sceneId = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/ViewSceneResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/scenes/ViewSceneResponse.java
@@ -244,12 +244,12 @@ public class ViewSceneResponse extends ZclScenesCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        status = (ZclStatus) deserializer.deserialize(ZclDataType.ZCL_STATUS);
-        groupId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        sceneId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        transitionTime = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        sceneName = (String) deserializer.deserialize(ZclDataType.CHARACTER_STRING);
-        extensionFieldSets = (List<ExtensionFieldSet>) deserializer.deserialize(ZclDataType.N_X_EXTENSION_FIELD_SET);
+        status = deserializer.deserialize(ZclDataType.ZCL_STATUS);
+        groupId = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        sceneId = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        transitionTime = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        sceneName = deserializer.deserialize(ZclDataType.CHARACTER_STRING);
+        extensionFieldSets = deserializer.deserialize(ZclDataType.N_X_EXTENSION_FIELD_SET);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/smartenergytunneling/AckTransferDataClientToServer.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/smartenergytunneling/AckTransferDataClientToServer.java
@@ -168,8 +168,8 @@ public class AckTransferDataClientToServer extends ZclSmartEnergyTunnelingComman
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        tunnelId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        numberOfBytesLeft = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        tunnelId = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        numberOfBytesLeft = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/smartenergytunneling/AckTransferDataServerToClient.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/smartenergytunneling/AckTransferDataServerToClient.java
@@ -168,8 +168,8 @@ public class AckTransferDataServerToClient extends ZclSmartEnergyTunnelingComman
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        tunnelId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        numberOfBytesLeft = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        tunnelId = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        numberOfBytesLeft = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/smartenergytunneling/CloseTunnel.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/smartenergytunneling/CloseTunnel.java
@@ -115,7 +115,7 @@ public class CloseTunnel extends ZclSmartEnergyTunnelingCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        tunnelId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        tunnelId = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/smartenergytunneling/GetSupportedTunnelProtocols.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/smartenergytunneling/GetSupportedTunnelProtocols.java
@@ -125,7 +125,7 @@ public class GetSupportedTunnelProtocols extends ZclSmartEnergyTunnelingCommand 
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        protocolOffset = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        protocolOffset = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/smartenergytunneling/Protocol.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/smartenergytunneling/Protocol.java
@@ -102,8 +102,8 @@ public class Protocol implements ZigBeeSerializable {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        manufacturerCode = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        protocolId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        manufacturerCode = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        protocolId = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/smartenergytunneling/ReadyDataClientToServer.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/smartenergytunneling/ReadyDataClientToServer.java
@@ -165,8 +165,8 @@ public class ReadyDataClientToServer extends ZclSmartEnergyTunnelingCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        tunnelId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        numberOfOctetsLeft = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        tunnelId = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        numberOfOctetsLeft = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/smartenergytunneling/ReadyDataServerToClient.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/smartenergytunneling/ReadyDataServerToClient.java
@@ -165,8 +165,8 @@ public class ReadyDataServerToClient extends ZclSmartEnergyTunnelingCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        tunnelId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        numberOfOctetsLeft = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        tunnelId = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        numberOfOctetsLeft = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/smartenergytunneling/RequestTunnel.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/smartenergytunneling/RequestTunnel.java
@@ -238,10 +238,10 @@ public class RequestTunnel extends ZclSmartEnergyTunnelingCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        protocolId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        manufacturerCode = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        flowControlSupport = (Boolean) deserializer.deserialize(ZclDataType.BOOLEAN);
-        maximumIncomingTransferSize = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        protocolId = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        manufacturerCode = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        flowControlSupport = deserializer.deserialize(ZclDataType.BOOLEAN);
+        maximumIncomingTransferSize = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/smartenergytunneling/RequestTunnelResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/smartenergytunneling/RequestTunnelResponse.java
@@ -194,9 +194,9 @@ public class RequestTunnelResponse extends ZclSmartEnergyTunnelingCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        tunnelId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        tunnelStatus = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        maximumIncomingTransferSize = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        tunnelId = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        tunnelStatus = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        maximumIncomingTransferSize = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/smartenergytunneling/SupportedTunnelProtocolsResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/smartenergytunneling/SupportedTunnelProtocolsResponse.java
@@ -176,8 +176,8 @@ public class SupportedTunnelProtocolsResponse extends ZclSmartEnergyTunnelingCom
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        protocolListComplete = (Boolean) deserializer.deserialize(ZclDataType.BOOLEAN);
-        protocolCount = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        protocolListComplete = deserializer.deserialize(ZclDataType.BOOLEAN);
+        protocolCount = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
         protocolList = new Protocol();
         protocolList.deserialize(deserializer);
     }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/smartenergytunneling/TransferDataClientToServer.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/smartenergytunneling/TransferDataClientToServer.java
@@ -166,8 +166,8 @@ public class TransferDataClientToServer extends ZclSmartEnergyTunnelingCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        tunnelId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        data = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        tunnelId = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        data = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/smartenergytunneling/TransferDataErrorClientToServer.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/smartenergytunneling/TransferDataErrorClientToServer.java
@@ -163,8 +163,8 @@ public class TransferDataErrorClientToServer extends ZclSmartEnergyTunnelingComm
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        tunnelId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        transferDataStatus = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        tunnelId = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        transferDataStatus = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/smartenergytunneling/TransferDataErrorServerToClient.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/smartenergytunneling/TransferDataErrorServerToClient.java
@@ -163,8 +163,8 @@ public class TransferDataErrorServerToClient extends ZclSmartEnergyTunnelingComm
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        tunnelId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        transferDataStatus = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        tunnelId = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        transferDataStatus = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/smartenergytunneling/TransferDataServerToClient.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/smartenergytunneling/TransferDataServerToClient.java
@@ -173,8 +173,8 @@ public class TransferDataServerToClient extends ZclSmartEnergyTunnelingCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        tunnelId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        data = (ByteArray) deserializer.deserialize(ZclDataType.OCTET_STRING);
+        tunnelId = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        data = deserializer.deserialize(ZclDataType.OCTET_STRING);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/smartenergytunneling/TunnelClosureNotification.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/smartenergytunneling/TunnelClosureNotification.java
@@ -117,7 +117,7 @@ public class TunnelClosureNotification extends ZclSmartEnergyTunnelingCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        tunnelId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        tunnelId = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/thermostat/GetRelayStatusLogResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/thermostat/GetRelayStatusLogResponse.java
@@ -240,12 +240,12 @@ public class GetRelayStatusLogResponse extends ZclThermostatCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        timeOfDay = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        relayStatus = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
-        localTemperature = (Integer) deserializer.deserialize(ZclDataType.SIGNED_16_BIT_INTEGER);
-        humidity = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        setpoint = (Integer) deserializer.deserialize(ZclDataType.SIGNED_16_BIT_INTEGER);
-        unreadEntries = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        timeOfDay = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        relayStatus = deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
+        localTemperature = deserializer.deserialize(ZclDataType.SIGNED_16_BIT_INTEGER);
+        humidity = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        setpoint = deserializer.deserialize(ZclDataType.SIGNED_16_BIT_INTEGER);
+        unreadEntries = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/thermostat/GetWeeklySchedule.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/thermostat/GetWeeklySchedule.java
@@ -124,8 +124,8 @@ public class GetWeeklySchedule extends ZclThermostatCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        daysToReturn = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
-        modeToReturn = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
+        daysToReturn = deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
+        modeToReturn = deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/thermostat/GetWeeklyScheduleResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/thermostat/GetWeeklyScheduleResponse.java
@@ -240,12 +240,12 @@ public class GetWeeklyScheduleResponse extends ZclThermostatCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        numberOfTransitions = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        dayOfWeek = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
-        mode = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
-        transition = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        heatSet = (Integer) deserializer.deserialize(ZclDataType.SIGNED_16_BIT_INTEGER);
-        coolSet = (Integer) deserializer.deserialize(ZclDataType.SIGNED_16_BIT_INTEGER);
+        numberOfTransitions = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        dayOfWeek = deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
+        mode = deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
+        transition = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        heatSet = deserializer.deserialize(ZclDataType.SIGNED_16_BIT_INTEGER);
+        coolSet = deserializer.deserialize(ZclDataType.SIGNED_16_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/thermostat/SetWeeklySchedule.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/thermostat/SetWeeklySchedule.java
@@ -250,12 +250,12 @@ public class SetWeeklySchedule extends ZclThermostatCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        numberOfTransitions = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        dayOfWeek = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
-        mode = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
-        transition = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        heatSet = (Integer) deserializer.deserialize(ZclDataType.SIGNED_16_BIT_INTEGER);
-        coolSet = (Integer) deserializer.deserialize(ZclDataType.SIGNED_16_BIT_INTEGER);
+        numberOfTransitions = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        dayOfWeek = deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
+        mode = deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
+        transition = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        heatSet = deserializer.deserialize(ZclDataType.SIGNED_16_BIT_INTEGER);
+        coolSet = deserializer.deserialize(ZclDataType.SIGNED_16_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/thermostat/SetpointRaiseLowerCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/thermostat/SetpointRaiseLowerCommand.java
@@ -124,8 +124,8 @@ public class SetpointRaiseLowerCommand extends ZclThermostatCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        mode = (Integer) deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
-        amount = (Integer) deserializer.deserialize(ZclDataType.SIGNED_8_BIT_INTEGER);
+        mode = deserializer.deserialize(ZclDataType.ENUMERATION_8_BIT);
+        amount = deserializer.deserialize(ZclDataType.SIGNED_8_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/windowcovering/WindowCoveringGoToLiftPercentage.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/windowcovering/WindowCoveringGoToLiftPercentage.java
@@ -97,7 +97,7 @@ public class WindowCoveringGoToLiftPercentage extends ZclWindowCoveringCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        percentageLiftValue = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        percentageLiftValue = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/windowcovering/WindowCoveringGoToLiftValue.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/windowcovering/WindowCoveringGoToLiftValue.java
@@ -97,7 +97,7 @@ public class WindowCoveringGoToLiftValue extends ZclWindowCoveringCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        liftValue = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        liftValue = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/windowcovering/WindowCoveringGoToTiltPercentage.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/windowcovering/WindowCoveringGoToTiltPercentage.java
@@ -97,7 +97,7 @@ public class WindowCoveringGoToTiltPercentage extends ZclWindowCoveringCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        percentageTiltValue = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        percentageTiltValue = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/windowcovering/WindowCoveringGoToTiltValue.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/windowcovering/WindowCoveringGoToTiltValue.java
@@ -97,7 +97,7 @@ public class WindowCoveringGoToTiltValue extends ZclWindowCoveringCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        tiltValue = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        tiltValue = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/field/AttributeInformation.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/field/AttributeInformation.java
@@ -72,8 +72,8 @@ public class AttributeInformation implements ZclListItemField, Comparable<Attrib
 
     @Override
     public void deserialize(final ZigBeeDeserializer deserializer) {
-        identifier = (int) deserializer.readZigBeeType(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        dataType = (ZclDataType) deserializer.readZigBeeType(ZclDataType.ZIGBEE_DATA_TYPE);
+        identifier = deserializer.readZigBeeType(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        dataType = deserializer.readZigBeeType(ZclDataType.ZIGBEE_DATA_TYPE);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/field/AttributeRecord.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/field/AttributeRecord.java
@@ -82,8 +82,8 @@ public class AttributeRecord implements ZclListItemField {
 
     @Override
     public void deserialize(final ZigBeeDeserializer deserializer) {
-        direction = (int) deserializer.readZigBeeType(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        attributeIdentifier = (int) deserializer.readZigBeeType(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        direction = deserializer.readZigBeeType(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        attributeIdentifier = deserializer.readZigBeeType(ZclDataType.UNSIGNED_16_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/field/AttributeReport.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/field/AttributeReport.java
@@ -96,7 +96,7 @@ public class AttributeReport implements ZclListItemField {
 
     @Override
     public void deserialize(final ZigBeeDeserializer deserializer) {
-        attributeIdentifier = (int) deserializer.readZigBeeType(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        attributeIdentifier = deserializer.readZigBeeType(ZclDataType.UNSIGNED_16_BIT_INTEGER);
         attributeDataType = ZclDataType.getType((int) deserializer.readZigBeeType(ZclDataType.UNSIGNED_8_BIT_INTEGER));
         attributeValue = deserializer.readZigBeeType(attributeDataType);
     }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/field/AttributeReportingConfigurationRecord.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/field/AttributeReportingConfigurationRecord.java
@@ -365,15 +365,15 @@ public class AttributeReportingConfigurationRecord implements ZclListItemField {
 
     @Override
     public void deserialize(final ZigBeeDeserializer deserializer) {
-        direction = (int) deserializer.readZigBeeType(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        attributeIdentifier = (int) deserializer.readZigBeeType(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        direction = deserializer.readZigBeeType(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        attributeIdentifier = deserializer.readZigBeeType(ZclDataType.UNSIGNED_16_BIT_INTEGER);
         if (direction == 1) {
             // If direction is set to 0x01, then the timeout period field is included in the payload,
             // and the attribute data type field, the minimum reporting interval field, the
             // maximum reporting interval field and the reportable change field are omitted. The
             // record is sent to a cluster client (or server) to configure how it should expect
             // reports from a server (or client) of the same cluster.
-            timeoutPeriod = (int) deserializer.readZigBeeType(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+            timeoutPeriod = deserializer.readZigBeeType(ZclDataType.UNSIGNED_16_BIT_INTEGER);
         } else {
             // If direction is set to 0x00, then the attribute data type field, the minimum
             // reporting interval field, the maximum reporting interval field and the reportable
@@ -382,8 +382,8 @@ public class AttributeReportingConfigurationRecord implements ZclListItemField {
             // a client (or server) of the same cluster.
             attributeDataType = ZclDataType
                     .getType((int) deserializer.readZigBeeType(ZclDataType.UNSIGNED_8_BIT_INTEGER));
-            minimumReportingInterval = (int) deserializer.readZigBeeType(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-            maximumReportingInterval = (int) deserializer.readZigBeeType(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+            minimumReportingInterval = deserializer.readZigBeeType(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+            maximumReportingInterval = deserializer.readZigBeeType(ZclDataType.UNSIGNED_16_BIT_INTEGER);
             if (attributeDataType.isAnalog()) {
                 // The reportable change field shall contain the minimum change to the attribute that
                 // will result in a report being issued. This field is of variable length. For attributes

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/field/AttributeReportingStatusRecord.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/field/AttributeReportingStatusRecord.java
@@ -412,8 +412,8 @@ public class AttributeReportingStatusRecord implements ZclListItemField {
     @Override
     public void deserialize(final ZigBeeDeserializer deserializer) {
         status = ZclStatus.getStatus((int) deserializer.readZigBeeType(ZclDataType.UNSIGNED_8_BIT_INTEGER));
-        direction = (int) deserializer.readZigBeeType(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        attributeIdentifier = (int) deserializer.readZigBeeType(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        direction = deserializer.readZigBeeType(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        attributeIdentifier = deserializer.readZigBeeType(ZclDataType.UNSIGNED_16_BIT_INTEGER);
         if (status != ZclStatus.SUCCESS) {
             return;
         }
@@ -424,7 +424,7 @@ public class AttributeReportingStatusRecord implements ZclListItemField {
             // maximum reporting interval field and the reportable change field are omitted. The
             // record is sent to a cluster client (or server) to configure how it should expect
             // reports from a server (or client) of the same cluster.
-            timeoutPeriod = (int) deserializer.readZigBeeType(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+            timeoutPeriod = deserializer.readZigBeeType(ZclDataType.UNSIGNED_16_BIT_INTEGER);
         } else {
             // If direction is set to 0x00, then the attribute data type field, the minimum
             // reporting interval field, the maximum reporting interval field and the reportable
@@ -433,8 +433,8 @@ public class AttributeReportingStatusRecord implements ZclListItemField {
             // a client (or server) of the same cluster.
             attributeDataType = ZclDataType
                     .getType((int) deserializer.readZigBeeType(ZclDataType.UNSIGNED_8_BIT_INTEGER));
-            minimumReportingInterval = (int) deserializer.readZigBeeType(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-            maximumReportingInterval = (int) deserializer.readZigBeeType(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+            minimumReportingInterval = deserializer.readZigBeeType(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+            maximumReportingInterval = deserializer.readZigBeeType(ZclDataType.UNSIGNED_16_BIT_INTEGER);
             if (attributeDataType.isAnalog()) {
                 // The reportable change field shall contain the minimum change to the attribute that
                 // will result in a report being issued. This field is of variable length. For attributes

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/field/AttributeStatusRecord.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/field/AttributeStatusRecord.java
@@ -100,9 +100,9 @@ public class AttributeStatusRecord implements ZclListItemField {
 
     @Override
     public void deserialize(final ZigBeeDeserializer deserializer) {
-        status = (ZclStatus) deserializer.readZigBeeType(ZclDataType.ZCL_STATUS);
-        direction = (boolean) deserializer.readZigBeeType(ZclDataType.BOOLEAN);
-        attributeIdentifier = (int) deserializer.readZigBeeType(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        status = deserializer.readZigBeeType(ZclDataType.ZCL_STATUS);
+        direction = deserializer.readZigBeeType(ZclDataType.BOOLEAN);
+        attributeIdentifier = deserializer.readZigBeeType(ZclDataType.UNSIGNED_16_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/field/ExtendedAttributeInformation.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/field/ExtendedAttributeInformation.java
@@ -129,8 +129,8 @@ public class ExtendedAttributeInformation implements ZclListItemField {
 
     @Override
     public void deserialize(final ZigBeeDeserializer deserializer) {
-        attributeIdentifier = (int) deserializer.readZigBeeType(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        attributeDataType = (int) deserializer.readZigBeeType(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        attributeIdentifier = deserializer.readZigBeeType(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        attributeDataType = deserializer.readZigBeeType(ZclDataType.UNSIGNED_8_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/field/ExtensionFieldSet.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/field/ExtensionFieldSet.java
@@ -86,8 +86,8 @@ public class ExtensionFieldSet implements ZclListItemField {
 
     @Override
     public void deserialize(final ZigBeeDeserializer deserializer) {
-        clusterId = (int) deserializer.readZigBeeType(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        data = (ByteArray) deserializer.readZigBeeType(ZclDataType.BYTE_ARRAY);
+        clusterId = deserializer.readZigBeeType(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        data = deserializer.readZigBeeType(ZclDataType.BYTE_ARRAY);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/field/NeighborInformation.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/field/NeighborInformation.java
@@ -169,12 +169,12 @@ public class NeighborInformation implements ZclListItemField {
 
     @Override
     public void deserialize(final ZigBeeDeserializer deserializer) {
-        neighborAddress = (Long) deserializer.readZigBeeType(ZclDataType.IEEE_ADDRESS);
-        coordinate1 = (int) deserializer.readZigBeeType(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        coordinate2 = (int) deserializer.readZigBeeType(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        coordinate3 = (int) deserializer.readZigBeeType(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        rssi = (int) deserializer.readZigBeeType(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        measurementCount = (int) deserializer.readZigBeeType(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        neighborAddress = deserializer.readZigBeeType(ZclDataType.IEEE_ADDRESS);
+        coordinate1 = deserializer.readZigBeeType(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        coordinate2 = deserializer.readZigBeeType(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        coordinate3 = deserializer.readZigBeeType(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        rssi = deserializer.readZigBeeType(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        measurementCount = deserializer.readZigBeeType(ZclDataType.UNSIGNED_8_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/field/ReadAttributeStatusRecord.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/field/ReadAttributeStatusRecord.java
@@ -124,8 +124,8 @@ public class ReadAttributeStatusRecord implements ZclListItemField {
 
     @Override
     public void deserialize(final ZigBeeDeserializer deserializer) {
-        attributeIdentifier = (int) deserializer.readZigBeeType(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        status = (ZclStatus) deserializer.readZigBeeType(ZclDataType.ZCL_STATUS);
+        attributeIdentifier = deserializer.readZigBeeType(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        status = deserializer.readZigBeeType(ZclDataType.ZCL_STATUS);
         if (status.equals(ZclStatus.SUCCESS)) {
             attributeDataType = ZclDataType
                     .getType((int) deserializer.readZigBeeType(ZclDataType.UNSIGNED_8_BIT_INTEGER));

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/field/WriteAttributeRecord.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/field/WriteAttributeRecord.java
@@ -96,7 +96,7 @@ public class WriteAttributeRecord implements ZclListItemField {
 
     @Override
     public void deserialize(final ZigBeeDeserializer deserializer) {
-        attributeIdentifier = (int) deserializer.readZigBeeType(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        attributeIdentifier = deserializer.readZigBeeType(ZclDataType.UNSIGNED_16_BIT_INTEGER);
         attributeDataType = ZclDataType.getType((int) deserializer.readZigBeeType(ZclDataType.UNSIGNED_8_BIT_INTEGER));
         attributeValue = deserializer.readZigBeeType(attributeDataType);
     }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/field/WriteAttributeStatusRecord.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/field/WriteAttributeStatusRecord.java
@@ -73,9 +73,9 @@ public class WriteAttributeStatusRecord implements ZclListItemField {
 
     @Override
     public void deserialize(final ZigBeeDeserializer deserializer) {
-        status = (ZclStatus) deserializer.readZigBeeType(ZclDataType.ZCL_STATUS);
+        status = deserializer.readZigBeeType(ZclDataType.ZCL_STATUS);
         if (status != ZclStatus.SUCCESS) {
-            attributeIdentifier = (int) deserializer.readZigBeeType(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+            attributeIdentifier = deserializer.readZigBeeType(ZclDataType.UNSIGNED_16_BIT_INTEGER);
         }
     }
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/ZdoCommand.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/ZdoCommand.java
@@ -29,7 +29,7 @@ public abstract class ZdoCommand extends ZigBeeCommand {
 
     @Override
     public void deserialize(final ZclFieldDeserializer deserializer) {
-        Integer sequenceNumber = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        Integer sequenceNumber = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
         setTransactionId(sequenceNumber);
     }
 }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ActiveEndpointsRequest.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ActiveEndpointsRequest.java
@@ -98,7 +98,7 @@ public class ActiveEndpointsRequest extends ZdoRequest implements ZigBeeTransact
     public void deserialize(final ZclFieldDeserializer deserializer) {
         super.deserialize(deserializer);
 
-        nwkAddrOfInterest = (Integer) deserializer.deserialize(ZclDataType.NWK_ADDRESS);
+        nwkAddrOfInterest = deserializer.deserialize(ZclDataType.NWK_ADDRESS);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ActiveEndpointsResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ActiveEndpointsResponse.java
@@ -133,16 +133,16 @@ public class ActiveEndpointsResponse extends ZdoResponse {
         // Create lists
         activeEpList = new ArrayList<Integer>();
 
-        status = (ZdoStatus) deserializer.deserialize(ZclDataType.ZDO_STATUS);
+        status = deserializer.deserialize(ZclDataType.ZDO_STATUS);
         if (status != ZdoStatus.SUCCESS) {
             // Don't read the full response if we have an error
             return;
         }
-        nwkAddrOfInterest = (Integer) deserializer.deserialize(ZclDataType.NWK_ADDRESS);
-        Integer activeEpCnt = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        nwkAddrOfInterest = deserializer.deserialize(ZclDataType.NWK_ADDRESS);
+        Integer activeEpCnt = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
         if (activeEpCnt != null) {
             for (int cnt = 0; cnt < activeEpCnt; cnt++) {
-                activeEpList.add((Integer) deserializer.deserialize(ZclDataType.ENDPOINT));
+                activeEpList.add(deserializer.deserialize(ZclDataType.ENDPOINT));
             }
         }
     }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/BackupBindTableResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/BackupBindTableResponse.java
@@ -75,7 +75,7 @@ public class BackupBindTableResponse extends ZdoResponse {
     public void deserialize(final ZclFieldDeserializer deserializer) {
         super.deserialize(deserializer);
 
-        status = (ZdoStatus) deserializer.deserialize(ZclDataType.ZDO_STATUS);
+        status = deserializer.deserialize(ZclDataType.ZDO_STATUS);
         if (status != ZdoStatus.SUCCESS) {
             // Don't read the full response if we have an error
             return;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/BackupSourceBindRequest.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/BackupSourceBindRequest.java
@@ -179,10 +179,10 @@ public class BackupSourceBindRequest extends ZdoRequest {
     public void deserialize(final ZclFieldDeserializer deserializer) {
         super.deserialize(deserializer);
 
-        sourceTableEntries = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        startIndex = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        sourceTableListCount = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        sourceTableList = (List<Long>) deserializer.deserialize(ZclDataType.N_X_IEEE_ADDRESS);
+        sourceTableEntries = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        startIndex = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        sourceTableListCount = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        sourceTableList = deserializer.deserialize(ZclDataType.N_X_IEEE_ADDRESS);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/BindRegisterResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/BindRegisterResponse.java
@@ -134,16 +134,16 @@ public class BindRegisterResponse extends ZdoResponse {
         // Create lists
         bindingTableList = new ArrayList<BindingTable>();
 
-        status = (ZdoStatus) deserializer.deserialize(ZclDataType.ZDO_STATUS);
+        status = deserializer.deserialize(ZclDataType.ZDO_STATUS);
         if (status != ZdoStatus.SUCCESS) {
             // Don't read the full response if we have an error
             return;
         }
-        bindingTableEntries = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        Integer bindingTableListCount = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        bindingTableEntries = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        Integer bindingTableListCount = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
         if (bindingTableListCount != null) {
             for (int cnt = 0; cnt < bindingTableListCount; cnt++) {
-                bindingTableList.add((BindingTable) deserializer.deserialize(ZclDataType.BINDING_TABLE));
+                bindingTableList.add(deserializer.deserialize(ZclDataType.BINDING_TABLE));
             }
         }
     }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/BindRequest.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/BindRequest.java
@@ -107,7 +107,7 @@ public class BindRequest extends ZdoRequest implements ZigBeeTransactionMatcher 
     public void deserialize(final ZclFieldDeserializer deserializer) {
         super.deserialize(deserializer);
 
-        bindingTableEntry = (BindingTable) deserializer.deserialize(ZclDataType.BINDING_TABLE);
+        bindingTableEntry = deserializer.deserialize(ZclDataType.BINDING_TABLE);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/BindResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/BindResponse.java
@@ -70,7 +70,7 @@ public class BindResponse extends ZdoResponse {
     public void deserialize(final ZclFieldDeserializer deserializer) {
         super.deserialize(deserializer);
 
-        status = (ZdoStatus) deserializer.deserialize(ZclDataType.ZDO_STATUS);
+        status = deserializer.deserialize(ZclDataType.ZDO_STATUS);
         if (status != ZdoStatus.SUCCESS) {
             // Don't read the full response if we have an error
             return;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ComplexDescriptorRequest.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ComplexDescriptorRequest.java
@@ -98,7 +98,7 @@ public class ComplexDescriptorRequest extends ZdoRequest implements ZigBeeTransa
     public void deserialize(final ZclFieldDeserializer deserializer) {
         super.deserialize(deserializer);
 
-        nwkAddrOfInterest = (Integer) deserializer.deserialize(ZclDataType.NWK_ADDRESS);
+        nwkAddrOfInterest = deserializer.deserialize(ZclDataType.NWK_ADDRESS);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ComplexDescriptorResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ComplexDescriptorResponse.java
@@ -154,14 +154,14 @@ public class ComplexDescriptorResponse extends ZdoResponse {
     public void deserialize(final ZclFieldDeserializer deserializer) {
         super.deserialize(deserializer);
 
-        status = (ZdoStatus) deserializer.deserialize(ZclDataType.ZDO_STATUS);
+        status = deserializer.deserialize(ZclDataType.ZDO_STATUS);
         if (status != ZdoStatus.SUCCESS) {
             // Don't read the full response if we have an error
             return;
         }
-        nwkAddrOfInterest = (Integer) deserializer.deserialize(ZclDataType.NWK_ADDRESS);
-        length = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        complexDescriptor = (ComplexDescriptor) deserializer.deserialize(ZclDataType.COMPLEX_DESCRIPTOR);
+        nwkAddrOfInterest = deserializer.deserialize(ZclDataType.NWK_ADDRESS);
+        length = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        complexDescriptor = deserializer.deserialize(ZclDataType.COMPLEX_DESCRIPTOR);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/DeviceAnnounce.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/DeviceAnnounce.java
@@ -153,9 +153,9 @@ public class DeviceAnnounce extends ZdoRequest {
     public void deserialize(final ZclFieldDeserializer deserializer) {
         super.deserialize(deserializer);
 
-        nwkAddrOfInterest = (Integer) deserializer.deserialize(ZclDataType.NWK_ADDRESS);
-        ieeeAddr = (IeeeAddress) deserializer.deserialize(ZclDataType.IEEE_ADDRESS);
-        capability = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
+        nwkAddrOfInterest = deserializer.deserialize(ZclDataType.NWK_ADDRESS);
+        ieeeAddr = deserializer.deserialize(ZclDataType.IEEE_ADDRESS);
+        capability = deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/EndDeviceBindRequest.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/EndDeviceBindRequest.java
@@ -250,20 +250,20 @@ public class EndDeviceBindRequest extends ZdoRequest {
         inClusterList = new ArrayList<Integer>();
         outClusterList = new ArrayList<Integer>();
 
-        bindingTarget = (Integer) deserializer.deserialize(ZclDataType.NWK_ADDRESS);
-        srcAddress = (IeeeAddress) deserializer.deserialize(ZclDataType.IEEE_ADDRESS);
-        srcEndpoint = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        profileId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        Integer inClusterCount = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        bindingTarget = deserializer.deserialize(ZclDataType.NWK_ADDRESS);
+        srcAddress = deserializer.deserialize(ZclDataType.IEEE_ADDRESS);
+        srcEndpoint = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        profileId = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        Integer inClusterCount = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
         if (inClusterCount != null) {
             for (int cnt = 0; cnt < inClusterCount; cnt++) {
-                inClusterList.add((Integer) deserializer.deserialize(ZclDataType.CLUSTERID));
+                inClusterList.add(deserializer.deserialize(ZclDataType.CLUSTERID));
             }
         }
-        Integer outClusterCount = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        Integer outClusterCount = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
         if (outClusterCount != null) {
             for (int cnt = 0; cnt < outClusterCount; cnt++) {
-                outClusterList.add((Integer) deserializer.deserialize(ZclDataType.CLUSTERID));
+                outClusterList.add(deserializer.deserialize(ZclDataType.CLUSTERID));
             }
         }
     }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/EndDeviceBindResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/EndDeviceBindResponse.java
@@ -66,7 +66,7 @@ public class EndDeviceBindResponse extends ZdoResponse {
     public void deserialize(final ZclFieldDeserializer deserializer) {
         super.deserialize(deserializer);
 
-        status = (ZdoStatus) deserializer.deserialize(ZclDataType.ZDO_STATUS);
+        status = deserializer.deserialize(ZclDataType.ZDO_STATUS);
         if (status != ZdoStatus.SUCCESS) {
             // Don't read the full response if we have an error
             return;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ExtendedSimpleDescriptorRequest.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ExtendedSimpleDescriptorRequest.java
@@ -151,9 +151,9 @@ public class ExtendedSimpleDescriptorRequest extends ZdoRequest {
     public void deserialize(final ZclFieldDeserializer deserializer) {
         super.deserialize(deserializer);
 
-        nwkAddrOfInterest = (Integer) deserializer.deserialize(ZclDataType.NWK_ADDRESS);
-        endpoint = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        startIndex = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        nwkAddrOfInterest = deserializer.deserialize(ZclDataType.NWK_ADDRESS);
+        endpoint = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        startIndex = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/IeeeAddressRequest.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/IeeeAddressRequest.java
@@ -155,9 +155,9 @@ public class IeeeAddressRequest extends ZdoRequest implements ZigBeeTransactionM
     public void deserialize(final ZclFieldDeserializer deserializer) {
         super.deserialize(deserializer);
 
-        nwkAddrOfInterest = (Integer) deserializer.deserialize(ZclDataType.NWK_ADDRESS);
-        requestType = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        startIndex = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        nwkAddrOfInterest = deserializer.deserialize(ZclDataType.NWK_ADDRESS);
+        requestType = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        startIndex = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/IeeeAddressResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/IeeeAddressResponse.java
@@ -193,21 +193,21 @@ public class IeeeAddressResponse extends ZdoResponse {
         // Create lists
         nwkAddrAssocDevList = new ArrayList<Integer>();
 
-        status = (ZdoStatus) deserializer.deserialize(ZclDataType.ZDO_STATUS);
+        status = deserializer.deserialize(ZclDataType.ZDO_STATUS);
         if (status != ZdoStatus.SUCCESS) {
             // Don't read the full response if we have an error
             return;
         }
-        ieeeAddrRemoteDev = (IeeeAddress) deserializer.deserialize(ZclDataType.IEEE_ADDRESS);
-        nwkAddrRemoteDev = (Integer) deserializer.deserialize(ZclDataType.NWK_ADDRESS);
+        ieeeAddrRemoteDev = deserializer.deserialize(ZclDataType.IEEE_ADDRESS);
+        nwkAddrRemoteDev = deserializer.deserialize(ZclDataType.NWK_ADDRESS);
         if (deserializer.isEndOfStream()) {
             return;
         }
-        Integer numAssocDev = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        startIndex = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        Integer numAssocDev = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        startIndex = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
         if (numAssocDev != null) {
             for (int cnt = 0; cnt < numAssocDev; cnt++) {
-                nwkAddrAssocDevList.add((Integer) deserializer.deserialize(ZclDataType.NWK_ADDRESS));
+                nwkAddrAssocDevList.add(deserializer.deserialize(ZclDataType.NWK_ADDRESS));
             }
         }
     }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ManagementBindRequest.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ManagementBindRequest.java
@@ -98,7 +98,7 @@ public class ManagementBindRequest extends ZdoRequest implements ZigBeeTransacti
     public void deserialize(final ZclFieldDeserializer deserializer) {
         super.deserialize(deserializer);
 
-        startIndex = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        startIndex = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ManagementBindResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ManagementBindResponse.java
@@ -164,17 +164,17 @@ public class ManagementBindResponse extends ZdoResponse {
         // Create lists
         bindingTableList = new ArrayList<BindingTable>();
 
-        status = (ZdoStatus) deserializer.deserialize(ZclDataType.ZDO_STATUS);
+        status = deserializer.deserialize(ZclDataType.ZDO_STATUS);
         if (status != ZdoStatus.SUCCESS) {
             // Don't read the full response if we have an error
             return;
         }
-        bindingTableEntries = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        startIndex = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        Integer bindingTableListCount = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        bindingTableEntries = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        startIndex = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        Integer bindingTableListCount = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
         if (bindingTableListCount != null) {
             for (int cnt = 0; cnt < bindingTableListCount; cnt++) {
-                bindingTableList.add((BindingTable) deserializer.deserialize(ZclDataType.BINDING_TABLE));
+                bindingTableList.add(deserializer.deserialize(ZclDataType.BINDING_TABLE));
             }
         }
     }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ManagementDirectJoinRequest.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ManagementDirectJoinRequest.java
@@ -122,8 +122,8 @@ public class ManagementDirectJoinRequest extends ZdoRequest {
     public void deserialize(final ZclFieldDeserializer deserializer) {
         super.deserialize(deserializer);
 
-        deviceAddress = (IeeeAddress) deserializer.deserialize(ZclDataType.IEEE_ADDRESS);
-        capabilityInformation = (Integer) deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
+        deviceAddress = deserializer.deserialize(ZclDataType.IEEE_ADDRESS);
+        capabilityInformation = deserializer.deserialize(ZclDataType.BITMAP_8_BIT);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ManagementDirectJoinResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ManagementDirectJoinResponse.java
@@ -66,7 +66,7 @@ public class ManagementDirectJoinResponse extends ZdoResponse {
     public void deserialize(final ZclFieldDeserializer deserializer) {
         super.deserialize(deserializer);
 
-        status = (ZdoStatus) deserializer.deserialize(ZclDataType.ZDO_STATUS);
+        status = deserializer.deserialize(ZclDataType.ZDO_STATUS);
         if (status != ZdoStatus.SUCCESS) {
             // Don't read the full response if we have an error
             return;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ManagementLeaveRequest.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ManagementLeaveRequest.java
@@ -128,8 +128,8 @@ public class ManagementLeaveRequest extends ZdoRequest implements ZigBeeTransact
     public void deserialize(final ZclFieldDeserializer deserializer) {
         super.deserialize(deserializer);
 
-        deviceAddress = (IeeeAddress) deserializer.deserialize(ZclDataType.IEEE_ADDRESS);
-        removeChildrenRejoin = (Boolean) deserializer.deserialize(ZclDataType.BOOLEAN);
+        deviceAddress = deserializer.deserialize(ZclDataType.IEEE_ADDRESS);
+        removeChildrenRejoin = deserializer.deserialize(ZclDataType.BOOLEAN);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ManagementLeaveResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ManagementLeaveResponse.java
@@ -71,7 +71,7 @@ public class ManagementLeaveResponse extends ZdoResponse {
     public void deserialize(final ZclFieldDeserializer deserializer) {
         super.deserialize(deserializer);
 
-        status = (ZdoStatus) deserializer.deserialize(ZclDataType.ZDO_STATUS);
+        status = deserializer.deserialize(ZclDataType.ZDO_STATUS);
         if (status != ZdoStatus.SUCCESS) {
             // Don't read the full response if we have an error
             return;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ManagementLqiRequest.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ManagementLqiRequest.java
@@ -98,7 +98,7 @@ public class ManagementLqiRequest extends ZdoRequest implements ZigBeeTransactio
     public void deserialize(final ZclFieldDeserializer deserializer) {
         super.deserialize(deserializer);
 
-        startIndex = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        startIndex = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ManagementLqiResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ManagementLqiResponse.java
@@ -164,17 +164,17 @@ public class ManagementLqiResponse extends ZdoResponse {
         // Create lists
         neighborTableList = new ArrayList<NeighborTable>();
 
-        status = (ZdoStatus) deserializer.deserialize(ZclDataType.ZDO_STATUS);
+        status = deserializer.deserialize(ZclDataType.ZDO_STATUS);
         if (status != ZdoStatus.SUCCESS) {
             // Don't read the full response if we have an error
             return;
         }
-        neighborTableEntries = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        startIndex = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        Integer neighborTableListCount = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        neighborTableEntries = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        startIndex = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        Integer neighborTableListCount = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
         if (neighborTableListCount != null) {
             for (int cnt = 0; cnt < neighborTableListCount; cnt++) {
-                neighborTableList.add((NeighborTable) deserializer.deserialize(ZclDataType.NEIGHBOR_TABLE));
+                neighborTableList.add(deserializer.deserialize(ZclDataType.NEIGHBOR_TABLE));
             }
         }
     }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ManagementNetworkDiscovery.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ManagementNetworkDiscovery.java
@@ -148,9 +148,9 @@ public class ManagementNetworkDiscovery extends ZdoRequest {
     public void deserialize(final ZclFieldDeserializer deserializer) {
         super.deserialize(deserializer);
 
-        scanChannels = (Integer) deserializer.deserialize(ZclDataType.BITMAP_32_BIT);
-        scanDuration = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        startIndex = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        scanChannels = deserializer.deserialize(ZclDataType.BITMAP_32_BIT);
+        scanDuration = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        startIndex = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ManagementNetworkUpdateNotify.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ManagementNetworkUpdateNotify.java
@@ -223,18 +223,18 @@ public class ManagementNetworkUpdateNotify extends ZdoRequest {
         // Create lists
         energyValues = new ArrayList<Integer>();
 
-        status = (ZdoStatus) deserializer.deserialize(ZclDataType.ZDO_STATUS);
+        status = deserializer.deserialize(ZclDataType.ZDO_STATUS);
         if (status != ZdoStatus.SUCCESS) {
             // Don't read the full response if we have an error
             return;
         }
-        scannedChannels = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
-        totalTransmissions = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        transmissionFailures = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        Integer scannedChannelsListCount = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        scannedChannels = deserializer.deserialize(ZclDataType.UNSIGNED_32_BIT_INTEGER);
+        totalTransmissions = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        transmissionFailures = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        Integer scannedChannelsListCount = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
         if (scannedChannelsListCount != null) {
             for (int cnt = 0; cnt < scannedChannelsListCount; cnt++) {
-                energyValues.add((Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER));
+                energyValues.add(deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER));
             }
         }
     }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ManagementPermitJoiningRequest.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ManagementPermitJoiningRequest.java
@@ -131,8 +131,8 @@ public class ManagementPermitJoiningRequest extends ZdoRequest implements ZigBee
     public void deserialize(final ZclFieldDeserializer deserializer) {
         super.deserialize(deserializer);
 
-        permitDuration = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        tcSignificance = (Boolean) deserializer.deserialize(ZclDataType.BOOLEAN);
+        permitDuration = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        tcSignificance = deserializer.deserialize(ZclDataType.BOOLEAN);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ManagementPermitJoiningResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ManagementPermitJoiningResponse.java
@@ -71,7 +71,7 @@ public class ManagementPermitJoiningResponse extends ZdoResponse {
     public void deserialize(final ZclFieldDeserializer deserializer) {
         super.deserialize(deserializer);
 
-        status = (ZdoStatus) deserializer.deserialize(ZclDataType.ZDO_STATUS);
+        status = deserializer.deserialize(ZclDataType.ZDO_STATUS);
         if (status != ZdoStatus.SUCCESS) {
             // Don't read the full response if we have an error
             return;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ManagementRoutingRequest.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ManagementRoutingRequest.java
@@ -98,7 +98,7 @@ public class ManagementRoutingRequest extends ZdoRequest implements ZigBeeTransa
     public void deserialize(final ZclFieldDeserializer deserializer) {
         super.deserialize(deserializer);
 
-        startIndex = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        startIndex = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ManagementRoutingResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ManagementRoutingResponse.java
@@ -164,17 +164,17 @@ public class ManagementRoutingResponse extends ZdoResponse {
         // Create lists
         routingTableList = new ArrayList<RoutingTable>();
 
-        status = (ZdoStatus) deserializer.deserialize(ZclDataType.ZDO_STATUS);
+        status = deserializer.deserialize(ZclDataType.ZDO_STATUS);
         if (status != ZdoStatus.SUCCESS) {
             // Don't read the full response if we have an error
             return;
         }
-        routingTableEntries = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        startIndex = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        Integer routingTableListCount = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        routingTableEntries = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        startIndex = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        Integer routingTableListCount = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
         if (routingTableListCount != null) {
             for (int cnt = 0; cnt < routingTableListCount; cnt++) {
-                routingTableList.add((RoutingTable) deserializer.deserialize(ZclDataType.ROUTING_TABLE));
+                routingTableList.add(deserializer.deserialize(ZclDataType.ROUTING_TABLE));
             }
         }
     }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/MatchDescriptorRequest.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/MatchDescriptorRequest.java
@@ -192,18 +192,18 @@ public class MatchDescriptorRequest extends ZdoRequest {
         inClusterList = new ArrayList<Integer>();
         outClusterList = new ArrayList<Integer>();
 
-        nwkAddrOfInterest = (Integer) deserializer.deserialize(ZclDataType.NWK_ADDRESS);
-        profileId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        Integer inClusterCount = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        nwkAddrOfInterest = deserializer.deserialize(ZclDataType.NWK_ADDRESS);
+        profileId = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        Integer inClusterCount = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
         if (inClusterCount != null) {
             for (int cnt = 0; cnt < inClusterCount; cnt++) {
-                inClusterList.add((Integer) deserializer.deserialize(ZclDataType.CLUSTERID));
+                inClusterList.add(deserializer.deserialize(ZclDataType.CLUSTERID));
             }
         }
-        Integer outClusterCount = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        Integer outClusterCount = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
         if (outClusterCount != null) {
             for (int cnt = 0; cnt < outClusterCount; cnt++) {
-                outClusterList.add((Integer) deserializer.deserialize(ZclDataType.CLUSTERID));
+                outClusterList.add(deserializer.deserialize(ZclDataType.CLUSTERID));
             }
         }
     }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/MatchDescriptorResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/MatchDescriptorResponse.java
@@ -133,16 +133,16 @@ public class MatchDescriptorResponse extends ZdoResponse {
         // Create lists
         matchList = new ArrayList<Integer>();
 
-        status = (ZdoStatus) deserializer.deserialize(ZclDataType.ZDO_STATUS);
+        status = deserializer.deserialize(ZclDataType.ZDO_STATUS);
         if (status != ZdoStatus.SUCCESS) {
             // Don't read the full response if we have an error
             return;
         }
-        nwkAddrOfInterest = (Integer) deserializer.deserialize(ZclDataType.NWK_ADDRESS);
-        Integer matchLength = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        nwkAddrOfInterest = deserializer.deserialize(ZclDataType.NWK_ADDRESS);
+        Integer matchLength = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
         if (matchLength != null) {
             for (int cnt = 0; cnt < matchLength; cnt++) {
-                matchList.add((Integer) deserializer.deserialize(ZclDataType.ENDPOINT));
+                matchList.add(deserializer.deserialize(ZclDataType.ENDPOINT));
             }
         }
     }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/NetworkAddressRequest.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/NetworkAddressRequest.java
@@ -165,9 +165,9 @@ public class NetworkAddressRequest extends ZdoRequest implements ZigBeeTransacti
     public void deserialize(final ZclFieldDeserializer deserializer) {
         super.deserialize(deserializer);
 
-        ieeeAddr = (IeeeAddress) deserializer.deserialize(ZclDataType.IEEE_ADDRESS);
-        requestType = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        startIndex = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        ieeeAddr = deserializer.deserialize(ZclDataType.IEEE_ADDRESS);
+        requestType = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        startIndex = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/NetworkAddressResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/NetworkAddressResponse.java
@@ -192,18 +192,18 @@ public class NetworkAddressResponse extends ZdoResponse {
         // Create lists
         nwkAddrAssocDevList = new ArrayList<Integer>();
 
-        status = (ZdoStatus) deserializer.deserialize(ZclDataType.ZDO_STATUS);
+        status = deserializer.deserialize(ZclDataType.ZDO_STATUS);
         if (status != ZdoStatus.SUCCESS) {
             // Don't read the full response if we have an error
             return;
         }
-        ieeeAddrRemoteDev = (IeeeAddress) deserializer.deserialize(ZclDataType.IEEE_ADDRESS);
-        nwkAddrRemoteDev = (Integer) deserializer.deserialize(ZclDataType.NWK_ADDRESS);
-        Integer numAssocDev = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        startIndex = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        ieeeAddrRemoteDev = deserializer.deserialize(ZclDataType.IEEE_ADDRESS);
+        nwkAddrRemoteDev = deserializer.deserialize(ZclDataType.NWK_ADDRESS);
+        Integer numAssocDev = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        startIndex = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
         if (numAssocDev != null) {
             for (int cnt = 0; cnt < numAssocDev; cnt++) {
-                nwkAddrAssocDevList.add((Integer) deserializer.deserialize(ZclDataType.NWK_ADDRESS));
+                nwkAddrAssocDevList.add(deserializer.deserialize(ZclDataType.NWK_ADDRESS));
             }
         }
     }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/NetworkUpdateRequest.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/NetworkUpdateRequest.java
@@ -207,11 +207,11 @@ public class NetworkUpdateRequest extends ZdoRequest {
     public void deserialize(final ZclFieldDeserializer deserializer) {
         super.deserialize(deserializer);
 
-        scanChannels = (Integer) deserializer.deserialize(ZclDataType.BITMAP_32_BIT);
-        scanDuration = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        scanCount = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        nwkUpdateId = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        nwkManagerAddr = (Integer) deserializer.deserialize(ZclDataType.NWK_ADDRESS);
+        scanChannels = deserializer.deserialize(ZclDataType.BITMAP_32_BIT);
+        scanDuration = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        scanCount = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        nwkUpdateId = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        nwkManagerAddr = deserializer.deserialize(ZclDataType.NWK_ADDRESS);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/NodeDescriptorRequest.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/NodeDescriptorRequest.java
@@ -98,7 +98,7 @@ public class NodeDescriptorRequest extends ZdoRequest implements ZigBeeTransacti
     public void deserialize(final ZclFieldDeserializer deserializer) {
         super.deserialize(deserializer);
 
-        nwkAddrOfInterest = (Integer) deserializer.deserialize(ZclDataType.NWK_ADDRESS);
+        nwkAddrOfInterest = deserializer.deserialize(ZclDataType.NWK_ADDRESS);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/NodeDescriptorResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/NodeDescriptorResponse.java
@@ -142,13 +142,13 @@ public class NodeDescriptorResponse extends ZdoResponse {
     public void deserialize(final ZclFieldDeserializer deserializer) {
         super.deserialize(deserializer);
 
-        status = (ZdoStatus) deserializer.deserialize(ZclDataType.ZDO_STATUS);
+        status = deserializer.deserialize(ZclDataType.ZDO_STATUS);
         if (status != ZdoStatus.SUCCESS) {
             // Don't read the full response if we have an error
             return;
         }
-        nwkAddrOfInterest = (Integer) deserializer.deserialize(ZclDataType.NWK_ADDRESS);
-        nodeDescriptor = (NodeDescriptor) deserializer.deserialize(ZclDataType.NODE_DESCRIPTOR);
+        nwkAddrOfInterest = deserializer.deserialize(ZclDataType.NWK_ADDRESS);
+        nodeDescriptor = deserializer.deserialize(ZclDataType.NODE_DESCRIPTOR);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ParentAnnounce.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ParentAnnounce.java
@@ -103,10 +103,10 @@ public class ParentAnnounce extends ZdoRequest {
         // Create lists
         childInfoList = new ArrayList<ParentAnnounceChildInfo>();
 
-        Integer numberOfChildren = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        Integer numberOfChildren = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
         if (numberOfChildren != null) {
             for (int cnt = 0; cnt < numberOfChildren; cnt++) {
-                childInfoList.add((ParentAnnounceChildInfo) deserializer.deserialize(ZclDataType.PARENT_ANNOUNCE_CHILD_INFO));
+                childInfoList.add(deserializer.deserialize(ZclDataType.PARENT_ANNOUNCE_CHILD_INFO));
             }
         }
     }

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/PowerDescriptorRequest.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/PowerDescriptorRequest.java
@@ -98,7 +98,7 @@ public class PowerDescriptorRequest extends ZdoRequest implements ZigBeeTransact
     public void deserialize(final ZclFieldDeserializer deserializer) {
         super.deserialize(deserializer);
 
-        nwkAddrOfInterest = (Integer) deserializer.deserialize(ZclDataType.NWK_ADDRESS);
+        nwkAddrOfInterest = deserializer.deserialize(ZclDataType.NWK_ADDRESS);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/PowerDescriptorResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/PowerDescriptorResponse.java
@@ -125,13 +125,13 @@ public class PowerDescriptorResponse extends ZdoResponse {
     public void deserialize(final ZclFieldDeserializer deserializer) {
         super.deserialize(deserializer);
 
-        status = (ZdoStatus) deserializer.deserialize(ZclDataType.ZDO_STATUS);
+        status = deserializer.deserialize(ZclDataType.ZDO_STATUS);
         if (status != ZdoStatus.SUCCESS) {
             // Don't read the full response if we have an error
             return;
         }
-        nwkAddrOfInterest = (Integer) deserializer.deserialize(ZclDataType.NWK_ADDRESS);
-        powerDescriptor = (PowerDescriptor) deserializer.deserialize(ZclDataType.POWER_DESCRIPTOR);
+        nwkAddrOfInterest = deserializer.deserialize(ZclDataType.NWK_ADDRESS);
+        powerDescriptor = deserializer.deserialize(ZclDataType.POWER_DESCRIPTOR);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/RecoverSourceBindRequest.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/RecoverSourceBindRequest.java
@@ -90,7 +90,7 @@ public class RecoverSourceBindRequest extends ZdoRequest {
     public void deserialize(final ZclFieldDeserializer deserializer) {
         super.deserialize(deserializer);
 
-        startIndex = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        startIndex = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/RemoveBackupBindEntryResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/RemoveBackupBindEntryResponse.java
@@ -100,12 +100,12 @@ public class RemoveBackupBindEntryResponse extends ZdoResponse {
     public void deserialize(final ZclFieldDeserializer deserializer) {
         super.deserialize(deserializer);
 
-        status = (ZdoStatus) deserializer.deserialize(ZclDataType.ZDO_STATUS);
+        status = deserializer.deserialize(ZclDataType.ZDO_STATUS);
         if (status != ZdoStatus.SUCCESS) {
             // Don't read the full response if we have an error
             return;
         }
-        entryCount = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        entryCount = deserializer.deserialize(ZclDataType.UNSIGNED_16_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ReplaceDeviceResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/ReplaceDeviceResponse.java
@@ -72,7 +72,7 @@ public class ReplaceDeviceResponse extends ZdoResponse {
     public void deserialize(final ZclFieldDeserializer deserializer) {
         super.deserialize(deserializer);
 
-        status = (ZdoStatus) deserializer.deserialize(ZclDataType.ZDO_STATUS);
+        status = deserializer.deserialize(ZclDataType.ZDO_STATUS);
         if (status != ZdoStatus.SUCCESS) {
             // Don't read the full response if we have an error
             return;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/SimpleDescriptorRequest.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/SimpleDescriptorRequest.java
@@ -127,8 +127,8 @@ public class SimpleDescriptorRequest extends ZdoRequest implements ZigBeeTransac
     public void deserialize(final ZclFieldDeserializer deserializer) {
         super.deserialize(deserializer);
 
-        nwkAddrOfInterest = (Integer) deserializer.deserialize(ZclDataType.NWK_ADDRESS);
-        endpoint = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        nwkAddrOfInterest = deserializer.deserialize(ZclDataType.NWK_ADDRESS);
+        endpoint = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/SimpleDescriptorResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/SimpleDescriptorResponse.java
@@ -154,14 +154,14 @@ public class SimpleDescriptorResponse extends ZdoResponse {
     public void deserialize(final ZclFieldDeserializer deserializer) {
         super.deserialize(deserializer);
 
-        status = (ZdoStatus) deserializer.deserialize(ZclDataType.ZDO_STATUS);
+        status = deserializer.deserialize(ZclDataType.ZDO_STATUS);
         if (status != ZdoStatus.SUCCESS) {
             // Don't read the full response if we have an error
             return;
         }
-        nwkAddrOfInterest = (Integer) deserializer.deserialize(ZclDataType.NWK_ADDRESS);
-        length = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        simpleDescriptor = (SimpleDescriptor) deserializer.deserialize(ZclDataType.SIMPLE_DESCRIPTOR);
+        nwkAddrOfInterest = deserializer.deserialize(ZclDataType.NWK_ADDRESS);
+        length = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        simpleDescriptor = deserializer.deserialize(ZclDataType.SIMPLE_DESCRIPTOR);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/StoreBackupBindEntryResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/StoreBackupBindEntryResponse.java
@@ -71,7 +71,7 @@ public class StoreBackupBindEntryResponse extends ZdoResponse {
     public void deserialize(final ZclFieldDeserializer deserializer) {
         super.deserialize(deserializer);
 
-        status = (ZdoStatus) deserializer.deserialize(ZclDataType.ZDO_STATUS);
+        status = deserializer.deserialize(ZclDataType.ZDO_STATUS);
         if (status != ZdoStatus.SUCCESS) {
             // Don't read the full response if we have an error
             return;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/UnbindRequest.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/UnbindRequest.java
@@ -105,7 +105,7 @@ public class UnbindRequest extends ZdoRequest implements ZigBeeTransactionMatche
     public void deserialize(final ZclFieldDeserializer deserializer) {
         super.deserialize(deserializer);
 
-        bindingTableEntry = (BindingTable) deserializer.deserialize(ZclDataType.BINDING_TABLE);
+        bindingTableEntry = deserializer.deserialize(ZclDataType.BINDING_TABLE);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/UnbindResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/UnbindResponse.java
@@ -71,7 +71,7 @@ public class UnbindResponse extends ZdoResponse {
     public void deserialize(final ZclFieldDeserializer deserializer) {
         super.deserialize(deserializer);
 
-        status = (ZdoStatus) deserializer.deserialize(ZclDataType.ZDO_STATUS);
+        status = deserializer.deserialize(ZclDataType.ZDO_STATUS);
         if (status != ZdoStatus.SUCCESS) {
             // Don't read the full response if we have an error
             return;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/UserDescriptorRequest.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/UserDescriptorRequest.java
@@ -98,7 +98,7 @@ public class UserDescriptorRequest extends ZdoRequest implements ZigBeeTransacti
     public void deserialize(final ZclFieldDeserializer deserializer) {
         super.deserialize(deserializer);
 
-        nwkAddrOfInterest = (Integer) deserializer.deserialize(ZclDataType.NWK_ADDRESS);
+        nwkAddrOfInterest = deserializer.deserialize(ZclDataType.NWK_ADDRESS);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/UserDescriptorResponse.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/command/UserDescriptorResponse.java
@@ -154,14 +154,14 @@ public class UserDescriptorResponse extends ZdoResponse {
     public void deserialize(final ZclFieldDeserializer deserializer) {
         super.deserialize(deserializer);
 
-        status = (ZdoStatus) deserializer.deserialize(ZclDataType.ZDO_STATUS);
+        status = deserializer.deserialize(ZclDataType.ZDO_STATUS);
         if (status != ZdoStatus.SUCCESS) {
             // Don't read the full response if we have an error
             return;
         }
-        nwkAddrOfInterest = (Integer) deserializer.deserialize(ZclDataType.NWK_ADDRESS);
-        length = (Integer) deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        userDescriptor = (UserDescriptor) deserializer.deserialize(ZclDataType.USER_DESCRIPTOR);
+        nwkAddrOfInterest = deserializer.deserialize(ZclDataType.NWK_ADDRESS);
+        length = deserializer.deserialize(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        userDescriptor = deserializer.deserialize(ZclDataType.USER_DESCRIPTOR);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/field/BindingTable.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/field/BindingTable.java
@@ -170,15 +170,15 @@ public class BindingTable {
     }
 
     public void deserialize(final ZigBeeDeserializer deserializer) {
-        srcAddr = (IeeeAddress) deserializer.readZigBeeType(ZclDataType.IEEE_ADDRESS);
-        srcEndpoint = (int) deserializer.readZigBeeType(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        clusterId = (int) deserializer.readZigBeeType(ZclDataType.CLUSTERID);
-        dstAddrMode = (int) deserializer.readZigBeeType(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        srcAddr = deserializer.readZigBeeType(ZclDataType.IEEE_ADDRESS);
+        srcEndpoint = deserializer.readZigBeeType(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        clusterId = deserializer.readZigBeeType(ZclDataType.CLUSTERID);
+        dstAddrMode = deserializer.readZigBeeType(ZclDataType.UNSIGNED_8_BIT_INTEGER);
         if (dstAddrMode == 1) {
-            dstGroupAddr = (int) deserializer.readZigBeeType(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+            dstGroupAddr = deserializer.readZigBeeType(ZclDataType.UNSIGNED_16_BIT_INTEGER);
         } else if (dstAddrMode == 3) {
-            dstAddr = (IeeeAddress) deserializer.readZigBeeType(ZclDataType.IEEE_ADDRESS);
-            dstNodeEndpoint = (int) deserializer.readZigBeeType(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+            dstAddr = deserializer.readZigBeeType(ZclDataType.IEEE_ADDRESS);
+            dstNodeEndpoint = deserializer.readZigBeeType(ZclDataType.UNSIGNED_8_BIT_INTEGER);
         }
     }
 

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/field/NeighborTable.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/field/NeighborTable.java
@@ -66,19 +66,19 @@ public class NeighborTable {
      */
     public void deserialize(ZigBeeDeserializer deserializer) {
         // Deserialize the fields
-        extendedPanId = (ExtendedPanId) deserializer.readZigBeeType(ZclDataType.EXTENDED_PANID);
-        extendedAddress = (IeeeAddress) deserializer.readZigBeeType(ZclDataType.IEEE_ADDRESS);
-        networkAddress = (Integer) deserializer.readZigBeeType(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        extendedPanId = deserializer.readZigBeeType(ZclDataType.EXTENDED_PANID);
+        extendedAddress = deserializer.readZigBeeType(ZclDataType.IEEE_ADDRESS);
+        networkAddress = deserializer.readZigBeeType(ZclDataType.UNSIGNED_16_BIT_INTEGER);
 
-        int temp = (int) deserializer.readZigBeeType(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        int temp = deserializer.readZigBeeType(ZclDataType.UNSIGNED_8_BIT_INTEGER);
         setDeviceType(temp & 0x03);
         setRxOnWhenIdle((temp & 0x0c) >> 2);
         setRelationship((temp & 0x70) >> 4);
 
-        temp = (int) deserializer.readZigBeeType(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        temp = deserializer.readZigBeeType(ZclDataType.UNSIGNED_8_BIT_INTEGER);
         setPermitJoining(temp & 0x03);
-        depth = (int) deserializer.readZigBeeType(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        lqi = (int) deserializer.readZigBeeType(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        depth = deserializer.readZigBeeType(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        lqi = deserializer.readZigBeeType(ZclDataType.UNSIGNED_8_BIT_INTEGER);
     }
 
     public ExtendedPanId getExtendedPanId() {

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/field/NodeDescriptor.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/field/NodeDescriptor.java
@@ -396,9 +396,9 @@ public class NodeDescriptor {
         // Deserialize the fields
 
         // Some flags...
-        int value1 = (int) deserializer.readZigBeeType(ZclDataType.DATA_8_BIT);
-        int value2 = (int) deserializer.readZigBeeType(ZclDataType.DATA_8_BIT);
-        int value3 = (int) deserializer.readZigBeeType(ZclDataType.DATA_8_BIT);
+        int value1 = deserializer.readZigBeeType(ZclDataType.DATA_8_BIT);
+        int value2 = deserializer.readZigBeeType(ZclDataType.DATA_8_BIT);
+        int value3 = deserializer.readZigBeeType(ZclDataType.DATA_8_BIT);
 
         setLogicalType(value1 & 0x07);
         complexDescriptorAvailable = (value1 & 0x08) != 0;
@@ -408,13 +408,13 @@ public class NodeDescriptor {
         setFrequencyBands((value2 & 0xf8) >> 3);
         setMacCapabilities(value3);
 
-        manufacturerCode = (int) deserializer.readZigBeeType(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        bufferSize = (int) deserializer.readZigBeeType(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        incomingTransferSize = (int) deserializer.readZigBeeType(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        manufacturerCode = deserializer.readZigBeeType(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        bufferSize = deserializer.readZigBeeType(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        incomingTransferSize = deserializer.readZigBeeType(ZclDataType.UNSIGNED_16_BIT_INTEGER);
 
         setServerCapabilities((int) deserializer.readZigBeeType(ZclDataType.SIGNED_16_BIT_INTEGER));
-        outgoingTransferSize = (int) deserializer.readZigBeeType(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        int descriptorCapabilities = (int) deserializer.readZigBeeType(ZclDataType.SIGNED_8_BIT_INTEGER);
+        outgoingTransferSize = deserializer.readZigBeeType(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        int descriptorCapabilities = deserializer.readZigBeeType(ZclDataType.SIGNED_8_BIT_INTEGER);
 
         extendedEndpointListAvailable = (descriptorCapabilities & 0x01) != 0;
         extendedSimpleDescriptorListAvailable = (descriptorCapabilities & 0x02) != 0;

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/field/ParentAnnounceChildInfo.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/field/ParentAnnounceChildInfo.java
@@ -31,7 +31,7 @@ public class ParentAnnounceChildInfo {
     }
 
     public void deserialize(final ZigBeeDeserializer deserializer) {
-        ieeeAddress = (IeeeAddress) deserializer.readZigBeeType(ZclDataType.IEEE_ADDRESS);
+        ieeeAddress = deserializer.readZigBeeType(ZclDataType.IEEE_ADDRESS);
     }
 
     @Override

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/field/PowerDescriptor.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/field/PowerDescriptor.java
@@ -258,8 +258,8 @@ public class PowerDescriptor {
      */
     public void deserialize(ZigBeeDeserializer deserializer) {
         // Deserialize the fields
-        int byte1 = (int) deserializer.readZigBeeType(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        int byte2 = (int) deserializer.readZigBeeType(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        int byte1 = deserializer.readZigBeeType(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        int byte2 = deserializer.readZigBeeType(ZclDataType.UNSIGNED_8_BIT_INTEGER);
 
         setCurrentPowerMode(byte1 & 0x0f);
         setAvailablePowerSources(byte1 >> 4 & 0x0f);

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/field/RoutingTable.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/field/RoutingTable.java
@@ -45,8 +45,8 @@ public class RoutingTable {
      */
     public void deserialize(ZigBeeDeserializer deserializer) {
         // Deserialize the fields
-        destinationAddress = (Integer) deserializer.readZigBeeType(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        int temp = (int) deserializer.readZigBeeType(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        destinationAddress = deserializer.readZigBeeType(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        int temp = deserializer.readZigBeeType(ZclDataType.UNSIGNED_8_BIT_INTEGER);
         switch (temp & 0x07) {
             case 0:
                 status = DiscoveryState.ACTIVE;
@@ -71,7 +71,7 @@ public class RoutingTable {
         memoryConstrained = (temp & 0x08) != 0;
         manyToOne = (temp & 0x10) != 0;
         routeRecordRequired = (temp & 0x20) != 0;
-        nextHopAddress = (int) deserializer.readZigBeeType(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        nextHopAddress = deserializer.readZigBeeType(ZclDataType.UNSIGNED_16_BIT_INTEGER);
     }
 
     public Integer getDestinationAddress() {

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/field/SimpleDescriptor.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zdo/field/SimpleDescriptor.java
@@ -46,12 +46,12 @@ public class SimpleDescriptor {
      */
     public void deserialize(ZigBeeDeserializer deserializer) {
         // Deserialize the fields
-        endpoint = (int) deserializer.readZigBeeType(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        profileId = (int) deserializer.readZigBeeType(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        deviceId = (int) deserializer.readZigBeeType(ZclDataType.UNSIGNED_16_BIT_INTEGER);
-        deviceVersion = (int) deserializer.readZigBeeType(ZclDataType.UNSIGNED_8_BIT_INTEGER);
-        inputClusterList = (List<Integer>) deserializer.readZigBeeType(ZclDataType.N_X_UNSIGNED_16_BIT_INTEGER);
-        outputClusterList = (List<Integer>) deserializer.readZigBeeType(ZclDataType.N_X_UNSIGNED_16_BIT_INTEGER);
+        endpoint = deserializer.readZigBeeType(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        profileId = deserializer.readZigBeeType(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        deviceId = deserializer.readZigBeeType(ZclDataType.UNSIGNED_16_BIT_INTEGER);
+        deviceVersion = deserializer.readZigBeeType(ZclDataType.UNSIGNED_8_BIT_INTEGER);
+        inputClusterList = deserializer.readZigBeeType(ZclDataType.N_X_UNSIGNED_16_BIT_INTEGER);
+        outputClusterList = deserializer.readZigBeeType(ZclDataType.N_X_UNSIGNED_16_BIT_INTEGER);
     }
 
     public int getEndpoint() {

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/TestUtilities.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/TestUtilities.java
@@ -41,6 +41,7 @@ public class TestUtilities {
     /**
      * Invokes a private method
      *
+     * @type <R> type of result
      * @param clazz the class where the method resides
      * @param object the object where the method resides
      * @param methodName the method name
@@ -52,7 +53,7 @@ public class TestUtilities {
      * @throws IllegalArgumentException
      * @throws InvocationTargetException
      */
-    public static Object invokeMethod(Class<?> clazz, Object object, String methodName, Object... params)
+    public static <T, R> R invokeMethod(Class<T> clazz, T object, String methodName, Object... params)
             throws NoSuchMethodException, SecurityException, IllegalAccessException, IllegalArgumentException,
             InvocationTargetException {
         int paramCount = params.length;
@@ -65,25 +66,32 @@ public class TestUtilities {
         }
         method = clazz.getDeclaredMethod(methodName, classArray);
         method.setAccessible(true);
-        return method.invoke(object, paramArray);
+
+        @SuppressWarnings("unchecked")
+        R result = (R) method.invoke(object, paramArray);
+        return result;
     }
 
     /**
      * Gets the value of the private field
      *
+     * @type <R> type of field
      * @param clazz the class where the field resides
      * @param object the object where the field resides
      * @param fieldName the field name
      * @return the {@link Object} containing the field value
      * @throws Exception
      */
-    public static Object getField(Class<?> clazz, Object object, String fieldName) throws Exception {
+    public static  <T, R> R getField(Class<T> clazz, T object, String fieldName) throws Exception {
         Field field = clazz.getDeclaredField(fieldName);
         field.setAccessible(true);
         Field modifiersField = Field.class.getDeclaredField("modifiers");
         modifiersField.setAccessible(true);
         modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
-        return field.get(object);
+
+        @SuppressWarnings("unchecked")
+        R result = (R) field.get(object);
+        return result;
     }
 
     /**

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeNetworkManagerTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ZigBeeNetworkManagerTest.java
@@ -1236,11 +1236,12 @@ public class ZigBeeNetworkManagerTest
 
         ZigBeeAnnounceListener announceListener = Mockito.mock(ZigBeeAnnounceListener.class);
         manager.addAnnounceListener(announceListener);
-        assertEquals(1, ((Collection<ZigBeeAnnounceListener>) TestUtilities.getField(ZigBeeNetworkManager.class,
-                manager, "announceListeners")).size());
+
+        Collection<ZigBeeAnnounceListener> announceListenersField = TestUtilities.getField(ZigBeeNetworkManager.class,
+                manager, "announceListeners");
+        assertEquals(1, announceListenersField.size());
         manager.addAnnounceListener(announceListener);
-        assertEquals(1, ((Collection<ZigBeeAnnounceListener>) TestUtilities.getField(ZigBeeNetworkManager.class,
-                manager, "announceListeners")).size());
+        assertEquals(1, announceListenersField.size());
 
         manager.nodeStatusUpdate(ZigBeeNodeStatus.DEVICE_LEFT, 1234, new IeeeAddress("123456789ABCDEF0"));
         Mockito.verify(node, Mockito.times(0)).setNodeState(ArgumentMatchers.any(ZigBeeNodeState.class));

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeNodeServiceDiscovererTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/app/discovery/ZigBeeNodeServiceDiscovererTest.java
@@ -335,7 +335,7 @@ public class ZigBeeNodeServiceDiscovererTest {
         tasks.add(NodeDiscoveryTask.NODE_DESCRIPTOR);
 
         TestUtilities.invokeMethod(ZigBeeNodeServiceDiscoverer.class, discoverer, "startDiscovery", Set.class, tasks);
-        Queue<NodeDiscoveryTask> tasksOut = (Queue<NodeDiscoveryTask>) TestUtilities.getField(
+        Queue<NodeDiscoveryTask> tasksOut = TestUtilities.getField(
                 ZigBeeNodeServiceDiscoverer.class, discoverer,
                 "discoveryTasks");
 

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/database/ZigBeeNetworkDatabaseManagerTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/database/ZigBeeNetworkDatabaseManagerTest.java
@@ -145,16 +145,20 @@ public class ZigBeeNetworkDatabaseManagerTest {
         ZigBeeNetworkDatabaseManager databaseManager = new ZigBeeNetworkDatabaseManager(networkManager);
 
         databaseManager.setDeferredWriteTime(10);
-        assertEquals(10,
+        asserEqualsWithType(10,
                 TestUtilities.getField(ZigBeeNetworkDatabaseManager.class, databaseManager, "deferredWriteTime"));
         databaseManager.setMaxDeferredWriteTime(5);
-        assertEquals(5,
+        asserEqualsWithType(5,
                 TestUtilities.getField(ZigBeeNetworkDatabaseManager.class, databaseManager, "deferredWriteTime"));
-        assertEquals(TimeUnit.MILLISECONDS.toNanos(5),
+        asserEqualsWithType(TimeUnit.MILLISECONDS.toNanos(5),
                 TestUtilities.getField(ZigBeeNetworkDatabaseManager.class, databaseManager, "deferredWriteTimeout"));
         databaseManager.setDeferredWriteTime(3);
-        assertEquals(3,
+        asserEqualsWithType(3,
                 TestUtilities.getField(ZigBeeNetworkDatabaseManager.class, databaseManager, "deferredWriteTime"));
+    }
+
+    private <T> void asserEqualsWithType(T expected, T actual) {
+        assertEquals(expected, actual);
     }
 
     @Test

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/internal/ZigBeeCommandNotifierTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/internal/ZigBeeCommandNotifierTest.java
@@ -37,7 +37,7 @@ public class ZigBeeCommandNotifierTest {
         ZigBeeCommandListener commandListener = Mockito.mock(ZigBeeCommandListener.class);
         notifier.addCommandListener(commandListener);
 
-        Set<ZigBeeCommandListener> commandListeners = (Set<ZigBeeCommandListener>) TestUtilities
+        Set<ZigBeeCommandListener> commandListeners = TestUtilities
                 .getField(ZigBeeCommandNotifier.class, notifier, "commandListeners");
         assertEquals(1, commandListeners.size());
         assertEquals(commandListener, commandListeners.iterator().next());

--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zcl/ZclClusterTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/zcl/ZclClusterTest.java
@@ -257,9 +257,7 @@ public class ZclClusterTest {
         createEndpoint();
 
         ZclCluster cluster = new ZclOnOffCluster(endpoint);
-        @SuppressWarnings("unchecked")
-        Set<ZclAttributeListener> attributeListeners = (Set<ZclAttributeListener>) TestUtilities
-                .getField(ZclCluster.class, cluster, "attributeListeners");
+        Set<ZclAttributeListener> attributeListeners = TestUtilities.getField(ZclCluster.class, cluster, "attributeListeners");
         assertEquals(0, attributeListeners.size());
 
         // This reports an incorrect type which is changed through the normalisation
@@ -390,9 +388,7 @@ public class ZclClusterTest {
 
         ZclCluster cluster = new ZclOnOffCluster(endpoint);
 
-        @SuppressWarnings("unchecked")
-        Set<ZclCommandListener> commandListeners = (Set<ZclCommandListener>) TestUtilities.getField(ZclCluster.class,
-                cluster, "commandListeners");
+        Set<ZclCommandListener> commandListeners = TestUtilities.getField(ZclCluster.class, cluster, "commandListeners");
         assertEquals(0, commandListeners.size());
         int tid = 123;
         ZclCommand command = Mockito.mock(ZclCommand.class);


### PR DESCRIPTION
Reduces explicit casting by using type interference instead. As it touches generated code, the generators are also changed to generate files using type interference.