### PR TITLE
Increase duplicate window detection to 15 seconds and make configurable

### DIFF
--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ZigBeeNetworkManager.java
@@ -598,6 +598,15 @@ public class ZigBeeNetworkManager implements ZigBeeTransportReceive {
     }
 
     /**
+     * Gets the {@link ApdDataEntity} in use by the network manager. This allows configuration of the APSDE.
+     *
+     * @return the {@link ApdDataEntity} in use by the network manager.
+     */
+    public ApsDataEntity getApsDataEntity() {
+        return apsDataEntity;
+    }
+
+    /**
      * Set the current link key in use by the system.
      * <p>
      * Note that this method may only be called following the {@link #initialize} call, and before the {@link #startup}

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/aps/ApsDataEntity.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/aps/ApsDataEntity.java
@@ -43,7 +43,7 @@ import com.zsmartsystems.zigbee.transport.ZigBeeTransportTransmit;
  *
  */
 public class ApsDataEntity {
-    private static final long DUPLICATE_TIME_WINDOW = 5000;
+    private static final long DUPLICATE_TIME_WINDOW = 15000;
 
     private static final int FRAGMENTATION_LENGTH = 78;
     private static final int FRAGMENTATION_WINDOW = 1;


### PR DESCRIPTION
This increases the default delay for the duplicate frame detection out to 15 seconds which should allow for sleepy device retries.

This also adds a method to the network manager to get the `ApsDataEntity` which allows configuration of this layer.