### PR TITLE
Improve command line interpretation of endpoint ID

### DIFF
--- a/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleAbstractCommand.java
+++ b/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleAbstractCommand.java
@@ -71,14 +71,22 @@ public abstract class ZigBeeConsoleAbstractCommand implements ZigBeeConsoleComma
      */
     protected ZigBeeEndpoint getEndpoint(final ZigBeeNetworkManager networkManager, final String endpointId)
             throws IllegalArgumentException {
-        for (final ZigBeeNode node : networkManager.getNodes()) {
-            for (final ZigBeeEndpoint endpoint : node.getEndpoints()) {
-                if (endpointId.equals(node.getNetworkAddress() + "/" + endpoint.getEndpointId())) {
-                    return endpoint;
-                }
-            }
+        String[] endpointParts = endpointId.split("/");
+        if (endpointParts.length != 2) {
+            throw new IllegalArgumentException("Invalid endpoint format '" + endpointId + "'");
         }
-        throw new IllegalArgumentException("Endpoint '" + endpointId + "' is not found");
+        ZigBeeNode node = getNode(networkManager, endpointParts[0]);
+        Integer endpointNumber;
+        try {
+            endpointNumber = Integer.parseInt(endpointParts[1]);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Invalid endpoint number '" + endpointParts[1] + "'");
+        }
+        ZigBeeEndpoint endpoint = node.getEndpoint(endpointNumber);
+        if (endpoint == null) {
+            throw new IllegalArgumentException("Endpoint '" + endpointId + "' is not found");
+        }
+        return endpoint;
     }
 
     /**

--- a/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleAbstractCommand.java
+++ b/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleAbstractCommand.java
@@ -76,7 +76,7 @@ public abstract class ZigBeeConsoleAbstractCommand implements ZigBeeConsoleComma
             throw new IllegalArgumentException("Invalid endpoint format '" + endpointId + "'");
         }
         ZigBeeNode node = getNode(networkManager, endpointParts[0]);
-        Integer endpointNumber;
+        int endpointNumber;
         try {
             endpointNumber = Integer.parseInt(endpointParts[1]);
         } catch (NumberFormatException e) {

--- a/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleReportingConfigCommand.java
+++ b/com.zsmartsystems.zigbee.console/src/main/java/com/zsmartsystems/zigbee/console/ZigBeeConsoleReportingConfigCommand.java
@@ -70,15 +70,17 @@ public class ZigBeeConsoleReportingConfigCommand extends ZigBeeConsoleAbstractCo
         if (result.isSuccess()) {
             final ReadReportingConfigurationResponse response = result.getResponse();
             final AttributeReportingStatusRecord attributeReportingStatusRecord = response.getRecords().get(0);
-            
+
             final ZclStatus statusCode = attributeReportingStatusRecord.getStatus();
             if (statusCode == ZclStatus.SUCCESS) {
                 out.println("Cluster " + response.getClusterId() + ", Attribute "
                         + attributeReportingStatusRecord.getAttributeIdentifier() + ", type "
                         + attributeReportingStatusRecord.getAttributeDataType() + ", minimum reporting interval: "
-                        + attributeReportingStatusRecord.getMinimumReportingInterval() + ", maximum reporting interval: "
-                        + attributeReportingStatusRecord.getMaximumReportingInterval() + ", timeout: " 
-                        + attributeReportingStatusRecord.getTimeoutPeriod());
+                        + attributeReportingStatusRecord.getMinimumReportingInterval()
+                        + ", maximum reporting interval: "
+                        + attributeReportingStatusRecord.getMaximumReportingInterval() + ", timeout: "
+                        + (attributeReportingStatusRecord.getTimeoutPeriod() == 0 ? "N/A"
+                                : attributeReportingStatusRecord.getTimeoutPeriod()));
             } else {
                 out.println("Attribute value read error: " + statusCode);
             }


### PR DESCRIPTION
Allows the same format as the node ID (ie decimal, hex, or IEEE)