### PR TITLE
Add outline ZLL Commissioning definition

### DIFF
--- a/com.zsmartsystems.zigbee.autocode/src/main/java/com/zsmartsystems/zigbee/autocode/ZigBeeCodeGenerator.java
+++ b/com.zsmartsystems.zigbee.autocode/src/main/java/com/zsmartsystems/zigbee/autocode/ZigBeeCodeGenerator.java
@@ -110,6 +110,8 @@ public class ZigBeeCodeGenerator {
         zclParser.addFile("src/main/resources/0B04_ElectricalMeasurement.xml");
         zclParser.addFile("src/main/resources/0B05_Diagnostics.xml");
 
+        zclParser.addFile("src/main/resources/1000_ZllCommissioning.xml");
+
         List<ZigBeeXmlCluster> zclClusters = zclParser.parseClusterConfiguration();
 
         ZigBeeXmlParser zdoParser = new ZigBeeXmlParser();

--- a/com.zsmartsystems.zigbee.autocode/src/main/resources/1000_ZllCommissioning.xml
+++ b/com.zsmartsystems.zigbee.autocode/src/main/resources/1000_ZllCommissioning.xml
@@ -1,0 +1,5 @@
+<cluster xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="zigbee-description.xsd" code="0x1000">
+    <name>Light Link Commissioning</name>
+    <description>Cluster used for commissioning ZLL devices, including touchlinking and network management.</description>
+</cluster>

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclLightLinkCommissioningCluster.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/clusters/ZclLightLinkCommissioningCluster.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2016-2024 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.zcl.clusters;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentSkipListMap;
+
+import javax.annotation.Generated;
+
+import com.zsmartsystems.zigbee.ZigBeeEndpoint;
+import com.zsmartsystems.zigbee.zcl.ZclAttribute;
+import com.zsmartsystems.zigbee.zcl.ZclCluster;
+
+/**
+ * <b>Light Link Commissioning</b> cluster implementation (<i>Cluster ID 0x1000</i>).
+ * <p>
+ * Cluster used for commissioning ZLL devices, including touchlinking and network
+ * management.
+ * <p>
+ * Code is auto-generated. Modifications may be overwritten!
+ */
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2024-11-19T22:12:16Z")
+public class ZclLightLinkCommissioningCluster extends ZclCluster {
+    /**
+     * The ZigBee Cluster Library Cluster ID
+     */
+    public static final int CLUSTER_ID = 0x1000;
+
+    /**
+     * The ZigBee Cluster Library Cluster Name
+     */
+    public static final String CLUSTER_NAME = "Light Link Commissioning";
+
+    @Override
+    protected Map<Integer, ZclAttribute> initializeClientAttributes() {
+        Map<Integer, ZclAttribute> attributeMap = super.initializeClientAttributes();
+
+        return attributeMap;
+    }
+
+    @Override
+    protected Map<Integer, ZclAttribute> initializeServerAttributes() {
+        Map<Integer, ZclAttribute> attributeMap = super.initializeServerAttributes();
+
+        return attributeMap;
+    }
+
+
+    /**
+     * Default constructor to create a Light Link Commissioning cluster.
+     *
+     * @param zigbeeEndpoint the {@link ZigBeeEndpoint} this cluster is contained within
+     */
+    public ZclLightLinkCommissioningCluster(final ZigBeeEndpoint zigbeeEndpoint) {
+        super(zigbeeEndpoint, CLUSTER_ID, CLUSTER_NAME);
+    }
+}

--- a/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/protocol/ZclClusterType.java
+++ b/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/zcl/protocol/ZclClusterType.java
@@ -41,6 +41,7 @@ import com.zsmartsystems.zigbee.zcl.clusters.ZclIlluminanceMeasurementCluster;
 import com.zsmartsystems.zigbee.zcl.clusters.ZclKeyEstablishmentCluster;
 import com.zsmartsystems.zigbee.zcl.clusters.ZclLeafWetnessMeasurementCluster;
 import com.zsmartsystems.zigbee.zcl.clusters.ZclLevelControlCluster;
+import com.zsmartsystems.zigbee.zcl.clusters.ZclLightLinkCommissioningCluster;
 import com.zsmartsystems.zigbee.zcl.clusters.ZclMessagingCluster;
 import com.zsmartsystems.zigbee.zcl.clusters.ZclMeterIdentificationCluster;
 import com.zsmartsystems.zigbee.zcl.clusters.ZclMeteringCluster;
@@ -75,7 +76,7 @@ import com.zsmartsystems.zigbee.zcl.clusters.ZclWindowCoveringCluster;
  *
  * @author Chris Jackson
  */
-@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2024-07-16T22:58:38Z")
+@Generated(value = "com.zsmartsystems.zigbee.autocode.ZigBeeCodeGenerator", date = "2024-11-19T22:12:16Z")
 public enum ZclClusterType {
     BASIC(0x0000, ZclBasicCluster.class, "Basic"),
     POWER_CONFIGURATION(0x0001, ZclPowerConfigurationCluster.class, "Power Configuration"),
@@ -130,7 +131,8 @@ public enum ZclClusterType {
     KEY_ESTABLISHMENT(0x0800, ZclKeyEstablishmentCluster.class, "Key Establishment"),
     METER_IDENTIFICATION(0x0B01, ZclMeterIdentificationCluster.class, "Meter Identification"),
     ELECTRICAL_MEASUREMENT(0x0B04, ZclElectricalMeasurementCluster.class, "Electrical Measurement"),
-    DIAGNOSTICS(0x0B05, ZclDiagnosticsCluster.class, "Diagnostics");
+    DIAGNOSTICS(0x0B05, ZclDiagnosticsCluster.class, "Diagnostics"),
+    LIGHT_LINK_COMMISSIONING(0x1000, ZclLightLinkCommissioningCluster.class, "Light Link Commissioning");
 
     private static final Map<Integer, ZclClusterType> idValueMap = new ConcurrentHashMap<>();
 


### PR DESCRIPTION
This just adds the cluster name so it's available and useful when listing clusters.