### PR TITLE
Avoid NPE following ASH error

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/ash/AshFrameHandler.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/ash/AshFrameHandler.java
@@ -869,17 +869,16 @@ public class AshFrameHandler implements EzspProtocolHandler {
         Future<EzspFrame> futureResponse = sendEzspRequestAsync(ezspTransaction);
         if (futureResponse == null) {
             logger.debug("ASH: Error sending EZSP transaction: Future is null");
-            return null;
-        }
-
-        try {
-            futureResponse.get(timeout, TimeUnit.SECONDS);
-        } catch (InterruptedException | ExecutionException e) {
-            futureResponse.cancel(true);
-            logger.debug("ASH interrupted in sendRequest while sending {}", ezspTransaction.getRequest());
-        } catch (TimeoutException e) {
-            futureResponse.cancel(true);
-            logger.debug("Sending EZSP transaction timed out after {} seconds", timeout);
+        } else {
+            try {
+                futureResponse.get(timeout, TimeUnit.SECONDS);
+            } catch (InterruptedException | ExecutionException e) {
+                futureResponse.cancel(true);
+                logger.debug("ASH interrupted in sendRequest while sending {}", ezspTransaction.getRequest());
+            } catch (TimeoutException e) {
+                futureResponse.cancel(true);
+                logger.debug("Sending EZSP transaction timed out after {} seconds", timeout);
+            }
         }
 
         return ezspTransaction;

--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/transaction/EzspTransaction.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/internal/transaction/EzspTransaction.java
@@ -59,7 +59,7 @@ public interface EzspTransaction {
      * response indicating the final state of the transaction.
      *
      * @return {@link EmberStatus} indicating the transaction completion state or
-     *         {@link EmberStatus#EMBED_UNKNOWN_STATUS} on error.
+     *         {@link EmberStatus#UNKNOWN} on error.
      */
     EmberStatus getStatus();
 }

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/ash/AshFrameHandlerTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/internal/ash/AshFrameHandlerTest.java
@@ -21,7 +21,6 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -33,6 +32,7 @@ import com.zsmartsystems.zigbee.dongle.ember.ezsp.EzspFrame;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.EzspFrameRequest;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspVersionRequest;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspVersionResponse;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EmberStatus;
 import com.zsmartsystems.zigbee.dongle.ember.internal.EzspFrameHandler;
 import com.zsmartsystems.zigbee.dongle.ember.internal.transaction.EzspSingleResponseTransaction;
 import com.zsmartsystems.zigbee.dongle.ember.internal.transaction.EzspTransaction;
@@ -170,7 +170,7 @@ public class AshFrameHandlerTest {
 
         @Override
         public void write(int[] bytes) {
-            for(int val : bytes) {
+            for (int val : bytes) {
                 outputData.add(val);
             }
         }
@@ -317,5 +317,20 @@ public class AshFrameHandlerTest {
         frameHandler.start(port);
 
         Mockito.verify(ezspHandler, Mockito.timeout(TIMEOUT)).handleLinkStateChange(true);
+    }
+
+    @Test
+    public void sendEzspTransactionNullCheck() {
+        EzspFrameHandler ezspHandler = Mockito.mock(EzspFrameHandler.class);
+        AshFrameHandler frameHandler = new AshFrameHandler(ezspHandler);
+
+        frameHandler.setClosing();
+        EzspVersionRequest request = new EzspVersionRequest();
+        EzspTransaction transaction = frameHandler
+                .sendEzspTransaction(new EzspSingleResponseTransaction(request, EzspVersionResponse.class));
+
+        assertNotNull(transaction);
+        assertEquals(EmberStatus.UNKNOWN, transaction.getStatus());
+        assertNull(transaction.getResponse());
     }
 }


### PR DESCRIPTION
Failure in `sendEzspTransaction` currently returns `null` which causes an NPE in `EmberNcp`. This change returns the transaction as normal, and failure is checked by getting the response.