### PR TITLE
Handle handler error during initialisation

### DIFF
--- a/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/main/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzsp.java
@@ -475,7 +475,10 @@ public class ZigBeeDongleEzsp implements ZigBeeTransportTransmit, ZigBeeTranspor
         if (networkParametersResponse == null) {
             return ZigBeeStatus.COMMUNICATION_ERROR;
         }
-        networkParameters = networkParametersResponse.getParameters();
+        EmberNetworkParameters localNetworkParameters = networkParametersResponse.getParameters();
+        if (localNetworkParameters != null) {
+            networkParameters = localNetworkParameters;
+        }
         logger.debug("Ember initial network parameters are {}", networkParameters);
 
         ieeeAddress = ncp.getIeeeAddress();

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzspTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeDongleEzspTest.java
@@ -728,4 +728,55 @@ public class ZigBeeDongleEzspTest {
         assertNull(dongle.getTcLinkKey());
         assertNotNull(dongle.getZigBeeNetworkKey());
     }
+
+    @Test
+    public void initializeNoNetorkParameters() {
+        System.out.println("--- " + Thread.currentThread().getStackTrace()[1].getMethodName());
+        final EmberNcp ncp = Mockito.mock(EmberNcp.class);
+        final EzspVersionResponse version = Mockito.mock(EzspVersionResponse.class);
+        Mockito.when(version.getProtocolVersion()).thenReturn(4);
+
+        Mockito.when(ncp.getVersion()).thenReturn(version);
+
+        final ZigBeePort port = Mockito.mock(ZigBeePort.class);
+        Mockito.when(port.open()).thenReturn(true);
+
+        ZigBeeDongleEzsp dongle = new ZigBeeDongleEzsp(port) {
+            @Override
+            public EmberNcp getEmberNcp() {
+                return ncp;
+            }
+        };
+
+        final ZigBeeTransportReceive receiver = Mockito.mock(ZigBeeTransportReceive.class);
+
+        dongle.setZigBeeTransportReceive(receiver);
+        assertEquals(ZigBeeStatus.COMMUNICATION_ERROR, dongle.initialize());
+    }
+
+    @Test
+    public void initializeSuccess() {
+        System.out.println("--- " + Thread.currentThread().getStackTrace()[1].getMethodName());
+        final EmberNcp ncp = Mockito.mock(EmberNcp.class);
+        final EzspVersionResponse version = Mockito.mock(EzspVersionResponse.class);
+        Mockito.when(version.getProtocolVersion()).thenReturn(4);
+
+        Mockito.when(ncp.getVersion()).thenReturn(version);
+        Mockito.when(ncp.getNetworkParameters()).thenReturn(Mockito.mock(EzspGetNetworkParametersResponse.class));
+
+        final ZigBeePort port = Mockito.mock(ZigBeePort.class);
+        Mockito.when(port.open()).thenReturn(true);
+
+        ZigBeeDongleEzsp dongle = new ZigBeeDongleEzsp(port) {
+            @Override
+            public EmberNcp getEmberNcp() {
+                return ncp;
+            }
+        };
+
+        final ZigBeeTransportReceive receiver = Mockito.mock(ZigBeeTransportReceive.class);
+
+        dongle.setZigBeeTransportReceive(receiver);
+        assertEquals(ZigBeeStatus.SUCCESS, dongle.initialize());
+    }
 }

--- a/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeTransportTransmitTest.java
+++ b/com.zsmartsystems.zigbee.dongle.ember/src/test/java/com/zsmartsystems/zigbee/dongle/ember/ZigBeeTransportTransmitTest.java
@@ -15,6 +15,7 @@ import com.zsmartsystems.zigbee.IeeeAddress;
 import com.zsmartsystems.zigbee.TestUtilities;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspGetNetworkParametersResponse;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspGetParentChildParametersResponse;
+import com.zsmartsystems.zigbee.dongle.ember.ezsp.command.EzspVersionResponse;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EmberCurrentSecurityState;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EmberNetworkParameters;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EmberNetworkStatus;
@@ -24,6 +25,7 @@ import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EzspPolicyId;
 import com.zsmartsystems.zigbee.dongle.ember.ezsp.structure.EzspStatus;
 import com.zsmartsystems.zigbee.dongle.ember.internal.EzspProtocolHandler;
 import com.zsmartsystems.zigbee.transport.ZigBeePort;
+import com.zsmartsystems.zigbee.transport.ZigBeeTransportReceive;
 import com.zsmartsystems.zigbee.transport.ZigBeeTransportTransmitAbstractTest;
 
 /**
@@ -52,6 +54,11 @@ public class ZigBeeTransportTransmitTest extends ZigBeeTransportTransmitAbstract
         Mockito.when(ncp.setRadioPower(ArgumentMatchers.anyInt())).thenReturn(EmberStatus.EMBER_SUCCESS);
         Mockito.when(ncp.getNwkAddress()).thenReturn(Integer.valueOf(0));
         Mockito.when(ncp.getIeeeAddress()).thenReturn(new IeeeAddress("1234567890ABCDEF"));
+        final EzspVersionResponse version = Mockito.mock(EzspVersionResponse.class);
+        Mockito.when(version.getProtocolVersion()).thenReturn(4);
+
+        Mockito.when(ncp.getVersion()).thenReturn(version);
+        Mockito.when(ncp.getNetworkParameters()).thenReturn(Mockito.mock(EzspGetNetworkParametersResponse.class));
 
         ZigBeePort port = Mockito.mock(ZigBeePort.class);
         Mockito.when(port.open()).thenReturn(Boolean.TRUE);
@@ -62,8 +69,13 @@ public class ZigBeeTransportTransmitTest extends ZigBeeTransportTransmitAbstract
                 return ncp;
             }
         };
+        EzspProtocolHandler frameHandler = Mockito.mock(EzspProtocolHandler.class);
+        Mockito.when(frameHandler.isAlive()).thenReturn(Boolean.TRUE);
+        TestUtilities.setField(ZigBeeDongleEzsp.class, dongle, "frameHandler", frameHandler);
 
-        TestUtilities.setField(ZigBeeDongleEzsp.class, dongle, "frameHandler", Mockito.mock(EzspProtocolHandler.class));
+        final ZigBeeTransportReceive receiver = Mockito.mock(ZigBeeTransportReceive.class);
+
+        dongle.setZigBeeTransportReceive(receiver);
 
         transport = dongle;
     }


### PR DESCRIPTION
If there is an error with the communications during initialisation, but after the version was requested, then the request to get the network parameter returns null, and this causes an NPE which is not handled, and results in no notification higher up the stack. Ultimately this block the `initialize` method returning.

This checks for null return, then checks if the ASH handler is alive at the end of initialisation. Any error will result in an error return from `initialize()`.