### PR TITLE
Little less overhead when trace/debug logging is disabled

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/ash/AshFrameHandler.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/ash/AshFrameHandler.java
@@ -189,7 +189,9 @@ public class AshFrameHandler implements EzspProtocolHandler {
 
         while (!closeHandler) {
             int val = port.read();
-            logger.trace("ASH RX: {}", String.format("%02X", val));
+            if (logger.isTraceEnabled()) {
+                logger.trace("ASH RX: {}", String.format("%02X", val));
+            }
             switch (val) {
                 case ASH_CANCEL_BYTE:
                     // Cancel Byte: Terminates a frame in progress. A Cancel Byte causes all data received since the
@@ -273,7 +275,9 @@ public class AshFrameHandler implements EzspProtocolHandler {
                     final AshFrame packet = AshFrame.createFromInput(packetData);
                     AshFrame responseFrame = null;
                     if (packet == null) {
-                        logger.debug("<-- RX ASH error: BAD PACKET {}", frameToString(packetData));
+                        if (logger.isDebugEnabled()) {
+                            logger.debug("<-- RX ASH error: BAD PACKET {}", frameToString(packetData));
+                        }
 
                         // Send a NAK and set rejection condition
                         if (!rejectionCondition) {
@@ -281,7 +285,7 @@ public class AshFrameHandler implements EzspProtocolHandler {
                             responseFrame = new AshFrameNak(ackNum);
                         }
                     } else {
-                        logger.debug("<-- RX ASH frame: {}", packet.toString());
+                        logger.debug("<-- RX ASH frame: {}", packet);
 
                         // Reset the exception counter
                         exceptionCnt = 0;


### PR DESCRIPTION
This PR will slightly lower the overhead of creating unused strings when a log level like `INFO` is set.

Signed-off-by: Jörg Sautter <joerg.sautter@gmx.net>